### PR TITLE
fix(warden): union local compose evidence in dead-internal-trail (TRL-843)

### DIFF
--- a/.changeset/trl-843-regrade-tracer-dead-internal.md
+++ b/.changeset/trl-843-regrade-tracer-dead-internal.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Fix a false `dead-internal-trail` warning by unioning file-local compose evidence with the project-context compose set, so same-file composition in scanned-but-unregistered packages is recognized.

--- a/packages/warden/src/__tests__/dead-internal-trail.test.ts
+++ b/packages/warden/src/__tests__/dead-internal-trail.test.ts
@@ -53,6 +53,37 @@ trail('entity.sync', {
     expect(diagnostics).toEqual([]);
   });
 
+  test('stays quiet when the internal trail is composed in-file but the project context omits it', () => {
+    // Mirrors the regrade tracer case (TRL-843): the project context only
+    // collects compose edges from registered app topos, so a package that is
+    // scanned but not part of any registered topo contributes a non-empty
+    // context set that nonetheless omits its own same-file compose edge. The
+    // rule must union the file-local compose evidence with the context set
+    // instead of preferring the incomplete context set.
+    const code = `
+const normalizeExportConstTrail = trail('regrade.literal.normalize-export-const', {
+  visibility: 'internal',
+  blaze: async () => Result.ok({}),
+});
+
+const literalRegradeTrail = trail('regrade.literal.run', {
+  composes: [normalizeExportConstTrail],
+  blaze: async (_input, ctx) => ctx.compose(normalizeExportConstTrail, {}),
+});
+`;
+
+    const diagnostics = deadInternalTrail.checkWithContext(code, TEST_FILE, {
+      // Non-empty, but omits the internal child id — exactly the topo-path gap.
+      composeTargetTrailIds: new Set(['some.other.trail']),
+      knownTrailIds: new Set([
+        'regrade.literal.run',
+        'regrade.literal.normalize-export-const',
+      ]),
+    });
+
+    expect(diagnostics).toEqual([]);
+  });
+
   test('stays quiet when the internal trail has on: activation', () => {
     const code = `
 trail('entity.audit', {

--- a/packages/warden/src/rules/dead-internal-trail.ts
+++ b/packages/warden/src/rules/dead-internal-trail.ts
@@ -127,11 +127,24 @@ export const deadInternalTrail: ProjectAwareWardenRule = {
     const localComposeTargetTrailIds = ast
       ? collectComposeTargetTrailIds(ast, sourceCode)
       : new Set<string>();
+    // Union project-wide compose evidence with the file-local evidence rather
+    // than preferring one over the other. The project context only collects
+    // compose edges from registered app topos, so a trail defined in a package
+    // that is scanned but not part of any registered topo (e.g. an internal
+    // child composed in its own module) would be absent from the context set
+    // yet present in the local set. Preferring the context set alone produced a
+    // false dead-internal-trail warning for those same-file compositions.
+    const composeTargetTrailIds = context.composeTargetTrailIds
+      ? new Set<string>([
+          ...context.composeTargetTrailIds,
+          ...localComposeTargetTrailIds,
+        ])
+      : localComposeTargetTrailIds;
     return checkDeadInternalTrails(
       ast,
       sourceCode,
       filePath,
-      context.composeTargetTrailIds ?? localComposeTargetTrailIds
+      composeTargetTrailIds
     );
   },
   description:


### PR DESCRIPTION
## Summary

Fixes a false `dead-internal-trail` Warden warning. The project-context pass only collected `ctx.compose()` edges from registered app topos, so a trail composed within a scanned-but-unregistered package looked unreachable. The rule now unions file-local compose evidence with the project-context compose set.

## Changes

- `packages/warden/src/rules/dead-internal-trail.ts`: union the file-local `ctx.compose()` targets with `context.composeTargetTrailIds` before deciding reachability.
- `dead-internal-trail.test.ts`: regression coverage for the same-file compose case.

## Testing

Warden suite green; the spurious regrade tracer warning is gone (repo-wide Warden 4 → 3 warnings). CI green (8/8).

Changeset: `@ontrails/warden` patch.

---

Stack base: #620. Linear: [TRL-843](https://linear.app/outfitter/issue/TRL-843).
