### PR TITLE
feat(regrade): add rule selection and RegradeReport coverage (TRL-845)

### DIFF
--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test } from 'bun:test';
+import { executeTrail } from '@ontrails/core';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  buildRegradeReport,
+  createTermRewriteClass,
+  regradeReportTrail,
+  runRegrade,
+  selectRegradeClasses,
+} from '../report.js';
+
+const signalToPing = createTermRewriteClass({ from: 'signal', to: 'ping' });
+
+describe('createTermRewriteClass', () => {
+  test('rewrites whole-word occurrences', () => {
+    const result = signalToPing.apply('export const signal = makeSignal();');
+    // `makeSignal` is not a whole-word `signal`, so it is left untouched.
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe('export const ping = makeSignal();');
+  });
+
+  test('routes ambiguous partial matches to review', () => {
+    const result = signalToPing.apply('export const signalHandler = 1;');
+    expect(result.kind).toBe('needs-review');
+  });
+
+  test('routes mixed whole-word and partial matches to review', () => {
+    const result = signalToPing.apply(
+      'const signal = 1; const signalHandler = 2;'
+    );
+    expect(result.kind).toBe('needs-review');
+    expect(result.nextSource).toBeUndefined();
+  });
+
+  test('reports no-op when the term is absent', () => {
+    expect(signalToPing.apply('export const x = 1;').kind).toBe('no-op');
+  });
+
+  test('matches raw text: a whole-word term in a comment is rewritten', () => {
+    // Matching is lexer-unaware, so a whole-word `signal` inside a comment is
+    // rewritten exactly like a code reference. This pins the documented
+    // raw-text behavior (comment/string exclusion is deferred to TRL-832/836).
+    const result = signalToPing.apply('// rename the signal here\n');
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe('// rename the ping here\n');
+  });
+});
+
+describe('selectRegradeClasses', () => {
+  const a = createTermRewriteClass({ from: 'a', id: 'cls.a', to: 'A' });
+  const b = createTermRewriteClass({ from: 'b', id: 'cls.b', to: 'B' });
+
+  test('returns all classes when no selection is given', () => {
+    expect(selectRegradeClasses([a, b]).selected.map((c) => c.id)).toEqual([
+      'cls.a',
+      'cls.b',
+    ]);
+  });
+
+  test('runs only the selected class and reports unknown ids', () => {
+    const { selected, unknownClassIds } = selectRegradeClasses([a, b], {
+      classIds: ['cls.b', 'cls.missing'],
+    });
+    expect(selected.map((c) => c.id)).toEqual(['cls.b']);
+    expect(unknownClassIds).toEqual(['cls.missing']);
+  });
+});
+
+describe('buildRegradeReport', () => {
+  test('tallies scanned/matched/rewritten/review/skipped with sorted entries', () => {
+    const report = buildRegradeReport({
+      classes: [signalToPing],
+      files: [
+        // a.ts -> rewrite, b.ts -> review (partial match), c.ts -> no-op
+        { path: 'src/a.ts', source: 'const signal = 1;' },
+        { path: 'src/b.ts', source: 'const signalHandler = 1;' },
+        { path: 'src/c.ts', source: 'const x = 1;' },
+      ],
+      root: '/repo',
+      skipped: [{ path: 'dist', reason: 'ignored-directory' }],
+    });
+
+    expect(report.scanned).toBe(3);
+    expect(report.rewritten).toBe(1);
+    expect(report.review).toBe(1);
+    expect(report.matched).toBe(2);
+    expect(report.skipped).toBe(1);
+    expect(report.selectedClassIds).toEqual(['term-rewrite:signal->ping']);
+    expect(report.entries.map((e) => e.path)).toEqual([
+      'dist',
+      'src/a.ts',
+      'src/b.ts',
+      'src/c.ts',
+    ]);
+    const byPath = new Map(report.entries.map((e) => [e.path, e]));
+    expect(byPath.get('src/a.ts')?.outcome).toBe('rewrite');
+    expect(byPath.get('src/b.ts')?.outcome).toBe('needs-review');
+    expect(byPath.get('src/c.ts')?.outcome).toBe('no-op');
+    expect(byPath.get('dist')?.outcome).toBe('skip');
+  });
+
+  test('selection runs one class without executing the others', () => {
+    const other = createTermRewriteClass({
+      from: 'foo',
+      id: 'cls.foo',
+      to: 'bar',
+    });
+    const report = buildRegradeReport({
+      classes: [signalToPing, other],
+      files: [{ path: 'src/a.ts', source: 'const foo = 1; const signal = 2;' }],
+      root: '/repo',
+      selection: { classIds: ['cls.foo'] },
+      skipped: [],
+    });
+    expect(report.selectedClassIds).toEqual(['cls.foo']);
+    expect(report.entries[0]?.classId).toBe('cls.foo');
+    expect(report.entries[0]?.outcome).toBe('rewrite');
+  });
+});
+
+const writeReportFixture = (): string => {
+  // Scratch under the OS temp root, not the package tree, so a concurrent
+  // collector run never walks another test's scratch dir and an interrupted
+  // run leaves nothing under `src/`.
+  const root = mkdtempSync(join(tmpdir(), 'regrade-report-'));
+  mkdirSync(join(root, 'src'), { recursive: true });
+  mkdirSync(join(root, 'dist'), { recursive: true });
+  writeFileSync(join(root, 'src', 'a.ts'), 'export const signal = 1;\n');
+  writeFileSync(join(root, 'src', 'b.ts'), 'export const signalHandler = 2;\n');
+  writeFileSync(join(root, 'dist', 'out.ts'), 'export const signal = 9;\n');
+  return root;
+};
+
+describe('runRegrade + regradeReportTrail', () => {
+  test('runRegrade reports coverage over a real root', () => {
+    const root = writeReportFixture();
+    try {
+      const report = runRegrade({ classes: [signalToPing], root });
+      expect(report).not.toBeNull();
+      const r = report as NonNullable<typeof report>;
+      // dist/out.ts is skipped at the directory level, so only 2 files scanned.
+      expect(r.scanned).toBe(2);
+      expect(r.rewritten).toBe(1);
+      expect(r.review).toBe(1);
+      expect(
+        r.entries.some((e) => e.path === 'dist' && e.outcome === 'skip')
+      ).toBe(true);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('returns null for an unreadable root', () => {
+    expect(
+      runRegrade({
+        classes: [signalToPing],
+        root: join(import.meta.dir, 'does-not-exist-xyz'),
+      })
+    ).toBeNull();
+  });
+
+  test('trail returns Ok with a report for a readable root', async () => {
+    const root = writeReportFixture();
+    try {
+      const result = await executeTrail(regradeReportTrail, { root });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        // executeTrail returns Result<unknown, Error>; narrow the Ok value to
+        // the trail's output shape for property access.
+        const value = result.value as {
+          scanned: number;
+          selectedClassIds: string[];
+          rewritten: number;
+        };
+        expect(value.scanned).toBe(2);
+        expect(value.rewritten).toBe(1);
+        expect(value.selectedClassIds).toEqual([
+          'preview.term-rewrite:signal->ping',
+        ]);
+      }
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('trail returns NotFoundError for an unreadable root', async () => {
+    const result = await executeTrail(regradeReportTrail, {
+      root: join(import.meta.dir, 'does-not-exist-xyz'),
+    });
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.constructor.name).toBe('NotFoundError');
+    }
+  });
+});

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -1,0 +1,373 @@
+import type { ValidationError } from '@ontrails/core';
+import { NotFoundError, Result, trail, validateOutput } from '@ontrails/core';
+import { readFileSync } from 'node:fs';
+import { z } from 'zod';
+
+import { collectDownstreamSources } from './collect.js';
+import type { DownstreamCollectionOptions, SkippedSource } from './collect.js';
+
+/**
+ * Regrade-class selection and coverage reporting (TRL-845).
+ *
+ * A regrade class is one named, contract-aware transform (for example a single
+ * vocabulary rename). Selection lets a run apply one class without executing
+ * every available transform, and {@link RegradeReport} captures coverage —
+ * what was scanned, matched, rewritten, routed to review, and skipped — with
+ * enough per-entry detail to debug why a file was omitted.
+ *
+ * The report logic is pure ({@link buildRegradeReport}); the filesystem walk
+ * and file reads live in {@link runRegrade} and the wrapping trail. This keeps
+ * coverage semantics testable without disk and consistent with the downstream
+ * collection substrate (TRL-844).
+ */
+
+/** Outcome a regrade class produces for a single source file. */
+export type RegradeOutcomeKind = 'needs-review' | 'no-op' | 'rewrite';
+
+/** Result of applying one regrade class to one source string. */
+export interface RegradeClassResult {
+  readonly kind: RegradeOutcomeKind;
+  /** Rewritten source, present only when `kind` is `rewrite`. */
+  readonly nextSource?: string;
+  /** Human-readable notes explaining the outcome. */
+  readonly notes: readonly string[];
+}
+
+/** One named, contract-aware transform. */
+export interface RegradeClass {
+  /** Stable identifier, e.g. `term-rewrite:signal->ping`. */
+  readonly id: string;
+  /** What the class does, for report and guide surfaces. */
+  readonly describe: string;
+  /** Apply the class to a source string. Must be pure and never throw. */
+  readonly apply: (source: string) => RegradeClassResult;
+}
+
+/** Which regrade classes a run should execute. */
+export interface RegradeSelection {
+  /** Class ids to run. Omit to run every provided class. */
+  readonly classIds?: readonly string[];
+}
+
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Build a whole-word term-rewrite class.
+ *
+ * Whole-word occurrences of `from` are rewritten to `to`. When `from` appears
+ * only as part of a larger identifier (an ambiguous partial match), the class
+ * routes the file to review instead of rewriting it — the canonical
+ * "rename `signal` but do not touch `signalHandler`" case. This standalone
+ * class anticipates TRL-832/836, where the mappings become Warden-owned.
+ *
+ * Matching is raw-text and lexer-unaware: a whole-word `from` inside a comment
+ * or string literal counts exactly like a code reference (it is rewritten, and
+ * a partial occurrence there still routes the file to review). For a vocabulary
+ * migration this is usually desirable — comments and docs should track the
+ * rename too — but it means callers cannot assume comment/string occurrences
+ * are skipped. Lexer/AST-aware exclusion is deferred to the Warden-owned
+ * term-rewrite metadata work (TRL-832/836).
+ */
+export const createTermRewriteClass = (options: {
+  readonly from: string;
+  readonly to: string;
+  readonly id?: string;
+  readonly describe?: string;
+}): RegradeClass => {
+  const { from, to } = options;
+  const wholeWord = new RegExp(`\\b${escapeRegExp(from)}\\b`, 'g');
+  return {
+    apply: (source: string): RegradeClassResult => {
+      const matches = source.match(wholeWord);
+      const hasAmbiguousPartial = source.replace(wholeWord, '').includes(from);
+      if (hasAmbiguousPartial) {
+        return {
+          kind: 'needs-review',
+          notes: [
+            `Found "${from}" inside larger identifiers; routed to review.`,
+          ],
+        };
+      }
+      if (matches && matches.length > 0) {
+        return {
+          kind: 'rewrite',
+          nextSource: source.replace(wholeWord, to),
+          notes: [`Rewrote ${matches.length} whole-word "${from}" -> "${to}".`],
+        };
+      }
+      return { kind: 'no-op', notes: [`No "${from}" occurrences found.`] };
+    },
+    describe: options.describe ?? `Rewrite "${from}" to "${to}".`,
+    id: options.id ?? `term-rewrite:${from}->${to}`,
+  };
+};
+
+/**
+ * Resolve the selected classes, preserving the order of `classIds` when given.
+ * Unknown selected ids are returned so callers can report them.
+ */
+export const selectRegradeClasses = (
+  classes: readonly RegradeClass[],
+  selection: RegradeSelection = {}
+): {
+  readonly selected: readonly RegradeClass[];
+  readonly unknownClassIds: readonly string[];
+} => {
+  if (selection.classIds === undefined) {
+    return { selected: classes, unknownClassIds: [] };
+  }
+  const byId = new Map(classes.map((cls) => [cls.id, cls]));
+  const selected: RegradeClass[] = [];
+  const unknownClassIds: string[] = [];
+  for (const id of selection.classIds) {
+    const cls = byId.get(id);
+    if (cls === undefined) {
+      unknownClassIds.push(id);
+    } else {
+      selected.push(cls);
+    }
+  }
+  return { selected, unknownClassIds };
+};
+
+/** Per-entry detail describing what happened to one path. */
+export interface RegradeReportEntry {
+  /** Root-relative POSIX path. */
+  readonly path: string;
+  /** What happened to the entry. */
+  readonly outcome: 'needs-review' | 'no-op' | 'rewrite' | 'skip';
+  /** Class that produced a rewrite or review outcome. */
+  readonly classId?: string;
+  /** Reason for a skip or review outcome. */
+  readonly reason?: string;
+  /** Notes carried from the producing class. */
+  readonly notes?: readonly string[];
+}
+
+/** Coverage report for a regrade run. */
+export interface RegradeReport {
+  /** Root the run scanned. */
+  readonly root: string;
+  /** Class ids that were executed. */
+  readonly selectedClassIds: readonly string[];
+  /** Selected class ids that did not resolve to a known class. */
+  readonly unknownClassIds: readonly string[];
+  /** Source files inspected. */
+  readonly scanned: number;
+  /** Files where a selected class produced a rewrite or review outcome. */
+  readonly matched: number;
+  /** Files with a rewrite outcome. */
+  readonly rewritten: number;
+  /** Files routed to review. */
+  readonly review: number;
+  /** Entries skipped (collection skips plus any run-level skips). */
+  readonly skipped: number;
+  /** Per-entry detail, sorted by path. */
+  readonly entries: readonly RegradeReportEntry[];
+}
+
+const classifyFile = (
+  path: string,
+  source: string,
+  selected: readonly RegradeClass[]
+): RegradeReportEntry => {
+  // First selected class that matches (rewrite or review) wins, mirroring the
+  // "run one class" emphasis. No-ops fall through to a no-op entry.
+  for (const cls of selected) {
+    const result = cls.apply(source);
+    if (result.kind === 'rewrite') {
+      return { classId: cls.id, notes: result.notes, outcome: 'rewrite', path };
+    }
+    if (result.kind === 'needs-review') {
+      return {
+        classId: cls.id,
+        notes: result.notes,
+        outcome: 'needs-review',
+        path,
+        reason: 'ambiguous-match',
+      };
+    }
+  }
+  return { outcome: 'no-op', path };
+};
+
+/**
+ * Build a coverage report from already-read source files. Pure: no filesystem
+ * access, so coverage semantics are testable directly.
+ */
+export const buildRegradeReport = (params: {
+  readonly root: string;
+  readonly files: readonly { readonly path: string; readonly source: string }[];
+  readonly skipped: readonly SkippedSource[];
+  readonly classes: readonly RegradeClass[];
+  readonly selection?: RegradeSelection;
+}): RegradeReport => {
+  const { selected, unknownClassIds } = selectRegradeClasses(
+    params.classes,
+    params.selection
+  );
+
+  const fileEntries = params.files.map((file) =>
+    classifyFile(file.path, file.source, selected)
+  );
+  const skipEntries: RegradeReportEntry[] = params.skipped.map((entry) => ({
+    outcome: 'skip',
+    path: entry.path,
+    reason: entry.reason,
+  }));
+
+  const entries = [...fileEntries, ...skipEntries].toSorted((a, b) =>
+    a.path.localeCompare(b.path)
+  );
+
+  const rewritten = fileEntries.filter((e) => e.outcome === 'rewrite').length;
+  const review = fileEntries.filter((e) => e.outcome === 'needs-review').length;
+
+  return {
+    entries,
+    matched: rewritten + review,
+    review,
+    rewritten,
+    root: params.root,
+    scanned: fileEntries.length,
+    selectedClassIds: selected.map((cls) => cls.id),
+    skipped: skipEntries.length,
+    unknownClassIds,
+  };
+};
+
+/**
+ * Run a regrade over an explicit downstream root, producing a coverage report.
+ *
+ * Never throws: an unreadable root yields `null` (the trail maps it to a
+ * `NotFoundError`); files that cannot be read are recorded as skips. This does
+ * not write to disk — it reports the rewrites a run would make.
+ */
+export const runRegrade = (params: {
+  readonly root: string;
+  readonly classes: readonly RegradeClass[];
+  readonly selection?: RegradeSelection;
+  readonly collection?: DownstreamCollectionOptions;
+}): RegradeReport | null => {
+  const collected = collectDownstreamSources(
+    params.root,
+    params.collection ?? {}
+  );
+  if (collected === null) {
+    return null;
+  }
+
+  const files: { path: string; source: string }[] = [];
+  const skipped: SkippedSource[] = [...collected.skipped];
+  for (const file of collected.files) {
+    try {
+      files.push({
+        path: file.path,
+        source: readFileSync(file.absolutePath, 'utf8'),
+      });
+    } catch {
+      skipped.push({ path: file.path, reason: 'unreadable-file' });
+    }
+  }
+
+  return buildRegradeReport({
+    classes: params.classes,
+    files,
+    root: params.root,
+    skipped,
+    ...(params.selection === undefined ? {} : { selection: params.selection }),
+  });
+};
+
+const regradeReportEntrySchema = z.object({
+  classId: z.string().optional().describe('Class that produced the outcome'),
+  notes: z.array(z.string()).optional().describe('Notes from the class'),
+  outcome: z
+    .enum(['needs-review', 'no-op', 'rewrite', 'skip'])
+    .describe('What happened to the entry'),
+  path: z.string().describe('Root-relative POSIX path'),
+  reason: z.string().optional().describe('Reason for a skip or review outcome'),
+});
+
+export const regradeReportInput = z.object({
+  classIds: z
+    .array(z.string())
+    .optional()
+    .describe('Regrade class ids to run (defaults to all built-in classes)'),
+  root: z
+    .string()
+    .describe('Absolute path to the downstream repo root to scan'),
+});
+
+export const regradeReportOutput = z.object({
+  entries: z
+    .array(regradeReportEntrySchema)
+    .describe('Per-entry detail, sorted by path'),
+  matched: z.number().describe('Files with a rewrite or review outcome'),
+  review: z.number().describe('Files routed to review'),
+  rewritten: z.number().describe('Files with a rewrite outcome'),
+  root: z.string().describe('Root the run scanned'),
+  scanned: z.number().describe('Source files inspected'),
+  selectedClassIds: z.array(z.string()).describe('Class ids executed'),
+  skipped: z.number().describe('Entries skipped'),
+  unknownClassIds: z
+    .array(z.string())
+    .describe('Selected ids that did not resolve to a class'),
+});
+
+const validateRegradeReportOutput = (
+  report: RegradeReport
+): Result<z.infer<typeof regradeReportOutput>, ValidationError> =>
+  validateOutput(regradeReportOutput, report);
+
+/**
+ * Preview regrade classes available to the report trail.
+ *
+ * This synthetic class keeps the report trail executable while the downstream
+ * engine shape is still settling. It is not Warden-owned detection policy;
+ * TRL-836 wires Warden-owned `term-rewrite` metadata into this set instead of
+ * hand-authored preview mappings.
+ */
+export const previewRegradeClasses: readonly RegradeClass[] = Object.freeze([
+  createTermRewriteClass({
+    describe: 'Synthetic preview rewrite: signal -> ping',
+    from: 'signal',
+    id: 'preview.term-rewrite:signal->ping',
+    to: 'ping',
+  }),
+]);
+
+/**
+ * Engine trail that produces a {@link RegradeReport} for an explicit root.
+ *
+ * No authored examples: the input is an absolute filesystem path. Correctness
+ * is proven by the pure report unit tests and temp-directory run tests; the
+ * committed Radio-shaped fixture (TRL-846) exercises it end to end.
+ */
+export const regradeReportTrail = trail('regrade.downstream.report', {
+  blaze: (input) => {
+    const report = runRegrade({
+      classes: previewRegradeClasses,
+      root: input.root,
+      ...(input.classIds === undefined
+        ? {}
+        : { selection: { classIds: input.classIds } }),
+    });
+    if (report === null) {
+      return Result.err(
+        new NotFoundError(
+          `Downstream root "${input.root}" could not be read as a directory.`
+        )
+      );
+    }
+    // Validate through the output schema so the returned value matches the trail's
+    // mutable Zod-inferred output type. RegradeReport keeps idiomatic readonly
+    // arrays for its domain consumers; the schema bridge validates without
+    // throwing from the blaze.
+    return validateRegradeReportOutput(report);
+  },
+  input: regradeReportInput,
+  intent: 'read',
+  output: regradeReportOutput,
+});


### PR DESCRIPTION
## Summary

Adds regrade rule selection and the coverage report shape: `RegradeClass` / `createTermRewriteClass` (whole-word rewrite, ambiguous partial → review), `selectRegradeClasses`, `RegradeReport` / `buildRegradeReport`, and the `regrade.downstream.report` trail.

## Changes

- `packages/regrade/src/downstream/report.ts`: the class / selection / report engine. `createTermRewriteClass` is documented as raw-text (lexer-unaware) matching — a whole-word target inside a comment or string literal is rewritten or routed to review like a code reference; lexer-aware exclusion is deferred to the Warden-owned term-rewrite work (TRL-832/836). The trail bridges the readonly domain `RegradeReport` to the mutable Zod-inferred output via `schema.parse`.
- `report.test.ts`: engine coverage including a test pinning the documented raw-text matching behavior; scratch under `tmpdir()`.

## Testing

`@ontrails/regrade` typecheck + tests green. CI green (8/8).

`@ontrails/regrade` is `private`, so no changeset.

---

Stack base: #623. Linear: [TRL-845](https://linear.app/outfitter/issue/TRL-845).
