### PR TITLE
test(warden): fix tests-config typecheck errors across warden test suite

### DIFF
--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -749,7 +749,7 @@ trail("entity.save", {
       detours: [
         {
           on: ConflictError,
-          recover: () => Result.ok({ ok: true }),
+          recover: async () => Result.ok({ ok: true }),
         },
       ],
       input: z.object({}),
@@ -764,7 +764,7 @@ trail("entity.save", {
           recover: 'not callable',
         },
       ],
-    } as typeof validTrail;
+    } as unknown as typeof validTrail;
 
     const report = await runWarden({
       topo: topo('invalid-detour-contract', {

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -62,7 +62,7 @@ const writeManifest = (dir: string, hash: string): Promise<string> =>
     { dir: committedLockDir(dir) }
   );
 
-const seedSavedTopo = (dir: string): string | undefined => {
+const seedSavedTopo = (dir: string): string => {
   const db = openWriteTrailsDb({ rootDir: dir });
   try {
     const result = createStoredTopoSnapshot(db, makeTopo(), {
@@ -75,7 +75,11 @@ const seedSavedTopo = (dir: string): string | undefined => {
     db.close();
   }
 
-  return createTopoStore({ rootDir: dir }).exports.get()?.topoGraphHash;
+  const hash = createTopoStore({ rootDir: dir }).exports.get()?.topoGraphHash;
+  if (hash === undefined) {
+    throw new Error('seedSavedTopo expected a stored topo graph hash');
+  }
+  return hash;
 };
 
 describe('checkDrift', () => {

--- a/packages/warden/src/__tests__/incomplete-accessor-for-standard-op.test.ts
+++ b/packages/warden/src/__tests__/incomplete-accessor-for-standard-op.test.ts
@@ -46,8 +46,13 @@ const crudOutputSchema = z.object({ ok: z.boolean() });
 type CrudInput = z.infer<typeof crudInputSchema>;
 type CrudOutput = z.infer<typeof crudOutputSchema>;
 
+// `AnyResource` (not `Resource<Connection>`): the introspection-safety tests
+// pass class-based accessors whose instance type is not assignable to
+// `Resource<Connection>` under `exactOptionalPropertyTypes`. The rule inspects
+// accessor shape at runtime, so the wider static param keeps those fixtures
+// expressible without weakening what is exercised.
 const baseCrudSpec = (
-  resourceValue: Resource<Connection>
+  resourceValue: AnyResource
 ): TrailSpec<CrudInput, CrudOutput> => ({
   blaze: () => Result.ok({ ok: true }),
   description: 'synthetic crud trail',
@@ -58,7 +63,7 @@ const baseCrudSpec = (
 
 const buildCrudTrail = (
   trailId: string,
-  resourceValue: Resource<Connection>
+  resourceValue: AnyResource
 ): AnyTrail =>
   trail<CrudInput, CrudOutput>(trailId, {
     ...baseCrudSpec(resourceValue),
@@ -67,7 +72,7 @@ const buildCrudTrail = (
 
 const buildTrailWithoutPattern = (
   trailId: string,
-  resourceValue: Resource<Connection>
+  resourceValue: AnyResource
 ): AnyTrail =>
   trail<CrudInput, CrudOutput>(trailId, baseCrudSpec(resourceValue));
 

--- a/packages/warden/src/__tests__/public-output-schema.test.ts
+++ b/packages/warden/src/__tests__/public-output-schema.test.ts
@@ -6,6 +6,7 @@ import { z } from 'zod';
 
 import { runWarden } from '../cli.js';
 import { publicOutputSchema } from '../rules/public-output-schema.js';
+import type { WardenDiagnostic } from '../rules/types.js';
 
 const emptyInput = z.object({});
 const outputSchema = z.object({ ok: z.boolean() });
@@ -36,8 +37,13 @@ const buildTopo = (...trails: readonly AnyTrail[]) =>
     )
   );
 
-const check = (...trails: readonly AnyTrail[]) =>
-  publicOutputSchema.checkTopo(buildTopo(...trails));
+const check = (...trails: readonly AnyTrail[]): readonly WardenDiagnostic[] => {
+  const diagnostics = publicOutputSchema.checkTopo(buildTopo(...trails));
+  if (diagnostics instanceof Promise) {
+    throw new TypeError('public-output-schema runs synchronously');
+  }
+  return diagnostics;
+};
 
 describe('public-output-schema', () => {
   test('flags public surface-eligible trails without output schemas', () => {

--- a/packages/warden/src/__tests__/public-union-output-discriminants.test.ts
+++ b/packages/warden/src/__tests__/public-union-output-discriminants.test.ts
@@ -5,6 +5,7 @@ import type { AnyTrail, TrailVisibility } from '@ontrails/core';
 import { z } from 'zod';
 
 import { publicUnionOutputDiscriminants } from '../rules/public-union-output-discriminants.js';
+import type { WardenDiagnostic } from '../rules/types.js';
 
 const emptyInput = z.object({});
 
@@ -31,8 +32,15 @@ const buildTopo = (...trails: readonly AnyTrail[]) =>
     )
   );
 
-const check = (...trails: readonly AnyTrail[]) =>
-  publicUnionOutputDiscriminants.checkTopo(buildTopo(...trails));
+const check = (...trails: readonly AnyTrail[]): readonly WardenDiagnostic[] => {
+  const diagnostics = publicUnionOutputDiscriminants.checkTopo(
+    buildTopo(...trails)
+  );
+  if (diagnostics instanceof Promise) {
+    throw new TypeError('public-union-output-discriminants runs synchronously');
+  }
+  return diagnostics;
+};
 
 describe('public-union-output-discriminants', () => {
   test('flags public object union outputs without a literal discriminator', () => {

--- a/packages/warden/src/__tests__/trail-versioning-rules.test.ts
+++ b/packages/warden/src/__tests__/trail-versioning-rules.test.ts
@@ -33,11 +33,11 @@ const versionedTrail = trail('versioned.clean', {
   version: 2,
   versions: {
     1: {
-      examples: [{ input: {}, output: { ok: true } }],
+      examples: [{ expected: { ok: true }, input: {}, name: 'version 1' }],
       input: z.object({}),
       output: z.object({ ok: z.boolean() }),
       transpose: {
-        input: ({ input }) => input,
+        input: () => ({}),
         output: ({ output }) => output,
       },
     },

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -20,7 +20,7 @@ describe('wardenTopo', () => {
 
   test('all rule trails expose Warden metadata', () => {
     for (const trail of wardenTopo.list()) {
-      const metadata = trail.meta?.warden as
+      const metadata = trail.meta?.['warden'] as
         | { lifecycle?: { state?: unknown }; tier?: unknown }
         | undefined;
 

--- a/packages/warden/src/__tests__/valid-detour-contract.test.ts
+++ b/packages/warden/src/__tests__/valid-detour-contract.test.ts
@@ -10,7 +10,7 @@ const validTrail = trail('entity.save', {
   detours: [
     {
       on: ConflictError,
-      recover: () => Result.ok({ ok: true }),
+      recover: async () => Result.ok({ ok: true }),
     },
   ],
   input: z.object({}),
@@ -18,26 +18,26 @@ const validTrail = trail('entity.save', {
 });
 
 describe('valid-detour-contract', () => {
-  test('passes for detours with an error constructor and callable recover', () => {
-    const diagnostics = validDetourContract.checkTopo(
+  test('passes for detours with an error constructor and callable recover', async () => {
+    const diagnostics = await validDetourContract.checkTopo(
       topo('valid-detour-contract', { validTrail })
     );
 
     expect(diagnostics).toEqual([]);
   });
 
-  test('flags detours with a non-constructor on value', () => {
+  test('flags detours with a non-constructor on value', async () => {
     const malformed = {
       ...validTrail,
       detours: [
         {
           on: 'ConflictError',
-          recover: () => Result.ok({ ok: true }),
+          recover: async () => Result.ok({ ok: true }),
         },
       ],
-    } as typeof validTrail;
+    } as unknown as typeof validTrail;
 
-    const diagnostics = validDetourContract.checkTopo(
+    const diagnostics = await validDetourContract.checkTopo(
       topo('invalid-on', { malformed } as Record<string, unknown>)
     );
 
@@ -46,7 +46,7 @@ describe('valid-detour-contract', () => {
     expect(diagnostics[0]?.message).toContain('error constructor');
   });
 
-  test('flags detours with a non-callable recover value', () => {
+  test('flags detours with a non-callable recover value', async () => {
     const malformed = {
       ...validTrail,
       detours: [
@@ -55,9 +55,9 @@ describe('valid-detour-contract', () => {
           recover: 'not callable',
         },
       ],
-    } as typeof validTrail;
+    } as unknown as typeof validTrail;
 
-    const diagnostics = validDetourContract.checkTopo(
+    const diagnostics = await validDetourContract.checkTopo(
       topo('invalid-recover', { malformed } as Record<string, unknown>)
     );
 
@@ -69,7 +69,7 @@ describe('valid-detour-contract', () => {
     expect(diagnostics[0]?.message).toContain('Result.err(...)');
   });
 
-  test('reports both issues when on and recover are malformed', () => {
+  test('reports both issues when on and recover are malformed', async () => {
     const malformed = {
       ...validTrail,
       detours: [
@@ -78,9 +78,9 @@ describe('valid-detour-contract', () => {
           recover: 'not callable',
         },
       ],
-    } as typeof validTrail;
+    } as unknown as typeof validTrail;
 
-    const diagnostics = validDetourContract.checkTopo(
+    const diagnostics = await validDetourContract.checkTopo(
       topo('invalid-contract', { malformed } as Record<string, unknown>)
     );
 

--- a/packages/warden/src/__tests__/wrap-rule.test.ts
+++ b/packages/warden/src/__tests__/wrap-rule.test.ts
@@ -10,9 +10,9 @@ describe('wrapRule', () => {
   test('copies built-in rule metadata into trail meta', () => {
     const wrapped = wrapRule({ examples: [], rule: noThrowInImplementation });
 
-    expect(wrapped.meta?.category).toBe('governance');
-    expect(wrapped.meta?.severity).toBe('error');
-    expect(wrapped.meta?.warden).toMatchObject({
+    expect(wrapped.meta?.['category']).toBe('governance');
+    expect(wrapped.meta?.['severity']).toBe('error');
+    expect(wrapped.meta?.['warden']).toMatchObject({
       lifecycle: { state: 'durable' },
       tier: 'source-static',
     });


### PR DESCRIPTION
## Summary

Clears ~25 pre-existing type errors in the Warden test suite that surface under `tsconfig.tests.json` (the test-aware editor/LSP config). These are test-only type-hygiene issues — the CI `tsc` gate uses the main config that excludes tests, so they never blocked CI, but they degraded the in-editor signal and masked real test-type drift. As the bottom branch of the Regrade Runway stack, this gives the whole stack a clean test typecheck.

## Changes

- `public-output-schema` / `public-union-output-discriminants`: narrow `checkTopo`'s synchronous-or-Promise return union in the `check` helper with a fail-loud `instanceof Promise` guard, so synchronous topo rules index cleanly.
- `valid-detour-contract` / `cli`: make detour `recover` `async` (the `Detour` type requires `Promise<Result<…>>`), cast deliberately-malformed fixtures via `as unknown as`, and `await` the union-returning `checkTopo`.
- `drift`: `seedSavedTopo` now returns a definite `string` (throws if the stored hash is missing) instead of `string | undefined`.
- `incomplete-accessor-for-standard-op`: widen crud-trail helper params to `AnyResource` (the class-based accessor fixtures are not assignable to `Resource<Connection>` under `exactOptionalPropertyTypes`), with an explanatory comment.
- `trail-versioning-rules`: correct the version example to the real `TrailExample` shape (`{ input, expected, name }`, not `{ input, output }`) and make `transpose.input` return the current input shape.
- `wrap-rule` / `trails`: index-signature access via brackets (`meta?.['x']`).

## Testing

`bunx tsc --noEmit -p tsconfig.tests.json` clean; full Warden suite green; CI green (8/8).

Test-only; no changeset.

---

Bottom of the Regrade Runway stack (base: `main`).
