### PR TITLE
fix: guard packed first-party package ranges

### DIFF
--- a/.agents/plans/2026-05-27-regrade-tracer-stack/GOAL.md
+++ b/.agents/plans/2026-05-27-regrade-tracer-stack/GOAL.md
@@ -1,0 +1,25 @@
+# Goal Prompt: Regrade Tracer Stack
+
+Paste this into the goal runtime:
+
+````markdown
+/goal From `/Users/mg/Developer/outfitter/trails`, execute `.agents/plans/2026-05-27-regrade-tracer-stack/PLAN.md`; use `.agents/plans/2026-05-27-regrade-tracer-stack/RETRO.md` as the durable ledger and `.agents/plans/2026-05-27-regrade-tracer-stack/REFS.md` as the source map.
+
+Objective: land the first Regrade proof stack: `TRL-823` packed-manifest first-party beta coherence, `TRL-819` `ctx.compose(trail,input)` inference without `composeInput`, then `TRL-825` experimental `packages/regrade` literal transform-trail tracer. Do not implement full `trails regrade`, downstream roots, package-source modes, Warden fix metadata, `term-rewrite`, or ADR work in this goal.
+
+Read first: `AGENTS.md`, `.agents/plans/PLANNING.md`, packet `PLAN.md`/`REFS.md`, `docs/adr/0000-core-premise.md`, `docs/tenets.md`, `docs/adr/0001-naming-conventions.md`, `docs/lexicon.md`, `docs/architecture.md`, and Linear `TRL-823`, `TRL-819`, `TRL-825`.
+
+Stack order: `trl-823-fail-publish-checks-when-packed-manifests-rewrite-first` -> `trl-819-fix-ctxcomposetrail-input-inference-for-trails-without` -> `trl-825-scaffold-packagesregrade-and-prove-literal-transform-trails`. Commit this packet on the lowest branch. Work from current `main`; run `gt sync`; inspect status/open PRs; do not touch unrelated PRs #602/#607 or untracked `.agents/plans/2026-05-26-radio-compose-proof/README.md`.
+
+Loop: one issue per Graphite branch. Report checkpoint, branch/issue, changes, commands/results, review state, blockers, next step. Use subagents everywhere possible; no fast mode. For well-defined coding/review tasks use GPT 5.4 subagents with high reasoning. Main agent owns all `git`/`gt` writes and tracker/PR mutation.
+
+Validation: run focused checks per branch (`publish:check -- --only @ontrails/trails` for TRL-823; `bun run --cwd packages/core typecheck` for TRL-819; `bun run --cwd packages/regrade typecheck` and `bun test packages/regrade` for TRL-825), then stack gates: `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run format:check`, `git diff --check`, `bun run check`. Record skipped checks in `RETRO.md`.
+
+Review: before ready, run local reviews until latest pass is clean or P3-only; record scores/findings/prompts in `RETRO.md`. Matt allows marking PRs ready once local review and CI are clean/P3-only. After ready, run at most 3 remote review-bot feedback rounds. Fix P0/P1/P2 on the affected branch directly, restack upward, and never use `gt absorb`. P3s may remain if recorded.
+
+Hard rules: no merge, publish, registry mutation, merge queue label, unrelated destructive changes, or subagent source-control writes without Matt approval. Add changesets for publishable package content. File follow-up Linear issues for real discoveries outside scope.
+
+Done only when draft/ready PRs exist or a precise blocker is recorded; Linear/PR bodies are current; CI/local/remote review states are recorded; P2+ review debt is cleared or blocked after max 3 rounds; forbidden actions are audited; and `RETRO.md` has final tracker, PR, review, verification, risk, and archive-readiness state. Final transcript must name proof.
+
+Stop/ask if dirty state cannot be isolated, repo/Linear/Graphite truth diverges, TRL-823 needs broad release redesign, TRL-819 needs public API redesign, TRL-825 disproves literal trails or requires publication/package-source decisions, unrelated verification keeps failing, or 3 post-ready review rounds still leave P2+ debt.
+````

