### PR TITLE
test(regrade): harden generated fixture temp handling

### DIFF
--- a/packages/regrade/src/__tests__/generated-fixture.test.ts
+++ b/packages/regrade/src/__tests__/generated-fixture.test.ts
@@ -1,11 +1,18 @@
 import { expect, test } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { join } from 'node:path';
 
 test('package consumer can run literal Regrade examples from a generated fixture', () => {
   const packageRoot = fileURLToPath(new URL('../..', import.meta.url));
-  const dir = mkdtempSync(join(packageRoot, '.tmp-fixture-'));
+  // Keep the generated fixture under the package root so the consumer resolves
+  // `@ontrails/regrade` via self-reference and `@ontrails/testing` via the
+  // package's node_modules. Nest it under `.tmp-tests/` — already covered by the
+  // root `.gitignore` `.tmp-tests/` rule — so an interrupted run leaves no
+  // visible untracked debris under `packages/regrade`.
+  const tmpRoot = join(packageRoot, '.tmp-tests');
+  mkdirSync(tmpRoot, { recursive: true });
+  const dir = mkdtempSync(join(tmpRoot, 'fixture-'));
   const fixture = join(dir, 'literal-regrade-fixture.test.ts');
 
   try {


### PR DESCRIPTION
## Summary

Relocates the generated package-consumer fixture's temporary directory from `packages/regrade/.tmp-fixture-*` to `packages/regrade/.tmp-tests/fixture-*`.

This keeps interrupted test runs from leaving visible untracked debris under `packages/regrade`, because `.tmp-tests/` is already covered by the repo's root `.gitignore` rule.

## Why This Shape

The fixture still lives under the `@ontrails/regrade` package root so the generated consumer continues to resolve:

- `@ontrails/regrade` through package self-reference
- `@ontrails/testing` through the package-local dependency path

That preserves the test's original purpose: proving a generated downstream consumer can import the package barrel and run the tracer examples.

## Verification

- `bun test packages/regrade`
- `bun run --cwd packages/regrade typecheck`
- `bun run format:check`
- `git diff --check`
- Simulated interrupted-run debris under `.tmp-tests/` and confirmed it is ignored by git
- GitHub CI green
- Greptile Review: 5/5, safe to merge

Closes TRL-841
