### PR TITLE
refactor(regrade): narrow @ontrails/regrade package boundary (TRL-840)

### DIFF
--- a/.agents/plans/2026-05-28-regrade-runway-stack/GOAL.md
+++ b/.agents/plans/2026-05-28-regrade-runway-stack/GOAL.md
@@ -1,0 +1,19 @@
+# Goal Prompt: Regrade Runway Stack
+
+Paste this into the goal runtime when Matt says to run it:
+
+````text
+/goal Work from the current Trails checkout. Packet: .agents/plans/2026-05-28-regrade-runway-stack/. Objective: build the larger Regrade runway stack TRL-840 -> TRL-843 -> TRL-842 -> TRL-844 -> TRL-845 -> TRL-846 -> TRL-831 -> TRL-832 -> TRL-833 -> TRL-834 -> TRL-836 -> TRL-829, stopping with draft PRs/review-ready evidence, not merge.
+
+Hard preflight: read AGENTS.md, .agents/plans/PLANNING.md, packet PLAN/REFS/RETRO, and relevant Linear issues. Confirm PR #618 is merged, current branch is fresh main, `gt sync` is clean, `git status --short --branch` has no unexpected tracked changes, and `gt ls` starts from main. Leave unrelated untracked .agents/plans dirs alone. Use Graphite and exact branch names from PLAN.md. Commit this packet on the lowest branch TRL-840 when execution begins. Do not run from a detached Codex worktree. Use Claude-agent execution unless Matt explicitly redirects; Clark is doctrine support, not executor.
+
+Stack contract: first close Regrade post-tracer seams (package boundary, Warden internal-child warning, transformed-schema example typing); then build downstream root collection, selection/report shape, and Radio-shaped fixture; then add Warden fix metadata, term-rewrite metadata, safe `warden --fix`, Warden fix metadata ADR, Warden-backed term-rewrite Regrade integration, and final Regrade ADR. Regrade is Trails using Trails, not a new primitive. Warden owns detection; Regrade owns application/provenance/validation/review. `RegradeReport` is output/report shape, not contour. `term-rewrite` is durable wording; `vocab-cutover` is historical only.
+
+Subagents: use bounded high-reasoning workers for audits/design/reviews; they may edit/run tests/write reports but must not run git/gt/gh/Linear writes. Main executor owns branches, commits, PRs, tracker updates, review replies, and any merge mechanics.
+
+Validation: per branch run focused package checks named in PLAN.md. Before stack submission run `bun run typecheck`, `bun run test`, `bun run lint`, `bun run lint:ast-grep`, `bun run format:check`, `bun run check`, `git diff --check`; run Warden guide sync/check commands if generated Warden/agent guidance changes; run ADR map/check for ADR branches. Keep PRs draft until CI and local review are clean/P3-only.
+
+Review loop: at least three local review lanes over the stack; each returns score n/5, summary, P0/P1/P2/P3 findings, and Prompt To Fix. Fix P0/P1/P2 bottom-up on owning branches without `gt absorb`. After ready, handle at most three remote review rounds; target Greptile 5/5 and no Prompt-for-AI blocks; Greptile errors are blockers/incomplete review.
+
+Maintain RETRO.md continuously. Before final handoff, update branch/PR/Linear ledger, verification commands/results, review signals/scores, follow-ups, forbidden-action audit (no merge, no publish/registry, no merge queue label, no subagent source-control writes), remaining risks, and archive readiness. Update Linear issues and parents TRL-827/TRL-830 with PR links/status. Stop and ask/report if public doctrine/API shape must change, preflight is unsafe, validation fails for unrelated reasons after focused retry, source-control state is dirty/conflicted, or scope wants public CLI/package-source/publish work.
+````

