### PR TITLE
fix(trails): reconcile create reruns

### DIFF
--- a/.agents/plans/2026-05-26-fieldwork-compounding-stack/RETRO.md
+++ b/.agents/plans/2026-05-26-fieldwork-compounding-stack/RETRO.md
@@ -25,7 +25,7 @@ Use this as the durable execution ledger. Update it before any final handoff, dr
 | --- | --- | --- | --- | --- | --- |
 | 1 | TRL-782 | `trl-782-resourcet-doesnt-flow-config-schemas-inferred-type-into` | | Committed locally | Resource config type inference. |
 | 2 | TRL-804 | `trl-804-warden-warn-topo-export-entry-should-not-open-a-surface-at` | | Committed locally | Warden top-level surface warning. |
-| 3 | TRL-781 | `trl-781-trails-create-errors-hard-on-re-run-instead-of-reconciling` | | Planned | Scaffold rerun reconciliation. |
+| 3 | TRL-781 | `trl-781-trails-create-errors-hard-on-re-run-instead-of-reconciling` | | Committed locally | Scaffold rerun reconciliation. |
 | 4 | TRL-789 | `trl-789-trails-create-starter-entity-complete-the-crud-entitylist` | | Planned | Entity starter CRUD completion. |
 | 5 | TRL-816 | `trl-816-post-compose-cutover-cleanup-fix-current-facing-stragglers` | | Planned | Current-facing compose straggler cleanup. |
 | 6 | TRL-814 | `trl-814-crosscompose-cutover-s6-radio-migration-follow-up` | | Planned proof lane | Radio migration; separate source-control lane unless approved. |
@@ -86,6 +86,16 @@ Use this as the durable execution ledger. Update it before any final handoff, dr
 - Changed: regenerated Warden guide blocks in `AGENTS.md`, `.claude/skills/clark/references/warden-guide.md`, and `plugin/skills/trails/references/warden-guide.md`.
 - Changed: added `.changeset/warden-top-level-surface.md` for `@ontrails/warden` patch.
 - Local review: subagent Rawls recommended binding-aware detection and warned against broad false positives; implemented the narrow imported-binding rule shape.
