### PR TITLE
feat: prove literal regrade transform trails

### DIFF
--- a/.agents/plans/2026-05-27-regrade-tracer-stack/RETRO.md
+++ b/.agents/plans/2026-05-27-regrade-tracer-stack/RETRO.md
@@ -1,8 +1,8 @@
 # Execution Retro: Regrade Tracer Stack
 
 Date started: 2026-05-27
-Date finalized: pending
-Status: Seeded
+Date finalized: 2026-05-27
+Status: Ready stack, CI green, remote review P3-only
 Plan: `.agents/plans/2026-05-27-regrade-tracer-stack/PLAN.md`
 Goal: `.agents/plans/2026-05-27-regrade-tracer-stack/GOAL.md`
 
@@ -14,21 +14,26 @@ handoff. Meaningful review-flow changes require a new retro entry.
 ## Execution Summary
 
 - Objective: Land the first Regrade proof stack: TRL-823, TRL-819, TRL-825.
-- Final outcome:
+- Final outcome: First Regrade proof stack landed as ready-for-review Graphite
+  PRs.
 - Final branch / stack tip:
-- Final PR range:
-- Final tracker state:
-- Final verification state:
-- Remaining risks / P3s:
-- Archive state:
+  `trl-825-scaffold-packagesregrade-and-prove-literal-transform-trails`.
+- Final PR range: #608 -> #609 -> #610.
+- Final tracker state: TRL-823, TRL-819, and TRL-825 remain In Progress with
+  Linear comments linking ready PRs and verification state.
+- Final verification state: local focused checks, stack gates, PR CI, and
+  Greptile review are green.
+- Remaining risks / P3s: TRL-819 deliberate `z.never()` composeInput edge;
+  TRL-825 private barrel width and generated-fixture temp-dir cleanup hardening.
+- Archive state: archive-ready; no merge/publish/merge-queue action taken.
 
 ## Branch / PR / Issue Ledger
 
 | Order | Issue | Branch | PR | Status | Notes |
 | --- | --- | --- | --- | --- | --- |
