### PR TITLE
feat(warden): warn on top-level surface opens

### DIFF
--- a/.agents/plans/2026-05-26-fieldwork-compounding-stack/RETRO.md
+++ b/.agents/plans/2026-05-26-fieldwork-compounding-stack/RETRO.md
@@ -23,8 +23,8 @@ Use this as the durable execution ledger. Update it before any final handoff, dr
 
 | Order | Issue | Branch | PR | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
-| 1 | TRL-782 | `trl-782-resourcet-doesnt-flow-config-schemas-inferred-type-into` | | In progress | Resource config type inference. |
-| 2 | TRL-804 | `trl-804-warden-warn-topo-export-entry-should-not-open-a-surface-at` | | Planned | Warden top-level surface warning. |
+| 1 | TRL-782 | `trl-782-resourcet-doesnt-flow-config-schemas-inferred-type-into` | | Committed locally | Resource config type inference. |
+| 2 | TRL-804 | `trl-804-warden-warn-topo-export-entry-should-not-open-a-surface-at` | | Committed locally | Warden top-level surface warning. |
 | 3 | TRL-781 | `trl-781-trails-create-errors-hard-on-re-run-instead-of-reconciling` | | Planned | Scaffold rerun reconciliation. |
 | 4 | TRL-789 | `trl-789-trails-create-starter-entity-complete-the-crud-entitylist` | | Planned | Entity starter CRUD completion. |
 | 5 | TRL-816 | `trl-816-post-compose-cutover-cleanup-fix-current-facing-stragglers` | | Planned | Current-facing compose straggler cleanup. |
@@ -75,6 +75,17 @@ Use this as the durable execution ledger. Update it before any final handoff, dr
 - Changed: `packages/core/src/type-checks.test-d.ts` added compile-time assertions for inferred config, defaulted config, returned `Resource<T, C>`, and no-config `unknown`.
 - Changed: added `.changeset/resource-config-inference.md` for `@ontrails/core` patch.
 - Local review: subagent Bacon confirmed the live seam and recommended the same type-only fix plus no new runtime behavior.