--- a/.agents/plans/2026-05-28-regrade-runway-stack/PLAN.md
+++ b/.agents/plans/2026-05-28-regrade-runway-stack/PLAN.md
@@ -1,0 +1,270 @@
+# Regrade Runway Stack
+
+Date: 2026-05-28
+Repo: current Trails checkout
+Status: executed; stack submitted and reopened for follow-up review fixes on 2026-05-29
+
+## Objective
+
+Build the next larger Regrade runway as one coherent Graphite stack:
+
+1. Close the post-tracer framework/package seams.
+2. Extend Regrade into a downstream-ready engine with reportable coverage.
+3. Add Warden fix metadata and safe fix execution.
+4. Prove Regrade can consume Warden-owned `term-rewrite` metadata.
+5. Draft the Warden and Regrade doctrine after the evidence exists.
+
+This intentionally supersedes the narrower downstream-only packet at
+`.agents/plans/2026-05-28-regrade-downstream-stack/`.
+
+## Doctrine Frame
+
+- Regrade is Trails using Trails, not a new primitive.
+- Warden owns detection. Regrade owns application, provenance, validation, and
+  routed review.
+- Fix metadata belongs with Warden diagnostics, not in a parallel Regrade rule
+  database.
+- `term-rewrite` is the durable mechanism name. `vocab-cutover` is historical
+  wording only.
+- `RegradeReport` is a trail output/report object, not a contour.
+- Public `trails regrade`, package-source modes, and publishing are downstream
+  delivery work, not this runway stack.
+
+## Current State
+
+As of packet creation:
+
+- `main` is synced at `7cd714ff1`:
+  `test(regrade): harden generated fixture temp handling (#618)`.
+- PR #618 / TRL-841 is merged.
+- `git status --short --branch` shows current branch `main...origin/main` with
+  only untracked `.agents/plans/...` packet directories.
+- `gt ls` shows `main` current and the old TRL-841 branch as merged.
+- Linear shows the intended stack issues in Backlog:
+  `TRL-840`, `TRL-843`, `TRL-842`, `TRL-844`, `TRL-845`, `TRL-846`,
+  `TRL-831`, `TRL-832`, `TRL-833`, `TRL-834`, `TRL-836`, `TRL-829`.
+- Linear shows prerequisites done:
+  `TRL-823`, `TRL-819`, `TRL-825`, `TRL-841`.
+
+Do not sweep unrelated untracked packet directories into a commit unless the
+execution branch explicitly commits this packet.
+
+## Hard Preflight
+
+Before implementation:
+
+1. Confirm the current Trails checkout is on `main`.
+2. Run `gt sync` and confirm `git status --short --branch` has no unexpected
+   tracked changes.
+3. Confirm `gt ls` starts the new stack from `main`.
+4. Confirm PR #618 is merged.
+5. Confirm the issue list and branch names below still match Linear.
+6. Leave unrelated untracked `.agents/plans/...` dirs alone.
+7. Use a Claude agent for execution unless Matt explicitly redirects; do not
+   use Clark as the executor.
+
+Stop if any preflight item fails. Do not stack on an old merged branch or
+detached Codex worktree.
+
+## Stack Order
+
+Use Graphite and exact Linear branch names.
+
+| Order | Issue | Branch | Purpose |
+| --- | --- | --- | --- |
+| 1 | TRL-840 | `trl-840-harden-ontrailsregrade-package-boundary-before-public-use` | Narrow `@ontrails/regrade` root exports and fix runtime/dev dependency shape. |
+| 2 | TRL-843 | `trl-843-eliminate-regrade-tracer-dead-internal-trail-warden-warning` | Fix Regrade tracer happy-path Warden reachability warning without suppression. |
+| 3 | TRL-842 | `trl-842-fix-or-document-example-typing-for-transformed-input-schemas` | Settle transformed-schema example typing and revisit the tracer cast. |
+| 4 | TRL-844 | `trl-844-support-downstream-root-source-collection-for-regrade` | Add explicit downstream-root source collection substrate. |
+| 5 | TRL-845 | `trl-845-add-regrade-rule-selection-and-coverage-report-shape` | Add rule selection and `RegradeReport` coverage detail. |
+| 6 | TRL-846 | `trl-846-add-radio-shaped-downstream-regrade-regression-fixture` | Add stable Radio-shaped downstream fixture. |
+| 7 | TRL-831 | `trl-831-define-the-warden-fix-metadata-contract` | Define Warden fix metadata contract. |
+| 8 | TRL-832 | `trl-832-add-term-rewrite-fix-metadata-for-retired-vocabulary` | Add `term-rewrite` metadata for retired vocabulary. |
+| 9 | TRL-833 | `trl-833-implement-warden-fix-for-safe-source-edits` | Implement safe `warden --fix` source edits. |
+| 10 | TRL-834 | `trl-834-draft-warden-fix-metadata-adr` | Draft Warden fix metadata ADR. |
+| 11 | TRL-836 | `trl-836-integrate-warden-backed-term-rewrite-regrades` | Consume Warden-owned `term-rewrite` metadata from Regrade. |
+| 12 | TRL-829 | `trl-829-draft-regrade-adr-from-tracer-evidence` | Draft Regrade ADR after tracer/downstream/Warden evidence. |
+
+## Branch Contracts
+
+### TRL-840
+
+- Root `@ontrails/regrade` exports only intended public/package surface.
+- Internal child transform trails remain reachable through topo/composes, not
+  the root package barrel.
+- Schema exports either become deliberate public contract or move behind a
+  harness/internal path.
+- Test-only deps such as `@ontrails/topographer` move to dev dependencies unless
+  production Regrade code imports them.
+- Existing generated-fixture and tracer tests still pass.
+
+### TRL-843
+
+- Reproduce the Regrade `dead-internal-trail` warning if still present.
+- Fix the smallest layer: Warden object-form `composes`, tracer declaration, or
+  topo evidence flow.
+- Do not suppress Warden globally or add Regrade-specific exemptions.
+- Add focused coverage for internal child reachability through object-form
+  `composes` if that is the bug.
+
+### TRL-842
+
+- Decide whether examples for transformed input schemas type against raw schema
+  input, blaze input, or an explicit dual shape.
+- Prefer a tested type fix if small enough.
+- If not small, document the limitation with a focused type/runtime test.
+- `testExamples()` must continue feeding raw pre-transform input through
+  validation.
+
+### TRL-844 / TRL-845 / TRL-846
+
+- Keep work package/engine-level; no public CLI.
+- Accept an explicit downstream root.
+- Collect deterministic candidate source files and skipped entries/reasons.
+- Let rule/regrade-class selection run one class without executing all
+  available transforms.
+- Define `RegradeReport` with scanned/matched/rewritten/review/skipped counts
+  plus enough detail to debug omissions.
+- Add a stable Radio-shaped fixture in this repo; do not depend on the live
+  Radio checkout.
+
+### TRL-831 / TRL-832 / TRL-833
+
+- Add structured Warden fix metadata covering rule id, transform class, target
+  span/source edit, safety level, reason/migration note, and fixture/examples.
+- Keep metadata authored on or near the detecting rule.
+- Project fix availability through manifest/guide surfaces without a parallel
+  rule database.
+- `warden --fix` applies only safe fixes; unsafe/review-required findings remain
+  reported.
+- Include at least one safe source edit and one non-fixable diagnostic test.
+
+### TRL-834 / TRL-836 / TRL-829
+
+- Draft Warden fix metadata ADR before Regrade consumes the metadata.
+- Integrate Regrade with Warden-backed `term-rewrite` without duplicating
+  replacement mappings outside Warden.
+- Model rename-class outcomes as `Rewrite`, `NeedsReview`, no-op, or structured
+  failure.
+- Draft Regrade ADR last, after evidence from literal trails, downstream roots,
+  Warden metadata, and `term-rewrite` integration exists.
+
+## Non-Goals
+
+- Public `trails regrade` CLI (`TRL-828`).
+- Package-source modes, published target install, local tarball closure, or
+  delivery proof (`TRL-826` / `TRL-835`).
+- Publishing `@ontrails/regrade`.
+- Live Radio repo mutation.
+- Reopening canceled legacy `TRL-818`.
+- Solving every Warden diagnostic guidance issue outside `TRL-830`.
+- Adding a new Trails primitive for Regrade.
+
+## Subagent Policy
+
+Use subagents aggressively for bounded work:
+
+- current Regrade package boundary audit;
+- Warden reachability/root-cause audit;
+- transformed-example type design;
+- downstream-source/report-shape design;
+- Warden fix metadata design;
+- local review lanes.
+
+Execution subagents should use GPT-5.4 or better, high reasoning, no fast mode.
+Subagents may edit files, run tests, and write reports, but must not run `git`,
+`gt`, `gh`, or Linear write operations. The main executor owns source control,
+PRs, tracker mutation, and review-thread replies.
+
+Subagent briefs must name concrete files, issue IDs, and expected evidence.
+"Unable to verify" is acceptable; invented paths, line numbers, branch states,
+or issue claims are a hard failure.
+
+## Source Control
+
+- Use Graphite.
+- Use exact Linear branch names.
+- Commit this packet on the lowest branch (`TRL-840`) when execution begins.
+- Keep each branch focused on its issue.
+- Do not use `gt absorb`.
+- For review fixes, check out the owning branch, verify with
+  `git branch --show-current`, fix there, `gt modify`, restack/walk upward, and
+  rerun affected checks.
+- Submit PRs as draft first.
+- Do not merge, publish, mutate registry state, or add merge-queue labels unless
+  Matt explicitly authorizes it.
+
+## Validation Ladder
+
+Run focused checks per branch:
+
+- Regrade package work:
+  - `bun run --cwd packages/regrade typecheck`
+  - `bun test packages/regrade`
+  - `bun run --cwd packages/regrade lint` when source lint is touched
+- Core/type work:
+  - `bun run --cwd packages/core typecheck`
+  - focused core tests or type tests
+- Warden work:
+  - focused `packages/warden/src/__tests__/*.test.ts`
+  - `bun run --cwd packages/warden typecheck`
+  - `bun run --cwd packages/warden test`
+- ADR work:
+  - `bun scripts/adr.ts map`
+  - `bun scripts/adr.ts check`
+
+Before submitting the full stack:
+
+```bash
+bun run typecheck
+bun run test
+bun run lint
+bun run lint:ast-grep
+bun run format:check
+bun run check
+git diff --check
+```
+
+If Warden guide or generated agent guidance changes:
+
+```bash
+bun run warden:agents:sync
+bun run warden:skills:sync
+bun run warden:agents:check
+bun run warden:skills:check
+```
+
+## Review Protocol
+
+Before ready:
+
+- Run at least three local review lanes over the stack.
+- Each reviewer reports score `n/5`, summary, P0/P1/P2/P3 findings, and a
+  concise "Prompt To Fix With AI" for actionable findings.
+- Latest local review must be clean/P3-only before PRs leave draft.
+
+After ready:
+
+- Check CI, unresolved review threads, Greptile summaries, and bot/human review
+  comments after each meaningful push.
+- Target Greptile `5/5` with no "Prompt for AI" blocks.
+- Treat Greptile errors as incomplete review, not success.
+- Fix P0/P1/P2 bottom-up on owning branches.
+- After at most three post-ready review rounds, stop and report exact remaining
+  state if P2+ findings remain.
+
+## Completion Condition
+
+The goal is complete when:
+
+- Draft PRs exist for the stack, or a narrower stopped point is explicitly
+  justified in `RETRO.md`.
+- CI is green or every skipped check is justified.
+- Local review is clean/P3-only.
+- Remote review has no unresolved P0/P1/P2 issues after allowed rounds.
+- Linear issues and parents `TRL-827`, `TRL-830`, and `TRL-825`/`TRL-829`
+  context are current with PR links/status.
+- `RETRO.md` contains final branch/PR links, verification, review signals,
+  tracker state, forbidden-action audit, and remaining risks.
+
+Do not merge unless Matt explicitly authorizes merge.