--- a/.agents/plans/2026-05-27-regrade-tracer-stack/PLAN.md
+++ b/.agents/plans/2026-05-27-regrade-tracer-stack/PLAN.md
@@ -1,0 +1,458 @@
+# Goal Plan: Regrade Tracer Stack
+
+Date: 2026-05-27
+Status: Planned
+
+## Objective
+
+Land the first executable Regrade stack: make package publication checks reject
+stale first-party beta rewrites, fix trail-object `ctx.compose(trail, input)`
+inference for trails without `composeInput`, then prove whether Regrade
+transform units can be literal `trail()` instances in an experimental
+`packages/regrade` package.
+
+This is the architecture proof slice. It should not try to ship the full
+`trails regrade` CLI, downstream-root coverage, Warden-backed `term-rewrite`,
+or package-source delivery UX.
+
+## Completion Condition
+
+The goal is complete only when:
+
+- A Graphite stack has draft PRs for `TRL-823`, `TRL-819`, and `TRL-825`, or
+  stops earlier with a precise blocker recorded in `RETRO.md`.
+- `TRL-823` proves packed manifests cannot silently rewrite first-party
+  `workspace:^` dependencies to stale beta versions.
+- `TRL-819` proves `ctx.compose(trailObject, input)` infers callable input and
+  output from a normal trail's authored contract when `composeInput` is absent.
+- `TRL-825` creates the smallest useful `packages/regrade` tracer and records
+  whether literal transform trails pollute topo/surfaces/runtime semantics.
+- Required branch-local changesets are present for publishable package content.
+- Local review is clean or P3-only before PRs are marked ready for review.
+- After ready-for-review, at most three remote review-bot feedback rounds are
+  attempted; P0/P1/P2 findings are fixed on the owning branch or left as an
+  explicit blocker.
+- Linear issues, PR bodies, CI state, review state, unresolved P3s, and any
+  follow-up issues are current.
+- No merge, package publish, registry mutation, merge queue label, or
+  subagent source-control write occurs without explicit Matt approval.
+- `RETRO.md` is updated as the durable execution record and final state ledger.
+
+## Non-Goals
+
+- Do not implement `TRL-826`, `TRL-827`, `TRL-828`, `TRL-829`, `TRL-830`, or
+  `TRL-836` inside this stack unless Matt explicitly expands scope.
+- Do not implement the full `trails regrade` CLI.
+- Do not implement downstream-root scanning, rule selection, coverage reports,
+  version-delta resolution, local tarball package modes, or `NeedsReview` UX
+  beyond the tracer's minimal output.
+- Do not implement Warden fix metadata, `warden --fix`, or `term-rewrite`.
+- Do not publish packages, mutate npm, add merge queue labels, or merge PRs.
+- Do not touch unrelated open PRs #602 / #607 or the untracked
+  `.agents/plans/2026-05-26-radio-compose-proof/README.md`.
+
+## Source Of Truth
+
+Read first:
+
+1. `AGENTS.md`
+2. `.agents/plans/PLANNING.md`
+3. `docs/adr/0000-core-premise.md`
+4. `docs/tenets.md`
+5. `docs/adr/0001-naming-conventions.md`
+6. `docs/lexicon.md`
+7. `docs/architecture.md`
+8. Linear `TRL-823`, `TRL-819`, `TRL-825`
+9. This packet's `REFS.md`
+
+Local planning note summarized into this packet:
+
+- `/Users/mg/Developer/outfitter/trailblazing/plans/regrade/README.md`
+
+Do not make execution depend on that local trailblazing note being present.
+This packet carries the load-bearing decisions.
+
+## Ruling Carried Into Execution
+
+Regrade is not a new Trails primitive. It is Trails using Trails to make
+Trails code upgradeable.
+
+Basis:
+
+- ADR-0000: author what's new, derive what's known, override what's wrong.
+- Tenets: contracts and derivation should make drift harder than alignment.
+- Lexicon: use `trail`, `blaze`, `topo`, `compose`, `surface`, `resource`, and
+  `layer` precisely.
+
+Stack implications:
+
+- Strengthen existing primitives first: `ctx.compose(trail, input)` should
+  derive from the authored trail contract.
+- Harden release tooling before trusting tarball/package-mode proofs.
+- Prove literal transform trails structurally before bringing in Warden-backed
+  rename/fix metadata.
+- Keep `RegradeReport` as output schema/report data. Do not model it as a
+  contour in this slice.
+
+## Stack Order
+
+Use one Graphite line for this goal:
+
+1. `trl-823-fail-publish-checks-when-packed-manifests-rewrite-first`
+2. `trl-819-fix-ctxcomposetrail-input-inference-for-trails-without`
+3. `trl-825-scaffold-packagesregrade-and-prove-literal-transform-trails`
+
+`TRL-823` and `TRL-819` are logically independent, but keeping one line avoids
+extra stack sprawl for this sprint. If `TRL-823` becomes contentious or blocks
+the tracer for reasons unrelated to Regrade, stop and ask before splitting the
+stack.
+
+## Work Plan
+
+### Phase 0: Preflight
+
+Intent:
+
+- Start from current `main` in the main checkout and avoid inherited stack
+  drift.
+
+Actions:
+
+- Work from `/Users/mg/Developer/outfitter/trails`.
+- Run `gt sync`, `gt ls`, `git status --short --untracked-files=all`, and
+  inspect open PRs.
+- Confirm PRs #602 and #607 are unrelated and leave them alone unless Graphite
+  reports a real branch conflict.
+- Preserve unrelated untracked local state, including
+  `.agents/plans/2026-05-26-radio-compose-proof/README.md`.
+- Move target Linear issues to In Progress only when starting their branch.
+
+Verification:
+
+- `git branch --show-current`
+- `gt ls`
+- `git status --short --untracked-files=all`
+
+Done when:
+
+- The executor knows the base branch, dirty state, and unrelated open PRs.
+
+### Phase 1: TRL-823 publish-check beta coherence
+
+Intent:
+
+- Make `bun run publish:check` fail when the packed artifact rewrites a
+  first-party workspace dependency to a stale beta range.
+
+Source anchors:
+
+- `scripts/publish.ts`
+- `scripts/__tests__/check-changeset-gate.test.ts` as a style reference for
+  script tests, if a new test file is needed.
+- `docs/adr/0047-stable-release-line-discipline.md`
+- `docs/releases/stable-cutover.md`
+
+Actions:
+
+- Parse the extracted packed `package/package.json`, not just source manifests.
+- Compare packed first-party dependency ranges against live workspace versions
+  when the source manifest used a `workspace:` range.
+- For `workspace:^`, expect `^${workspace.version}`.
+- Preserve existing `workspace:` / `catalog:` leakage checks.
+- Add a focused test or fixture proving stale packed first-party deps fail even
+  when no raw `workspace:` or `catalog:` string remains.
+
+Verification:
+
+- Focused script tests for the publish helper or new fixture.
+- `bun run publish:check -- --only @ontrails/trails`
+- `bun run typecheck`
+- `bun run lint`
+- `bun run format:check`
+- `git diff --check`
+
+Done when:
+
+- A stale packed dependency error is actionable and names package, dependency,
+  actual range, expected range, and source package path.
+
+### Phase 2: TRL-819 trail-object compose inference
+
+Intent:
+
+- Fix the happy path so trail objects carry enough type information for
+  `ctx.compose(trailObject, input)` without `composeInput`.
+
+Source anchors:
+
+- `packages/core/src/types.ts`
+- `packages/core/src/type-utils.ts`
+- `packages/core/src/trail.ts`
+- `packages/core/src/type-checks.test-d.ts`
+- `packages/testing/src/__tests__/contracts.test.ts`
+
+Known suspicion:
+
+- `ComposeInput<T>` currently checks `NonNullable<T['composeInput']>`; for a
+  plain `Trail<I, O>` this can collapse through the `never` default and make
+  object-compose input unusable. Verify this before editing.
+
+Actions:
+
+- Add a failing compile-time assertion for a plain trail object with `input`
+  and `output` but no `composeInput`.
+- Fix the type utility or overload so `ComposeInput<T>` falls back to
+  `TrailInput<T>` when the trail's compose-input generic is `never` or absent.
+- Preserve typed behavior for trails that do declare `composeInput`.
+- Preserve string-id compose and batch compose behavior.
+- Add no runtime behavior unless tests prove a runtime bug.
+
+Verification:
+
+- `bun run --cwd packages/core typecheck`
+- Focused core/testing tests if touched.
+- `bun run typecheck`
+- `bun run lint`
+- `bun run format:check`
+- `git diff --check`
+
+Done when:
+
+- Type assertions prove object-compose input/output inference for both plain
+  trails and compose-input trails.
+
+### Phase 3: TRL-825 literal Regrade tracer
+
+Intent:
+
+- Prove or disprove that Regrade transforms can be ordinary literal `trail()`
+  instances.
+
+Source anchors:
+
+- `packages/wayfinder/` as a package-shell shape reference.
+- `packages/core/src/trail.ts` for trail visibility and composition behavior.
+- `packages/testing/src/examples.ts` for example execution with composed
+  trails.
+- `packages/topographer/src/derive.ts` and related tests for topo projection
+  evidence.
+- `apps/trails/package.json` only if the tracer needs local app consumption.
+
+Actions:
+
+- Create experimental `packages/regrade` with a minimal package shape.
+- Keep it private or otherwise non-public until the boundary hardens.
+- Define the minimal tracer record/output types needed to answer the topology
+  question; do not build the whole Regrade domain.
+- Implement one tiny parent regrade as a literal `trail()`.
+- Implement one child structural transform as a literal `trail()`.
+- Parent composes child by object.
+- Use code-string fixtures in trail examples to prove example execution can
+  model transform behavior.
+- Add tests that inspect whether transform trails leak into app topo,
+  user-facing surfaces, or require awkward visibility markers.
+- If literal trails are polluted, document why a trail-shaped transform
+  interface is needed and stop before building around the wrong shape.
+
+Verification:
+
+- `bun run --cwd packages/regrade typecheck`
+- `bun test packages/regrade`
+- Relevant topo/testing focused tests.
+- `bun run typecheck`
+- `bun run test`
+- `bun run lint`
+- `bun run format:check`
+- `git diff --check`
+- `bun run check`
+
+Done when:
+
+- `TRL-825` has an evidence-backed answer: literal transform trails are clean
+  enough to ratify later, or they fail with precise boundary evidence.
+
+## Source-Control Plan
+
+- Branching model: Graphite.
+- Work from `/Users/mg/Developer/outfitter/trails`, not this Codex planning
+  worktree.
+- Use exact Linear branch names listed above.
+- Commit this packet on the lowest execution branch, `TRL-823`.
+- Main agent owns all `git` and `gt` writes.
+- Subagents may edit files, run checks, and write reports, but must not run
+  `git add`, `git commit`, `git push`, `gt create`, `gt modify`, `gt submit`,
+  `gt restack`, merge commands, or PR mutation commands.
+- For review fixes, check out the affected branch directly, verify it with
+  `git branch --show-current`, apply the fix there, run focused checks,
+  `gt modify`, then restack/walk upward through affected descendants.
+- Do not use `gt absorb`.
+- Keep PRs draft until CI and local review are clean or P3-only.
+- After local review is P3-only or clean, Matt has authorized marking PRs ready
+  for review.
+- Do not merge unless Matt explicitly asks after the review loop.
+
+## Subagent Strategy
+
+- Use subagents everywhere a task can be bounded by concrete files, predicates,
+  and verification commands.
+- Do not use fast mode for any subagent.
+- For well-defined execution/coding tasks, use GPT 5.4 subagents with high
+  reasoning.
+- Use Spark-style subagents for tightly scoped implementation, fixture, search,
+  and review tasks where available.
+- Keep branch shape, tracker state, Graphite writes, doctrine/API decisions,
+  and scope decisions in the main agent loop.
+- Give every subagent anchored briefs: issue ID, branch/scope, exact files or
+  commands, allowed write targets, expected tests, and the rule that "unable to
+  verify" is better than invented claims.
+
+Suggested lanes:
+
+- TRL-823: publish-script test/fixture scout.
+- TRL-819: type-level inference scout.
+- TRL-825: package-shape/tracer scaffold scout.
+- Local review: type/API review, release-safety review, Regrade doctrine/tracer
+  review, and test adequacy review.
+
+## Tracker Plan
+
+- Move each issue to In Progress only when its branch begins.
+- Add PR links/comments when each draft PR opens.
+- Leave `TRL-826` blocked by `TRL-823` and `TRL-827`.
+- Leave `TRL-827`, `TRL-828`, `TRL-829`, `TRL-830`, and `TRL-836` untouched
+  unless follow-up comments are needed to explain discoveries.
+- File focused follow-up Linear issues for real out-of-goal discoveries, such
+  as package-mode tarball gaps, Warden fix metadata requirements, or tracer
+  pollution that needs a separate design fix.
+- Do not mark issues Done until merged.
+
+## Local Review
+
+Before marking PRs ready for review:
+
+- Run at least three local review passes across the stack unless the latest
+  pass is clean earlier and Matt explicitly accepts the risk.
+- Stop local review only when the latest pass has no P0/P1/P2 findings.
+- P3 findings may remain if recorded in `RETRO.md` with fix/defer rationale.
+
+Reviewer output contract:
+
+```markdown
+Overall score: n/5
+
+Summary:
+<one short prose judgment>
+
+Findings:
+- P0/P1/P2/P3 - <file:line> - <finding>
+  Prompt To Fix With AI:
+  <concise fix prompt>
+
+No-findings statement:
+<what was inspected and residual risk>
+```
+
+Review lanes:
+
+- Type/API review: `ctx.compose`, `ComposeInput`, public type compatibility.
+- Release/package review: packed manifest coherence, publish script behavior,
+  failure messages.
+- Regrade doctrine review: literal trail tracer, topo/surface pollution,
+  vocabulary, no new primitive.
+- Test adequacy review: compile-time tests, package tests, fixture coverage,
+  false positives.
+
+## Remote Review
+
+After local review and CI are clean or P3-only:
+
+- Mark PRs ready for review.
+- Run at most three rounds of remote review-bot feedback.
+- In each round, fetch CI state, review summaries, unresolved threads, scores,
+  and any "Prompt To Fix With AI" / "Prompt for AI" text.
+- Fix P0/P1/P2 findings on the branch they affect, then restack and validate
+  upward. Do not use `gt absorb`.
+- P3 findings may be fixed if cheap or recorded as deferred.
+- Treat review-bot errors as incomplete until rerun or explicitly explained.
+- If P2+ debt remains after three rounds, stop and hand off with exact review
+  state, not a ready-to-merge claim.
+
+## Validation Ladder
+
+Run checks from narrow to broad:
+
+- TRL-823 targeted:
+  - focused script tests
+  - `bun run publish:check -- --only @ontrails/trails`
+- TRL-819 targeted:
+  - `bun run --cwd packages/core typecheck`
+  - focused core/testing tests if touched
+- TRL-825 targeted:
+  - `bun run --cwd packages/regrade typecheck`
+  - `bun test packages/regrade`
+  - focused topo/testing tests for tracer evidence
+- Stack/repo:
+  - `bun run typecheck`
+  - `bun run test`
+  - `bun run lint`
+  - `bun run lint:ast-grep`
+  - `bun run format:check`
+  - `git diff --check`
+  - `bun run check`
+
+If Warden guide content or generated agent skill content changes, also run:
+
+- `bun run warden:agents:sync`
+- `bun run warden:skills:sync`
+- `bun run warden:agents:check`
+- `bun run warden:skills:check`
+
+## Progress Reporting
+
+After each execution turn, report:
+
+- Current checkpoint
+- Branch and issue
+- What changed
+- What was verified
+- Command/output summary
+- What remains
+- Blocker status
+- Next checkpoint
+
+## Stop / Pause Rules
+
+Stop and ask if:
+
+- The plan appears stale against `main`, Linear, Graphite, or open PR state.
+- Dirty local state cannot be isolated safely.
+- `TRL-823` requires a broader release/publish redesign than packed-manifest
+  validation.
+- `TRL-819` requires a public type/API redesign beyond deriving from authored
+  trail contracts.
+- `TRL-825` proves literal transform trails pollute topo/surfaces/runtime
+  enough that the architecture choice changes.
+- Creating `packages/regrade` requires deciding public publication, bundling,
+  or package-source UX beyond the tracer.
+- Verification fails for unrelated reasons after focused retry.
+- More than three post-ready remote review rounds have run and P2+ feedback
+  remains unresolved.
+- Secrets, credentials, production systems, publishing, merge queue, or merge
+  actions are needed.
+
+## Handoff Audit
+
+- [x] Objective is singular and end-to-end.
+- [x] Completion condition is objectively checkable.
+- [x] Tracker state is current as of 2026-05-27.
+- [x] Branch names/order are exact.
+- [x] Dependencies/blockers are represented.
+- [x] Ignored/untracked source docs are summarized or avoided.
+- [x] Validation commands match repo conventions.
+- [x] `GOAL.md` requires transcript-visible proof.
+- [x] `GOAL.md` requires `RETRO.md` finalization before completion.
+- [x] Stop rules are concrete.
+- [x] `RETRO.md` has concrete sections for execution, tracker, review,
+      verification, remote state, forbidden actions, final state, and archive
+      readiness.
+- [x] Packet can be executed without chat history.

