### PR TITLE
docs: clean up compose stragglers

### DIFF
--- a/.agents/plans/2026-05-26-fieldwork-compounding-stack/RETRO.md
+++ b/.agents/plans/2026-05-26-fieldwork-compounding-stack/RETRO.md
@@ -1,8 +1,8 @@
 # Execution Retro: Fieldwork Compounding Stack
 
 Date started: 2026-05-26
-Date finalized:
-Status: In progress
+Date finalized: 2026-05-26 16:55 EDT
+Status: Submitted draft stack; ready-for-review prep
 Plan: `.agents/plans/2026-05-26-fieldwork-compounding-stack/PLAN.md`
 Goal: `.agents/plans/2026-05-26-fieldwork-compounding-stack/GOAL.md`
 
@@ -10,25 +10,25 @@ Use this as the durable execution ledger. Update it before any final handoff, dr
 
 ## Execution Summary
 
-- Objective:
-- Final outcome:
-- Final branch / stack tip:
-- Final PR range:
-- Final tracker state:
-- Final verification state:
-- Remaining risks / P3s:
-- Archive state:
+- Objective: Build the Fieldwork compounding stack before Radio migration: TRL-782, TRL-804, TRL-781, TRL-789, TRL-816, then stop at TRL-814 as the Radio proof lane.
+- Final outcome: Trails-side stack submitted as draft PRs. PRs remain draft because Greptile has not produced a 5/5 summary yet.
+- Final branch / stack tip: `trl-816-post-compose-cutover-cleanup-fix-current-facing-stragglers`
+- Final PR range: #597 -> #601
+- Final tracker state: TRL-782, TRL-804, TRL-781, TRL-789, and TRL-816 are In Review with PR links. TRL-814 remains Backlog with a prerequisite-state comment and no Radio source-control mutation.
+- Final verification state: Local focused checks passed per branch; stack-tip `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run format:check`, `git diff --check`, and `bun run check` passed. GitHub CI passed for #597-#601, including the final #601 run after the RETRO ledger update.
+- Remaining risks / P3s: Review bots have not reviewed the draft PRs yet. Greptile 5/5 / no prompt-to-fix is not verified, so ready-for-review is intentionally blocked. Generated `dist/crosses.*` residue was classified as generated/uncertain and left untouched.
+- Archive state: Not archive-ready until review-bot state is known and any required review findings are resolved.
 
 ## Branch / PR / Issue Ledger
 
 | Order | Issue | Branch | PR | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
