### PR TITLE
fix: infer compose input for plain trails

### DIFF
--- a/.agents/plans/2026-05-27-regrade-tracer-stack/RETRO.md
+++ b/.agents/plans/2026-05-27-regrade-tracer-stack/RETRO.md
@@ -64,6 +64,7 @@ issues created or updated during planning/execution.
 | 2026-05-27 13:34 EDT | TRL-827 | Created downstream roots/rule selection/coverage issue from canceled TRL-818. | <https://linear.app/outfitter/issue/TRL-827/support-downstream-roots-rule-selection-and-coverage-reporting> |
 | 2026-05-27 13:35 EDT | TRL-830..TRL-835 | Created Warden/release-integrity adjacent issues outside Regrade. | See `REFS.md`. |
 | 2026-05-27 13:52 EDT | TRL-823 | Moved to In Progress when the lowest branch began. | Linear update returned status `In Progress`; branch `trl-823-fail-publish-checks-when-packed-manifests-rewrite-first`. |
+| 2026-05-27 13:56 EDT | TRL-819 | Moved to In Progress when its stack branch began. | Linear update returned status `In Progress`; branch `trl-819-fix-ctxcomposetrail-input-inference-for-trails-without`. |
 
 ## Execution Log
 
@@ -93,6 +94,15 @@ Append meaningful state changes, especially before handoff points.
 - Proof: `bun run publish:check -- --only @ontrails/trails` first failed with stale `^1.0.0-beta.17` packed deps, then passed after the lockfile refresh.
 - Next: commit TRL-823 branch, then stack TRL-819 above it.
 - Blockers: none.