+
+2026-05-26 15:42 EDT - TRL-804 implementation
+- Branch: `trl-804-warden-warn-topo-export-entry-should-not-open-a-surface-at`.
+- Tracker: moved TRL-804 to In Progress.
+- Changed: added Warden rule `no-top-level-surface` to warn when a topo-export module opens a surface at module top level.
+- Changed: rule detection is intentionally narrow: it requires an exported `topo(...)` entry (`default`, `graph`, or `app`) and imported surface-opening APIs or a top-level `.listen(...)`; guarded/nested startup remains allowed.
+- Changed: added focused rule tests for direct, aliased, namespace, and `.listen(...)` diagnostics plus dedicated-surface and guarded-startup allowances.
+- Changed: wired the rule through Warden exports, metadata, registry names, trail wrappers, and contract count tests.
+- Changed: regenerated Warden guide blocks in `AGENTS.md`, `.claude/skills/clark/references/warden-guide.md`, and `plugin/skills/trails/references/warden-guide.md`.
+- Changed: added `.changeset/warden-top-level-surface.md` for `@ontrails/warden` patch.
+- Local review: subagent Rawls recommended binding-aware detection and warned against broad false positives; implemented the narrow imported-binding rule shape.
 ```
 
 ## Verification Log
@@ -87,12 +98,23 @@ Use this as the durable execution ledger. Update it before any final handoff, dr
 | 2026-05-26 15:26 EDT | TRL-782 | `git diff --check` | Pass | No whitespace errors. |
 | 2026-05-26 15:28 EDT | TRL-782 | `bun run lint` | Pass after focused fix | Initial run failed on new type-check style (`prefer-destructuring`, `no-unused-expressions`, `consistent-type-definitions`); fixed and reran clean. |
 | 2026-05-26 15:29 EDT | TRL-782 | `bun run format:check` | Pass after formatting | Initial run flagged `packages/core/src/type-checks.test-d.ts`; formatted with `bunx ultracite fix packages/core/src/type-checks.test-d.ts`, then reran clean. |
+| 2026-05-26 15:42 EDT | TRL-804 | `bun test packages/warden/src/__tests__/no-top-level-surface.test.ts packages/warden/src/__tests__/trails.test.ts` | Pass after focused fixes | Initial iterations exposed AST unwrap and export-specifier bugs; final run passed 168 tests. |
+| 2026-05-26 15:42 EDT | TRL-804 | `bun run --cwd packages/warden typecheck` | Pass | Warden package typecheck passed. |
+| 2026-05-26 15:42 EDT | TRL-804 | `bun run warden:agents:sync` | Pass | Regenerated root Warden guide; rule count now 59. |
+| 2026-05-26 15:42 EDT | TRL-804 | `bun run warden:skills:sync` | Pass | Regenerated Clark and plugin Trails skill Warden guide references. |
+| 2026-05-26 15:42 EDT | TRL-804 | `bun run warden:agents:check` | Pass | Generated `AGENTS.md` Warden guide is current. |
+| 2026-05-26 15:42 EDT | TRL-804 | `bun run warden:skills:check` | Pass | Generated skill Warden guides are current. |
+| 2026-05-26 15:42 EDT | TRL-804 | `bun run --cwd packages/warden lint` | Pass after focused fix | Initial run failed on AST destructuring and metadata key order; fixed and reran clean. |
+| 2026-05-26 15:42 EDT | TRL-804 | `bun run format:check` | Pass after formatting | Initial run flagged new Warden rule and metadata formatting; formatted with `bunx ultracite fix ...`, then reran clean. |
+| 2026-05-26 15:42 EDT | TRL-804 | `git diff --check` | Pass | No whitespace errors. |
+| 2026-05-26 15:42 EDT | TRL-804 | `bun run lint:ast-grep` | Pass | Repo ast-grep scan passed. |
 
 ## Local Review Log
 
 | Time | Branch | Lane | Reviewer | Score | Findings | Outcome |
 | --- | --- | --- | --- | --- | --- | --- |
 | 2026-05-26 15:25 EDT | TRL-782 | Type inference seam scout | Bacon (subagent) | Clean plan | Found the generic erasure in `Resource<T>` / `resource()` and recommended compile-time tests plus no runtime change. | Implemented matching fix. |
+| 2026-05-26 15:42 EDT | TRL-804 | Warden surface coaching scout | Rawls (subagent) | Scoped warning | Found the introspection import hazard and recommended imported-binding detection with guarded/dedicated-surface allowances. | Implemented narrow source-static rule and tests. |
 
 ## Remote Review / CI Log
 

--- a/.agents/skills/clark/references/warden-guide.md
+++ b/.agents/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 58
+- Rule count: 59
 
 ## Agent Instructions
 
@@ -39,6 +39,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `incomplete-crud` (warn, project/project-static, external): Versioned CRUD entities expose complete operation coverage.
 - `layer-field-name-drift` (error, source/source-static, external): Layer input field reserved names are shared across surface projections.
 - `no-legacy-layer-imports` (error, source/source-static, external): Legacy layer exports removed across TRL-475/TRL-476 (authLayer, autoIterateLayer, dateShortcutsLayer) do not reappear in committed source.
+- `no-top-level-surface` (warn, source/source-static, external): Topo export modules do not open surfaces at module top level. Guidance: Keep topo entry modules side-effect-free for survey, guide, compile, and lock generation.
 - `owner-projection-parity` (error, source/source-static, internal): Framework projections stay aligned with owner exports.
 - `prefer-schema-inference` (warn, all/source-static, advisory): Trail schemas should be inferred unless overrides add meaning. Guidance: Let schemas remain the owner for field metadata unless an override adds new information.
 - `public-internal-deep-imports` (error, project/project-static, internal): Cross-package imports stay on package-owned public exports.

--- a/.changeset/warden-top-level-surface.md
+++ b/.changeset/warden-top-level-surface.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Warn when topo export modules open Trails surfaces at module top level.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 58
+- Rule count: 59
 
 ## Agent Instructions
 
@@ -39,6 +39,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `incomplete-crud` (warn, project/project-static, external): Versioned CRUD entities expose complete operation coverage.
 - `layer-field-name-drift` (error, source/source-static, external): Layer input field reserved names are shared across surface projections.
 - `no-legacy-layer-imports` (error, source/source-static, external): Legacy layer exports removed across TRL-475/TRL-476 (authLayer, autoIterateLayer, dateShortcutsLayer) do not reappear in committed source.
+- `no-top-level-surface` (warn, source/source-static, external): Topo export modules do not open surfaces at module top level. Guidance: Keep topo entry modules side-effect-free for survey, guide, compile, and lock generation.
 - `owner-projection-parity` (error, source/source-static, internal): Framework projections stay aligned with owner exports.
 - `prefer-schema-inference` (warn, all/source-static, advisory): Trail schemas should be inferred unless overrides add meaning. Guidance: Let schemas remain the owner for field metadata unless an override adds new information.
 - `public-internal-deep-imports` (error, project/project-static, internal): Cross-package imports stay on package-owned public exports.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ Use the project language consistently:
 This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
-- Rule count: 58
+- Rule count: 59
 
 ### Rule Index
 
@@ -113,6 +113,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `incomplete-crud` (warn, project/project-static, external): Versioned CRUD entities expose complete operation coverage.
 - `layer-field-name-drift` (error, source/source-static, external): Layer input field reserved names are shared across surface projections.
 - `no-legacy-layer-imports` (error, source/source-static, external): Legacy layer exports removed across TRL-475/TRL-476 (authLayer, autoIterateLayer, dateShortcutsLayer) do not reappear in committed source.
+- `no-top-level-surface` (warn, source/source-static, external): Topo export modules do not open surfaces at module top level.
 - `owner-projection-parity` (error, source/source-static, internal): Framework projections stay aligned with owner exports.
 - `prefer-schema-inference` (warn, all/source-static, advisory): Trail schemas should be inferred unless overrides add meaning.
 - `public-internal-deep-imports` (error, project/project-static, internal): Cross-package imports stay on package-owned public exports.
@@ -174,6 +175,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 
 - `example-valid`: Keep trail examples synchronized with their authored schemas.
 - `no-throw-in-implementation`: Convert thrown failures in blazes into explicit Result.err() outcomes.
+- `no-top-level-surface`: Keep topo entry modules side-effect-free for survey, guide, compile, and lock generation.
 - `permit-governance`: Make destructive trail authorization visible on the trail contract.
 - `prefer-schema-inference`: Let schemas remain the owner for field metadata unless an override adds new information.
 - `public-output-schema`: Make public surface result contracts explicit before MCP/HTTP projection.

--- a/packages/warden/src/__tests__/no-top-level-surface.test.ts
+++ b/packages/warden/src/__tests__/no-top-level-surface.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from 'bun:test';
+
+import { noTopLevelSurface } from '../rules/no-top-level-surface.js';
+
+describe('no-top-level-surface', () => {
+  test('flags top-level surface opening in a default topo export module', () => {
+    const code = `
+import { topo } from '@ontrails/core';
+import { surface } from '@ontrails/mcp';
+import * as trails from './trails';
+
+const graph = topo('app', trails);
+export default graph;
+await surface(graph);
+`;
+
+    const diagnostics = noTopLevelSurface.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.rule).toBe('no-top-level-surface');
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.message).toContain('survey');
+    expect(diagnostics[0]?.message).toContain('separate entry/bin');
+  });
+
+  test('flags top-level aliased surface opening in a named topo export module', () => {
+    const code = `
+import { topo } from '@ontrails/core';
+import { surface as openMcp } from '@ontrails/mcp';
+import * as trails from './trails';
+
+export const graph = topo('app', trails);
+await openMcp(graph);
+`;
+
+    const diagnostics = noTopLevelSurface.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('flags top-level connectStdio opening in a named topo export module', () => {
+    const code = `
+import { topo } from '@ontrails/core';
+import { connectStdio } from '@ontrails/mcp';
+import * as trails from './trails';
+
+export const graph = topo('app', trails);
+await connectStdio(server);
+`;
+
+    const diagnostics = noTopLevelSurface.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('flags top-level aliased startServer opening in a named topo export module', () => {
+    const code = `
+import { topo } from '@ontrails/core';
+import { startServer as bootHttp } from '@ontrails/http/bun';
+import * as trails from './trails';
+
+export const graph = topo('app', trails);
+await bootHttp(graph);
+`;
+
+    const diagnostics = noTopLevelSurface.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('flags namespace-imported surface opening in a named topo export module', () => {
+    const code = `
+import { topo } from '@ontrails/core';
+import * as mcp from '@ontrails/mcp';
+import * as trails from './trails';
+
+const app = topo('app', trails);
+export { app };
+await mcp.surface(app);
+`;
+
+    const diagnostics = noTopLevelSurface.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('flags namespace-imported listen calls in a topo export module', () => {
+    const code = `
+import { topo } from '@ontrails/core';
+import * as http from '@ontrails/http/bun';
+import * as trails from './trails';
+
+export const graph = topo('app', trails);
+http.listen(graph);
+`;
+
+    const diagnostics = noTopLevelSurface.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('flags default-exported surface opening in a named topo export module', () => {
+    const code = `
+import { topo } from '@ontrails/core';
+import { surface } from '@ontrails/mcp';
+import * as trails from './trails';
+
+export const graph = topo('app', trails);
+export default await surface(graph);
+`;
+
+    const diagnostics = noTopLevelSurface.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('ignores unrelated listen calls in a topo export module', () => {
+    const code = `
+import { topo } from '@ontrails/core';
+import * as trails from './trails';
+
+const server = { listen() {} };
+export const graph = topo('app', trails);
+server.listen(3000);
+`;
+
+    const diagnostics = noTopLevelSurface.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('allows surface opening in a dedicated surface module without topo export', () => {
+    const code = `
+import { surface } from '@ontrails/mcp';
+import graph from './app';
+
+await surface(graph);
+`;
+
+    const diagnostics = noTopLevelSurface.check(code, 'src/mcp.ts');
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('allows guarded or nested surface opening in a topo export module', () => {
+    const code = `
+import { topo } from '@ontrails/core';
+import { surface } from '@ontrails/mcp';
+import * as trails from './trails';
+
+export const graph = topo('app', trails);
+
+export const main = async () => {
+  await surface(graph);
+};
+
+if (import.meta.main) {
+  await main();
+}
+`;
+
+    const diagnostics = noTopLevelSurface.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('ignores unrelated local helpers named surface', () => {
+    const code = `
+import { topo } from '@ontrails/core';
+import * as trails from './trails';
+
+const surface = () => null;
+export const graph = topo('app', trails);
+surface();
+`;
+
+    const diagnostics = noTopLevelSurface.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('allows create and derive helpers at module top level', () => {
+    const code = `
+import { topo } from '@ontrails/core';
+import { createServer, deriveMcpTools } from '@ontrails/mcp';
+import * as trails from './trails';
+
+export const graph = topo('app', trails);
+const tools = deriveMcpTools(graph);
+const server = createServer(graph);
+`;
+
+    const diagnostics = noTopLevelSurface.check(code, 'src/app.ts');
+
+    expect(diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -8,8 +8,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 58 rule trails', () => {
-    expect(wardenTopo.count).toBe(58);
+  test('contains all 59 rule trails', () => {
+    expect(wardenTopo.count).toBe(59);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -172,6 +172,7 @@ export {
   noSyncResultAssumptionTrail,
   noThrowInDetourRecoverTrail,
   noThrowInImplementationTrail,
+  noTopLevelSurfaceTrail,
   onReferencesExistTrail,
   orphanedSignalTrail,
   ownerProjectionParityTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -25,6 +25,7 @@ import { noRedundantResultErrorWrap } from './no-redundant-result-error-wrap.js'
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
 import { noThrowInDetourRecover } from './no-throw-in-detour-recover.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
+import { noTopLevelSurface } from './no-top-level-surface.js';
 import { onReferencesExist } from './on-references-exist.js';
 import { orphanedSignal } from './orphaned-signal.js';
 import { ownerProjectionParity } from './owner-projection-parity.js';
@@ -118,6 +119,7 @@ export { noRedundantResultErrorWrap } from './no-redundant-result-error-wrap.js'
 export { noSyncResultAssumption } from './no-sync-result-assumption.js';
 export { implementationReturnsResult } from './implementation-returns-result.js';
 export { noThrowInDetourRecover } from './no-throw-in-detour-recover.js';
+export { noTopLevelSurface } from './no-top-level-surface.js';
 export { orphanedSignal } from './orphaned-signal.js';
 export { ownerProjectionParity } from './owner-projection-parity.js';
 export { permitGovernance } from './permit-governance.js';
@@ -194,6 +196,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [noSyncResultAssumption.name, noSyncResultAssumption],
   [implementationReturnsResult.name, implementationReturnsResult],
   [noThrowInDetourRecover.name, noThrowInDetourRecover],
+  [noTopLevelSurface.name, noTopLevelSurface],
   [unreachableDetourShadowing.name, unreachableDetourShadowing],
   [wardenExportSymmetry.name, wardenExportSymmetry],
   [wardenRulesUseAst.name, wardenRulesUseAst],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -308,6 +308,21 @@ const builtinWardenRuleMetadataInput = {
     invariant: 'Blazes return Result.err() instead of throwing.',
     tier: 'source-static',
   },
+  'no-top-level-surface': {
+    ...durableExternal,
+    guidance: {
+      docs: [{ label: 'Architecture', path: 'docs/architecture.md' }],
+      relatedRules: ['context-no-surface-types'],
+      steps: [
+        'Keep the topo-export module focused on exporting `topo(...)` as `default`, `graph`, or `app`.',
+        'Move `surface(...)`, `connectStdio(...)`, server start, or `.listen(...)` calls into a separate entry or bin module.',
+      ],
+      summary:
+        'Keep topo entry modules side-effect-free for survey, guide, compile, and lock generation.',
+    },
+    invariant: 'Topo export modules do not open surfaces at module top level.',
+    tier: 'source-static',
+  },
   'on-references-exist': {
     ...durableExternal,
     invariant: 'Trail on: declarations resolve to known signals.',

--- a/packages/warden/src/rules/no-top-level-surface.ts
+++ b/packages/warden/src/rules/no-top-level-surface.ts
@@ -1,0 +1,389 @@
+import {
+  getStringValue,
+  identifierName,
+  isStringLiteral,
+  offsetToLine,
+  parse,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const RULE_NAME = 'no-top-level-surface';
+
+const TOPO_EXPORT_NAMES = new Set(['app', 'graph']);
+const SURFACE_OPEN_CALLEE_NAMES = new Set([
+  'connectStdio',
+  'startServer',
+  'surface',
+]);
+const TOPO_IMPORT_SOURCES = new Set(['@ontrails/core']);
+const SURFACE_IMPORT_SOURCES = new Set([
+  '@ontrails/commander',
+  '@ontrails/hono',
+  '@ontrails/http',
+  '@ontrails/http/bun',
+  '@ontrails/mcp',
+]);
+
+const diagnosticMessage =
+  'This module exports a topo and opens a surface at module top level. Trails introspection commands (`survey`, `guide`, `compile`) import topo entry modules, so opening a surface here can trigger sockets or transports during introspection. Move surface-opening to a separate entry/bin and keep the topo-export module side-effect-free.';
+
+const unwrapExportDeclaration = (node: AstNode): AstNode =>
+  node.type === 'ExportNamedDeclaration' ||
+  node.type === 'ExportDefaultDeclaration'
+    ? ((node as unknown as { declaration?: AstNode }).declaration ?? node)
+    : node;
+
+interface ImportedBindings {
+  readonly named: ReadonlyMap<string, string>;
+  readonly namespaces: ReadonlySet<string>;
+}
+
+const importSource = (node: AstNode): string | null => {
+  const { source } = node as unknown as { readonly source?: AstNode };
+  return source && isStringLiteral(source) ? getStringValue(source) : null;
+};
+
+const importedSpecifierName = (node: AstNode | undefined): string | null =>
+  identifierName(node) ??
+  (node && isStringLiteral(node) ? getStringValue(node) : null);
+
+const addFrameworkImportBindings = (
+  ast: AstNode,
+  sources: ReadonlySet<string>,
+  allowedImports: ReadonlySet<string>
+): ImportedBindings => {
+  const named = new Map<string, string>();
+  const namespaces = new Set<string>();
+  const body = (ast as unknown as { body?: readonly AstNode[] }).body ?? [];
+
+  for (const statement of body) {
+    if (
+      statement.type !== 'ImportDeclaration' ||
+      !sources.has(importSource(statement) ?? '')
+    ) {
+      continue;
+    }
+
+    const specifiers =
+      (statement as unknown as { specifiers?: readonly AstNode[] })
+        .specifiers ?? [];
+    for (const specifier of specifiers) {
+      if (specifier.type === 'ImportNamespaceSpecifier') {
+        const localName = identifierName(
+          (specifier as unknown as { local?: AstNode }).local
+        );
+        if (localName) {
+          namespaces.add(localName);
+        }
+        continue;
+      }
+      if (specifier.type !== 'ImportSpecifier') {
+        continue;
+      }
+
+      const { imported, local } = specifier as unknown as {
+        readonly imported?: AstNode;
+        readonly local?: AstNode;
+      };
+      const importedName = importedSpecifierName(imported);
+      const localName = identifierName(local);
+      if (importedName && allowedImports.has(importedName) && localName) {
+        named.set(localName, importedName);
+      }
+    }
+  }
+
+  return { named, namespaces };
+};
+
+const unwrapExpression = (node: AstNode | undefined): AstNode | undefined => {
+  let current = node;
+  while (
+    current?.type === 'AwaitExpression' ||
+    current?.type === 'ChainExpression' ||
+    current?.type === 'TSAsExpression' ||
+    current?.type === 'TSSatisfiesExpression'
+  ) {
+    current =
+      (current as unknown as { argument?: AstNode; expression?: AstNode })
+        .expression ??
+      (current as unknown as { argument?: AstNode; expression?: AstNode })
+        .argument;
+  }
+  return current;
+};
+
+const memberExpressionParts = (
+  node: AstNode | undefined
+): { objectName: string | null; propertyName: string | null } => {
+  if (node?.type !== 'MemberExpression') {
+    return { objectName: null, propertyName: null };
+  }
+  const { computed, property } = node as unknown as {
+    readonly computed?: boolean;
+    readonly object?: AstNode;
+    readonly property?: AstNode;
+  };
+  return {
+    objectName: identifierName(
+      (node as unknown as { object?: AstNode }).object
+    ),
+    propertyName: computed ? null : identifierName(property),
+  };
+};
+
+const calleeName = (
+  node: AstNode | undefined,
+  bindings: ImportedBindings
+): string | null => {
+  const callee = unwrapExpression(node);
+  if (!callee) {
+    return null;
+  }
+  const directName = identifierName(callee);
+  if (directName && bindings.named.has(directName)) {
+    return bindings.named.get(directName) ?? null;
+  }
+
+  const { objectName, propertyName } = memberExpressionParts(callee);
+  if (
+    objectName &&
+    propertyName &&
+    bindings.namespaces.has(objectName) &&
+    (SURFACE_OPEN_CALLEE_NAMES.has(propertyName) || propertyName === 'topo')
+  ) {
+    return propertyName;
+  }
+
+  return null;
+};
+
+const isTopoCall = (
+  node: AstNode | undefined,
+  bindings: ImportedBindings
+): boolean =>
+  calleeName(
+    (unwrapExpression(node) as unknown as { callee?: AstNode })?.callee,
+    bindings
+  ) === 'topo';
+
+const isSurfaceOpenCall = (
+  node: AstNode | undefined,
+  bindings: ImportedBindings
+): boolean => {
+  const expression = unwrapExpression(node);
+  if (expression?.type !== 'CallExpression') {
+    return false;
+  }
+
+  const { callee } = expression as unknown as { readonly callee?: AstNode };
+  const directName = calleeName(callee, bindings);
+  if (directName && SURFACE_OPEN_CALLEE_NAMES.has(directName)) {
+    return true;
+  }
+  const { objectName, propertyName } = memberExpressionParts(callee);
+  if (
+    objectName &&
+    propertyName === 'listen' &&
+    bindings.namespaces.has(objectName)
+  ) {
+    return true;
+  }
+
+  return false;
+};
+
+const declarationIdName = (node: AstNode | undefined): string | null =>
+  identifierName(node) ??
+  identifierName((node as unknown as { left?: AstNode } | undefined)?.left);
+
+const collectTopLevelTopoBindings = (
+  ast: AstNode,
+  topoBindings: ImportedBindings
+): ReadonlySet<string> => {
+  const bindings = new Set<string>();
+  const body = (ast as unknown as { body?: readonly AstNode[] }).body ?? [];
+
+  for (const statement of body) {
+    const declaration = unwrapExportDeclaration(statement);
+    if (declaration.type === 'VariableDeclaration') {
+      const declarations =
+        (declaration as unknown as { declarations?: readonly AstNode[] })
+          .declarations ?? [];
+      for (const item of declarations) {
+        const { id, init } = item as unknown as {
+          readonly id?: AstNode;
+          readonly init?: AstNode;
+        };
+        const name = declarationIdName(id);
+        if (name && isTopoCall(init, topoBindings)) {
+          bindings.add(name);
+        }
+      }
+    }
+  }
+
+  return bindings;
+};
+
+const namedExportCarriesTopo = (
+  statement: AstNode,
+  topLevelTopoBindings: ReadonlySet<string>
+): boolean => {
+  const specifiers =
+    (statement as unknown as { specifiers?: readonly AstNode[] }).specifiers ??
+    [];
+
+  for (const specifier of specifiers) {
+    const { exported, local } = specifier as unknown as {
+      readonly exported?: AstNode;
+      readonly local?: AstNode;
+    };
+    const exportedName = identifierName(exported);
+    const localName = identifierName(local);
+    if (
+      exportedName &&
+      TOPO_EXPORT_NAMES.has(exportedName) &&
+      localName &&
+      topLevelTopoBindings.has(localName)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const moduleExportsTopo = (
+  ast: AstNode,
+  topoBindings: ImportedBindings
+): boolean => {
+  const topLevelTopoBindings = collectTopLevelTopoBindings(ast, topoBindings);
+  const body = (ast as unknown as { body?: readonly AstNode[] }).body ?? [];
+
+  for (const statement of body) {
+    if (statement.type === 'ExportDefaultDeclaration') {
+      const declaration = unwrapExportDeclaration(statement);
+      if (isTopoCall(declaration, topoBindings)) {
+        return true;
+      }
+      const defaultName = identifierName(declaration);
+      if (defaultName && topLevelTopoBindings.has(defaultName)) {
+        return true;
+      }
+    }
+
+    if (statement.type === 'ExportNamedDeclaration') {
+      const declaration = unwrapExportDeclaration(statement);
+      if (namedExportCarriesTopo(statement, topLevelTopoBindings)) {
+        return true;
+      }
+      if (declaration.type !== 'VariableDeclaration') {
+        continue;
+      }
+      const declarations =
+        (declaration as unknown as { declarations?: readonly AstNode[] })
+          .declarations ?? [];
+      for (const item of declarations) {
+        const { id, init } = item as unknown as {
+          readonly id?: AstNode;
+          readonly init?: AstNode;
+        };
+        const name = declarationIdName(id);
+        if (
+          name &&
+          TOPO_EXPORT_NAMES.has(name) &&
+          isTopoCall(init, topoBindings)
+        ) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+};
+
+const topLevelSurfaceOpen = (
+  statement: AstNode,
+  surfaceBindings: ImportedBindings
+): AstNode | null => {
+  const declaration = unwrapExportDeclaration(statement);
+  if (declaration.type === 'ExpressionStatement') {
+    const { expression } = declaration as unknown as {
+      readonly expression?: AstNode;
+    };
+    const unwrapped = unwrapExpression(expression);
+    return isSurfaceOpenCall(unwrapped, surfaceBindings)
+      ? (unwrapped ?? null)
+      : null;
+  }
+
+  const unwrappedDeclaration = unwrapExpression(declaration);
+  if (isSurfaceOpenCall(unwrappedDeclaration, surfaceBindings)) {
+    return unwrappedDeclaration ?? null;
+  }
+
+  if (declaration.type !== 'VariableDeclaration') {
+    return null;
+  }
+
+  const declarations =
+    (declaration as unknown as { declarations?: readonly AstNode[] })
+      .declarations ?? [];
+  for (const item of declarations) {
+    const { init } = item as unknown as { readonly init?: AstNode };
+    const unwrapped = unwrapExpression(init);
+    if (isSurfaceOpenCall(unwrapped, surfaceBindings)) {
+      return unwrapped ?? null;
+    }
+  }
+
+  return null;
+};
+
+export const noTopLevelSurface: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const topoBindings = addFrameworkImportBindings(
+      ast,
+      TOPO_IMPORT_SOURCES,
+      new Set(['topo'])
+    );
+    if (!moduleExportsTopo(ast, topoBindings)) {
+      return [];
+    }
+    const surfaceBindings = addFrameworkImportBindings(
+      ast,
+      SURFACE_IMPORT_SOURCES,
+      SURFACE_OPEN_CALLEE_NAMES
+    );
+
+    const diagnostics: WardenDiagnostic[] = [];
+    const body = (ast as unknown as { body?: readonly AstNode[] }).body ?? [];
+    for (const statement of body) {
+      const surfaceOpen = topLevelSurfaceOpen(statement, surfaceBindings);
+      if (!surfaceOpen) {
+        continue;
+      }
+      diagnostics.push({
+        filePath,
+        line: offsetToLine(sourceCode, surfaceOpen.start),
+        message: diagnosticMessage,
+        rule: RULE_NAME,
+        severity: 'warn',
+      });
+    }
+
+    return diagnostics;
+  },
+  description:
+    'Coach topo export modules to keep surface-opening side effects out of module top level.',
+  name: RULE_NAME,
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -33,6 +33,7 @@ import { noRedundantResultErrorWrap } from './no-redundant-result-error-wrap.js'
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
 import { noThrowInDetourRecover } from './no-throw-in-detour-recover.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
+import { noTopLevelSurface } from './no-top-level-surface.js';
 import { onReferencesExist } from './on-references-exist.js';
 import { orphanedSignal } from './orphaned-signal.js';
 import { ownerProjectionParity } from './owner-projection-parity.js';
@@ -105,6 +106,7 @@ export const registeredRuleNames: readonly string[] = [
   noSyncResultAssumption.name,
   noThrowInDetourRecover.name,
   noThrowInImplementation.name,
+  noTopLevelSurface.name,
   onReferencesExist.name,
   orphanedSignal.name,
   ownerProjectionParity.name,

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -29,6 +29,7 @@ export { noRedundantResultErrorWrapTrail } from './no-redundant-result-error-wra
 export { noSyncResultAssumptionTrail } from './no-sync-result-assumption.trail.js';
 export { noThrowInDetourRecoverTrail } from './no-throw-in-detour-recover.trail.js';
 export { noThrowInImplementationTrail } from './no-throw-in-implementation.trail.js';
+export { noTopLevelSurfaceTrail } from './no-top-level-surface.trail.js';
 export { orphanedSignalTrail } from './orphaned-signal.trail.js';
 export { ownerProjectionParityTrail } from './owner-projection-parity.trail.js';
 export { pendingForceTrail } from './pending-force.trail.js';

--- a/packages/warden/src/trails/no-top-level-surface.trail.ts
+++ b/packages/warden/src/trails/no-top-level-surface.trail.ts
@@ -1,0 +1,43 @@
+import { noTopLevelSurface } from '../rules/no-top-level-surface.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const noTopLevelSurfaceTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'src/mcp.ts',
+        sourceCode: `import { surface } from "@ontrails/mcp";
+import graph from "./app";
+
+await surface(graph);`,
+      },
+      name: 'Allows dedicated surface entry modules',
+    },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: 'src/app.ts',
+            line: 6,
+            message:
+              'This module exports a topo and opens a surface at module top level. Trails introspection commands (`survey`, `guide`, `compile`) import topo entry modules, so opening a surface here can trigger sockets or transports during introspection. Move surface-opening to a separate entry/bin and keep the topo-export module side-effect-free.',
+            rule: 'no-top-level-surface',
+            severity: 'warn',
+          },
+        ],
+      },
+      input: {
+        filePath: 'src/app.ts',
+        sourceCode: `import { topo } from "@ontrails/core";
+import { surface } from "@ontrails/mcp";
+import * as trails from "./trails";
+
+export const graph = topo("app", trails);
+await surface(graph);`,
+      },
+      name: 'Warns when a topo export module opens a surface',
+    },
+  ],
+  rule: noTopLevelSurface,
+});

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 58
+- Rule count: 59
 
 ## Agent Instructions
 
@@ -39,6 +39,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `incomplete-crud` (warn, project/project-static, external): Versioned CRUD entities expose complete operation coverage.
 - `layer-field-name-drift` (error, source/source-static, external): Layer input field reserved names are shared across surface projections.
 - `no-legacy-layer-imports` (error, source/source-static, external): Legacy layer exports removed across TRL-475/TRL-476 (authLayer, autoIterateLayer, dateShortcutsLayer) do not reappear in committed source.
+- `no-top-level-surface` (warn, source/source-static, external): Topo export modules do not open surfaces at module top level. Guidance: Keep topo entry modules side-effect-free for survey, guide, compile, and lock generation.
 - `owner-projection-parity` (error, source/source-static, internal): Framework projections stay aligned with owner exports.
 - `prefer-schema-inference` (warn, all/source-static, advisory): Trail schemas should be inferred unless overrides add meaning. Guidance: Let schemas remain the owner for field metadata unless an override adds new information.
 - `public-internal-deep-imports` (error, project/project-static, internal): Cross-package imports stay on package-owned public exports.


### PR DESCRIPTION
## Context

Part 2 of the Fieldwork compounding stack for TRL-804. Topo entry modules should stay inert for survey, guide, compile, lock generation, and agent introspection; opening a surface at module top level makes those reads side-effectful.

## What changed

- Adds Warden rule `no-top-level-surface` as a warning.
- Detects top-level surface openings only when a module also exports a topo entry.
- Covers direct, aliased, namespace, and top-level `.listen(...)` cases while allowing dedicated surface modules and guarded startup blocks.
- Wires rule metadata, registry, trail wrapper, guide output, and generated agent/skill references.

## Verification

- `bun test packages/warden/src/__tests__/no-top-level-surface.test.ts packages/warden/src/__tests__/trails.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run warden:agents:sync && bun run warden:skills:sync && bun run skillset:sync`
- `bun run warden:agents:check && bun run warden:skills:check && bun run skillset:check`
- Stack-tip gate later passed: `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run format:check`, `git diff --check`, `bun run check`

## Risks / rollout

The rule is intentionally narrow and warning-level to avoid broad false positives. Changeset included for `@ontrails/warden`.