--- a/.agents/plans/2026-05-27-regrade-tracer-stack/REFS.md
+++ b/.agents/plans/2026-05-27-regrade-tracer-stack/REFS.md
@@ -1,0 +1,123 @@
+# References: Regrade Tracer Stack
+
+## Tracked / Portable Sources
+
+- `AGENTS.md` - repo commands, vocabulary, Warden guide, Graphite workflow,
+  subagent source-control rules, release policy, and Linear team details.
+- `.agents/plans/PLANNING.md` - goal packet conventions, review protocol,
+  Graphite preferences, validation commands, and stop rules.
+- `docs/adr/0000-core-premise.md` - "author what's new, derive what's known,
+  override what's wrong."
+- `docs/tenets.md` - Trails doctrine for contract-first derivation and drift
+  reduction.
+- `docs/adr/0001-naming-conventions.md` - naming hierarchy and vocabulary
+  discipline.
+- `docs/lexicon.md` - canonical terms: trail, blaze, topo, compose, surface,
+  resource, layer.
+- `docs/architecture.md` - current framework architecture.
+- `docs/adr/0047-stable-release-line-discipline.md` - release/package
+  coherence doctrine for TRL-823.
+- `docs/releases/stable-cutover.md` - publish-check and registry workflow
+  context.
+- `scripts/publish.ts` - TRL-823 implementation target; currently packs and
+  rejects unresolved `workspace:` / `catalog:` ranges.
+- `packages/core/src/types.ts` - `ComposeFn` overloads and `TrailContext`.
+- `packages/core/src/type-utils.ts` - `TrailInput`, `TrailOutput`,
+  `ComposeInput`, and suspected TRL-819 seam.
+- `packages/core/src/trail.ts` - `Trail`, `TrailSpec`, trail visibility,
+  compose ref normalization, and `AnyTrail`.
+- `packages/core/src/type-checks.test-d.ts` - compile-time type assertions for
+  compose and resource inference.
+- `packages/testing/src/examples.ts` - example execution for trails with
+  `composes`; useful for TRL-825 code-string fixture examples.
+- `packages/testing/src/__tests__/contracts.test.ts` - composition contract
+  test precedent.
+- `packages/topographer/src/derive.ts` - topo projection source for tracer
+  pollution evidence.
+- `packages/wayfinder/package.json` and `packages/wayfinder/src/` - minimal
+  package-shell reference for a new experimental package.
+- `apps/trails/package.json` - local app dependency surface if the tracer needs
+  integrated CLI consumption.
+
+## Untracked / Local-Only Sources
+
+- `/Users/mg/Developer/outfitter/trailblazing/plans/regrade/README.md` -
+  source planning spine for Regrade. Load-bearing decisions are summarized in
+  `PLAN.md`; execution should not depend on this file existing.
+- `/Users/mg/Developer/outfitter/trailblazing/inbox/2026-05-27-regrade-migration-as-composite-trails.md` -
+  pre-ADR narrative source. This packet carries the relevant execution
+  decisions.
+- `.agents/plans/2026-05-26-radio-compose-proof/README.md` - unrelated
+  untracked local state in the main checkout; do not touch.
+
+## Copied Or Summarized Sources
+
+- `PLAN.md` summarizes the Regrade Linear setup, doctrine, and first-stack
+  scope from the trailblazing plan.
+- `RETRO.md` records the Linear project/issue IDs created before this packet.
+
+## Tracker Records
+
+- Regrade project - <https://linear.app/outfitter/project/regrade-f8b27fadc302>
+- TRL-819 - <https://linear.app/outfitter/issue/TRL-819/fix-ctxcomposetrail-input-inference-for-trails-without-composeinput>
+  - Role: hard blocker for TRL-825; fixes trail-object compose inference.
+- TRL-823 - <https://linear.app/outfitter/issue/TRL-823/fail-publish-checks-when-packed-manifests-rewrite-first-party-deps-to>
+  - Role: release/package guardrail; first branch in this stack.
+- TRL-825 - <https://linear.app/outfitter/issue/TRL-825/scaffold-packagesregrade-and-prove-literal-transform-trails>
+  - Role: architecture tracer; stack tip.
+- TRL-826 - <https://linear.app/outfitter/issue/TRL-826/prove-regrade-package-source-modes>
+  - Role: next-stack package-source modes; out of scope here.
+- TRL-827 - <https://linear.app/outfitter/issue/TRL-827/support-downstream-roots-rule-selection-and-coverage-reporting>
+  - Role: next-stack downstream reach; out of scope here.
+- TRL-828 - <https://linear.app/outfitter/issue/TRL-828/implement-trails-regrade-and-needsreview-routing>
+  - Role: later CLI/NeedsReview work; blocked by TRL-825.
+- TRL-829 - <https://linear.app/outfitter/issue/TRL-829/draft-regrade-adr-from-tracer-evidence>
+  - Role: later ADR; blocked by TRL-825.
+- TRL-830 - <https://linear.app/outfitter/issue/TRL-830/define-warden-fix-metadata-and-safe-fix-execution>
+  - Role: Warden fix metadata; blocks rename-class integration only.
+- TRL-831 - <https://linear.app/outfitter/issue/TRL-831/define-the-warden-fix-metadata-contract>
+- TRL-832 - <https://linear.app/outfitter/issue/TRL-832/add-term-rewrite-fix-metadata-for-retired-vocabulary>
+- TRL-833 - <https://linear.app/outfitter/issue/TRL-833/implement-warden-fix-for-safe-source-edits>
+- TRL-834 - <https://linear.app/outfitter/issue/TRL-834/draft-warden-fix-metadata-adr>
+- TRL-835 - <https://linear.app/outfitter/issue/TRL-835/triage-trails-warden-help-and-hook-integrity-package-mode>
+- TRL-836 - <https://linear.app/outfitter/issue/TRL-836/integrate-warden-backed-term-rewrite-regrades>
+  - Role: later Warden-backed Regrade integration; blocked by TRL-825/827/830.
+
+## PRs / Branches
+
+- PR #602 - existing unrelated draft docs stack; do not touch unless Graphite
+  reports a real base conflict.
+- PR #607 - existing unrelated draft TRL-824 stack; do not touch unless
+  Graphite reports a real base conflict.
+- Planned branch:
+  `trl-823-fail-publish-checks-when-packed-manifests-rewrite-first`
+- Planned branch:
+  `trl-819-fix-ctxcomposetrail-input-inference-for-trails-without`
+- Planned branch:
+  `trl-825-scaffold-packagesregrade-and-prove-literal-transform-trails`
+
+## Prior Plans
+
+- `.agents/plans/2026-05-26-fieldwork-compounding-stack/` - useful precedent
+  for stacked execution, subagent use, review logging, and retro discipline.
+- `.agents/plans/2026-05-26-compose-cutover-stack/` - useful precedent for
+  compose vocabulary doctrine and branch/review handling.
+
+## Validation Commands
+
+- `/Users/mg/.agents/skills/goal-planning/scripts/context-prime.sh` - planning
+  snapshot for git, Graphite, PRs, and packet conventions.
+- `gt sync` - bring main/stack state current before branching.
+- `gt ls` - inspect stack state and merged/stale branches.
+- `git status --short --untracked-files=all` - detect unrelated dirty state.
+- `bun run publish:check -- --only @ontrails/trails` - TRL-823 artifact check.
+- `bun run --cwd packages/core typecheck` - TRL-819 compile-time type proof.
+- `bun run --cwd packages/regrade typecheck` - TRL-825 package typecheck.
+- `bun test packages/regrade` - TRL-825 package tests.
+- `bun run typecheck` - repo type gate.
+- `bun run test` - repo test gate.
+- `bun run lint` - repo lint gate.
+- `bun run lint:ast-grep` - repo ast-grep gate.
+- `bun run format:check` - formatting gate.
+- `git diff --check` - whitespace/conflict-marker gate.
+- `bun run check` - aggregate repo gate.