--- a/.agents/plans/2026-05-28-regrade-runway-stack/REFS.md
+++ b/.agents/plans/2026-05-28-regrade-runway-stack/REFS.md
@@ -1,0 +1,92 @@
+# References: Regrade Runway Stack
+
+## Tracked / Portable Sources
+
+- `AGENTS.md` - repo workflow, Graphite, Trails rules, Warden guide, subagent constraints.
+- `.agents/plans/PLANNING.md` - goal packet conventions, no `gt absorb`, review protocol, validation ladder.
+- `packages/regrade/src/index.ts` - current root export leak for internal child trail/schema harness.
+- `packages/regrade/src/literal-transform.ts` - literal Regrade tracer implementation and transformed-input example cast.
+- `packages/regrade/src/__tests__/literal-transform.test.ts` - topo/surface proof for parent and internal child trails.
+- `packages/regrade/src/__tests__/generated-fixture.test.ts` - package-consumer fixture proof hardened by PR #618.
+- `packages/regrade/package.json` - current private package boundary and dependency shape.
+- `packages/warden/src/rules/types.ts` - current Warden metadata, guidance, diagnostic, and rule types.
+- `packages/warden/src/rules/metadata.ts` - built-in Warden rule metadata registry.
+- `packages/warden/src/guide.ts` - Warden guide/manifest projection path.
+- `packages/warden/src/cli.ts` and `packages/warden/src/command.ts` - current Warden runner/CLI command paths.
+- `docs/adr/README.md` and `docs/adr/drafts/README.md` - ADR authoring locations.
+
+## Adjacent Local Sources
+
+- Trailblazing Regrade planning spine - canonical external planning context summarized in `PLAN.md`; not copied wholesale.
+
+## Prior Plans
+
+- `.agents/plans/2026-05-27-regrade-tracer-stack/` - prior proof stack that landed `TRL-823`, `TRL-819`, `TRL-825`; its retro is evidence for post-tracer follow-ups.
+- `.agents/plans/2026-05-27-regrade-framework-seams-stack/` - stale broad packet superseded by this packet because it still gates on old PR #610 and includes TRL-841 handling.
+- `.agents/plans/2026-05-28-regrade-downstream-stack/` - narrower downstream-only packet superseded by this larger runway stack.
+- `.agents/plans/2026-05-26-radio-compose-proof/` - Radio compose proof context; do not mutate unless the execution needs to cite it in TRL-846 text.
+
+## Tracker Records
+
+| Issue | Status at planning | Branch | Role |
+| --- | --- | --- | --- |
+| TRL-840 | Backlog | `trl-840-harden-ontrailsregrade-package-boundary-before-public-use` | Regrade package boundary. |
+| TRL-843 | Backlog | `trl-843-eliminate-regrade-tracer-dead-internal-trail-warden-warning` | Warden object-form compose/reachability seam. |
+| TRL-842 | Backlog | `trl-842-fix-or-document-example-typing-for-transformed-input-schemas` | Transformed-schema example typing. |
+| TRL-827 | Backlog | `trl-827-support-downstream-roots-rule-selection-and-coverage` | Parent for downstream root/report/fixture. |
+| TRL-844 | Backlog | `trl-844-support-downstream-root-source-collection-for-regrade` | Downstream root source collection. |
+| TRL-845 | Backlog | `trl-845-add-regrade-rule-selection-and-coverage-report-shape` | Rule selection and coverage report shape. |
+| TRL-846 | Backlog | `trl-846-add-radio-shaped-downstream-regrade-regression-fixture` | Radio-shaped downstream fixture. |
+| TRL-830 | Backlog | `trl-830-define-warden-fix-metadata-and-safe-fix-execution` | Parent for Warden fix metadata/safe fix execution. |
+| TRL-831 | Backlog | `trl-831-define-the-warden-fix-metadata-contract` | Warden fix metadata contract. |
+| TRL-832 | Backlog | `trl-832-add-term-rewrite-fix-metadata-for-retired-vocabulary` | `term-rewrite` fix metadata. |
+| TRL-833 | Backlog | `trl-833-implement-warden-fix-for-safe-source-edits` | Safe `warden --fix`. |
+| TRL-834 | Backlog | `trl-834-draft-warden-fix-metadata-adr` | Warden fix metadata ADR. |
+| TRL-836 | Backlog | `trl-836-integrate-warden-backed-term-rewrite-regrades` | Regrade consumes Warden metadata. |
+| TRL-829 | Backlog | `trl-829-draft-regrade-adr-from-tracer-evidence` | Regrade ADR. |
+
+Completed prerequisites observed:
+
+- `TRL-823` - packed manifest stale beta check.
+- `TRL-819` - `ctx.compose(trail, input)` inference without `composeInput`.
+- `TRL-825` - literal Regrade transform tracer.
+- `TRL-841` / PR #618 - generated-fixture temp handling.
+
+Deferred/out-of-goal:
+
+- `TRL-826` - package-source modes.
+- `TRL-828` - public `trails regrade` and `NeedsReview` routing.
+- `TRL-835` - `trails warden --help` and hook-integrity package mode triage.
+- `TRL-838` - packed manifest integration coverage.
+
+## PRs / Branches
+
+- PR #618 - merged at 2026-05-28T23:26:27Z; merge commit `7cd714ff1ea0efb3ac9b591088932347aebbe1bf`.
+- Current branch at planning: `main`.
+- Old local branch `trl-841-harden-regrade-generated-fixture-temp-directory-handling` remains in `gt ls` as merged; do not stack on it.
+
+## Validation Commands
+
+- `bun run --cwd packages/regrade typecheck` - Regrade package typecheck.
+- `bun test packages/regrade` - Regrade package tests.
+- `bun run --cwd packages/regrade lint` - Regrade package lint when source lint is relevant.
+- `bun run --cwd packages/core typecheck` - core type surface check for transformed example typing.
+- `bun run --cwd packages/warden typecheck` - Warden package typecheck.
+- `bun run --cwd packages/warden test` - Warden package tests.
+- `bun scripts/adr.ts map` - ADR map generation/check input for ADR branches.
+- `bun scripts/adr.ts check` - ADR consistency check.
+- `bun run typecheck` - repo typecheck.
+- `bun run test` - repo tests.
+- `bun run lint` - repo lint.
+- `bun run lint:ast-grep` - AST-grep lint gate.
+- `bun run format:check` - formatting gate.
+- `bun run check` - full repo check.
+- `git diff --check` - whitespace and patch sanity.
+
+Run Warden guide sync/check commands if generated Warden or agent guide content
+changes:
+
+- `bun run warden:agents:sync`
+- `bun run warden:skills:sync`
+- `bun run warden:agents:check`
+- `bun run warden:skills:check`