+
+2026-05-27 14:09 EDT - TRL-819 implementation proof
+- Branch: `trl-819-fix-ctxcomposetrail-input-inference-for-trails-without`, stacked on TRL-823.
+- Scout finding: `ComposeInput<T>` mirrored `composeInput` with `NonNullable<T['composeInput']>`, so plain `Trail<I, O>` still exposed `z.ZodType<never> | undefined` and collapsed object-compose input to `never`.
+- Changed: `packages/core/src/type-utils.ts` now uses a tuple-guard fallback so inferred `CI = never` returns `TrailInput<T>` while authored compose input still merges as `TrailInput<T> & CI`.
+- Changed: `packages/core/src/type-checks.test-d.ts` now includes constrained assertions and concrete `ComposeFn` call-site assignments for plain trail-object compose, compose-input trail-object compose, batch compose, and string-id compose.
+- Verification: `bun run --cwd packages/core typecheck`, `bun run typecheck`, `bun run lint`, and `git diff --check` passed.
+- Next: commit TRL-819 branch, then stack TRL-825 above it.
+- Blockers: none.
 ```
 
 ## Local Review Log
@@ -118,6 +128,10 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | `bun run lint` | TRL-823 | pass | 23 lint/build tasks successful, cached. |
 | `bun run format:check` | TRL-823 | pass | Ultracite found 0 warnings / 0 errors. |
 | `git diff --check` | TRL-823 | pass | No whitespace/conflict-marker findings. |
+| `bun run --cwd packages/core typecheck` | TRL-819 | pass | Proves plain trail-object compose input no longer collapses to `never` and composeInput trails still require extra fields. |
+| `bun run typecheck` | TRL-819 | pass | 22 package typecheck tasks successful. |
+| `bun run lint` | TRL-819 | pass | 23 lint/build tasks successful. |
+| `git diff --check` | TRL-819 | pass | No whitespace/conflict-marker findings. |
 
 ## Remote Review / CI Log
 

--- a/.changeset/plain-compose-input.md
+++ b/.changeset/plain-compose-input.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/core": patch
+---
+
+Fix `ctx.compose(trail, input)` inference for trails that do not define a
+`composeInput` schema while preserving authored compose-input requirements.

--- a/packages/core/src/type-checks.test-d.ts
+++ b/packages/core/src/type-checks.test-d.ts
@@ -28,6 +28,14 @@ import type { z } from 'zod';
 // Helpers
 // ---------------------------------------------------------------------------
 
+type Assert<T extends true> = T;
+type IsExact<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? (<T>() => T extends B ? 1 : 2) extends <T>() => T extends A ? 1 : 2
+      ? true
+      : false
+    : false;
+
 /** A trail with composeInput declared. */
 type ComposeTrail = Trail<
   { name: string },
@@ -53,6 +61,9 @@ type AssertMerged = WithComposeInput extends {
   ? true
   : false;
 export type Merged = [AssertMerged] extends [true] ? 'pass' : never;
+export type MergedAssert = Assert<
+  IsExact<WithComposeInput, { name: string } & { forkedFrom: string }>
+>;
 
 // ---------------------------------------------------------------------------
 // ComposeInput<T> falls back to TrailInput<T> when no composeInput
@@ -67,6 +78,9 @@ type AssertFallback2 = BaseInput extends WithoutComposeInput ? true : false;
 export type Fallback = [AssertFallback1, AssertFallback2] extends [true, true]
   ? 'pass'
   : never;
+export type FallbackAssert = Assert<
+  IsExact<WithoutComposeInput, TrailInput<PlainTrail>>
+>;
 
 // ---------------------------------------------------------------------------
 // ComposeFn preserves typed trail-object output inference
@@ -92,6 +106,37 @@ export type TypedTrailObjectComposeOutput = [
 ] extends [true, true]
   ? 'pass'
   : never;
+export type TypedTrailObjectComposeNotNeverAssert =
+  Assert<AssertTypedComposeNotNever>;
+
+declare const compose: ComposeFn;
+declare const composeTrail: ComposeTrail;
+
+export const plainTrailObjectComposeOk: Promise<Result<{ id: string }, Error>> =
+  compose(plainTrail, { name: 'Ada' });
+export const composeInputTrailObjectComposeOk: Promise<
+  Result<{ id: string }, Error>
+> = compose(composeTrail, { forkedFrom: 'root', name: 'Ada' });
+// @ts-expect-error composeInput fields remain required when authored.
+compose(composeTrail, { name: 'Ada' });
+export const batchTrailObjectComposeOk: Promise<
+  readonly [
+    Result<{ id: string }, Error>,
+    Result<{ id: string }, Error>,
+    Result<unknown, Error>,
+  ]
+> = compose([
+  [plainTrail, { name: 'Ada' }],
+  [composeTrail, { forkedFrom: 'root', name: 'Ada' }],
+  ['audit.log', { event: 'typed' }],
+] as const);
+
+type StringIdComposeCallable = ComposeFn extends {
+  (id: string, input: unknown): Promise<Result<unknown, Error>>;
+}
+  ? true
+  : false;
+export type StringIdComposeStillCallable = Assert<StringIdComposeCallable>;
 
 // ---------------------------------------------------------------------------
 // BlazeInput: blaze receives composeInput fields when declared

--- a/packages/core/src/type-utils.ts
+++ b/packages/core/src/type-utils.ts
@@ -37,7 +37,9 @@ export type TrailOutput<T extends AnyTrail> = T extends {
  */
 export type ComposeInput<T extends AnyTrail> =
   NonNullable<T['composeInput']> extends z.ZodType<infer CI>
-    ? TrailInput<T> & CI
+    ? [CI] extends [never]
+      ? TrailInput<T>
+      : TrailInput<T> & CI
     : TrailInput<T>;
 
 /**


### PR DESCRIPTION
## Context
TRL-819 fixes typed `ctx.compose(trail, input)` inference for trail objects that do not define `composeInput`, unblocking the Regrade literal tracer proof above it.

## What changed
- Update `ComposeInput<T>` to fall back to the trail input when inferred compose input is `never`.
- Preserve authored `composeInput` merging and requirements.
- Strengthen compile-time type checks for plain trail-object compose, compose-input trails, batch compose, and string-id compose.
- Add a patch changeset for `@ontrails/core`.

## Verification
- `bun run --cwd packages/core typecheck`
- `bun run typecheck`
- `bun run lint`
- `git diff --check`
- local review reran focused core tests: `bun test packages/core/src/__tests__/type-utils.test.ts packages/core/src/__tests__/execute.test.ts`
- CI green on PR #609

## Risks
- Local review found no P3s for this branch.