### PR TITLE
chore: bump Trails plugin version to 0.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Build with the Trails framework — contract-first trails, surfaces, testing, and governance.",
-    "version": "0.3.0"
+    "version": "0.3.1"
   },
   "repository": "https://github.com/outfitter-dev/trails",
   "plugins": [
     {
       "name": "trails",
       "source": "./plugin",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "description": "Skills for building Trails applications — trail creation, surfaces, testing, debugging, migration, and governance."
     }
   ]

--- a/docs/releases/plugin-release.md
+++ b/docs/releases/plugin-release.md
@@ -2,7 +2,7 @@
 
 This runbook covers the Trails Claude plugin and bundled skills under `plugin/` plus the marketplace manifest at `.claude-plugin/marketplace.json`. It is separate from the framework package publish path in [Stable Cutover Runbook](./stable-cutover.md).
 
-The current plugin manifest version is `0.3.0`. The bundled `trails` skill targets Trails framework `1.0.0-beta.18` through `metadata.trails.version`. Those versions are intentionally independent: plugin version names the Claude plugin bundle, while the skill target names the framework package line the guidance was refreshed against.
+The current plugin manifest version is `0.3.1`. The bundled `trails` skill targets Trails framework `1.0.0-beta.18` through `metadata.trails.version`. Those versions are intentionally independent: plugin version names the Claude plugin bundle, while the skill target names the framework package line the guidance was refreshed against.
 
 ## Stop Rules
 
@@ -56,16 +56,16 @@ Every future release packet should replace or supersede that pointer with fresh 
 
 Current refresh evidence records two release-readiness risks that must be refreshed before future publication: raw scaffold output was not clean without edits, and published `@ontrails/trails@1.0.0-beta.18` exposed `warden` but not `compile`/`validate`. These do not require publishing the plugin to stop, but release notes and install docs must not imply a published CLI already has commands that only exist in the repo.
 
-## Changes Since Plugin 0.3.0 Manifest
+## Plugin 0.3.1 Bundle
 
-The refresh stack keeps the manifest at `0.3.0` unless the operator chooses to bump it before publication. Before publishing, decide whether the marketplace requires a version bump for the refreshed bundle. If it does, update `plugin/.claude-plugin/plugin.json`, then run:
+The refreshed bundle is recorded as plugin manifest version `0.3.1`. If the marketplace requires another version bump before publication, update `plugin/.claude-plugin/plugin.json`, then run:
 
 ```bash
 bun run plugin:metadata:sync
 bun run plugin:metadata:check
 ```
 
-Branch-local changes since the current `0.3.0` manifest include:
+The `0.3.1` bundle includes:
 
 - public README/API docs drift fixes and M1 packet archive;
 - refreshed main `trails` skill for CLI, MCP, Hono HTTP, Bun-native HTTP,
@@ -99,7 +99,7 @@ Before any external publication:
 3. Confirm `TRL-755` public-docs cleanup and M1 archive are included.
 4. Confirm `TRL-757` through `TRL-760` are either accepted deferred follow-ups
    or explicitly promoted into the release gate.
-5. Confirm whether plugin version remains `0.3.0` or is bumped, then rerun
+5. Confirm whether plugin version remains `0.3.1` or is bumped again, then rerun
    metadata checks.
 6. Run the manual/external checks above only with explicit approval.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "trails",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Build with the Trails framework — contract-first trails, surfaces, testing, and governance for agent-assisted development.",
   "author": {
     "name": "Outfitter",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -43,7 +43,7 @@ Plugin release and republish steps are tracked in the repo runbook:
 
 - [Plugin Release Runbook](../docs/releases/plugin-release.md)
 
-The runbook keeps plugin version `0.3.0` separate from the bundled skill's Trails framework target version. It also names the stop rules for marketplace, registry, `npx skills`, and global installed-skill mutations. Do not treat a local/global `trails` skill as current until `bun run plugin:installed-skill:check` passes or an operator explicitly chooses to keep it decoupled.
+The runbook keeps plugin version `0.3.1` separate from the bundled skill's Trails framework target version. It also names the stop rules for marketplace, registry, `npx skills`, and global installed-skill mutations. Do not treat a local/global `trails` skill as current until `bun run plugin:installed-skill:check` passes or an operator explicitly chooses to keep it decoupled.
 
 ## What's Included
 


### PR DESCRIPTION
## Context

The bundled Trails plugin/skills content has changed materially since the `0.3.0` plugin manifest was recorded, while the framework package target remains `1.0.0-beta.18`.

Plugin version and framework version are intentionally separate:

- `plugin/.claude-plugin/plugin.json` owns the Claude plugin bundle version.
- `packages/core/package.json` owns the Trails framework version targeted by the bundled `trails` skill.
- `.claude-plugin/marketplace.json` mirrors the plugin bundle version.
- `plugin/skills/trails/SKILL.md` continues to target the framework version via `metadata.trails.version`.

## What Changed

- Bumped the Claude plugin bundle from `0.3.0` to `0.3.1`.
- Synced `.claude-plugin/marketplace.json` to the new plugin version.
- Updated plugin README and plugin release runbook language to describe the `0.3.1` bundle.

## Verification

- `bun run plugin:metadata:check`
- `bun run plugin:installed-skill:check`
- `bun run skillset:check`
- `bun run warden:skills:check`
- `bun run warden:agents:check`
- `bun run format:check`

## Notes

No framework package version changes are included here. All public `@ontrails/*` packages remain lockstep at `1.0.0-beta.18`.