--- a/.agents/plans/2026-05-28-regrade-runway-stack/RETRO.md
+++ b/.agents/plans/2026-05-28-regrade-runway-stack/RETRO.md
@@ -1,0 +1,151 @@
+# Execution Retro: Regrade Runway Stack
+
+Date started: 2026-05-28
+Date finalized: 2026-05-29; refreshed during third-pass review hygiene on 2026-05-29
+Status: executed — 9 planned issues built + 2 inserted hygiene branches, local review loop complete, and Graphite stack submitted. TRL-834/836/829 deferred (not in this stack). Third-pass follow-up fixes are applied, final local verification passed, and the stack is prepared for final resubmit.
+Plan: `.agents/plans/2026-05-28-regrade-runway-stack/PLAN.md`
+Goal: `.agents/plans/2026-05-28-regrade-runway-stack/GOAL.md`
+
+Use this as the durable execution ledger. For stacked work, this should normally
+be the last meaningful file touched before local completion, draft submission,
+ready-for-review, remote review closeout, merge readiness, archive, or final
+handoff. Meaningful review-flow changes require a new retro entry.
+
+## Execution Summary
+
+- Objective: build the larger Regrade runway stack from post-tracer seams
+  through downstream engine, Warden fix metadata, Warden-backed `term-rewrite`,
+  and ADR doctrine.
+- Final outcome: Downstream regrade engine + Warden fix-metadata trio (831/832/833) delivered. Two CI-only latent bugs surfaced by the full ladder and fixed: (a) `apps/trails` warden-guide output schema drift after TRL-831 added manifest `fix` metadata (fixed on TRL-831 by exporting `wardenFixClasses`/`wardenFixSafeties` + adding the `fix` field to the app schema); (b) the TRL-846 fixture `dist/` was gitignored repo-wide so it never reached CI (fixed by committing it as `dist-guard/` with a runtime rename to `dist`). A bottom-of-stack `warden-tests-type-hygiene` branch (#619) was inserted to clear ~25 pre-existing `tsconfig.tests.json` baseline errors.
+- Final branch / stack tip: `trl-833-implement-warden-fix-for-safe-source-edits` (12 commits over main incl. the vocab-audit base branch and warden test-hygiene branch).
+- Final PR range: #632 inserted under #619, then #619–#628 chained main → #632 → #619 → #620(840) → #621(843) → #622(842) → #623(844) → #624(845) → #625(846) → #626(831) → #627(832) → #628(833).
+- Final tracker state: Linear NOT updated (deferred per instruction).
+- Final verification state: build, full tests, `bun run check`, package publish checks, and focused third-pass checks passed locally after accepted review fixes. `bun run check` now reports 0 Warden errors and the three existing demo signal warnings.
+- Remaining risks / P3s: term-rewrite classifier matches raw text incl. comments/strings (now documented + pinned by a test; lexer-aware exclusion deferred to TRL-832/836). No open P0/P1/P2 after second-pass local Regrade and Warden review or third-pass final predicate recheck. Rejected P3 (gratuitous `await`) recorded below with evidence.
+- Archive state: not archived; stack in review.
+
+## Branch / PR / Issue Ledger
+
+| Order | Issue | Branch | PR | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| -1 | (none) | `chore/vocab/audit-allowlist-bootstrap-cleanup` | #632 | submitted/ready, final resubmit prepared | Inserted under the stack on 2026-05-29 to refresh vocab-audit allowlists and hold the local review-loop packet. |
+| 0 | (none) | `warden-tests-type-hygiene` | #619 | submitted/ready, final resubmit prepared | Inserted bottom-of-stack: cleared ~25 pre-existing `tsconfig.tests.json` baseline errors across 9 warden test files. Test-only; no changeset. |
+| 1 | TRL-840 | `trl-840-harden-ontrailsregrade-package-boundary-before-public-use` | #620 | submitted/ready, final resubmit prepared | Regrade root barrel narrowed; topographer → devDependencies. Holds packet + this RETRO. |
+| 2 | TRL-843 | `trl-843-eliminate-regrade-tracer-dead-internal-trail-warden-warning` | #621 | submitted/ready, final resubmit prepared | dead-internal-trail union fix. Changeset: `@ontrails/warden` patch. |
+| 3 | TRL-842 | `trl-842-fix-or-document-example-typing-for-transformed-input-schemas` | #622 | submitted/ready, final resubmit prepared | z.input/z.infer typing for transformed-input example. |
+| 4 | TRL-844 | `trl-844-support-downstream-root-source-collection-for-regrade` | #623 | submitted/ready, final resubmit prepared | Downstream collect + never-throw walk. Review: scratch → tmpdir(); third pass normalized relative roots. |
+| 5 | TRL-845 | `trl-845-add-regrade-rule-selection-and-coverage-report-shape` | #624 | submitted/ready, final resubmit prepared | Selection + `RegradeReport`. Review: raw-text matching doc+test; scratch → tmpdir(); third pass renamed synthetic preview mapping. |
+| 6 | TRL-846 | `trl-846-add-radio-shaped-downstream-regrade-regression-fixture` | #625 | submitted/ready, final resubmit prepared | Radio fixture. CI-fix: `dist/` gitignored → committed as `dist-guard/` + runtime rename. |
+| 7 | TRL-831 | `trl-831-define-the-warden-fix-metadata-contract` | #626 | submitted/ready, final resubmit prepared | Fix-metadata contract + guide projection. CI-fix: app warden-guide schema + `wardenFixClasses/Safeties` exports. Changeset: `@ontrails/warden` minor + `@ontrails/trails` patch. |
+| 8 | TRL-832 | `trl-832-add-term-rewrite-fix-metadata-for-retired-vocabulary` | #627 | submitted/ready, final resubmit prepared | term-rewrite metadata on no-legacy-layer-imports (review, no edits). Changeset: `@ontrails/warden` patch. |
+| 9 | TRL-833 | `trl-833-implement-warden-fix-for-safe-source-edits` | #628 | submitted/ready, final resubmit prepared | Safe `warden --fix` executor + CLI. Review: doc fix + overlap test; third pass hardened edit offsets, report filtering, drift blocking, app flag projection, app write intent, and explicit public access. Changeset: `@ontrails/warden` minor + `@ontrails/trails` patch. |
+| 10 | TRL-834 | `trl-834-draft-warden-fix-metadata-adr` |  | deferred | Warden ADR — not in this stack. |
+| 11 | TRL-836 | `trl-836-integrate-warden-backed-term-rewrite-regrades` |  | deferred | Regrade consumes Warden metadata — not in this stack. |
+| 12 | TRL-829 | `trl-829-draft-regrade-adr-from-tracer-evidence` |  | deferred | Regrade ADR — not in this stack. |
+
+## Planning Discoveries
+
+| Discovery | Evidence | Decision | Impact |
+| --- | --- | --- | --- |
+| PR #618 is merged and `main` is synced. | `gt sync`; `git log -1 --oneline`; `gh pr view 618` showed merged at 2026-05-28T23:26:27Z. | Remove the old #618 preflight gate from the active goal. | Stack can start from `main` after preflight. |
+| The older broad packet is stale. | `.agents/plans/2026-05-27-regrade-framework-seams-stack/PLAN.md` still gates on #610 and includes now-completed TRL-841 path. | Seed a new packet rather than mutate the stale one. | Executor gets current branch order and live state. |
+| Narrow downstream packet is too small for Matt's requested larger stack. | `.agents/plans/2026-05-28-regrade-downstream-stack/PLAN.md` only covers TRL-844/845/846. | Supersede it with this runway stack. | Keeps downstream slice but adds package/Warden/ADR runway. |
+| Package-source modes and public CLI are still premature. | Trailblazing Regrade spine and Linear TRL-826/828 descriptions. | Keep TRL-826/828 out of this stack. | Avoids delivery UX before engine/report/Warden integration hardens. |
+| Codex `blazer` session stopped correctly. | cmux `blazer` scrollback and downstream RETRO. | Do not reuse it as executor; prefer Claude agent when Matt starts the goal. | Prevents repeating the wrong-worker-lane mistake. |
+
+## Deferred / Follow-Up Discoveries
+
+| Issue | Discovery | Why Out Of Goal | Link |
+| --- | --- | --- | --- |
+| TRL-826 | Package-source modes and local tarball/published target proof. | Needs downstream engine/report first and delivery proof scope. | <https://linear.app/outfitter/issue/TRL-826/prove-regrade-package-source-modes> |
+| TRL-828 | Public `trails regrade` and `NeedsReview` CLI routing. | Should follow engine/report/Warden integration, not lead it. | <https://linear.app/outfitter/issue/TRL-828/implement-trails-regrade-and-needsreview-routing> |
+| TRL-835 | `trails warden --help` / hook-integrity package mode triage. | Adjacent delivery integrity work, not engine runway. | <https://linear.app/outfitter/issue/TRL-835/triage-trails-warden-help-and-hook-integrity-package-mode> |
+| TRL-838 | Integration coverage for packed manifest mismatch checks. | P3 release coverage, not central to Regrade runway. | <https://linear.app/outfitter/issue/TRL-838/add-integration-coverage-for-packed-first-party-dependency-mismatch> |
+
+## Tracker Mutations
+
+| Time | Tracker Item | Mutation | Evidence |
+| --- | --- | --- | --- |
+| 2026-05-28 planning | Linear issues | Read current state only; no tracker writes during packet prep. | Linear fetch/list for TRL-840/843/842/844/845/846/831/832/833/834/836/829. |
+
+## Initial Planning Snapshot
+
+```text
+2026-05-28 19:34 EDT - planning seed
+- Changed: created .agents/plans/2026-05-28-regrade-runway-stack/.
+- Verified: main synced at #618 merge commit; relevant Linear issue state; old broad/narrow Regrade packets; Trailblazing Regrade spine; current packages/regrade and packages/warden shapes.
+- Historical result at packet creation: packet seeded, not yet run.
+- Superseded next step: wait for Matt to launch the goal with the pasteable prompt.
+- Blockers: none for planning; execution intentionally paused.
+
+2026-05-28 19:40 EDT - packet self-check
+- Verified: `GOAL.md` pasteable prompt is 3,243 characters; `retro-check.sh` passes in non-final mode; repo status still shows `main...origin/main` with only untracked packet directories.
+- Historical result at packet handoff: packet ready; goal not yet run.
+```
+
+## Local Review Log
+
+| Round | Scope / Lanes | Report Paths | P0/P1/P2 Result | Fix Commits / Notes |
+| --- | --- | --- | --- | --- |
+| 1 (2026-05-29) | 3 parallel read-only Claude Code subagent lanes over the full 10-PR stack: (A) regrade engine + fixture, (B) warden fix-metadata + cross-package, (C) test-hygiene + changesets + ownership. | Inline subagent reports (transcript); summarized in Review Feedback Resolutions below. | Lane scores 4/5, 5/5, 5/5. 0 P0, 0 P1, 1 P2, 5 P3 (1 rejected). All P0–P2 resolved before ready. | Fixes amended on owning branches: P2 doc+test on TRL-845; P3 comment+overlap-test on TRL-833; P3 temp-dir on TRL-844/845; P3 AnyResource comment on #619. Rejected P3 (gratuitous await) recorded with evidence. |
+| 2 (2026-05-29) | Regrade, Warden, test hygiene, and Clark contract review lanes over the locally changed stack after inserting the vocab-audit base branch. | `.agents/plans/2026-05-29-regrade-runway-review-loop/RETRO.md`. | Accepted P1/P2 findings fixed on owning branches; second-pass Regrade and Warden lanes reported no P0-P2. | Key fixes: mixed whole-word/partial term rewrite review routing (TRL-845), package-boundary comment/id cleanup (TRL-840/843), safe-fix scanned-file guard + fix output coverage (TRL-833), agent-guide fix metadata (TRL-831/832), and Warden-traceable report validation (TRL-845). |
+| 3 (2026-05-29) | Fresh Regrade, Warden, Clark contract, and stack-hygiene lanes after stale subagents were closed. | `.agents/plans/2026-05-29-regrade-runway-review-loop/RETRO.md`. | Accepted P2/P3 findings fixed bottom-up. Greptile could not review because the account-level free trial had ended, so it is not counted as a clean remote-review signal. | Fixes landed on TRL-844, TRL-845, TRL-833, the inserted vocab-audit base branch, and this packet branch. |
+| 4 (2026-05-29) | Final predicate-only recheck after accepted fixes. | Inline final subagent report; summarized in `.agents/plans/2026-05-29-regrade-runway-review-loop/RETRO.md`. | No P0-P3 findings. One local final-check warning was then fixed before resubmit. | Confirmed Warden write intent, `@ontrails/trails` changeset coverage, historical packet wording, and clean local stack pending submit. Final `trails warden` warning from the write-intent change was resolved by declaring explicit public access. |
+
+## Verification Log
+
+| Check | Scope | Result | Evidence / Notes |
+| --- | --- | --- | --- |
+| `gt sync` | planning | pass | Repo synced; current branch moved to `main`. |
+| `git status --short --branch` | planning | pass with caveat | `main...origin/main`; only untracked planning dirs. |
+| `gt ls` | planning | pass | `main` current; old TRL-841 branch marked merged. |
+| `gh pr view 618` | planning | pass | PR #618 merged. |
+| Linear issue fetch/list | planning | pass | Current issue states captured in `REFS.md`. |
+| `awk` prompt length check | planning | pass | Pasteable prompt in `GOAL.md` is 3,243 characters. |
+| `retro-check.sh RETRO.md` | planning | pass | Required retro sections exist; final-mode intentionally not applicable before execution. |
+
+## Remote Review / CI Log
+
+| Time | PR | CI State | Review State | Scores / Signals | Unresolved P0/P1/P2 | Action |
+| --- | --- | --- | --- | --- | --- | --- |
+|  |  |  |  |  |  |  |
+
+## Review Feedback Resolutions
+
+| Source | Score / Signal | Severity | Finding | Prompt To Fix | Resolution | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| Local review lane A | 4/5 | P2 | `createTermRewriteClass` matches raw text incl. comments/strings; lexer-unaware; undocumented + unpinned. Fixture wording masked it. (TRL-845) | Document raw-text matching; add a test pinning a comment occurrence → rewrite; note deferral to TRL-832/836. | Fixed on TRL-845: extended TSDoc on `createTermRewriteClass` + added `report.test.ts` test "matches raw text: a whole-word term in a comment is rewritten". | `packages/regrade/src/downstream/report.ts` TSDoc; `report.test.ts` new test (regrade suite 28/28). |
+| Local review lane B | 5/5 | P3 | `applySafeFixesToFiles` body comment wrongly said topo diagnostics are counted as skipped (they are not). (TRL-833) | Correct the comment: only fix-bearing-but-unsafe diagnostics are skipped; no-fix/topo are excluded from the count. | Fixed on TRL-833: corrected the doc comment; behavior unchanged. | `packages/warden/src/cli.ts` `applySafeFixesToFiles` doc. |
+| Local review lane B | 5/5 | P3 | Overlap-detection `RangeError` branch in `applyEdits` untested. (TRL-833) | Add a test for overlapping safe edits. | Fixed on TRL-833: added "throws on overlapping safe edits" test (fix.test.ts 7/7). | `packages/warden/src/__tests__/fix.test.ts`. |
+| Local review lane A | 4/5 | P3 | `report.test.ts`/`collect.test.ts` scratch dirs under package tree, contradicting radio-fixture's documented OS-temp-root safety rationale. (TRL-844/845) | Move scratch to `tmpdir()`. | Fixed on TRL-844 (collect.test.ts) and TRL-845 (report.test.ts): `mkdtempSync(join(tmpdir(), 'regrade-…'))`. | Both helpers now use `tmpdir()`; regrade suites green. |
+| Local review lane C | 5/5 | P3 | `AnyResource` widening on crud-trail helpers loses type precision. (#619) | Restore narrow type if it type-checks, else leave + comment. | Kept (widening is required by `exactOptionalPropertyTypes` for the class-based fixture) + added explanatory comment. | `incomplete-accessor-for-standard-op.test.ts` comment. |
+| Local review lane C | 5/5 | P3 — REJECTED | Claimed `await checkTopo(...)` is gratuitous in valid-detour-contract/cli tests. | Drop the `await`. | Rejected: `TopoAwareWardenRule.checkTopo` returns a `readonly WardenDiagnostic[]`-or-`Promise` union and the rule is exported `: TopoAwareWardenRule`, so the`await` resolves the union for `[0]` indexing; dropping it re-breaks TS7053. No change. | `packages/warden/src/rules/types.ts:322`; `valid-detour-contract.ts:70` `: TopoAwareWardenRule`. |
+
+## Forbidden Actions Audit
+
+| Action / Constraint | Status | Evidence |
+| --- | --- | --- |
+| No merge without explicit user approval | respected | PRs were created and updated, but no branch was merged. |
+| No package publish / registry mutation unless authorized | respected | No publish commands run; `publish:check` was dry-run verification only. |
+| No merge queue label unless authorized | respected | No merge queue labels added. |
+| No source-control writes by subagents | respected | Subagents were briefed as read-only for source control; the main agent handled Graphite writes. |
+| No goal execution before explicit start | respected | Execution began only after Matt said to proceed. |
+| No Clark executor use | respected | Clark was used only as a review/contract lane, not as the source-control executor. |
+
+## Final State
+
+- Goal completion condition: initial execution complete; third-pass review fixes applied locally and prepared for final resubmit.
+- Graphite / branch state: stack remains ordered from inserted #632 through #628.
+- PR state: #632 and #619-#628 exist; final third-pass submit prepared at this checkpoint.
+- Source-control host lag: Graphite/GitHub state should be refreshed after final submit.
+- Tracker state: Linear issue updates deferred.
+- Local review state: three local review rounds complete; accepted P2/P3 findings fixed.
+- Remote review state: GitHub CI previously green; Greptile unavailable due account-level trial limit.
+- Remote review scores: Greptile score unavailable; local subagent findings are recorded in the review-loop retro.
+- Verification: focused third-pass Regrade/Warden checks, final predicate recheck, build, full tests, `bun run check`, and `bun run publish:check` passed. `bun trails warden` passed after explicit public access removed the new permit-governance warning.
+- Skipped checks: none intentionally skipped in the final pass.
+- Remaining P3s / risks: Greptile unavailable unless account access is restored; term-rewrite lexical refinement remains deferred.
+- Follow-up issues created: none in this pass.
+- Forbidden actions confirmation: no merge, package publish, registry mutation, merge queue label, or subagent source-control write.
+- Packet archive readiness: not archived; stack remains in review.
+- Final transcript proof: this retro plus `.agents/plans/2026-05-29-regrade-runway-review-loop/RETRO.md`.

--- a/packages/regrade/package.json
+++ b/packages/regrade/package.json
@@ -17,10 +17,10 @@
   },
   "dependencies": {
     "@ontrails/core": "workspace:^",
-    "@ontrails/topographer": "workspace:^",
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@ontrails/testing": "workspace:^"
+    "@ontrails/testing": "workspace:^",
+    "@ontrails/topographer": "workspace:^"
   }
 }

