### PR TITLE
feat(regrade): collect downstream root source files (TRL-844)

### DIFF
--- a/packages/regrade/src/downstream/__tests__/collect.test.ts
+++ b/packages/regrade/src/downstream/__tests__/collect.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from 'bun:test';
+import { executeTrail } from '@ontrails/core';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative, resolve } from 'node:path';
+
+import {
+  classifyDownstreamEntry,
+  collectDownstreamSources,
+  collectDownstreamSourcesTrail,
+} from '../collect.js';
+
+describe('classifyDownstreamEntry', () => {
+  test('collects supported source extensions', () => {
+    expect(classifyDownstreamEntry('signal.ts', 'file')).toEqual({
+      action: 'collect',
+    });
+    expect(classifyDownstreamEntry('view.tsx', 'file')).toEqual({
+      action: 'collect',
+    });
+  });
+
+  test('skips unsupported extensions with a reason', () => {
+    expect(classifyDownstreamEntry('README.md', 'file')).toEqual({
+      action: 'skip',
+      reason: 'unsupported-extension',
+    });
+    expect(classifyDownstreamEntry('Makefile', 'file')).toEqual({
+      action: 'skip',
+      reason: 'unsupported-extension',
+    });
+  });
+
+  test('recurses into ordinary directories and skips ignored ones', () => {
+    expect(classifyDownstreamEntry('src', 'directory')).toEqual({
+      action: 'recurse',
+    });
+    for (const ignored of [
+      'node_modules',
+      'dist',
+      '.turbo',
+      '.git',
+      '.trails',
+    ]) {
+      expect(classifyDownstreamEntry(ignored, 'directory')).toEqual({
+        action: 'skip',
+        reason: 'ignored-directory',
+      });
+    }
+  });
+
+  test('skips non-file non-directory entries', () => {
+    expect(classifyDownstreamEntry('socket', 'other')).toEqual({
+      action: 'skip',
+      reason: 'unsupported-entry',
+    });
+  });
+
+  test('honors custom extension and ignored-directory options', () => {
+    expect(
+      classifyDownstreamEntry('app.js', 'file', { extensions: ['.js'] })
+    ).toEqual({ action: 'collect' });
+    expect(
+      classifyDownstreamEntry('build', 'directory', {
+        ignoredDirectories: ['build'],
+      })
+    ).toEqual({ action: 'skip', reason: 'ignored-directory' });
+  });
+});
+
+const writeFixture = (): string => {
+  // Scratch under the OS temp root, not the package tree, so a concurrent
+  // collector run never walks another test's scratch dir and an interrupted
+  // run leaves nothing under `src/`.
+  const root = mkdtempSync(join(tmpdir(), 'regrade-collect-'));
+  mkdirSync(join(root, 'src'), { recursive: true });
+  mkdirSync(join(root, 'src', 'nested'), { recursive: true });
+  mkdirSync(join(root, 'node_modules', 'dep'), { recursive: true });
+  mkdirSync(join(root, 'dist'), { recursive: true });
+  writeFileSync(join(root, 'src', 'signal.ts'), 'export const a = 1;\n');
+  writeFileSync(join(root, 'src', 'view.tsx'), 'export const b = 2;\n');
+  writeFileSync(join(root, 'src', 'README.md'), '# docs\n');
+  writeFileSync(
+    join(root, 'src', 'nested', 'ping.ts'),
+    'export const c = 3;\n'
+  );
+  writeFileSync(join(root, 'node_modules', 'dep', 'index.ts'), 'export {};\n');
+  writeFileSync(join(root, 'dist', 'out.ts'), 'export {};\n');
+  return root;
+};
+
+describe('collectDownstreamSources', () => {
+  test('collects supported sources deterministically and records skips', () => {
+    const root = writeFixture();
+    try {
+      const collection = collectDownstreamSources(root);
+      expect(collection).not.toBeNull();
+      const result = collection as NonNullable<typeof collection>;
+
+      expect(result.files.map((file) => file.path)).toEqual([
+        'src/nested/ping.ts',
+        'src/signal.ts',
+        'src/view.tsx',
+      ]);
+      // node_modules and dist are skipped at the directory level — their
+      // contents never appear as collected files.
+      const skippedReasons = new Map(
+        result.skipped.map((entry) => [entry.path, entry.reason])
+      );
+      expect(skippedReasons.get('node_modules')).toBe('ignored-directory');
+      expect(skippedReasons.get('dist')).toBe('ignored-directory');
+      expect(skippedReasons.get('src/README.md')).toBe('unsupported-extension');
+      expect(
+        result.files.some((file) => file.path.startsWith('node_modules/'))
+      ).toBe(false);
+
+      // Absolute paths resolve back under the root.
+      for (const file of result.files) {
+        expect(file.absolutePath.startsWith(root)).toBe(true);
+      }
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('normalizes relative roots to preserve absolute file paths', () => {
+    const root = writeFixture();
+    try {
+      const relativeRoot = relative(process.cwd(), root);
+      const collection = collectDownstreamSources(relativeRoot);
+      expect(collection).not.toBeNull();
+      const result = collection as NonNullable<typeof collection>;
+
+      expect(result.root).toBe(resolve(relativeRoot));
+      expect(result.files[0]?.absolutePath).toBe(
+        join(result.root, 'src', 'nested', 'ping.ts')
+      );
+      for (const file of result.files) {
+        expect(file.absolutePath.startsWith(result.root)).toBe(true);
+      }
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('returns null for a root that cannot be read', () => {
+    expect(
+      collectDownstreamSources(join(import.meta.dir, 'does-not-exist-xyz'))
+    ).toBeNull();
+  });
+});
+
+describe('collectDownstreamSourcesTrail', () => {
+  test('returns Ok with the collection for a readable root', async () => {
+    const root = writeFixture();
+    try {
+      const result = await executeTrail(collectDownstreamSourcesTrail, {
+        root,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        // executeTrail returns Result<unknown, Error>; narrow the Ok value to
+        // the trail's output shape for property access.
+        const value = result.value as { files: { path: string }[] };
+        expect(value.files.map((file) => file.path)).toEqual([
+          'src/nested/ping.ts',
+          'src/signal.ts',
+          'src/view.tsx',
+        ]);
+      }
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('returns a NotFoundError for an unreadable root', async () => {
+    const result = await executeTrail(collectDownstreamSourcesTrail, {
+      root: join(import.meta.dir, 'does-not-exist-xyz'),
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.constructor.name).toBe('NotFoundError');
+    }
+  });
+});

--- a/packages/regrade/src/downstream/collect.ts
+++ b/packages/regrade/src/downstream/collect.ts
@@ -1,0 +1,267 @@
+import { NotFoundError, Result, trail } from '@ontrails/core';
+import { readdirSync } from 'node:fs';
+import { join, posix, relative, resolve, sep } from 'node:path';
+import { z } from 'zod';
+
+/**
+ * Downstream source collection (TRL-844).
+ *
+ * Walks an explicit downstream-repo root and collects the deterministic set of
+ * candidate source files a regrade may operate on, alongside the entries it
+ * skipped and why. This is the engine substrate for the downstream Regrade
+ * work; it has no public CLI and reads only the root it is given.
+ *
+ * The interesting decision logic — which entries are collected, recursed into,
+ * or skipped with a reason — lives in the pure {@link classifyDownstreamEntry}
+ * helper so it can be exercised without touching the filesystem.
+ */
+
+/** Directory names never descended into during collection. */
+export const DEFAULT_IGNORED_DIRECTORIES: readonly string[] = Object.freeze([
+  '.git',
+  '.turbo',
+  '.trails',
+  'dist',
+  'node_modules',
+]);
+
+/** Source file extensions collected by default. */
+export const DEFAULT_SOURCE_EXTENSIONS: readonly string[] = Object.freeze([
+  '.ts',
+  '.tsx',
+]);
+
+/** Kind of a raw directory entry as reported by the filesystem walk. */
+export type DownstreamEntryKind = 'directory' | 'file' | 'other';
+
+/** A collected candidate source file. */
+export interface CollectedSource {
+  /** Root-relative POSIX path, used as the stable identity for the entry. */
+  readonly path: string;
+  /** Absolute path on disk. */
+  readonly absolutePath: string;
+}
+
+/** An entry that was inspected but not collected, with a machine-readable reason. */
+export interface SkippedSource {
+  /** Root-relative POSIX path of the skipped entry. */
+  readonly path: string;
+  /** Why the entry was skipped, e.g. `ignored-directory`. */
+  readonly reason: string;
+}
+
+/** Deterministic result of collecting downstream sources from a root. */
+export interface DownstreamSourceCollection {
+  /** The root the collection ran against. */
+  readonly root: string;
+  /** Collected candidate source files, sorted by `path`. */
+  readonly files: readonly CollectedSource[];
+  /** Skipped entries with reasons, sorted by `path`. */
+  readonly skipped: readonly SkippedSource[];
+}
+
+/** Options shared by the classifier and the filesystem walk. */
+export interface DownstreamCollectionOptions {
+  /** Directory names to skip. Defaults to {@link DEFAULT_IGNORED_DIRECTORIES}. */
+  readonly ignoredDirectories?: readonly string[];
+  /** Source extensions to collect. Defaults to {@link DEFAULT_SOURCE_EXTENSIONS}. */
+  readonly extensions?: readonly string[];
+}
+
+/** Outcome of classifying a single directory entry. */
+export type DownstreamEntryClassification =
+  | { readonly action: 'collect' }
+  | { readonly action: 'recurse' }
+  | { readonly action: 'skip'; readonly reason: string };
+
+const extensionOf = (name: string): string => {
+  const dot = name.lastIndexOf('.');
+  return dot <= 0 ? '' : name.slice(dot);
+};
+
+/**
+ * Decide what to do with a single directory entry. Pure: no filesystem access,
+ * so collection policy can be tested directly with synthetic entries.
+ */
+export const classifyDownstreamEntry = (
+  name: string,
+  kind: DownstreamEntryKind,
+  options: DownstreamCollectionOptions = {}
+): DownstreamEntryClassification => {
+  const ignoredDirectories =
+    options.ignoredDirectories ?? DEFAULT_IGNORED_DIRECTORIES;
+  const extensions = options.extensions ?? DEFAULT_SOURCE_EXTENSIONS;
+
+  if (kind === 'directory') {
+    return ignoredDirectories.includes(name)
+      ? { action: 'skip', reason: 'ignored-directory' }
+      : { action: 'recurse' };
+  }
+  if (kind === 'other') {
+    return { action: 'skip', reason: 'unsupported-entry' };
+  }
+  return extensions.includes(extensionOf(name))
+    ? { action: 'collect' }
+    : { action: 'skip', reason: 'unsupported-extension' };
+};
+
+const toPosixRelative = (root: string, absolutePath: string): string => {
+  const rel = relative(root, absolutePath);
+  return sep === posix.sep ? rel : rel.split(sep).join(posix.sep);
+};
+
+const direntKind = (dirent: {
+  isDirectory(): boolean;
+  isFile(): boolean;
+}): DownstreamEntryKind => {
+  if (dirent.isDirectory()) {
+    return 'directory';
+  }
+  return dirent.isFile() ? 'file' : 'other';
+};
+
+type DirectoryRead =
+  | {
+      readonly ok: true;
+      readonly entries: readonly {
+        readonly name: string;
+        readonly kind: DownstreamEntryKind;
+      }[];
+    }
+  | { readonly ok: false };
+
+const readDirectory = (absoluteDir: string): DirectoryRead => {
+  try {
+    const entries = readdirSync(absoluteDir, { withFileTypes: true }).map(
+      (dirent) => ({ kind: direntKind(dirent), name: dirent.name })
+    );
+    return { entries, ok: true };
+  } catch {
+    return { ok: false };
+  }
+};
+
+/**
+ * Walk an explicit downstream root and collect candidate source files.
+ *
+ * Never throws: an unreadable root yields `null` (the trail maps that to a
+ * `NotFoundError`), and unreadable subdirectories are recorded as skipped
+ * entries. Output is deterministic — files and skipped entries are sorted by
+ * their root-relative POSIX path.
+ */
+export const collectDownstreamSources = (
+  root: string,
+  options: DownstreamCollectionOptions = {}
+): DownstreamSourceCollection | null => {
+  const absoluteRoot = resolve(root);
+  const rootRead = readDirectory(absoluteRoot);
+  if (!rootRead.ok) {
+    return null;
+  }
+
+  const files: CollectedSource[] = [];
+  const skipped: SkippedSource[] = [];
+  const queue: string[] = [absoluteRoot];
+
+  while (queue.length > 0) {
+    const current = queue.shift() as string;
+    const read = current === absoluteRoot ? rootRead : readDirectory(current);
+    if (!read.ok) {
+      skipped.push({
+        path: toPosixRelative(absoluteRoot, current),
+        reason: 'unreadable-directory',
+      });
+      continue;
+    }
+
+    for (const entry of read.entries) {
+      const absolutePath = join(current, entry.name);
+      const path = toPosixRelative(absoluteRoot, absolutePath);
+      const classification = classifyDownstreamEntry(
+        entry.name,
+        entry.kind,
+        options
+      );
+      if (classification.action === 'collect') {
+        files.push({ absolutePath, path });
+      } else if (classification.action === 'recurse') {
+        queue.push(absolutePath);
+      } else {
+        skipped.push({ path, reason: classification.reason });
+      }
+    }
+  }
+
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  skipped.sort((a, b) => a.path.localeCompare(b.path));
+  return { files, root: absoluteRoot, skipped };
+};
+
+export const collectDownstreamSourcesInput = z.object({
+  extensions: z
+    .array(z.string())
+    .optional()
+    .describe('Source file extensions to collect (defaults to .ts and .tsx)'),
+  ignoredDirectories: z
+    .array(z.string())
+    .optional()
+    .describe('Directory names to skip during collection'),
+  root: z
+    .string()
+    .describe('Absolute path to the downstream repo root to scan'),
+});
+
+export const collectDownstreamSourcesOutput = z.object({
+  files: z
+    .array(
+      z.object({
+        absolutePath: z.string().describe('Absolute path on disk'),
+        path: z.string().describe('Root-relative POSIX path'),
+      })
+    )
+    .describe('Collected candidate source files, sorted by path'),
+  root: z.string().describe('Root the collection ran against'),
+  skipped: z
+    .array(
+      z.object({
+        path: z.string().describe('Root-relative POSIX path'),
+        reason: z.string().describe('Why the entry was skipped'),
+      })
+    )
+    .describe('Skipped entries with reasons, sorted by path'),
+});
+
+/**
+ * Engine trail that collects downstream source files from an explicit root.
+ *
+ * No examples are authored: the input is an absolute filesystem path, which
+ * cannot be encoded as a portable literal. Correctness is proven by the
+ * collector unit tests (synthetic classifier cases and temp-directory walks)
+ * and, from TRL-846, the committed Radio-shaped fixture.
+ */
+export const collectDownstreamSourcesTrail = trail(
+  'regrade.downstream.collect',
+  {
+    blaze: (input) => {
+      const collection = collectDownstreamSources(input.root, {
+        ...(input.extensions === undefined
+          ? {}
+          : { extensions: input.extensions }),
+        ...(input.ignoredDirectories === undefined
+          ? {}
+          : { ignoredDirectories: input.ignoredDirectories }),
+      });
+      if (collection === null) {
+        return Result.err(
+          new NotFoundError(
+            `Downstream root "${input.root}" could not be read as a directory.`
+          )
+        );
+      }
+      return Result.ok(collection);
+    },
+    input: collectDownstreamSourcesInput,
+    intent: 'read',
+    output: collectDownstreamSourcesOutput,
+  }
+);


### PR DESCRIPTION
## Summary

Adds downstream root source collection for regrade: a `regrade.downstream.collect` trail backed by a pure `classifyDownstreamEntry` and a never-throwing recursive directory walk. Output is deterministic (sorted files plus skipped-with-reason), so downstream coverage is reproducible.

## Changes

- `packages/regrade/src/downstream/collect.ts`: `collectDownstreamSources` walk (try/catch around `readdir`, ignored-directory and unsupported-extension skips carrying reasons, `localeCompare`-sorted output), `classifyDownstreamEntry`, and the `regrade.downstream.collect` trail.
- `collect.test.ts`: coverage including unreadable / never-throw paths; scratch under `tmpdir()`.

## Testing

`@ontrails/regrade` typecheck + tests green. CI green (8/8).

`@ontrails/regrade` is `private`, so no changeset.

---

Stack base: #622. Linear: [TRL-844](https://linear.app/outfitter/issue/TRL-844).
