### PR TITLE
test(regrade): add Radio-shaped downstream regrade fixture (TRL-846)

### DIFF
--- a/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/README.md.txt
+++ b/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/README.md.txt
@@ -1,0 +1,11 @@
+# Radio-shaped downstream fixture
+
+Synthetic source tree shaped like the Radio app for regrade regression tests.
+This is a committed, stable fixture — it does NOT depend on the live Radio
+checkout. Fixture source files carry a trailing `.txt` guard so they are
+invisible to this package's typecheck, lint, test discovery, and Warden scan;
+the test (`radio-fixture.test.ts`) materializes them into a temp directory with
+their real `.ts` / `.tsx` extensions before running the regrade engine.
+
+This `README.md.txt` materializes to `README.md` and exercises the
+`unsupported-extension` skip path.

--- a/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/dist-guard/bundle.ts.txt
+++ b/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/dist-guard/bundle.ts.txt
@@ -1,0 +1,5 @@
+// Radio-shaped fixture: build output materialized under dist/. The collector
+// must skip the entire dist/ directory, so this `signal` occurrence is never
+// scanned. Committed under `dist-guard/` because `dist/` is gitignored
+// repo-wide; materializeFixture renames it back to `dist/` at runtime.
+export const signal = 'built-artifact';

--- a/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/src/components/now-playing.tsx.txt
+++ b/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/src/components/now-playing.tsx.txt
@@ -1,0 +1,3 @@
+// Radio-shaped fixture: a .tsx component with no matching term — a no-op for
+// the term-rewrite class, and proof that .tsx files are collected.
+export const NowPlaying = (): null => null;

--- a/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/src/signals/track.ts.txt
+++ b/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/src/signals/track.ts.txt
@@ -1,0 +1,8 @@
+// Radio-shaped fixture: a notification-source module. The whole-word binding
+// below is the rewrite target; `defineSignal` is a partial match and must stay
+// untouched.
+import { defineSignal } from '@radio/runtime';
+
+export const signal = defineSignal('track.changed', {
+  trackId: 'string',
+});

--- a/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/src/trails/play.ts.txt
+++ b/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/src/trails/play.ts.txt
@@ -1,0 +1,5 @@
+// Radio-shaped fixture: a trail module where the term appears only inside the
+// larger identifier `signalHandler`. The term-rewrite class must route this to
+// review rather than rewrite a partial match.
+export const signalHandler = (trackId: string): string =>
+  `playing ${trackId}`;