--- a/packages/regrade/src/__tests__/literal-transform.test.ts
+++ b/packages/regrade/src/__tests__/literal-transform.test.ts
@@ -30,6 +30,9 @@ describe('literal Regrade transform tracer', () => {
       (entry) => entry.id
     );
     expect(surfaceIds).toContain(literalRegradeTrail.id);
+    expect(normalizeExportConstTrail.id).toBe(
+      'regrade.literal.normalize-export-const'
+    );
     expect(surfaceIds).not.toContain(normalizeExportConstTrail.id);
 
     const topoGraph = deriveTopoGraph(literalRegradeTopo);

--- a/packages/regrade/src/index.ts
+++ b/packages/regrade/src/index.ts
@@ -1,7 +1,10 @@
+// Root package surface for `@ontrails/regrade`.
+//
+// Only the runnable graph and its public parent trail are exported here. The
+// internal child transform trail stays reachable through the topo and the
+// parent's `composes` declaration. The transform schemas remain internal
+// package test harness details until Regrade has a deliberate public contract.
 export {
   literalRegradeTopo,
   literalRegradeTrail,
-  normalizeExportConstTrail,
-  regradeTransformInput,
-  regradeTransformOutput,
 } from './literal-transform.js';

--- a/packages/regrade/src/literal-transform.ts
+++ b/packages/regrade/src/literal-transform.ts
@@ -16,7 +16,7 @@ const childInput = z.object({
 });
 
 export const normalizeExportConstTrail = trail(
-  'regrade.literal.normalizeExportConst',
+  'regrade.literal.normalize-export-const',
   {
     blaze: (input) => {
       const nextSource = input.source.replaceAll('export const', 'export let');


### PR DESCRIPTION
## Summary

Hardens the `@ontrails/regrade` package boundary before any public use: the root barrel now exports only the topo and the public parent trail, and `@ontrails/topographer` moves to `devDependencies` (it is used only by tests). This keeps the not-yet-public package's surface intentional rather than incidental. Also lands the Regrade Runway stack planning packet (GOAL/PLAN/REFS) and the durable execution RETRO.

## Changes

- `packages/regrade/src/index.ts`: narrow the root barrel to the topo + public parent trail; drop internal literal-transform helpers from the public surface.
- `packages/regrade/package.json`: move `@ontrails/topographer` to `devDependencies` (test-only).
- `.agents/plans/2026-05-28-regrade-runway-stack/`: stack planning packet + execution RETRO (the review/verification ledger for the whole stack).

## Testing

`@ontrails/regrade` typecheck + tests green; no external consumer imported the removed helpers. CI green (8/8).

`@ontrails/regrade` is `private`, so no changeset.

---

Stack base: #619. Linear: [TRL-840](https://linear.app/outfitter/issue/TRL-840).