+
+2026-05-26 15:52 EDT - TRL-781 implementation
+- Branch: `trl-781-trails-create-errors-hard-on-re-run-instead-of-reconciling`.
+- Tracker: moved TRL-781 to In Progress.
+- Changed: scaffold planning/application now supports preserve-existing mode; `create.scaffold` uses it so reruns only write missing scaffold files.
+- Changed: `add.surface` now reconciles an existing surface entrypoint by preserving the file and still patching required package dependencies.
+- Changed: `add.verify` preserves existing verification files while still patching verify dependencies.
+- Changed: `create` preserves an existing README rather than overwriting it during rerun reconciliation.
+- Changed: added a regression test for a Radio-like partial project with an existing CLI entry, custom package fields, existing README/app/tsconfig, and a requested MCP surface.
+- Changed: added `.changeset/create-rerun-reconciliation.md` for `@ontrails/trails` patch.
 ```
 
 ## Verification Log
@@ -108,6 +118,12 @@ Use this as the durable execution ledger. Update it before any final handoff, dr
 | 2026-05-26 15:42 EDT | TRL-804 | `bun run format:check` | Pass after formatting | Initial run flagged new Warden rule and metadata formatting; formatted with `bunx ultracite fix ...`, then reran clean. |
 | 2026-05-26 15:42 EDT | TRL-804 | `git diff --check` | Pass | No whitespace errors. |
 | 2026-05-26 15:42 EDT | TRL-804 | `bun run lint:ast-grep` | Pass | Repo ast-grep scan passed. |
+| 2026-05-26 15:52 EDT | TRL-781 | `bun test apps/trails/src/__tests__/create.test.ts apps/trails/src/__tests__/project-writes.test.ts` | Pass | 22 tests passed, including rerun reconciliation and idempotent existing surface coverage. |
+| 2026-05-26 15:52 EDT | TRL-781 | `bun run --cwd apps/trails typecheck` | Pass | Trails app typecheck passed. |
+| 2026-05-26 15:52 EDT | TRL-781 | `bun run --cwd apps/trails lint` | Pass | Trails app lint passed. |
+| 2026-05-26 15:52 EDT | TRL-781 | `bun run lint:ast-grep` | Pass | Repo ast-grep scan passed. |
+| 2026-05-26 15:52 EDT | TRL-781 | `git diff --check` | Pass | No whitespace errors. |
+| 2026-05-26 15:52 EDT | TRL-781 | `bun run format:check` | Pass after formatting | Initial run flagged `apps/trails/src/trails/create-scaffold.ts`; formatted with `bunx ultracite fix ...`, then reran clean. |
 
 ## Local Review Log
 

--- a/.changeset/create-rerun-reconciliation.md
+++ b/.changeset/create-rerun-reconciliation.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Make `trails create` reruns reconcile existing scaffold files instead of overwriting present files and then failing on existing surfaces.

--- a/apps/trails/src/__tests__/create.test.ts
+++ b/apps/trails/src/__tests__/create.test.ts
@@ -609,6 +609,61 @@ describe('trails create', () => {
       });
     });
 
+    test('reruns reconcile missing scaffold pieces without overwriting existing files', async () => {
+      await withTempProject(async (dir) => {
+        mkdirSync(join(dir, 'src'), { recursive: true });
+        mkdirSync(join(dir, '.trails'), { recursive: true });
+        writeFileSync(
+          join(dir, 'package.json'),
+          JSON.stringify(
+            {
+              dependencies: { '@ontrails/core': ontrailsPackageRange },
+              name: basename(dir),
+              scripts: { keep: 'echo keep' },
+              workspaceNote: 'preserve me',
+            },
+            null,
+            2
+          )
+        );
+        writeFileSync(join(dir, 'tsconfig.json'), '{"custom":true}\n');
+        writeFileSync(join(dir, 'README.md'), '# Existing README\n');
+        writeFileSync(
+          join(dir, 'src', 'app.ts'),
+          "import { topo } from '@ontrails/core';\nexport const app = topo('existing');\n"
+        );
+        writeFileSync(join(dir, 'src', 'cli.ts'), 'existing cli\n');
+
+        const result = expectOk(
+          await runCreate(dir, { surfaces: ['cli', 'mcp'] })
+        );
+
+        expectCreatedPaths(result.created, [
+          'src/mcp.ts',
+          'src/trails/hello.ts',
+          '__tests__/examples.test.ts',
+          'lefthook.yml',
+        ]);
+        expect(result.created).not.toContain('src/cli.ts');
+        expect(readText(dir, 'src/cli.ts')).toBe('existing cli\n');
+        expect(readText(dir, 'src/app.ts')).toContain("topo('existing')");
+        expect(readText(dir, 'tsconfig.json')).toBe('{"custom":true}\n');
+        expect(readText(dir, 'README.md')).toBe('# Existing README\n');
+        expectPaths(dir, ['src/mcp.ts', 'src/trails/hello.ts'], true);
+
+        const pkg = readJson(dir, 'package.json');
+        expect(pkg['workspaceNote']).toBe('preserve me');
+        expect(pkg['scripts']).toEqual({ keep: 'echo keep' });
+        const deps = pkg['dependencies'] as Record<string, string>;
+        expectExactOntrailsPin(deps['@ontrails/cli']);
+        expectExactOntrailsPin(deps['@ontrails/commander']);
+        expectExactOntrailsPin(deps['@ontrails/mcp']);
+        const devDeps = pkg['devDependencies'] as Record<string, string>;
+        expectExactOntrailsPin(devDeps['@ontrails/testing']);
+        expectExactOntrailsPin(devDeps['@ontrails/warden']);
+      });
+    });
+
     test('rejects path-shaped project names before writing', async () => {
       await withTempProject(async (dir) => {
         const error = expectErr(
@@ -689,18 +744,26 @@ describe('trails create', () => {
       });
     });
 
-    test('detects existing surface entrypoint', async () => {
+    test('reconciles existing surface entrypoint', async () => {
       await withTempProject(async (dir) => {
         mkdirSync(join(dir, 'src'), { recursive: true });
         mkdirSync(join(dir, '.trails'), { recursive: true });
+        writeFileSync(
+          join(dir, 'package.json'),
+          JSON.stringify({ name: basename(dir) }, null, 2)
+        );
         writeFileSync(join(dir, 'src', 'mcp.ts'), 'existing content');
 
-        const error = expectErr(
+        const result = expectOk(
           await addSurface.blaze({ dir, surface: 'mcp' }, {} as never)
         );
-        expect(error.message).toBe(
-          'MCP surface already exists. Nothing to do.'
-        );
+        expect(result.created).toBeNull();
+        expect(readText(dir, 'src/mcp.ts')).toBe('existing content');
+        const deps = readJson(dir, 'package.json')['dependencies'] as Record<
+          string,
+          string
+        >;
+        expectExactOntrailsPin(deps['@ontrails/mcp']);
       });
     });
   });

--- a/apps/trails/src/project-writes.ts
+++ b/apps/trails/src/project-writes.ts
@@ -36,6 +36,10 @@ export type ProjectWriteOperation =
       readonly path: string;
     };
 
+interface ProjectOperationOptions {
+  readonly existing?: 'overwrite' | 'preserve';
+}
+
 export const validateProjectName = (
   name: string
 ): TrailsResult<string, ValidationError> =>
@@ -222,12 +226,59 @@ export const planProjectOperation = (
   }
 };
 
+const shouldApplyProjectOperation = (
+  projectDir: string,
+  operation: ProjectWriteOperation,
+  options: ProjectOperationOptions
+): TrailsResult<boolean, Error> => {
+  if (options.existing !== 'preserve' || operation.kind === 'rename') {
+    return Result.ok(true);
+  }
+
+  const { path } = operation;
+  const target = resolveProjectPath(projectDir, path);
+  if (target.isErr()) {
+    return Result.err(target.error);
+  }
+
+  return Result.ok(!existsSync(target.value));
+};
+
+const selectProjectOperations = (
+  projectDir: string,
+  operations: readonly ProjectWriteOperation[],
+  options: ProjectOperationOptions
+): TrailsResult<ProjectWriteOperation[], Error> => {
+  const selected: ProjectWriteOperation[] = [];
+  for (const operation of operations) {
+    const shouldApply = shouldApplyProjectOperation(
+      projectDir,
+      operation,
+      options
+    );
+    if (shouldApply.isErr()) {
+      return Result.err(shouldApply.error);
+    }
+    if (shouldApply.value) {
+      selected.push(operation);
+    }
+  }
+
+  return Result.ok(selected);
+};
+
 export const planProjectOperations = (
   projectDir: string,
-  operations: readonly ProjectWriteOperation[]
+  operations: readonly ProjectWriteOperation[],
+  options: ProjectOperationOptions = {}
 ): TrailsResult<PlannedProjectOperation[], Error> => {
+  const selected = selectProjectOperations(projectDir, operations, options);
+  if (selected.isErr()) {
+    return Result.err(selected.error);
+  }
+
   const planned: PlannedProjectOperation[] = [];
-  for (const operation of operations) {
+  for (const operation of selected.value) {
     const result = planProjectOperation(projectDir, operation);
     if (result.isErr()) {
       return Result.err(result.error);
@@ -302,14 +353,20 @@ const applyProjectOperation = async (
 
 export const applyProjectOperations = async (
   projectDir: string,
-  operations: readonly ProjectWriteOperation[]
+  operations: readonly ProjectWriteOperation[],
+  options: ProjectOperationOptions = {}
 ): Promise<TrailsResult<PlannedProjectOperation[], Error>> => {
-  const planned = planProjectOperations(projectDir, operations);
+  const selected = selectProjectOperations(projectDir, operations, options);
+  if (selected.isErr()) {
+    return Result.err(selected.error);
+  }
+
+  const planned = planProjectOperations(projectDir, selected.value);
   if (planned.isErr()) {
     return Result.err(planned.error);
   }
 
-  for (const operation of operations) {
+  for (const operation of selected.value) {
     const applied = await applyProjectOperation(projectDir, operation);
     if (applied.isErr()) {
       return Result.err(applied.error);

--- a/apps/trails/src/trails/add-surface.ts
+++ b/apps/trails/src/trails/add-surface.ts
@@ -7,7 +7,7 @@
 import { existsSync } from 'node:fs';
 import { basename, resolve } from 'node:path';
 
-import { AlreadyExistsError, Result, trail } from '@ontrails/core';
+import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import {
@@ -137,17 +137,13 @@ export const addSurface = trail('add.surface', {
       return entryExists;
     }
 
-    if (entryExists.value) {
-      return Result.err(
-        new AlreadyExistsError(
-          `${surface.toUpperCase()} surface already exists. Nothing to do.`
-        )
-      );
-    }
-
-    const created = await writeSurfaceEntry(cwd, surface);
-    if (created.isErr()) {
-      return created;
+    let created: string | null = null;
+    if (!entryExists.value) {
+      const written = await writeSurfaceEntry(cwd, surface);
+      if (written.isErr()) {
+        return written;
+      }
+      created = entryFile;
     }
 
     const dependency = await updatePkgJsonForSurface(cwd, surface);
@@ -156,7 +152,7 @@ export const addSurface = trail('add.surface', {
     }
 
     return Result.ok({
-      created: created.value,
+      created,
       dependency: dependency.value,
     });
   },
@@ -166,7 +162,7 @@ export const addSurface = trail('add.surface', {
     surface: z.enum(['cli', 'http', 'mcp']).describe('Surface to add'),
   }),
   output: z.object({
-    created: z.string(),
+    created: z.string().nullable(),
     dependency: z.string(),
   }),
 });

--- a/apps/trails/src/trails/add-verify.ts
+++ b/apps/trails/src/trails/add-verify.ts
@@ -10,6 +10,7 @@ import { z } from 'zod';
 import {
   PROJECT_NAME_MESSAGE,
   PROJECT_NAME_PATTERN,
+  projectPathExists,
   resolveProjectDir,
   resolveProjectPath,
   writeProjectFile,
@@ -89,6 +90,14 @@ export const addVerify = trail('add.verify', {
       relativePath: string,
       content: string
     ): Promise<Result<void, Error>> => {
+      const exists = projectPathExists(projectDir, relativePath);
+      if (exists.isErr()) {
+        return Result.err(exists.error);
+      }
+      if (exists.value) {
+        return Result.ok();
+      }
+
       const written = await writeProjectFile(projectDir, relativePath, content);
       if (written.isErr()) {
         return Result.err(written.error);

--- a/apps/trails/src/trails/create-scaffold.ts
+++ b/apps/trails/src/trails/create-scaffold.ts
@@ -477,13 +477,19 @@ export const createScaffold = trail('create.scaffold', {
     const fileMap = collectScaffoldFiles(input.name, starter);
     const operations = collectScaffoldOperations(fileMap);
     const plannedOperations = dryRun
-      ? planProjectOperations(projectDir, operations)
-      : await applyProjectOperations(projectDir, operations);
+      ? planProjectOperations(projectDir, operations, { existing: 'preserve' })
+      : await applyProjectOperations(projectDir, operations, {
+          existing: 'preserve',
+        });
     if (plannedOperations.isErr()) {
       return Result.err(plannedOperations.error);
     }
 
-    const created = dryRun ? [] : [...fileMap.keys()];
+    const created = dryRun
+      ? []
+      : plannedOperations.value
+          .filter((operation) => operation.kind === 'write')
+          .map((operation) => operation.path);
 
     return Result.ok({
       created,

--- a/apps/trails/src/trails/create.ts
+++ b/apps/trails/src/trails/create.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 import {
   PROJECT_NAME_MESSAGE,
   PROJECT_NAME_PATTERN,
+  projectPathExists,
   writeProjectFile,
 } from '../project-writes.js';
 
@@ -49,7 +50,7 @@ interface ScaffoldedProject {
 }
 
 interface SurfaceResult {
-  readonly created: string;
+  readonly created: string | null;
   readonly dependency: string;
 }
 
@@ -87,7 +88,9 @@ const collectSurfaceFiles = async (
     if (result.isErr()) {
       return Result.err(result.error);
     }
-    created.push(result.value.created);
+    if (result.value.created !== null) {
+      created.push(result.value.created);
+    }
   }
 
   return Result.ok(created);
@@ -111,8 +114,11 @@ const collectCreatedFiles = (
   scaffolded: readonly string[],
   surfaces: readonly string[],
   verify: readonly string[],
-  readme: string
-): string[] => [...scaffolded, ...surfaces, ...verify, readme];
+  readme: string | null
+): string[] =>
+  readme === null
+    ? [...scaffolded, ...surfaces, ...verify]
+    : [...scaffolded, ...surfaces, ...verify, readme];
 
 const surfaceReadmeLines = {
   cli: '- `src/cli.ts` - CLI surface entry point',
@@ -172,7 +178,15 @@ ${starterReadmeLines[input.starter]}
 const writeReadme = async (
   input: CreateInput,
   dir: string
-): Promise<Result<string, Error>> => {
+): Promise<Result<string | null, Error>> => {
+  const exists = projectPathExists(dir, 'README.md');
+  if (exists.isErr()) {
+    return Result.err(exists.error);
+  }
+  if (exists.value) {
+    return Result.ok(null);
+  }
+
   const written = await writeProjectFile(
     dir,
     'README.md',


### PR DESCRIPTION
## Context

Part 3 of the Fieldwork compounding stack for TRL-781. `trails create` errored on reruns when a partial project already existed, which blocks Radio-style migration where existing files need to be preserved and missing scaffold pieces reconciled.

## What changed

- Adds preserve-existing planning/application behavior for scaffold writes.
- Makes `create.scaffold` reruns write only missing files.
- Makes `add.surface` preserve existing entrypoints while still patching required dependencies.
- Makes `add.verify` preserve existing verification files while still patching dependencies.
- Makes `create` preserve an existing README.
- Adds a Radio-like partial-project regression test.

## Verification

- `bun test apps/trails/src/__tests__/create.test.ts apps/trails/src/__tests__/project-writes.test.ts`
- `bun run --cwd apps/trails typecheck`
- `bun run --cwd apps/trails lint`
- Stack-tip gate later passed: `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run format:check`, `git diff --check`, `bun run check`

## Risks / rollout

Preserve mode is scoped to scaffold reconciliation; it avoids destructive overwrite behavior. Changeset included for `@ontrails/trails`.