-| 1 | TRL-782 | `trl-782-resourcet-doesnt-flow-config-schemas-inferred-type-into` | | Committed locally | Resource config type inference. |
-| 2 | TRL-804 | `trl-804-warden-warn-topo-export-entry-should-not-open-a-surface-at` | | Committed locally | Warden top-level surface warning. |
-| 3 | TRL-781 | `trl-781-trails-create-errors-hard-on-re-run-instead-of-reconciling` | | Committed locally | Scaffold rerun reconciliation. |
-| 4 | TRL-789 | `trl-789-trails-create-starter-entity-complete-the-crud-entitylist` | | Committed locally | Entity starter CRUD completion. |
-| 5 | TRL-816 | `trl-816-post-compose-cutover-cleanup-fix-current-facing-stragglers` | | Planned | Current-facing compose straggler cleanup. |
-| 6 | TRL-814 | `trl-814-crosscompose-cutover-s6-radio-migration-follow-up` | | Planned proof lane | Radio migration; separate source-control lane unless approved. |
+| 1 | TRL-782 | `trl-782-resourcet-doesnt-flow-config-schemas-inferred-type-into` | [#597](https://github.com/outfitter-dev/trails/pull/597) | Draft submitted; CI passed | Resource config type inference. |
+| 2 | TRL-804 | `trl-804-warden-warn-topo-export-entry-should-not-open-a-surface-at` | [#598](https://github.com/outfitter-dev/trails/pull/598) | Draft submitted; CI passed | Warden top-level surface warning. |
+| 3 | TRL-781 | `trl-781-trails-create-errors-hard-on-re-run-instead-of-reconciling` | [#599](https://github.com/outfitter-dev/trails/pull/599) | Draft submitted; CI passed | Scaffold rerun reconciliation. |
+| 4 | TRL-789 | `trl-789-trails-create-starter-entity-complete-the-crud-entitylist` | [#600](https://github.com/outfitter-dev/trails/pull/600) | Draft submitted; CI passed | Entity starter CRUD completion. |
+| 5 | TRL-816 | `trl-816-post-compose-cutover-cleanup-fix-current-facing-stragglers` | [#601](https://github.com/outfitter-dev/trails/pull/601) | Draft submitted; CI passed after final ledger update | Current-facing compose straggler cleanup. |
+| 6 | TRL-814 | `trl-814-crosscompose-cutover-s6-radio-migration-follow-up` | | Proof lane stopped | Radio migration; no branch, no Radio source-control mutation. |
 
 ## Planning Discoveries
 
@@ -106,6 +106,22 @@ Use this as the durable execution ledger. Update it before any final handoff, dr
 - Changed: entity starter tests now assert generated CRUD trail IDs, store helper imports, list output, and delete permit declaration.
 - Changed: added `.changeset/entity-starter-crud.md` for `@ontrails/trails` patch.
 - Local review: subagent Laplace confirmed the current starter only had `show`/`add`, identified `entity.list`/`entity.delete` as the issue-scoped gap, and flagged permit governance for destructive trails.
+
+2026-05-26 16:15 EDT - TRL-816 implementation
+- Branch: `trl-816-post-compose-cutover-cleanup-fix-current-facing-stragglers`.
+- Tracker: moved TRL-816 to In Progress.
+- Changed: refreshed current-facing compose vocabulary in accepted ADR prose/examples and package READMEs for core, testing, tracing, and Warden.
+- Changed: renamed a stale `crossesEntry` test variable in `packages/topographer/src/__tests__/derive.test.ts` while preserving the existing `.composes` assertion.
+- Changed: added `.changeset/compose-straggler-cleanup.md` for publishable package README updates.
+- Local review: subagent Hume confirmed the same current-facing anchors and classified ADR-0049, the migration guide, and generated `dist/crosses.*` residue as leave/uncertain rather than branch edits.
+- Explicit leave: `docs/adr/0049-composition-is-compose-not-cross.md`, `docs/migration/cross-to-compose.md`, release notes, lexicon negative examples, and generated `dist` files were not edited.
+
+2026-05-26 16:10 EDT - draft stack submission
+- Submitted draft PRs #597, #598, #599, #600, and #601 with `gt submit --draft`.
+- Populated PR bodies after submit because Graphite created empty descriptions.
+- Moved TRL-782, TRL-804, TRL-781, TRL-789, and TRL-816 to In Review and attached their draft PR links.
+- Added a TRL-814 comment recording the Trails prerequisite state, local proof, CI/review state, and that Radio was not mutated.
+- Remote review state: no review-bot reviews or comments were present yet; Greptile 5/5 is not verified, so PRs remain draft.
 ```
 
 ## Verification Log
@@ -140,6 +156,25 @@ Use this as the durable execution ledger. Update it before any final handoff, dr
 | 2026-05-26 15:55 EDT | TRL-789 | `bun run format:check` | Pass | Repo format check passed. |
 | 2026-05-26 15:55 EDT | TRL-789 | `bun run lint:ast-grep` | Pass | Repo ast-grep scan passed. |
 | 2026-05-26 15:55 EDT | TRL-789 | `git diff --check` | Pass | No whitespace errors. |
+| 2026-05-26 16:15 EDT | TRL-816 | `bun test packages/topographer/src/__tests__/derive.test.ts` | Pass | 36 tests passed; focused coverage for renamed local variable context. |
+| 2026-05-26 16:15 EDT | TRL-816 | `bun scripts/adr.ts check` | Pass | Numbered ADRs, drafts, index, and decision map all clean. |
+| 2026-05-26 16:15 EDT | TRL-816 | `bun run vocab:audit` | Pass | Repo cutover audit found no legacy patterns in the target set. |
+| 2026-05-26 16:15 EDT | TRL-816 | `bun run lint:ast-grep` | Pass | Repo ast-grep scan passed. |
+| 2026-05-26 16:15 EDT | TRL-816 | `bun run format:check` | Pass | Repo format check passed. |
+| 2026-05-26 16:15 EDT | TRL-816 | `git diff --check` | Pass | No whitespace errors. |
+| 2026-05-26 16:25 EDT | stack tip | `bun run typecheck` | Pass | 22 Turbo typecheck tasks passed. |
+| 2026-05-26 16:26 EDT | stack tip | `bun run test` | Pass | 37 Turbo test/build tasks passed. |
+| 2026-05-26 16:27 EDT | stack tip | `bun run lint` | Pass | 23 Turbo lint/build tasks passed. |
+| 2026-05-26 16:27 EDT | stack tip | `bun run lint:ast-grep` | Pass | Repo ast-grep scan passed. |
+| 2026-05-26 16:27 EDT | stack tip | `bun run format:check` | Pass | Repo format check passed. |
+| 2026-05-26 16:27 EDT | stack tip | `git diff --check` | Pass | No whitespace errors. |
+| 2026-05-26 16:28 EDT | stack tip | `bun run check` | Failed then fixed | Initial run failed at `skillset:check` because `.agents/skills/clark/references/warden-guide.md` was stale. Ran `bun run skillset:sync`, amended the generated guide into TRL-804, returned to the stack tip, and reran. |
+| 2026-05-26 16:30 EDT | stack tip | `bun run check` | Pass | Aggregate gate passed: lint, ast-grep, vocab audit, format, typecheck, docs links/snippets/API examples, taxonomy/scaffold checks, Warden guide checks, skillset check, `trails warden`, and dead-code. `trails warden` reported the repo's existing 26 warnings and 0 errors. |
+| 2026-05-26 16:11 EDT | PR #597 | `gh pr checks 597 --watch=false` | Pass | Build, CI Gate, Changeset, Dead Code, Governance, Lint & Format, Test, and Typecheck all passed. |
+| 2026-05-26 16:11 EDT | PR #598 | `gh pr checks 598 --watch=false` | Pass | Build, CI Gate, Changeset, Dead Code, Governance, Lint & Format, Test, and Typecheck all passed. |
+| 2026-05-26 16:11 EDT | PR #599 | `gh pr checks 599 --watch=false` | Pass | Build, CI Gate, Changeset, Dead Code, Governance, Lint & Format, Test, and Typecheck all passed. |
+| 2026-05-26 16:11 EDT | PR #600 | `gh pr checks 600 --watch=false` | Pass | Build, CI Gate, Changeset, Dead Code, Governance, Lint & Format, Test, and Typecheck all passed. |
+| 2026-05-26 16:11 EDT | PR #601 | `gh pr checks 601 --watch=false` | Pass | Build, CI Gate, Changeset, Dead Code, Governance, Lint & Format, Test, and Typecheck all passed before final RETRO ledger update. |
 
 ## Local Review Log
 
@@ -148,20 +183,26 @@ Use this as the durable execution ledger. Update it before any final handoff, dr
 | 2026-05-26 15:25 EDT | TRL-782 | Type inference seam scout | Bacon (subagent) | Clean plan | Found the generic erasure in `Resource<T>` / `resource()` and recommended compile-time tests plus no runtime change. | Implemented matching fix. |
 | 2026-05-26 15:42 EDT | TRL-804 | Warden surface coaching scout | Rawls (subagent) | Scoped warning | Found the introspection import hazard and recommended imported-binding detection with guarded/dedicated-surface allowances. | Implemented narrow source-static rule and tests. |
 | 2026-05-26 15:55 EDT | TRL-789 | Entity starter CRUD scout | Laplace (subagent) | Scoped gap | Confirmed generated starter has `show`/`add` plus non-CRUD `search`; issue-scoped missing trails are `entity.list` and `entity.delete`, with permit governance needed for destroy intent. | Implemented list/delete and tests. |
+| 2026-05-26 16:15 EDT | TRL-816 | Compose straggler scout | Hume (subagent) | Scoped cleanup | Identified current-facing `cross` residue in ADR-0025, package READMEs, ADR-0000, and ADR-0007; classified migration/history/generated outputs separately. | Implemented current-facing cleanup only. |
 
 ## Remote Review / CI Log
 
 | Time | PR | Source | State | Details | Outcome |
 | --- | --- | --- | --- | --- | --- |
-| | | | | | |
+| 2026-05-26 16:10 EDT | #597 | GitHub CI | Pass | All required checks passed. | Kept draft; no review-bot state yet. |
+| 2026-05-26 16:10 EDT | #598 | GitHub CI | Pass | All required checks passed. | Kept draft; no review-bot state yet. |
+| 2026-05-26 16:10 EDT | #599 | GitHub CI | Pass | All required checks passed. | Kept draft; no review-bot state yet. |
+| 2026-05-26 16:10 EDT | #600 | GitHub CI | Pass | All required checks passed. | Kept draft; no review-bot state yet. |
+| 2026-05-26 16:15 EDT | #601 | GitHub CI | Pass after final ledger update | All required checks passed after the final RETRO-only commit. | Kept draft; no review-bot state yet. |
+| 2026-05-26 16:12 EDT | #597-#601 | Review bots | Pending | `gh pr view ... --json reviews,comments` found Linear linkbacks and Graphite stack comments only; no Greptile, Codex, Claude, or Copilot reviews/comments yet. | Ready-for-review blocked until Greptile 5/5 / no prompt-to-fix can be verified. |
 
 ## Forbidden Actions Audit
 
-- Merge:
-- Package publish / registry mutation:
-- Merge queue label:
-- Subagent source-control write:
-- Radio source-control mutation:
+- Merge: none.
+- Package publish / registry mutation: none.
+- Merge queue label: none.
+- Subagent source-control write: none; all git/gt writes were main-agent owned.
+- Radio source-control mutation: none.
 
 ## Deferred / Follow-Up Discoveries
 
@@ -171,4 +212,4 @@ Use this as the durable execution ledger. Update it before any final handoff, dr
 
 ## Final State
 
-Not finalized.
+Submitted draft Trails stack and stopped at TRL-814 proof lane. Not ready-for-review because Greptile has not reviewed the draft PRs yet.

--- a/.changeset/compose-straggler-cleanup.md
+++ b/.changeset/compose-straggler-cleanup.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/core": patch
+"@ontrails/testing": patch
+"@ontrails/tracing": patch
+"@ontrails/warden": patch
+---
+
+Refresh current-facing compose vocabulary in package documentation after the composition cutover.

--- a/docs/adr/0000-core-premise.md
+++ b/docs/adr/0000-core-premise.md
@@ -124,7 +124,7 @@ Because they're structured, they serve multiple purposes simultaneously:
 - **Documentation:** Agents and developers read examples to understand behavior
 - **Validation:** The warden checks that examples parse against schemas
 - **Mock data:** Testing infrastructure derives mocks from example data
-- **Composition testing:** Failure injection references examples from crossed trails
+- **Composition testing:** Failure injection references examples from composed trails
 - **Contract coverage:** The warden reports which behaviors have examples and which don't
 
 One write, many reads. The developer authors an example. The framework reads it six different ways.
@@ -133,7 +133,7 @@ One write, many reads. The developer authors an example. The framework reads it 
 
 The topo isn't just a collection. It's a queryable graph:
 
-- `survey` introspects the full topology — trails, schemas, examples, cross graph, intent and meta (`meta`)
+- `survey` introspects the full topology — trails, schemas, examples, composition graph, intent and meta (`meta`)
 - `warden` governs the topology — lint rules, drift detection, coaching suggestions
 - `guide` generates guidance from the topology — documentation, agent instructions, API references
 - TopoGraph generation captures the full contract as a diffable, hashable artifact

--- a/docs/adr/0007-governance-as-trails.md
+++ b/docs/adr/0007-governance-as-trails.md
@@ -12,7 +12,7 @@ owners: ['[galligan](https://github.com/galligan)']
 
 ## Context
 
-The warden is Trails' governance system. It checks that code follows framework conventions: no throws in blazes, Result returns, cross declarations matching usage, no surface types in domain logic, and so on. It exists because the type system alone can't catch everything — `throw` is legal TypeScript, and nothing in the compiler prevents importing `Request` into a blaze.
+The warden is Trails' governance system. It checks that code follows framework conventions: no throws in blazes, Result returns, compose declarations matching usage, no surface types in domain logic, and so on. It exists because the type system alone can't catch everything — `throw` is legal TypeScript, and nothing in the compiler prevents importing `Request` into a blaze.
 
 Early warden rules used regex pattern matching on source code. This worked for the simplest cases but broke down fast. A `throw` inside a JSDoc comment triggered false positives. A string literal containing `new Request` looked like a surface type import. Nested scopes were invisible — regex can't tell the difference between a `throw` inside a `.map()` callback and a `throw` inside the blaze body itself.
 

--- a/docs/adr/0025-composition-testing.md
+++ b/docs/adr/0025-composition-testing.md
@@ -99,12 +99,12 @@ import { scenario } from '@ontrails/testing';
 
 scenario('Fork flow', app, [
   {
-    cross: createGist,
+    compose: createGist,
     input: { description: 'Original', content: '# Hello' },
     as: 'original',
   },
   {
-    cross: forkGist,
+    compose: forkGist,
     input: { id: ref('original.id') },
     as: 'forked',
     expectedMatch: {
@@ -117,8 +117,8 @@ scenario('Fork flow', app, [
 
 **Key design choices:**
 
-- **`ref()` for cross-step references.** `ref('original.id')` reads the `id` field from the step aliased as `original`. This keeps scenarios as structured data — no callbacks, no lambdas, no imperative control flow. The reference is resolved at runtime when the step executes.
-- **Each step is a cross.** The scenario runner invokes each trail through the normal execution pipeline — validation, layers, blaze, Result. It's not a shortcut. Layers run. Resources resolve. Tracing records.
+- **`ref()` for compose-step references.** `ref('original.id')` reads the `id` field from the step aliased as `original`. This keeps scenarios as structured data — no callbacks, no lambdas, no imperative control flow. The reference is resolved at runtime when the step executes.
+- **Each step is a composition.** The scenario runner invokes each trail through the normal execution pipeline — validation, layers, blaze, Result. It's not a shortcut. Layers run. Resources resolve. Tracing records.
 - **`as` names the step's output.** Subsequent steps can reference it via `ref()`. If a step fails, the scenario stops and reports which step failed with the full Result.
 - **`expectedMatch` on steps.** Each step can assert partial output, same semantics as on trail examples.
 - **Scenarios are structured data.** They're arrays of objects with known shapes. The framework can read them the same way it reads examples — for agent guidance, documentation generation, warden analysis, and coverage reporting.
@@ -130,7 +130,7 @@ Trail examples live ON the trail — they're part of the contract, visible to ag
 The distinction matters:
 
 - **Examples** answer: "What does THIS trail do?" One trail, one input, one output.
-- **Scenarios** answer: "How do these trails work TOGETHER?" Multiple trails, sequential steps, cross-step references.
+- **Scenarios** answer: "How do these trails work TOGETHER?" Multiple trails, sequential steps, compose-step references.
 
 Putting scenarios on a trail definition would mean one trail "owns" a multi-trail flow. That's backwards — the flow is a property of the composition, not of any single trail.
 
@@ -144,9 +144,9 @@ testAll(graph);
 
 // Scenarios test composition flows
 scenario('Create and star', graph, [
-  { cross: createGist, input: { description: 'Test', content: '# Hi' }, as: 'gist' },
-  { cross: starGist, input: { gistId: ref('gist.id'), userId: 'u1' } },
-  { cross: showGist, input: { id: ref('gist.id') }, expectedMatch: { starred: true } },
+  { compose: createGist, input: { description: 'Test', content: '# Hi' }, as: 'gist' },
+  { compose: starGist, input: { gistId: ref('gist.id'), userId: 'u1' } },
+  { compose: showGist, input: { id: ref('gist.id') }, expectedMatch: { starred: true } },
 ]);
 ```
 
@@ -180,12 +180,12 @@ These are coaching rules — suggestions, not errors. They guide the developer t
 ### Tradeoffs
 
 - **Two new concepts.** `expectedMatch` is a small addition to the example spec. `scenario()` is a new testing function. Both need documentation and examples of their own.
-- **`ref()` is a mini-DSL.** Cross-step references introduce a resolution mechanism that doesn't exist elsewhere in examples. The tradeoff is accepted because the alternative — callbacks or lambdas — would break examples-as-data.
+- **`ref()` is a mini-DSL.** Compose-step references introduce a resolution mechanism that doesn't exist elsewhere in examples. The tradeoff is accepted because the alternative — callbacks or lambdas — would break examples-as-data.
 - **Scenario coverage is hard to measure.** The warden can detect that composing graphs lack scenarios, but it can't assess whether existing scenarios cover the interesting paths. Coverage suggestions will be noisy initially.
 
 ## Non-decisions
 
-- **`scenario()` step types beyond `cross`.** Steps that emit signals, wait for fires, or assert intermediate state. These expand the scenario vocabulary and should be designed when signal testing matures.
+- **`scenario()` step types beyond `compose`.** Steps that emit signals, wait for fires, or assert intermediate state. These expand the scenario vocabulary and should be designed when signal testing matures.
 - **Scenario fixtures.** How scenarios declare and manage test data (seed records, deterministic IDs). This interacts with the broader fixtures design from the stash retro.
 - **Snapshot-based `expectedMatch`.** Auto-generating `expectedMatch` from a passing run and storing it as a snapshot. Convenient but introduces snapshot maintenance burden. Deferred.
 

--- a/docs/adr/0027-visibility-and-filtering.md
+++ b/docs/adr/0027-visibility-and-filtering.md
@@ -21,7 +21,7 @@ A simple Trails app has 5-10 trails. Every trail is a public verb. `surface(grap
 
 A pack-scale app has 40-80 trails across multiple capability boundaries. Some trails exist only to support composition via `composes`. Others are debug or operator tools that shouldn't appear in a public API. Others make sense on CLI but not MCP. The current mechanism for managing this is `include`/`exclude` on surface options, which works but has two problems:
 
-1. **It's surface-side knowledge about trail-side intent.** The trail author knows "this trail is not a public verb, it exists to be crossed into." That information lives in the author's head, not in the trail definition. Every surface must independently be told to exclude it.
+1. **It's surface-side knowledge about trail-side intent.** The trail author knows "this trail is not a public verb, it exists to be composed into." That information lives in the author's head, not in the trail definition. Every surface must independently be told to exclude it.
 
 2. **It doesn't scale.** Flat string lists of trail IDs become unwieldy. Adding a new composing target requires updating exclude lists on every surface. Forgetting one surface silently exposes an internal trail.
 
@@ -169,9 +169,9 @@ export default defineConfig({
 });
 ```
 
-Profile exclusions apply before surface-level options. A trail excluded by the profile is not in the topo for that environment. It can't be crossed, run, or exposed on a surface.
+Profile exclusions apply before surface-level options. A trail excluded by the profile is not in the topo for that environment. It can't be composed, run, or exposed on a surface.
 
-The warden validates profile integrity: a profile that excludes a trail crossed by an included trail is a dependency violation.
+The warden validates profile integrity: a profile that excludes a trail composed by an included trail is a dependency violation.
 
 ### Part 6: CLI help hierarchy from namespaces
 

--- a/docs/adr/0038-typed-signal-emission.md
+++ b/docs/adr/0038-typed-signal-emission.md
@@ -21,7 +21,7 @@ lockfile could serialize it. But a trail could not yet say "this happened" in a
 typed, runtime-observable way.
 
 That gap weakened the primitive. A signal without a fire path is metadata, not a
-live graph edge. A trail that completed meaningful work had to either cross
+live graph edge. A trail that completed meaningful work had to either compose
 another trail directly or leave follow-up work to application glue.
 
 ### The schema must be the first thing preserved

--- a/docs/adr/0039-reactive-trail-activation.md
+++ b/docs/adr/0039-reactive-trail-activation.md
@@ -292,7 +292,7 @@ Warden rules coach the pieces static validation cannot fully express:
 
 - signal consumers with no producer declaration;
 - declared or produced signals with no useful graph edge;
-- internal trails that are neither crossed nor activated;
+- internal trails that are neither composed nor activated;
 - scheduled destroy trails that deserve explicit scrutiny;
 - activation source kinds that are known but not materialized by the current
   stack;

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -48,7 +48,7 @@ const onboard = trail('entity.onboard', {
 | `blobRefSchema` / `createBlobRef(...)` | Declare and create binary output references with a shared descriptor contract |
 | `topo(name, ...modules, options?)` | Collect trail modules into a queryable topology with optional `observe:` sinks |
 | `deriveTrail(contour, operation, spec)` | Derive CRUD-shaped trail contracts from a contour on the `@ontrails/core/trails` subpath |
-| `validateTopo(topo)` | Structural validation: cross targets exist, no cycles, examples parse, output schemas present |
+| `validateTopo(topo)` | Structural validation: compose targets exist, no cycles, examples parse, output schemas present |
 
 ### Execution
 
@@ -173,7 +173,7 @@ packages build on:
   `ensureSubsystemSchema`, `openReadTrailsDb`, and `openWriteTrailsDb` are the
   generic database primitive used by framework subsystems.
 - **Surface projection helpers** -- safe error projection, layer field
-  projection, cross-batch validation, late-bound signal references, and Zod
+  projection, compose-batch validation, late-bound signal references, and Zod
   default-wrapper stripping are stable root exports for first-party surfaces,
   store helpers, and tests.
 

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -72,7 +72,7 @@ When you need to isolate a composite trail and stub out its dependencies, use `c
 import { createComposeContext, testTrail } from '@ontrails/testing';
 import { Result } from '@ontrails/core';
 
-const cross = createComposeContext({
+const compose = createComposeContext({
   responses: {
     'entity.add': Result.ok({ id: '1', name: 'Delta', type: 'tool' }),
     'search': Result.ok({ results: [] }),
@@ -84,7 +84,7 @@ testTrail(onboardTrail, [
     input: { name: 'Delta', type: 'tool' },
     expectOk: true,
   },
-], { cross });
+], { compose });
 ```
 
 Calls to unregistered trail IDs return `Result.err` with a descriptive message, so missing stubs fail loudly.

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -530,12 +530,12 @@ describe('deriveTopoGraph', () => {
       });
       const tp = topoFrom({ base, r });
       const map = deriveTopoGraph(tp);
-      const crossesEntry = map.entries.find((e) => e.id === 'user.update');
-      expect(crossesEntry).toBeDefined();
+      const composesEntry = map.entries.find((e) => e.id === 'user.update');
+      expect(composesEntry).toBeDefined();
 
-      expect(crossesEntry?.kind).toBe('trail');
-      expect(crossesEntry?.cli?.path).toEqual(['user', 'update']);
-      expect(crossesEntry?.composes).toEqual(['user.get']);
+      expect(composesEntry?.kind).toBe('trail');
+      expect(composesEntry?.cli?.path).toEqual(['user', 'update']);
+      expect(composesEntry?.composes).toEqual(['user.get']);
     });
 
     test("signal entries are included with kind 'signal'", () => {

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -208,7 +208,7 @@ summaries remain available through the redacted `trails.signal.payload.*`
 digest/shape/size attributes.
 
 Lineage follows the Trails-native `TraceRecord` fields. Root records without a
-parent map to OTel `SERVER`; child spans, crossed trails, signal lifecycle
+parent map to OTel `SERVER`; child spans, composed trails, signal lifecycle
 records, and activated trails with `parentId` map to `INTERNAL` and keep the
 same `traceId`. Status maps `ok` to `OK`, `err` to `ERROR`, and `cancelled` to
 `UNSET`; the Trails error category remains on `trails.error.category`.

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -38,7 +38,7 @@ static table into docs.
 Rules cover several families:
 
 - blaze and `Result` contract checks
-- cross, fire, resource, and detour declaration drift
+- compose, fire, resource, and detour declaration drift
 - draft-state containment
 - source-static guardrails such as surface-type leakage
 - topo-aware checks that need the resolved graph or resource mock shape


### PR DESCRIPTION
## Context

Part 5 of the Fieldwork compounding stack for TRL-816. After the compose cutover, a few current-facing docs/examples still taught `cross` vocabulary even though migration/history docs intentionally preserve the old term.

## What changed

- Refreshes current-facing compose vocabulary in package READMEs for core, testing, tracing, and Warden.
- Updates accepted ADR prose/examples that still taught current `cross` wording.
- Renames a stale `crossesEntry` test variable to `composesEntry` while keeping the existing `.composes` assertion.
- Leaves migration ADRs, migration guide, release notes, lexicon negative examples, and generated `dist` residue untouched.

## Verification

- `bun test packages/topographer/src/__tests__/derive.test.ts`
- `bun scripts/adr.ts check`
- `bun run vocab:audit`
- Stack-tip gate passed: `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run format:check`, `git diff --check`, `bun run check`

## Risks / rollout

Docs/test cleanup only, with publishable README updates covered by a changeset for the affected packages.