-| 1 | TRL-823 | `trl-823-fail-publish-checks-when-packed-manifests-rewrite-first` | | Planned | Publish check packed-manifest beta coherence. |
-| 2 | TRL-819 | `trl-819-fix-ctxcomposetrail-input-inference-for-trails-without` | | Planned | Trail-object compose inference without `composeInput`. |
-| 3 | TRL-825 | `trl-825-scaffold-packagesregrade-and-prove-literal-transform-trails` | | Planned | Experimental literal Regrade tracer. |
+| 1 | TRL-823 | `trl-823-fail-publish-checks-when-packed-manifests-rewrite-first` | [#608](https://github.com/outfitter-dev/trails/pull/608) | Ready; CI green; Greptile 5/5 | Publish check packed-manifest beta coherence. |
+| 2 | TRL-819 | `trl-819-fix-ctxcomposetrail-input-inference-for-trails-without` | [#609](https://github.com/outfitter-dev/trails/pull/609) | Ready; CI green; Greptile 5/5 | Trail-object compose inference without `composeInput`; includes `@ontrails/core` patch changeset. |
+| 3 | TRL-825 | `trl-825-scaffold-packagesregrade-and-prove-literal-transform-trails` | [#610](https://github.com/outfitter-dev/trails/pull/610) | Ready; CI green; Greptile 5/5 | Experimental literal Regrade tracer. |
 
 ## Planning Discoveries
 
@@ -65,6 +70,10 @@ issues created or updated during planning/execution.
 | 2026-05-27 13:35 EDT | TRL-830..TRL-835 | Created Warden/release-integrity adjacent issues outside Regrade. | See `REFS.md`. |
 | 2026-05-27 13:52 EDT | TRL-823 | Moved to In Progress when the lowest branch began. | Linear update returned status `In Progress`; branch `trl-823-fail-publish-checks-when-packed-manifests-rewrite-first`. |
 | 2026-05-27 13:56 EDT | TRL-819 | Moved to In Progress when its stack branch began. | Linear update returned status `In Progress`; branch `trl-819-fix-ctxcomposetrail-input-inference-for-trails-without`. |
+| 2026-05-27 14:09 EDT | TRL-825 | Moved to In Progress when its stack branch began. | Linear update returned status `In Progress`; branch `trl-825-scaffold-packagesregrade-and-prove-literal-transform-trails`. |
+| 2026-05-27 14:23 EDT | TRL-823 | Added PR/CI/review status comment. | Linear comment `9db80504-5f6b-4b61-8b30-ec8fd69e3f97` linked PR #608 and recorded CI/local review state. |
+| 2026-05-27 14:23 EDT | TRL-819 | Added PR/CI/review status comment. | Linear comment `6865d653-b61b-42b1-b41e-98f2670af6c8` linked PR #609 and recorded CI/local review state. |
+| 2026-05-27 14:23 EDT | TRL-825 | Added PR/CI/review status comment. | Linear comment `4946938a-a9ea-441f-884d-7e1f0e65d8b1` linked PR #610 and recorded CI/local review state. |
 
 ## Execution Log
 
@@ -103,6 +112,34 @@ Append meaningful state changes, especially before handoff points.
 - Verification: `bun run --cwd packages/core typecheck`, `bun run typecheck`, `bun run lint`, and `git diff --check` passed.
 - Next: commit TRL-819 branch, then stack TRL-825 above it.
 - Blockers: none.
+
+2026-05-27 14:09 EDT - TRL-825 implementation proof
+- Branch: `trl-825-scaffold-packagesregrade-and-prove-literal-transform-trails`, stacked on TRL-819.
+- Changed: added private workspace `@ontrails/regrade` with a literal transform tracer, package-local typecheck/lint/test scripts, and public exports for the proof.
+- Changed: added parent trail `regrade.literal.run` whose input schema transforms raw `{ source }` into child input, composes internal child trail `regrade.literal.normalizeExportConst`, returns explicit `Result` boundaries, and exposes an output schema plus example.
+- Changed: added tests proving runtime execution by trail object, example execution, topo composition evidence, internal child surface exclusion, and a generated package-root consumer fixture importing `@ontrails/regrade`.
+- Verification: `bun run --cwd packages/regrade typecheck`, `bun test packages/regrade`, `bun run --cwd packages/regrade lint`, `bun run lint:ast-grep`, `git diff --check`, and `bun run check` passed.
+- Notes: `bun run check` still reports a Warden warning for the new internal child reachability plus three pre-existing demo signal warnings, but the Warden gate is PASS and `bun run check` exits 0.
+- Next: commit TRL-825 branch, run local review, submit draft stack.
+- Blockers: none.
+
+2026-05-27 14:10 EDT - local review pass complete
+- Review lanes: release/package integrity, TRL-819 type/API behavior, TRL-825 Regrade doctrine, and tests/verification adequacy.
+- Scores: all four lanes returned 9/10.
+- P0/P1/P2: none; latest local review state is P2+ clean.
+- P3s recorded: TRL-823 guard tests are narrower than the implementation surface; TRL-823 durable tests stop short of a full pack/extract integration test; TRL-825 private package barrel exports the internal child/schema harness surface.
+- Decision: record P3s and proceed to draft PR submission because the requested local review gate is clean/P3-only and the stack gates passed.
+- Next: amend ledger onto the tip branch, submit stack drafts, record PR/CI state.
+- Blockers: none.
+
+2026-05-27 14:34 EDT - remote review closeout
+- PRs: #608, #609, and #610 are open and ready for review.
+- CI: GitHub CI passed on all three PRs after fixing the missing TRL-819 changeset and resubmitting the restacked branches.
+- Remote review: Greptile reruns completed with confidence 5/5 on all three PRs.
+- Remote fixes applied: TRL-823 removed the private-workspace skip from packed first-party mismatch checks and expanded tests across dependency fields/protocol forms; TRL-825 tightened the generated fixture pass assertion and clarified the transformed-example cast.
+- Remaining remote P3s: TRL-819 `z.never()` composeInput edge is intentionally not treated as blocking because `z.never()` is not an authored "cannot compose" contract today; TRL-825 private barrel width and `.tmp-fixture-*` gitignore hardening remain future cleanup before publication/harder test isolation.
+- Source host note: Graphite mergeability checks for upper PRs can lag because downstack PRs remain open; no merge queue labels were applied.
+- Blockers: none.
 ```
 
 ## Local Review Log
@@ -112,7 +149,10 @@ P3s. Do not mark local review complete while P0/P1/P2 findings remain.
 
 | Round | Scope / Lanes | Report Paths | P0/P1/P2 Result | Fix Commits / Notes |
 | --- | --- | --- | --- | --- |
-| | | | | |
+| 1 | Release/package integrity | Subagent `019e6aa1-c8ef-7f51-b592-f995da8f82d1` | P2+ clean; score 9/10 | P3: publish guard tests only cover `dependencies` + `workspace:^`, not all dependency fields/protocol forms/private skip. Recorded; no blocking fix. |
+| 1 | Type/API behavior | Subagent `019e6aa1-eb57-76a3-89a4-02ffa3d2e13c` | P2+ clean; score 9/10 | No P3s. Reviewer also ran focused core typecheck and tests. |
+| 1 | Regrade doctrine/architecture | Subagent `019e6aa2-0cd9-70b2-89b9-94e179820a76` | P2+ clean; score 9/10 | P3: package barrel is wider than a future public experimental boundary because it exports child/schema harness symbols. Recorded; package remains private. |
+| 1 | Tests/verification adequacy | Subagent `019e6aa2-5fb9-7eb0-b2ed-db288f42aef0` | P2+ clean; score 9/10 | P3: TRL-823 proof relies partly on live `publish:check` evidence instead of a full pack/extract integration test. Recorded; live focused check passed. |
 
 ## Verification Log
 
@@ -132,6 +172,29 @@ Record exact commands and artifact checks. Include skipped checks with reasons.
 | `bun run typecheck` | TRL-819 | pass | 22 package typecheck tasks successful. |
 | `bun run lint` | TRL-819 | pass | 23 lint/build tasks successful. |
 | `git diff --check` | TRL-819 | pass | No whitespace/conflict-marker findings. |
+| `bun run --cwd packages/regrade typecheck` | TRL-825 | pass | `@ontrails/regrade` typecheck passed after package scaffold. |
+| `bun test packages/regrade` | TRL-825 | pass | 5 tests passed across literal runtime/topo/example proof and generated package-root consumer fixture. |
+| `bun run --cwd packages/regrade lint` | TRL-825 | pass | Oxlint found 0 warnings / 0 errors in 4 files. |
+| `bun run lint:ast-grep` | TRL-825 | pass | AST-grep rule scan passed after using `InternalError` instead of native `Error` in Result boundary. |
+| `git diff --check` | TRL-825 | pass | No whitespace/conflict-marker findings. |
+| `bun run typecheck` | stack gate | pass | 23 package typecheck tasks successful after adding `@ontrails/regrade`. |
+| `bun run test` | stack gate | pass | 38 successful tasks; package suites including core, Trails, Warden, and Regrade passed. |
+| `bun run lint` | stack gate | pass | 24 lint/build tasks successful after adding `@ontrails/regrade`. |
+| `bun run format:check` | stack gate | pass | Ultracite found 0 warnings / 0 errors. |
+| `bun run check` | stack gate | pass | Full check exited 0. Warden report passed with 4 warnings: new Regrade internal-child reachability warning and three existing demo signal warnings. |
+| `bun test packages/core/src/__tests__/type-utils.test.ts packages/core/src/__tests__/execute.test.ts` | local review | pass | Review lane rerun; 73 tests passed. |
+| `bun scripts/check-changeset-gate.ts --changed-files <(git diff ... e1d5174a5^ e1d5174a5)` | local review | pass | Review lane confirmed TRL-823 commit has no publishable package-affecting files requiring a changeset. |
+| `bun scripts/check-changeset-gate.ts --changed-files <(git diff ... f09bbbbc2^ f09bbbbc2)` | local review | pass | Review lane confirmed private `@ontrails/regrade` package does not require a changeset. |
+| `bun test scripts/__tests__/publish.test.ts` | remote review fix | pass | 4 tests passed after expanding TRL-823 coverage for field/protocol forms and private first-party deps. |
+| `bun run publish:check -- --only @ontrails/trails` | remote review fix | pass | Pack check passed for `@ontrails/trails@1.0.0-beta.18` after Greptile round 1 fixes. |
+| `bun run format:check` | remote review fix | pass | Formatting passed after TRL-823 review fixes. |
+| `bun run lint:ast-grep` | remote review fix | pass | AST-grep passed after TRL-823 review fixes. |
+| `git diff --check` | remote review fix | pass | No whitespace/conflict-marker findings after TRL-823 and TRL-825 review fixes. |
+| `bun run --cwd packages/regrade typecheck` | remote review fix | pass | Regrade package typecheck passed after tightening review nits. |
+| `bun test packages/regrade` | remote review fix | pass | 5 tests passed after generated fixture assertion hardening. |
+| GitHub CI | PR #608 | pass | Build, Lint & Format, Dead Code, Typecheck, Test, Governance, Changeset, and CI Gate passed on head `2c6eabb0`. |
+| GitHub CI | PR #609 | pass | Build, Lint & Format, Dead Code, Typecheck, Test, Governance, Changeset, and CI Gate passed on head `946a9a54`. |
+| GitHub CI | PR #610 | pass | Build, Lint & Format, Dead Code, Typecheck, Test, Governance, Changeset, and CI Gate passed on head `fff47064`. |
 
 ## Remote Review / CI Log
 
@@ -143,13 +206,24 @@ if inline threads are resolved.
 
 | Time | PR | CI State | Review State | Scores / Signals | Unresolved P0/P1/P2 | Action |
 | --- | --- | --- | --- | --- | --- | --- |
-| | | | | | | |
+| 2026-05-27 14:18 EDT | [#608](https://github.com/outfitter-dev/trails/pull/608) | pass | Draft submitted, then marked ready after CI green. | pending | none known | Waited for Greptile. |
+| 2026-05-27 14:20 EDT | [#609](https://github.com/outfitter-dev/trails/pull/609) | fail then pass | Initial Changeset job failed because TRL-819 touched publishable `@ontrails/core`; added patch changeset and resubmitted. | pending | Changeset failure fixed | Added `.changeset/plain-compose-input.md` on TRL-819. |
+| 2026-05-27 14:21 EDT | [#610](https://github.com/outfitter-dev/trails/pull/610) | pass | Draft submitted, then marked ready after CI green. | pending | none known | Waited for Greptile. |
+| 2026-05-27 14:33 EDT | [#608](https://github.com/outfitter-dev/trails/pull/608) | pass | Greptile rerun complete. | 5/5 | none | Fixed first-round Greptile findings on TRL-823. |
+| 2026-05-27 14:31 EDT | [#609](https://github.com/outfitter-dev/trails/pull/609) | pass | Greptile rerun complete. | 5/5 | none | No changes needed after rerun; `z.never()` note treated as P3/edge-case documentation. |
+| 2026-05-27 14:32 EDT | [#610](https://github.com/outfitter-dev/trails/pull/610) | pass | Greptile rerun complete. | 5/5 | none | Fixed generated fixture assertion and clarified transformed example cast; barrel width remains P3. |
 
 ## Review Feedback Resolutions
 
 | Source | Score / Signal | Severity | Finding | Prompt To Fix | Resolution | Evidence |
 | --- | --- | --- | --- | --- | --- | --- |
-| | | | | | | |
+| Local release/package review | 9/10 | P3 | Publish guard tests only cover `dependencies` and `workspace:^`, while implementation covers all dependency fields and workspace protocol forms. | Add table-driven cases for peer/optional deps, `workspace:*`, `workspace:~`, and private-workspace skip path. | Recorded as P3; not fixed in this stack because P2+ clean and live `publish:check` proof passed. | Subagent `019e6aa1-c8ef-7f51-b592-f995da8f82d1`. |
+| Local tests/verification review | 9/10 | P3 | TRL-823 durable test exercises the pure helper, while production enforcement happens through pack/extract `assertManifestClean()`. | Add an integration-style publish test that drives the packed-manifest path and asserts the stale-range error through `assertManifestClean()` / `--check`. | Recorded as P3; not fixed in this stack because P2+ clean and live `publish:check -- --only @ontrails/trails` passed. | Subagent `019e6aa2-5fb9-7eb0-b2ed-db288f42aef0`. |
+| Local Regrade doctrine review | 9/10 | P3 | `packages/regrade/src/index.ts` exports internal child/schema harness symbols, which would be wider than a future public package boundary. | Narrow the barrel or mark child/schema exports as harness-only before future publication. | Recorded as P3; not fixed because package is private and this proof intentionally exposes harness evidence locally. | Subagent `019e6aa2-0cd9-70b2-89b9-94e179820a76`. |
+| Greptile #608 round 1 | 4/5 | P2/P3 mix | Tests used a CWD-derived repo root, private first-party workspace deps were skipped, and field/protocol coverage was narrow. | Fix all three issues. | Fixed on TRL-823 by deriving repo root from `import.meta.url`, removing the `dep.isPrivate` skip, and expanding tests. | Greptile rerun on #608 returned 5/5 with no prompt-to-fix. |
+| Greptile #609 round 1 | 4/5 | P3 | Tuple guard also absorbs a hypothetical explicit `z.never()` `composeInput`. | Consider preserving uncallable compose for explicit `z.never()`. | Recorded as P3; not fixed because `z.never()` is not an authored cannot-compose contract and the public API does not document it as one. | Greptile rerun on #609 returned 5/5 with no prompt-to-fix. |
+| Greptile #610 round 1 | 4/5 | P3 | Example cast needed clearer note, public barrel exports internal/harness symbols, and generated fixture assertion was broad. | Clarify cast intent, narrow barrel before publication, and assert `\\d+ pass`. | Clarified comment and hardened assertion; barrel width remains P3 while package is private. | Greptile rerun on #610 returned 5/5; only remaining prompt is non-blocking temp-dir gitignore hardening. |
+| Greptile #610 round 2 | 5/5 | P3 | `.tmp-fixture-*` leftover dirs are not ignored if test process is killed. | Add ignore coverage or move fixture under an already ignored temp root. | Recorded as P3; no observed leftover dirs and test cleanup uses `finally`. | Greptile #610 5/5 states safe to merge. |
 
 ## Forbidden Actions Audit
 
@@ -157,32 +231,45 @@ Record constraints that stayed true. Add or remove rows to match the goal.
 
 | Action / Constraint | Status | Evidence |
 | --- | --- | --- |
-| No merge without explicit user approval | respected in planning | No merge commands run. |
-| No package publish / registry mutation unless authorized | respected in planning | No publish commands run. |
-| No merge queue label unless authorized | respected in planning | No PR/label mutation beyond prior Linear setup. |
-| No source-control writes by subagents | respected in planning | No subagents used for source-control writes. |
-| No unrelated destructive changes | respected in planning | Only new packet files created. |
-| No `gt absorb` | respected in planning | No source-control writes run. |
+| No merge without explicit user approval | respected | No merge commands run. |
+| No package publish / registry mutation unless authorized | respected | No publish commands run; only `publish:check` dry-run pack validation. |
+| No merge queue label unless authorized | respected | No `queue:merge` or `queue:priority` labels applied. |
+| No source-control writes by subagents | respected | Subagents were read-only reviewers/scouts; main agent performed all `gt` writes. |
+| No unrelated destructive changes | respected | Unrelated `.agents/plans/2026-05-26-radio-compose-proof/README.md` remained untracked and untouched. |
+| No `gt absorb` | respected | No `gt absorb` commands run. |
 
 ## Final State
 
 Fill before claiming completion, handoff, merge readiness, or archive.
 
-- Goal completion condition:
-- Graphite / branch state:
-- PR state:
-- Source-control host lag:
-- Tracker state:
-- Local review state:
-- Remote review state:
-- Remote review scores:
-- Verification:
-- Skipped checks:
-- Remaining P3s / risks:
-- Follow-up issues created:
-- Forbidden actions confirmation:
-- Packet archive readiness:
-- Final transcript proof:
+- Goal completion condition: satisfied; ready PRs exist for TRL-823, TRL-819,
+  and TRL-825 with CI green and remote review P2+ clear.
+- Graphite / branch state: stack tip is
+  `trl-825-scaffold-packagesregrade-and-prove-literal-transform-trails`; stack
+  order is TRL-823 -> TRL-819 -> TRL-825.
+- PR state: #608, #609, and #610 are open and ready for review.
+- Source-control host lag: Graphite mergeability checks for upper PRs can lag
+  while downstack PRs remain open; no merge queue action taken.
+- Tracker state: Linear comments added for TRL-823, TRL-819, and TRL-825 with
+  PR links and status.
+- Local review state: four GPT-5.4/high subagent review lanes returned 9/10 and
+  P2+ clean.
+- Remote review state: Greptile reruns completed successfully on all three PRs.
+- Remote review scores: #608 5/5, #609 5/5, #610 5/5.
+- Verification: local focused checks, stack gates, GitHub CI, and Greptile
+  review passed; see Verification Log.
+- Skipped checks: none from the requested validation list; full `bun run check`
+  passed before submission and CI passed after review-fix resubmits.
+- Remaining P3s / risks: TRL-819 explicit `z.never()` composeInput edge is not
+  a documented cannot-compose contract; TRL-825 private barrel exports harness
+  symbols and `.tmp-fixture-*` leftover ignore hardening should be revisited
+  before publication or repeated fixture expansion.
+- Follow-up issues created: none; existing TRL-826/827/830/836 cover known next
+  Regrade/release-integrity work.
+- Forbidden actions confirmation: no merge, publish, registry mutation,
+  merge-queue label, destructive unrelated change, or `gt absorb`.
+- Packet archive readiness: ready to archive after Matt accepts the stack state.
+- Final transcript proof: `literal-transform-trail tracer proof`.
 
 Do not mark complete until the goal completion condition has been proven, this
 section is filled or explicitly marked blocked, and the final transcript names

--- a/bun.lock
+++ b/bun.lock
@@ -199,6 +199,18 @@
         "@ontrails/observe": "workspace:^",
       },
     },
+    "packages/regrade": {
+      "name": "@ontrails/regrade",
+      "version": "1.0.0-beta.18",
+      "dependencies": {
+        "@ontrails/core": "workspace:^",
+        "@ontrails/topographer": "workspace:^",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@ontrails/testing": "workspace:^",
+      },
+    },
     "packages/store": {
       "name": "@ontrails/store",
       "version": "1.0.0-beta.18",
@@ -398,6 +410,8 @@
     "@ontrails/permits": ["@ontrails/permits@workspace:packages/permits"],
 
     "@ontrails/pino": ["@ontrails/pino@workspace:packages/pino"],
+
+    "@ontrails/regrade": ["@ontrails/regrade@workspace:packages/regrade"],
 
     "@ontrails/store": ["@ontrails/store@workspace:packages/store"],
 

--- a/packages/regrade/package.json
+++ b/packages/regrade/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@ontrails/regrade",
+  "version": "1.0.0-beta.18",
+  "private": true,
+  "description": "Experimental Regrade tracer proving whether transform units can be literal Trails trails.",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "dependencies": {
+    "@ontrails/core": "workspace:^",
+    "@ontrails/topographer": "workspace:^",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@ontrails/testing": "workspace:^"
+  }
+}

--- a/packages/regrade/src/__tests__/generated-fixture.test.ts
+++ b/packages/regrade/src/__tests__/generated-fixture.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+
+test('package consumer can run literal Regrade examples from a generated fixture', () => {
+  const packageRoot = fileURLToPath(new URL('../..', import.meta.url));
+  const dir = mkdtempSync(join(packageRoot, '.tmp-fixture-'));
+  const fixture = join(dir, 'literal-regrade-fixture.test.ts');
+
+  try {
+    writeFileSync(
+      fixture,
+      `import { testExamples } from '@ontrails/testing';
+import { literalRegradeTopo } from '@ontrails/regrade';
+
+testExamples(literalRegradeTopo);
+`
+    );
+
+    const proc = Bun.spawnSync(['bun', 'test', fixture], {
+      cwd: packageRoot,
+      stderr: 'pipe',
+      stdout: 'pipe',
+    });
+
+    const stdout = proc.stdout.toString();
+    const stderr = proc.stderr.toString();
+    expect(proc.exitCode, `${stdout}\n${stderr}`).toBe(0);
+    expect(`${stdout}\n${stderr}`).toMatch(/\d+ pass/);
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});

--- a/packages/regrade/src/__tests__/literal-transform.test.ts
+++ b/packages/regrade/src/__tests__/literal-transform.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'bun:test';
+import { executeTrail, filterSurfaceTrails } from '@ontrails/core';
+import { testExamples } from '@ontrails/testing';
+import { deriveTopoGraph } from '@ontrails/topographer';
+
+import {
+  literalRegradeTopo,
+  literalRegradeTrail,
+  normalizeExportConstTrail,
+} from '../literal-transform.js';
+
+describe('literal Regrade transform tracer', () => {
+  test('runs a parent transform trail that composes a child transform trail by object', async () => {
+    const result = await executeTrail(
+      literalRegradeTrail,
+      { source: 'export const answer = 41;' },
+      { topo: literalRegradeTopo }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(result.value).toEqual({
+      changed: true,
+      nextSource: 'export let answer = 41;',
+      notes: ['Rewrote export const declarations to export let.'],
+    });
+  });
+
+  test('keeps internal transform trails off surfaces while retaining topo evidence', () => {
+    const surfaceIds = filterSurfaceTrails(literalRegradeTopo.list()).map(
+      (entry) => entry.id
+    );
+    expect(surfaceIds).toContain(literalRegradeTrail.id);
+    expect(surfaceIds).not.toContain(normalizeExportConstTrail.id);
+
+    const topoGraph = deriveTopoGraph(literalRegradeTopo);
+    const parent = topoGraph.entries.find(
+      (entry) => entry.id === literalRegradeTrail.id
+    );
+    const child = topoGraph.entries.find(
+      (entry) => entry.id === normalizeExportConstTrail.id
+    );
+
+    expect(parent?.kind).toBe('trail');
+    expect(parent?.composes).toEqual([normalizeExportConstTrail.id]);
+    expect(parent?.exampleCount).toBe(1);
+    expect(child?.kind).toBe('trail');
+    expect(child?.surfaces).toEqual([]);
+  });
+});
+
+describe('literal Regrade transform examples', () => {
+  testExamples(literalRegradeTopo);
+});

--- a/packages/regrade/src/index.ts
+++ b/packages/regrade/src/index.ts
@@ -1,0 +1,7 @@
+export {
+  literalRegradeTopo,
+  literalRegradeTrail,
+  normalizeExportConstTrail,
+  regradeTransformInput,
+  regradeTransformOutput,
+} from './literal-transform.js';

--- a/packages/regrade/src/literal-transform.ts
+++ b/packages/regrade/src/literal-transform.ts
@@ -1,0 +1,74 @@
+import { InternalError, Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const regradeTransformInput = z.object({
+  source: z.string().describe('Source text to transform'),
+});
+
+export const regradeTransformOutput = z.object({
+  changed: z.boolean().describe('Whether the transform changed the source'),
+  nextSource: z.string().describe('Transformed source text'),
+  notes: z.array(z.string()).describe('Tracer notes for the transform run'),
+});
+
+const childInput = z.object({
+  source: z.string(),
+});
+
+export const normalizeExportConstTrail = trail(
+  'regrade.literal.normalizeExportConst',
+  {
+    blaze: (input) => {
+      const nextSource = input.source.replaceAll('export const', 'export let');
+      return Result.ok({
+        changed: nextSource !== input.source,
+        nextSource,
+        notes:
+          nextSource === input.source
+            ? ['No export const declaration found.']
+            : ['Rewrote export const declarations to export let.'],
+      });
+    },
+    input: childInput,
+    output: regradeTransformOutput,
+    visibility: 'internal',
+  }
+);
+
+export const literalRegradeTrail = trail('regrade.literal.run', {
+  blaze: async (input, ctx) => {
+    if (!ctx.compose) {
+      return Result.err(
+        new InternalError(
+          'Literal Regrade tracer requires compose-capable execution.'
+        )
+      );
+    }
+    return await ctx.compose(normalizeExportConstTrail, input.child);
+  },
+  composes: [normalizeExportConstTrail],
+  examples: [
+    {
+      expected: {
+        changed: true,
+        nextSource: 'export let answer = 41;',
+        notes: ['Rewrote export const declarations to export let.'],
+      },
+      // Trail examples execute raw input before Zod transforms; the authored type
+      // currently reflects the post-transform blaze input shape.
+      input: { source: 'export const answer = 41;' } as unknown as {
+        child: { source: string };
+      },
+      name: 'code-string fixture',
+    },
+  ],
+  input: regradeTransformInput.transform(({ source }) => ({
+    child: { source },
+  })),
+  output: regradeTransformOutput,
+});
+
+export const literalRegradeTopo = topo('regrade-literal', {
+  literalRegradeTrail,
+  normalizeExportConstTrail,
+});

--- a/packages/regrade/tsconfig.json
+++ b/packages/regrade/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/packages/regrade/tsconfig.tests.json
+++ b/packages/regrade/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Context
TRL-825 lands the first Regrade proof: an experimental private `@ontrails/regrade` package that models a literal transform as Trails contracts. This intentionally does not implement full `trails regrade`, package-source modes, Warden fix metadata, term-rewrite, downstream roots, or ADR work.

## What changed
- Add private workspace `packages/regrade`.
- Add `regrade.literal.run`, a parent transform trail that transforms raw `{ source }` input, composes an internal child trail by object, and returns explicit `Result` output.
- Add tests proving runtime execution, examples, topo composition evidence, internal child surface exclusion, and generated package-root consumer usage.

## Verification
- `bun run --cwd packages/regrade typecheck`
- `bun test packages/regrade`
- `bun run --cwd packages/regrade lint`
- `bun run lint:ast-grep`
- `git diff --check`
- stack gates: `bun run typecheck`, `bun run test`, `bun run lint`, `bun run format:check`, `bun run check`
- CI green on PR #610

## Risks
- Local review P3: the private package barrel exports child/schema harness symbols; narrow or mark those before any future publication decision.
- `bun run check` reports Warden warnings only: the new internal child reachability warning plus pre-existing demo signal warnings; the gate passes.