### PR TITLE
fix(lefthook): set GIT_PAGER=cat per command to prevent pager hangs (TRL-824)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,21 +1,39 @@
+# NOTE: `GIT_PAGER: cat` is set on every command. Lefthook attaches a PTY to
+# stage stdout so it can render its box-style output, which tricks child `git`
+# processes into thinking stdout is a real terminal. Contributors with a
+# configured pager (e.g. `core.pager = delta`) then hit indefinite hangs when a
+# stage invokes `git grep` / `git log` / etc., because the pager spawns inside
+# the PTY and waits for terminal input that never arrives. Forcing
+# `GIT_PAGER=cat` makes child git processes bypass the pager. Hook-level `env`
+# in lefthook 2.1.5 does not propagate to stage children, so it must be set
+# per-command. See TRL-824 for the full diagnosis.
+
 pre-commit:
   piped: true
   commands:
     format_guard:
       priority: 1
+      env:
+        GIT_PAGER: cat
       run: bun run format:guard
     format:
       priority: 2
+      env:
+        GIT_PAGER: cat
       glob: '**/*.{ts,tsx,js,jsx,json,jsonc}'
       run: bun run format:file {staged_files}
       stage_fixed: true
     clark_agent:
       priority: 3
+      env:
+        GIT_PAGER: cat
       glob: '{.claude/skills/clark/**,.agents/skills/clark-consult/scripts/render-clark-agent}'
       run: bun run clark:sync
       stage_fixed: true
     markdownlint:
       priority: 4
+      env:
+        GIT_PAGER: cat
       glob: '*.md'
       run: bun run mdlint:fix {staged_files}
       stage_fixed: true
@@ -23,8 +41,14 @@ pre-commit:
 pre-push:
   commands:
     warden:
+      env:
+        GIT_PAGER: cat
       run: bun trails warden --pre-push
     test:
+      env:
+        GIT_PAGER: cat
       run: bun run test
     typecheck:
+      env:
+        GIT_PAGER: cat
       run: bun run typecheck


### PR DESCRIPTION
## Context

The lefthook pre-commit hook hangs indefinitely for any contributor whose git config has a pager set as `core.pager` (delta is the most common case; `bat`, fancy `less`, etc. also trigger it).

Diagnosis from [TRL-824](https://linear.app/outfitter/issue/TRL-824):

1. Lefthook attaches a PTY to each stage's stdout so it can render its box-style output (`┃  format_guard ❯`).
2. The PTY makes `isatty(stdout)` return true for child processes inside the stage.
3. The `format_guard` stage invokes `git grep -nE "..." -- ":!bun.lock"` (via `bun run format:guard`).
4. Because stdout looks like a TTY, `git grep` activates the configured pager (delta).
5. Delta spawns inside the PTY, attempts terminal-capability negotiation, and hangs waiting for input that never arrives.
6. Lefthook never sees the stage exit, so `git commit` hangs forever.

`GIT_TRACE=1` confirmed `trace: start_command: /opt/homebrew/bin/delta` immediately before the hang. `git status` in a stage works fine (no pager activation); `git grep` is the specific trigger today, but `git log`, `git show`, `git blame`, etc. would all hit the same hang if a future stage invoked them.

## What changed

- `lefthook.yml`: added `env: { GIT_PAGER: cat }` to every stage in both `pre-commit` (`format_guard`, `format`, `clark_agent`, `markdownlint`) and `pre-push` (`warden`, `test`, `typecheck`). 7 stages × 2 lines = 24 lines.
- Top-of-file comment captures the diagnosis so future contributors don't re-debug this.

## Why per-command env (not hook-level)

I verified empirically that lefthook 2.1.5 does **not** propagate top-level `pre-commit: env:` or top-level `env:` to stage child processes. Smoke-tested both forms and got the same indefinite hang. Per-command `env:` is the only shape that works in this version. If lefthook is upgraded later and the propagation rules change, the per-command entries can be collapsed.

A script-level fix (`git --no-pager grep ...` in `package.json`'s `format:guard`) was considered but rejected — it would protect only the one stage and any future lefthook stage that calls a pager-triggering git command would regress to the hang.

## Verification

- **Dogfood.** The fix's own commit went through the (now-fixed) pre-commit hook cleanly: `format_guard 0.14s`, other stages skipped because `lefthook.yml` doesn't match their globs.
- **Pre-push gate.** `bun run test` ✓, `bun run typecheck` ✓, `bun trails warden --pre-push` ✓ (4 pre-existing warnings, unrelated to this change).
- **Smoke commit after PR was open** ran the full pre-commit pipeline (format_guard + markdownlint) in ~0.5s total.

## Risks / rollout

- **No-op for contributors without a pager configured.** Setting `GIT_PAGER=cat` is identical to git's no-pager-configured default — those contributors see no behavior change.
- **No package code change.** This is config-only. `release:none` label applies; no changeset needed.
- **Stacked on [#602](https://github.com/outfitter-dev/trails/pull/602)** ([TRL-817](https://linear.app/outfitter/issue/TRL-817)) — merge that first so this lands cleanly.

## Related

- [TRL-824](https://linear.app/outfitter/issue/TRL-824) — full diagnosis
- [TRL-817](https://linear.app/outfitter/issue/TRL-817) / [#602](https://github.com/outfitter-dev/trails/pull/602) — where this hang was first observed (had to land via `--no-verify` because of it)
- Upstream context: [delta discussion #1387](https://github.com/dandavison/delta/discussions/1387), [creack/pty issue #132](https://github.com/creack/pty/issues/132), [lefthook discussion #1060](https://github.com/evilmartians/lefthook/discussions/1060), [delta issue #1919](https://github.com/dandavison/delta/issues/1919) — same family of PTY-hang bugs, different triggers