--- a/packages/regrade/src/downstream/__tests__/radio-fixture.test.ts
+++ b/packages/regrade/src/downstream/__tests__/radio-fixture.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test';
+import { cpSync, mkdtempSync, readdirSync, renameSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { collectDownstreamSources } from '../collect.js';
+import { createTermRewriteClass, runRegrade } from '../report.js';
+
+/**
+ * Radio-shaped downstream regrade regression fixture (TRL-846).
+ *
+ * The committed fixture under `fixtures/radio-shaped/` is a synthetic source
+ * tree shaped like the Radio app. Its source files carry a trailing `.txt`
+ * guard so they stay invisible to this package's typecheck, lint, test
+ * discovery, and Warden scan, and the build-output directory is committed as
+ * `dist-guard/` because a literal `dist/` is gitignored repo-wide. Here we
+ * materialize the tree into a temp directory with the real extensions and the
+ * real `dist/` name, then run the regrade engine against it, locking the
+ * downstream collection + coverage behavior without depending on the live
+ * Radio checkout.
+ */
+
+const FIXTURE_ROOT = join(import.meta.dir, 'fixtures', 'radio-shaped');
+
+/** Recursively strip the `.txt` guard from every materialized fixture file. */
+const stripTxtGuards = (dir: string): void => {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      stripTxtGuards(full);
+    } else if (entry.isFile() && entry.name.endsWith('.txt')) {
+      renameSync(full, full.slice(0, -'.txt'.length));
+    }
+  }
+};
+
+/**
+ * Copy the committed fixture into a temp dir and reveal real extensions.
+ *
+ * The temp dir lives under the OS temp root, not the package tree, so a
+ * concurrent full-suite run never walks another test's scratch directory and
+ * an interrupted run leaves nothing under `src/`.
+ */
+const materializeFixture = (): string => {
+  // Copy into a fresh dest that does not yet exist, nested under a unique temp
+  // parent. Copying into an already-created mkdtemp dir can merge a second copy
+  // of the tree under a concurrent full-suite run; a non-existing dest makes
+  // the copy unambiguous and the walk deterministic.
+  const parent = mkdtempSync(join(tmpdir(), 'regrade-radio-'));
+  const root = join(parent, 'fixture');
+  cpSync(FIXTURE_ROOT, root, { recursive: true });
+  stripTxtGuards(root);
+  // Reveal the build-output directory's real name. `dist/` is gitignored
+  // repo-wide, so the fixture commits it as `dist-guard/`; without this rename a
+  // fresh CI checkout would lack any `dist/` and the ignored-directory skip
+  // would go unexercised (the failure mode this guard exists to prevent).
+  renameSync(join(root, 'dist-guard'), join(root, 'dist'));
+  return root;
+};
+
+describe('Radio-shaped downstream fixture (TRL-846)', () => {
+  test('collects only in-scope source files and records skips', () => {
+    const root = materializeFixture();
+    try {
+      const collection = collectDownstreamSources(root);
+      expect(collection).not.toBeNull();
+      const result = collection as NonNullable<typeof collection>;
+
+      expect(result.files.map((file) => file.path)).toEqual([
+        'src/components/now-playing.tsx',
+        'src/signals/track.ts',
+        'src/trails/play.ts',
+      ]);
+
+      const skippedReasons = new Map(
+        result.skipped.map((entry) => [entry.path, entry.reason])
+      );
+      expect(skippedReasons.get('dist')).toBe('ignored-directory');
+      expect(skippedReasons.get('README.md')).toBe('unsupported-extension');
+      // The dist/ bundle is never scanned, so its `signal` is invisible.
+      expect(result.files.some((file) => file.path.startsWith('dist/'))).toBe(
+        false
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('regrade coverage over the fixture is deterministic', () => {
+    const root = materializeFixture();
+    try {
+      const report = runRegrade({
+        classes: [createTermRewriteClass({ from: 'signal', to: 'ping' })],
+        root,
+      });
+      expect(report).not.toBeNull();
+      const r = report as NonNullable<typeof report>;
+
+      // track.ts -> rewrite (whole-word signal), play.ts -> review
+      // (signalHandler partial), now-playing.tsx -> no-op.
+      expect(r.scanned).toBe(3);
+      expect(r.rewritten).toBe(1);
+      expect(r.review).toBe(1);
+      expect(r.matched).toBe(2);
+
+      const byPath = new Map(r.entries.map((entry) => [entry.path, entry]));
+      expect(byPath.get('src/signals/track.ts')?.outcome).toBe('rewrite');
+      expect(byPath.get('src/trails/play.ts')?.outcome).toBe('needs-review');
+      expect(byPath.get('src/components/now-playing.tsx')?.outcome).toBe(
+        'no-op'
+      );
+      expect(byPath.get('dist')?.outcome).toBe('skip');
+      expect(byPath.get('README.md')?.outcome).toBe('skip');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a Radio-shaped downstream regrade regression fixture that exercises the engine end to end without depending on the live Radio checkout. The committed fixture is a synthetic source tree; the test materializes it into an OS temp dir with real extensions and runs collect + report deterministically.

## Changes

- `fixtures/radio-shaped/**`: synthetic tree with trailing `.txt` guards (invisible to tsc / lint / test-discovery / Warden). The build-output directory is committed as `dist-guard/` because a literal `dist/` is gitignored repo-wide; `materializeFixture` renames it to `dist/` at runtime — a directory-level parallel to the `.txt` file guard, so a fresh CI checkout still exercises the ignored-directory skip.
- `radio-fixture.test.ts`: materialize (strip `.txt`, reveal `dist/`) then assert deterministic coverage and per-path outcomes (rewrite / needs-review / no-op / skip).

## Testing

Regrade suite green; verified the fixture is fully git-tracked (no gitignored paths) and the test passes against a clean-checkout-equivalent tree. CI green (8/8).

> Note: an earlier revision committed the build-output dir as `dist/`, which is gitignored repo-wide and therefore never reached CI — the `dist-guard/` + runtime-rename approach fixes that local-vs-CI gap.

`@ontrails/regrade` is `private`, so no changeset.

---

Stack base: #624. Linear: [TRL-846](https://linear.app/outfitter/issue/TRL-846).
