### PR TITLE
refactor(regrade): make transformed-input example typing honest (TRL-842)

### DIFF
--- a/packages/regrade/src/__tests__/literal-transform.test.ts
+++ b/packages/regrade/src/__tests__/literal-transform.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { executeTrail, filterSurfaceTrails } from '@ontrails/core';
+import {
+  executeTrail,
+  filterSurfaceTrails,
+  validateInput,
+} from '@ontrails/core';
 import { testExamples } from '@ontrails/testing';
 import { deriveTopoGraph } from '@ontrails/topographer';
 
@@ -18,11 +22,13 @@ describe('literal Regrade transform tracer', () => {
     );
 
     expect(result.isOk()).toBe(true);
-    expect(result.value).toEqual({
-      changed: true,
-      nextSource: 'export let answer = 41;',
-      notes: ['Rewrote export const declarations to export let.'],
-    });
+    if (result.isOk()) {
+      expect(result.value).toEqual({
+        changed: true,
+        nextSource: 'export let answer = 41;',
+        notes: ['Rewrote export const declarations to export let.'],
+      });
+    }
   });
 
   test('keeps internal transform trails off surfaces while retaining topo evidence', () => {
@@ -48,6 +54,36 @@ describe('literal Regrade transform tracer', () => {
     expect(parent?.exampleCount).toBe(1);
     expect(child?.kind).toBe('trail');
     expect(child?.surfaces).toEqual([]);
+  });
+});
+
+describe('transformed input schema validation (TRL-842)', () => {
+  test('validates raw pre-transform input and projects it to blaze input', () => {
+    // The parent trail's input schema is a `.transform()` schema. Examples and
+    // testExamples() feed RAW pre-transform input ({ source }); validation must
+    // accept it and project it into the post-transform blaze input
+    // ({ child: { source } }). This pins the runtime contract that the
+    // type-level divergence documented in literal-transform.ts depends on.
+    const validated = validateInput(literalRegradeTrail.input, {
+      source: 'export const answer = 41;',
+    });
+
+    expect(validated.isOk()).toBe(true);
+    if (validated.isOk()) {
+      expect(validated.value).toEqual({
+        child: { source: 'export const answer = 41;' },
+      });
+    }
+  });
+
+  test('rejects input missing the raw pre-transform field', () => {
+    const validated = validateInput(literalRegradeTrail.input, {
+      // Post-transform shape is NOT valid raw input — the schema expects
+      // `source`, proving validation runs against the raw input contract.
+      child: { source: 'export const answer = 41;' },
+    });
+
+    expect(validated.isErr()).toBe(true);
   });
 });
 

--- a/packages/regrade/src/literal-transform.ts
+++ b/packages/regrade/src/literal-transform.ts
@@ -15,6 +15,51 @@ const childInput = z.object({
   source: z.string(),
 });
 
+/**
+ * Parent input schema with its raw-to-blaze transform attached.
+ *
+ * Naming the transformed schema lets examples and tests reference both its raw
+ * pre-transform input (`z.input`) and its post-transform blaze input
+ * (`z.infer`) without restating either shape by hand.
+ */
+const regradeTransformInputToChild = regradeTransformInput.transform(
+  ({ source }) => ({
+    child: { source },
+  })
+);
+
+/**
+ * Raw, pre-transform input accepted by {@link regradeTransformInputToChild}.
+ *
+ * Trail examples and `testExamples()` feed this shape through validation; the
+ * Zod transform then projects it into the blaze input.
+ */
+type RegradeTransformRawInput = z.input<typeof regradeTransformInputToChild>;
+
+/**
+ * Post-transform blaze input shape — the trail's inferred input type `I`.
+ *
+ * TRL-842: With a `.transform()` input schema, the trail's inferred input type
+ * `I` is the transform OUTPUT (the blaze input), while examples and
+ * `testExamples()` validate the raw pre-transform INPUT. Those two shapes are
+ * disjoint, so an authored example must carry raw input typed as the
+ * post-transform shape. A framework-level fix would thread a separate
+ * `z.input<>` raw-input type parameter through `TrailSpec`, `Trail`, and every
+ * `trail()` overload — a core-wide generics change beyond this tracer. Until
+ * then the divergence is captured by the two named types here and exercised by
+ * the runtime validation test in `__tests__/literal-transform.test.ts`.
+ */
+type RegradeTransformBlazeInput = z.infer<typeof regradeTransformInputToChild>;
+
+/**
+ * Raw example input, statically checked as valid pre-transform input. If the
+ * input schema changes so this literal is no longer valid raw input, source
+ * typecheck fails here instead of silently relying on the cast below.
+ */
+const codeStringExampleInput: RegradeTransformRawInput = {
+  source: 'export const answer = 41;',
+};
+
 export const normalizeExportConstTrail = trail(
   'regrade.literal.normalize-export-const',
   {
@@ -54,17 +99,15 @@ export const literalRegradeTrail = trail('regrade.literal.run', {
         nextSource: 'export let answer = 41;',
         notes: ['Rewrote export const declarations to export let.'],
       },
-      // Trail examples execute raw input before Zod transforms; the authored type
-      // currently reflects the post-transform blaze input shape.
-      input: { source: 'export const answer = 41;' } as unknown as {
-        child: { source: string };
-      },
+      // TRL-842: author the raw pre-transform value (validated as
+      // RegradeTransformRawInput) and widen through `unknown` to the trail's
+      // inferred post-transform input type. The runtime still parses raw input;
+      // see RegradeTransformBlazeInput for why the two shapes diverge.
+      input: codeStringExampleInput as unknown as RegradeTransformBlazeInput,
       name: 'code-string fixture',
     },
   ],
-  input: regradeTransformInput.transform(({ source }) => ({
-    child: { source },
-  })),
+  input: regradeTransformInputToChild,
   output: regradeTransformOutput,
 });
 


### PR DESCRIPTION
## Summary

Replaces an `as unknown as` cast on the literal-transform tracer's transformed-input example with schema-derived types, so the example's typing is honest about the raw-input vs blaze-input divergence instead of papering over it.

## Changes

- `packages/regrade/src/literal-transform.ts`: derive the example input/output types from the schemas (`z.input` / `z.infer`); document why a full framework fix (threading a raw-input type param through `TrailSpec`) is out of scope, and keep only the one residual cast the current generics genuinely require.
- `literal-transform.test.ts`: runtime validation tests that lock the raw-input contract.

## Testing

`@ontrails/regrade` typecheck + tests green. CI green (8/8).

`@ontrails/regrade` is `private`, so no changeset.

---

Stack base: #621. Linear: [TRL-842](https://linear.app/outfitter/issue/TRL-842).