--- a/.agents/plans/2026-05-27-regrade-tracer-stack/RETRO.md
+++ b/.agents/plans/2026-05-27-regrade-tracer-stack/RETRO.md
@@ -1,0 +1,175 @@
+# Execution Retro: Regrade Tracer Stack
+
+Date started: 2026-05-27
+Date finalized: pending
+Status: Seeded
+Plan: `.agents/plans/2026-05-27-regrade-tracer-stack/PLAN.md`
+Goal: `.agents/plans/2026-05-27-regrade-tracer-stack/GOAL.md`
+
+Use this as the durable execution ledger. For stacked work, this should normally
+be the last meaningful file touched before local completion, draft submission,
+ready-for-review, remote review closeout, merge readiness, archive, or final
+handoff. Meaningful review-flow changes require a new retro entry.
+
+## Execution Summary
+
+- Objective: Land the first Regrade proof stack: TRL-823, TRL-819, TRL-825.
+- Final outcome:
+- Final branch / stack tip:
+- Final PR range:
+- Final tracker state:
+- Final verification state:
+- Remaining risks / P3s:
+- Archive state:
+
+## Branch / PR / Issue Ledger
+
+| Order | Issue | Branch | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| 1 | TRL-823 | `trl-823-fail-publish-checks-when-packed-manifests-rewrite-first` | | Planned | Publish check packed-manifest beta coherence. |
+| 2 | TRL-819 | `trl-819-fix-ctxcomposetrail-input-inference-for-trails-without` | | Planned | Trail-object compose inference without `composeInput`. |
+| 3 | TRL-825 | `trl-825-scaffold-packagesregrade-and-prove-literal-transform-trails` | | Planned | Experimental literal Regrade tracer. |
+
+## Planning Discoveries
+
+| Discovery | Evidence | Decision | Impact |
+| --- | --- | --- | --- |
+| Regrade project exists and first proof issues are created. | Linear project `Regrade`; issues TRL-825..TRL-836. | Scope this goal to TRL-823, TRL-819, TRL-825 only. | Keeps first sprint executable and avoids smuggling full Regrade into the tracer. |
+| `TRL-823` and `TRL-819` are logically independent, but both feed the first Regrade proof arc. | Linear blockers: TRL-825 blocked by TRL-819; TRL-826 blocked by TRL-823. | Use one Graphite line for this goal unless TRL-823 becomes a real blocker. | Avoids multi-stack merge friction while preserving stop rule for split. |
+| Main checkout has unrelated untracked planning state. | `git status --short --untracked-files=all` showed `.agents/plans/2026-05-26-radio-compose-proof/README.md`. | Do not touch or include it. | Prevents accidental unrelated packet churn. |
+| Active local checkout is `main`, but context-prime saw older merged branches in nearby worktrees. | `context-prime.sh`, `gt ls`, worktree list. | Goal starts with `gt sync`, `gt ls`, and status verification from `/Users/mg/Developer/outfitter/trails`. | Avoids stale worktree assumptions. |
+
+## Deferred / Follow-Up Discoveries
+
+Out-of-goal discoveries belong here first. Create focused follow-up issues when
+they represent real future work.
+
+| Issue | Discovery | Why Out Of Goal | Link |
+| --- | --- | --- | --- |
+| TRL-826 | Package-source modes and tarball/published runtime selection. | Blocked by TRL-823 and TRL-827; beyond tracer proof. | <https://linear.app/outfitter/issue/TRL-826/prove-regrade-package-source-modes> |
+| TRL-827 | Downstream roots, rule selection, coverage, Radio fixture. | Next Regrade engine slice, not required to prove literal transform trails. | <https://linear.app/outfitter/issue/TRL-827/support-downstream-roots-rule-selection-and-coverage-reporting> |
+| TRL-830 | Warden fix metadata and `warden --fix`. | Blocks rename-class integration only, not structural tracer. | <https://linear.app/outfitter/issue/TRL-830/define-warden-fix-metadata-and-safe-fix-execution> |
+| TRL-836 | Warden-backed `term-rewrite` Regrade integration. | Requires TRL-825/827/830 first. | <https://linear.app/outfitter/issue/TRL-836/integrate-warden-backed-term-rewrite-regrades> |
+
+## Tracker Mutations
+
+Record issues, milestones, labels, dependency links, comments, and follow-up
+issues created or updated during planning/execution.
+
+| Time | Tracker Item | Mutation | Evidence |
+| --- | --- | --- | --- |
+| 2026-05-27 13:33 EDT | Linear Project Regrade | Created under Trails v1.0 before this packet. | <https://linear.app/outfitter/project/regrade-f8b27fadc302> |
+| 2026-05-27 13:34 EDT | TRL-825 | Created Regrade tracer issue; blocked by TRL-819. | <https://linear.app/outfitter/issue/TRL-825/scaffold-packagesregrade-and-prove-literal-transform-trails> |
+| 2026-05-27 13:34 EDT | TRL-826 | Created package-source modes issue; blocked by TRL-823 and TRL-827. | <https://linear.app/outfitter/issue/TRL-826/prove-regrade-package-source-modes> |
+| 2026-05-27 13:34 EDT | TRL-827 | Created downstream roots/rule selection/coverage issue from canceled TRL-818. | <https://linear.app/outfitter/issue/TRL-827/support-downstream-roots-rule-selection-and-coverage-reporting> |
+| 2026-05-27 13:35 EDT | TRL-830..TRL-835 | Created Warden/release-integrity adjacent issues outside Regrade. | See `REFS.md`. |
+| 2026-05-27 13:52 EDT | TRL-823 | Moved to In Progress when the lowest branch began. | Linear update returned status `In Progress`; branch `trl-823-fail-publish-checks-when-packed-manifests-rewrite-first`. |
+
+## Execution Log
+
+Append meaningful state changes, especially before handoff points.
+
+```text
+2026-05-27 13:42 EDT - planning packet seeded
+- Changed: created `.agents/plans/2026-05-27-regrade-tracer-stack/` with PLAN.md, GOAL.md, REFS.md, and RETRO.md.
+- Verified: fetched live Linear issue state for TRL-819, TRL-823, TRL-825, TRL-826, and TRL-827; inspected main checkout status and recent packet pattern.
+- Result: packet ready for execution; implementation not started.
+- Next: hand pasteable GOAL.md prompt to executor.
+- Blockers: none for starting; executor must sync/check status before branching.
+
+2026-05-27 13:52 EDT - preflight complete
+- Branch: started from `main`; created `trl-823-fail-publish-checks-when-packed-manifests-rewrite-first` with `gt create`.
+- Graphite: `gt sync` completed with warning that merged PR #606 cannot be cleaned up because another worktree has that branch checked out; no conflict in this checkout.
+- Status: only untracked `.agents/plans/2026-05-26-radio-compose-proof/README.md` and the Regrade packet were present before branch work.
+- Open PRs: #602 and #607 remain unrelated and untouched.
+- Linear: fetched TRL-823, TRL-819, TRL-825; moved only TRL-823 to In Progress.
+- Subagents: spawned read-only GPT-5.4/high scouts for TRL-823, TRL-819, and TRL-825; no source-control writes delegated.
+
+2026-05-27 14:00 EDT - TRL-823 implementation proof
+- Branch: `trl-823-fail-publish-checks-when-packed-manifests-rewrite-first`.
+- Changed: `scripts/publish.ts` now parses the extracted packed `package/package.json`, preserves unresolved `workspace:` / `catalog:` leakage checks, and compares packed first-party `@ontrails/*` ranges against live workspace versions when the source manifest used `workspace:`.
+- Changed: added `scripts/__tests__/publish.test.ts` for stale packed dependency failure and matching-range success.
+- Changed: ran `bun install --lockfile-only` after the new check exposed stale beta.17 workspace metadata in `bun.lock`; lockfile workspace versions now match beta.18 so packed manifests resolve coherently.
+- Proof: `bun run publish:check -- --only @ontrails/trails` first failed with stale `^1.0.0-beta.17` packed deps, then passed after the lockfile refresh.
+- Next: commit TRL-823 branch, then stack TRL-819 above it.
+- Blockers: none.
+```
+
+## Local Review Log
+
+Record local review rounds, reports, P0/P1/P2 findings, fixes, and remaining
+P3s. Do not mark local review complete while P0/P1/P2 findings remain.
+
+| Round | Scope / Lanes | Report Paths | P0/P1/P2 Result | Fix Commits / Notes |
+| --- | --- | --- | --- | --- |
+| | | | | |
+
+## Verification Log
+
+Record exact commands and artifact checks. Include skipped checks with reasons.
+
+| Check | Scope | Result | Evidence / Notes |
+| --- | --- | --- | --- |
+| `/Users/mg/.agents/skills/goal-planning/scripts/context-prime.sh` | planning | pass | Showed main/worktree state, recent plans, and open PRs. |
+| Linear fetches for TRL-819/823/825/826/827 | planning | pass | Current issue bodies and blocker state captured in packet. |
+| `bun test scripts/__tests__/publish.test.ts` | TRL-823 | pass | 2 tests passed; proves stale packed first-party dep detection without raw `workspace:` / `catalog:` leakage. |
+| `bun run publish:check -- --only @ontrails/trails` | TRL-823 | fail then pass | First run failed on stale beta.17 packed deps; after `bun install --lockfile-only`, rerun passed for `@ontrails/trails@1.0.0-beta.18`. |
+| `bun run typecheck` | TRL-823 | pass | 22 package typecheck tasks successful, cached. |
+| `bun run lint` | TRL-823 | pass | 23 lint/build tasks successful, cached. |
+| `bun run format:check` | TRL-823 | pass | Ultracite found 0 warnings / 0 errors. |
+| `git diff --check` | TRL-823 | pass | No whitespace/conflict-marker findings. |
+
+## Remote Review / CI Log
+
+Record remote review state after submission and after each meaningful fix round.
+Treat code-review bot/agent errors and unresolved P0/P1/P2 comments as
+incomplete. Also record summary scores and prompt-to-fix text from code-review
+bots/agents; a lower score with concrete fixable feedback is review debt even
+if inline threads are resolved.
+
+| Time | PR | CI State | Review State | Scores / Signals | Unresolved P0/P1/P2 | Action |
+| --- | --- | --- | --- | --- | --- | --- |
+| | | | | | | |
+
+## Review Feedback Resolutions
+
+| Source | Score / Signal | Severity | Finding | Prompt To Fix | Resolution | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| | | | | | | |
+
+## Forbidden Actions Audit
+
+Record constraints that stayed true. Add or remove rows to match the goal.
+
+| Action / Constraint | Status | Evidence |
+| --- | --- | --- |
+| No merge without explicit user approval | respected in planning | No merge commands run. |
+| No package publish / registry mutation unless authorized | respected in planning | No publish commands run. |
+| No merge queue label unless authorized | respected in planning | No PR/label mutation beyond prior Linear setup. |
+| No source-control writes by subagents | respected in planning | No subagents used for source-control writes. |
+| No unrelated destructive changes | respected in planning | Only new packet files created. |
+| No `gt absorb` | respected in planning | No source-control writes run. |
+
+## Final State
+
+Fill before claiming completion, handoff, merge readiness, or archive.
+
+- Goal completion condition:
+- Graphite / branch state:
+- PR state:
+- Source-control host lag:
+- Tracker state:
+- Local review state:
+- Remote review state:
+- Remote review scores:
+- Verification:
+- Skipped checks:
+- Remaining P3s / risks:
+- Follow-up issues created:
+- Forbidden actions confirmation:
+- Packet archive readiness:
+- Final transcript proof:
+
+Do not mark complete until the goal completion condition has been proven, this
+section is filled or explicitly marked blocked, and the final transcript names
+the updated retro state.

--- a/bun.lock
+++ b/bun.lock
@@ -26,7 +26,7 @@
     },
     "adapters/commander": {
       "name": "@ontrails/commander",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "dependencies": {
         "@ontrails/cli": "workspace:^",
         "@ontrails/core": "workspace:^",
@@ -38,7 +38,7 @@
     },
     "adapters/drizzle": {
       "name": "@ontrails/drizzle",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "dependencies": {
         "@ontrails/core": "workspace:^",
         "drizzle-orm": "^0.45.2",
@@ -50,7 +50,7 @@
     },
     "adapters/hono": {
       "name": "@ontrails/hono",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "dependencies": {
         "@ontrails/core": "workspace:^",
         "hono": "^4.7.0",
@@ -62,7 +62,7 @@
     },
     "adapters/vite": {
       "name": "@ontrails/vite",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "devDependencies": {
         "@ontrails/core": "workspace:^",
         "@ontrails/hono": "workspace:^",
@@ -71,7 +71,7 @@
     },
     "apps/trails": {
       "name": "@ontrails/trails",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "bin": {
         "trails": "./bin/trails.ts",
       },
@@ -119,7 +119,7 @@
     },
     "packages/cli": {
       "name": "@ontrails/cli",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -129,7 +129,7 @@
     },
     "packages/config": {
       "name": "@ontrails/config",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -137,14 +137,14 @@
     },
     "packages/core": {
       "name": "@ontrails/core",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "peerDependencies": {
         "zod": "catalog:",
       },
     },
     "packages/http": {
       "name": "@ontrails/http",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -154,14 +154,14 @@
     },
     "packages/logtape": {
       "name": "@ontrails/logtape",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "peerDependencies": {
         "@ontrails/observe": "workspace:^",
       },
     },
     "packages/mcp": {
       "name": "@ontrails/mcp",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -172,21 +172,21 @@
     },
     "packages/observe": {
       "name": "@ontrails/observe",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
       },
     },
     "packages/oxlint-plugin": {
       "name": "@ontrails/oxlint-plugin",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "dependencies": {
         "@oxlint/plugins": "1.62.0",
       },
     },
     "packages/permits": {
       "name": "@ontrails/permits",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -194,14 +194,14 @@
     },
     "packages/pino": {
       "name": "@ontrails/pino",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "peerDependencies": {
         "@ontrails/observe": "workspace:^",
       },
     },
     "packages/store": {
       "name": "@ontrails/store",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -211,7 +211,7 @@
     },
     "packages/testing": {
       "name": "@ontrails/testing",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "devDependencies": {
         "@ontrails/drizzle": "workspace:^",
         "@ontrails/store": "workspace:^",
@@ -224,10 +224,15 @@
         "@ontrails/observe": "workspace:^",
         "zod": "catalog:",
       },
+      "optionalPeers": [
+        "@ontrails/cli",
+        "@ontrails/http",
+        "@ontrails/mcp",
+      ],
     },
     "packages/topographer": {
       "name": "@ontrails/topographer",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -235,7 +240,7 @@
     },
     "packages/tracing": {
       "name": "@ontrails/tracing",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -243,7 +248,7 @@
     },
     "packages/warden": {
       "name": "@ontrails/warden",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "bin": {
         "warden": "./bin/warden.ts",
       },
@@ -266,7 +271,7 @@
     },
     "packages/wayfinder": {
       "name": "@ontrails/wayfinder",
-      "version": "1.0.0-beta.17",
+      "version": "1.0.0-beta.18",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "@ontrails/topographer": "workspace:^",

--- a/scripts/__tests__/publish.test.ts
+++ b/scripts/__tests__/publish.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+import { findPackedFirstPartyDependencyMismatches } from '../publish.ts';
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url));
+
+const workspace = ({
+  isPrivate = false,
+  name = '@ontrails/core',
+  version = '1.0.0-beta.18',
+}: {
+  readonly isPrivate?: boolean;
+  readonly name?: string;
+  readonly version?: string;
+} = {}) => ({
+  isPrivate,
+  name,
+  path: join(repoRoot, 'packages', name.split('/').at(-1) ?? 'core'),
+  version,
+  workspaceDeps: [],
+});
+
+describe('publish manifest checks', () => {
+  test('flags stale packed first-party dependency ranges from workspace sources', () => {
+    const workspacesByName = new Map([['@ontrails/core', workspace()]]);
+
+    const errors = findPackedFirstPartyDependencyMismatches({
+      packageName: '@ontrails/trails',
+      packagePath: join(repoRoot, 'apps/trails'),
+      packedPackage: {
+        dependencies: {
+          '@ontrails/core': '^1.0.0-beta.17',
+        },
+      },
+      sourcePackage: {
+        dependencies: {
+          '@ontrails/core': 'workspace:^',
+        },
+      },
+      workspacesByName,
+    });
+
+    expect(errors).toEqual([
+      'Packed manifest for @ontrails/trails (apps/trails) contains stale first-party workspace dependency ranges:',
+      '  @ontrails/trails packed dependencies @ontrails/core resolved to ^1.0.0-beta.17, expected ^1.0.0-beta.18 from packages/core/package.json',
+    ]);
+  });
+
+  test('accepts packed first-party dependency ranges matching live workspace versions', () => {
+    const workspacesByName = new Map([['@ontrails/core', workspace()]]);
+
+    const errors = findPackedFirstPartyDependencyMismatches({
+      packageName: '@ontrails/trails',
+      packagePath: join(repoRoot, 'apps/trails'),
+      packedPackage: {
+        dependencies: {
+          '@ontrails/core': '^1.0.0-beta.18',
+        },
+      },
+      sourcePackage: {
+        dependencies: {
+          '@ontrails/core': 'workspace:^',
+        },
+      },
+      workspacesByName,
+    });
+
+    expect(errors).toEqual([]);
+  });
+
+  test('checks first-party workspace ranges across dependency fields and protocol forms', () => {
+    const workspacesByName = new Map([
+      [
+        '@ontrails/core',
+        workspace({ name: '@ontrails/core', version: '1.0.0-beta.18' }),
+      ],
+      [
+        '@ontrails/testing',
+        workspace({ name: '@ontrails/testing', version: '1.0.0-beta.18' }),
+      ],
+      [
+        '@ontrails/private-harness',
+        workspace({
+          isPrivate: true,
+          name: '@ontrails/private-harness',
+          version: '1.0.0-beta.18',
+        }),
+      ],
+    ]);
+
+    const errors = findPackedFirstPartyDependencyMismatches({
+      packageName: '@ontrails/trails',
+      packagePath: join(repoRoot, 'apps/trails'),
+      packedPackage: {
+        dependencies: {
+          '@ontrails/core': '~1.0.0-beta.17',
+        },
+        optionalDependencies: {
+          '@ontrails/private-harness': '1.0.0-beta.17',
+        },
+        peerDependencies: {
+          '@ontrails/testing': '1.0.0-beta.17',
+        },
+      },
+      sourcePackage: {
+        dependencies: {
+          '@ontrails/core': 'workspace:~',
+        },
+        optionalDependencies: {
+          '@ontrails/private-harness': 'workspace:*',
+        },
+        peerDependencies: {
+          '@ontrails/testing': 'workspace:',
+        },
+      },
+      workspacesByName,
+    });
+
+    expect(errors).toEqual([
+      'Packed manifest for @ontrails/trails (apps/trails) contains stale first-party workspace dependency ranges:',
+      '  @ontrails/trails packed dependencies @ontrails/core resolved to ~1.0.0-beta.17, expected ~1.0.0-beta.18 from packages/core/package.json',
+      '  @ontrails/trails packed peerDependencies @ontrails/testing resolved to 1.0.0-beta.17, expected 1.0.0-beta.18 from packages/testing/package.json',
+      '  @ontrails/trails packed optionalDependencies @ontrails/private-harness resolved to 1.0.0-beta.17, expected 1.0.0-beta.18 from packages/private-harness/package.json',
+    ]);
+  });
+
+  test('accepts explicit workspace protocol ranges unchanged', () => {
+    const workspacesByName = new Map([['@ontrails/core', workspace()]]);
+
+    const errors = findPackedFirstPartyDependencyMismatches({
+      packageName: '@ontrails/trails',
+      packagePath: join(repoRoot, 'apps/trails'),
+      packedPackage: {
+        peerDependencies: {
+          '@ontrails/core': '>=1.0.0-beta.18 <2',
+        },
+      },
+      sourcePackage: {
+        peerDependencies: {
+          '@ontrails/core': 'workspace:>=1.0.0-beta.18 <2',
+        },
+      },
+      workspacesByName,
+    });
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -48,6 +48,12 @@ interface PackageJson {
   optionalDependencies?: Record<string, string>;
 }
 
+type DependencyField =
+  | 'dependencies'
+  | 'devDependencies'
+  | 'peerDependencies'
+  | 'optionalDependencies';
+
 /** A discovered, publishable workspace. */
 interface Workspace {
   readonly name: string;
@@ -56,6 +62,13 @@ interface Workspace {
   readonly isPrivate: boolean;
   readonly workspaceDeps: readonly string[];
 }
+
+const DEPENDENCY_FIELDS: readonly DependencyField[] = [
+  'dependencies',
+  'devDependencies',
+  'peerDependencies',
+  'optionalDependencies',
+];
 
 const USAGE = `Usage: bun scripts/publish.ts [options]
 
@@ -214,13 +227,7 @@ const discoverWorkspaceDirs = async (
 /** Collect all `workspace:`-referenced dep names from a package.json. */
 const collectWorkspaceDeps = (pkg: PackageJson): string[] => {
   const deps = new Set<string>();
-  const fields: readonly (keyof PackageJson)[] = [
-    'dependencies',
-    'devDependencies',
-    'peerDependencies',
-    'optionalDependencies',
-  ];
-  for (const field of fields) {
+  for (const field of DEPENDENCY_FIELDS) {
     const map = pkg[field];
     if (!map || typeof map !== 'object') {
       continue;
@@ -232,6 +239,78 @@ const collectWorkspaceDeps = (pkg: PackageJson): string[] => {
     }
   }
   return [...deps];
+};
+
+const expectedPackedWorkspaceRange = (
+  sourceRange: string,
+  dep: Workspace
+): string | undefined => {
+  if (!sourceRange.startsWith('workspace:')) {
+    return undefined;
+  }
+  const protocolRange = sourceRange.slice('workspace:'.length);
+  if (protocolRange === '^') {
+    return `^${dep.version}`;
+  }
+  if (protocolRange === '~') {
+    return `~${dep.version}`;
+  }
+  if (protocolRange === '*' || protocolRange === '') {
+    return dep.version;
+  }
+  return protocolRange;
+};
+
+export const findPackedFirstPartyDependencyMismatches = ({
+  packageName,
+  packagePath,
+  packedPackage,
+  sourcePackage,
+  workspacesByName,
+}: {
+  readonly packageName: string;
+  readonly packagePath: string;
+  readonly packedPackage: PackageJson;
+  readonly sourcePackage: PackageJson;
+  readonly workspacesByName: ReadonlyMap<string, Workspace>;
+}): string[] => {
+  const mismatches: string[] = [];
+  for (const field of DEPENDENCY_FIELDS) {
+    const sourceDeps = sourcePackage[field];
+    if (!sourceDeps || typeof sourceDeps !== 'object') {
+      continue;
+    }
+    const packedDeps = packedPackage[field] ?? {};
+    for (const [depName, sourceRange] of Object.entries(sourceDeps)) {
+      const dep = workspacesByName.get(depName);
+      if (
+        !dep ||
+        !dep.name.startsWith('@ontrails/') ||
+        typeof sourceRange !== 'string'
+      ) {
+        continue;
+      }
+      const expected = expectedPackedWorkspaceRange(sourceRange, dep);
+      if (!expected) {
+        continue;
+      }
+      const actual = packedDeps[depName] ?? '(missing)';
+      if (actual !== expected) {
+        const depPath = relative(REPO_ROOT, dep.path);
+        mismatches.push(
+          `${packageName} packed ${field} ${depName} resolved to ${actual}, expected ${expected} from ${depPath}/package.json`
+        );
+      }
+    }
+  }
+  if (mismatches.length === 0) {
+    return [];
+  }
+  const relPath = relative(REPO_ROOT, packagePath);
+  return [
+    `Packed manifest for ${packageName} (${relPath}) contains stale first-party workspace dependency ranges:`,
+    ...mismatches.map((mismatch) => `  ${mismatch}`),
+  ];
 };
 
 /** Discover all workspace packages and enrich with dep edges. */
@@ -357,7 +436,10 @@ const spawnCapture = async (
  *
  * @throws When packing fails or forbidden ranges are found.
  */
-const assertManifestClean = async (ws: Workspace): Promise<void> => {
+const assertManifestClean = async (
+  ws: Workspace,
+  workspacesByName: ReadonlyMap<string, Workspace>
+): Promise<void> => {
   const tmp = await mkdtemp(join(tmpdir(), 'trails-publish-'));
   try {
     // Use `bun pm pack` so the packed manifest reflects what `bun publish`
@@ -397,6 +479,16 @@ const assertManifestClean = async (ws: Workspace): Promise<void> => {
       );
     }
 
+    let packedPackage: PackageJson;
+    try {
+      packedPackage = JSON.parse(manifestText) as PackageJson;
+    } catch (error) {
+      throw new Error(
+        `Invalid packed package.json for ${ws.name}: ${(error as Error).message}`,
+        { cause: error }
+      );
+    }
+
     const offenders: string[] = [];
     for (const [lineNo, line] of manifestText.split('\n').entries()) {
       if (line.includes('"workspace:') || line.includes('"catalog:')) {
@@ -411,13 +503,30 @@ const assertManifestClean = async (ws: Workspace): Promise<void> => {
         `Packed manifest for ${ws.name} (${relPath}) contains forbidden ranges:\n${offenders.join('\n')}\n${hint}`
       );
     }
+    const sourcePackage = await readJson<PackageJson>(
+      join(ws.path, 'package.json')
+    );
+    const mismatches = findPackedFirstPartyDependencyMismatches({
+      packageName: ws.name,
+      packagePath: ws.path,
+      packedPackage,
+      sourcePackage,
+      workspacesByName,
+    });
+    if (mismatches.length > 0) {
+      throw new Error(mismatches.join('\n'));
+    }
   } finally {
     await rm(tmp, { force: true, recursive: true });
   }
 };
 
 /** Run `--check` flow: pack dry-run plus manifest-range assertion per package. */
-const runCheck = async (workspaces: readonly Workspace[]): Promise<number> => {
+const runCheck = async (
+  workspaces: readonly Workspace[],
+  allWorkspaces: readonly Workspace[]
+): Promise<number> => {
+  const workspacesByName = new Map(allWorkspaces.map((ws) => [ws.name, ws]));
   for (const ws of workspaces) {
     if (ws.isPrivate) {
       info(`Skipping ${ws.name} (private)`);
@@ -433,7 +542,7 @@ const runCheck = async (workspaces: readonly Workspace[]): Promise<number> => {
       return 1;
     }
     try {
-      await assertManifestClean(ws);
+      await assertManifestClean(ws, workspacesByName);
     } catch (error) {
       fail((error as Error).message);
       return 1;
@@ -512,7 +621,7 @@ const main = async (): Promise<number> => {
   }
 
   if (opts.mode === 'check') {
-    return await runCheck(selected);
+    return await runCheck(selected, all);
   }
 
   const tag = opts.tag ?? (await resolveDefaultTag());
@@ -523,14 +632,16 @@ const main = async (): Promise<number> => {
   return await runPublish(selected, tag, opts.otp);
 };
 
-try {
-  const code = await main();
-  process.exit(code);
-} catch (error) {
-  const msg = error instanceof Error ? error.message : String(error);
-  fail(msg);
-  if (process.env.DEBUG === '1' && error instanceof Error && error.stack) {
-    console.error(error.stack);
+if (import.meta.main) {
+  try {
+    const code = await main();
+    process.exit(code);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    fail(msg);
+    if (process.env.DEBUG === '1' && error instanceof Error && error.stack) {
+      console.error(error.stack);
+    }
+    process.exit(1);
   }
-  process.exit(1);
 }


### PR DESCRIPTION
## Context
TRL-823 closes the first release-integrity proof for the Regrade stack: packed manifests should fail publish checks when first-party workspace ranges resolve to stale beta versions.

## What changed
- Parse the extracted packed `package/package.json` during publish checks.
- Compare packed first-party `@ontrails/*` dependency ranges against the live workspace versions when the source manifest used `workspace:`.
- Keep the existing unresolved `workspace:` / `catalog:` leakage guard.
- Add focused unit coverage for stale and matching packed dependency ranges.

## Verification
- `bun test scripts/__tests__/publish.test.ts`
- `bun run publish:check -- --only @ontrails/trails`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `git diff --check`
- CI green on PR #608

## Risks
- Local review P3: helper tests cover the new comparison seam, while a deeper pack/extract integration test remains a future hardening opportunity.