### PR TITLE
feat(warden): add term-rewrite fix metadata to legacy-layer rule (TRL-832)

### DIFF
--- a/.changeset/trl-832-warden-term-rewrite-fix-metadata.md
+++ b/.changeset/trl-832-warden-term-rewrite-fix-metadata.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Attach term-rewrite fix metadata to the `no-legacy-layer-imports` rule, marking it review-required with no mechanical edits (the legacy layers were removed, not renamed) so `warden --fix` reports but never auto-applies the migration.

--- a/packages/warden/src/__tests__/guide.test.ts
+++ b/packages/warden/src/__tests__/guide.test.ts
@@ -68,4 +68,31 @@ describe('warden guide manifest', () => {
     expect(parsed.rules.at(-1)).toHaveProperty('concern');
     expect(parsed.rules.at(-1)).not.toHaveProperty('category');
   });
+
+  test('projects rule fix capability faithfully (TRL-831/832)', () => {
+    // The fix field projects exactly the rules that declare a capability.
+    // no-legacy-layer-imports is the first fixable rule (TRL-832): a
+    // review-required term-rewrite. Rules without a capability omit the field.
+    const manifest = buildWardenGuideManifest();
+
+    const legacy = manifest.rules.find(
+      (rule) => rule.id === 'no-legacy-layer-imports'
+    );
+    expect(legacy?.fix).toEqual({ class: 'term-rewrite', safety: 'review' });
+    expect(
+      buildWardenAgentGuide(manifest).rules.find(
+        (rule) => rule.id === 'no-legacy-layer-imports'
+      )?.fix
+    ).toEqual({ class: 'term-rewrite', safety: 'review' });
+
+    const throwRule = manifest.rules.find(
+      (rule) => rule.id === 'no-throw-in-implementation'
+    );
+    expect(throwRule?.fix).toBeUndefined();
+
+    // A fixable rule advertises a Fix line in the rendered guide markdown.
+    expect(formatWardenGuideMarkdown(manifest)).toContain(
+      '- Fix: `term-rewrite`'
+    );
+  });
 });

--- a/packages/warden/src/__tests__/no-legacy-layer-imports.test.ts
+++ b/packages/warden/src/__tests__/no-legacy-layer-imports.test.ts
@@ -28,6 +28,22 @@ describe('no-legacy-layer-imports', () => {
     );
   });
 
+  test('carries review-required term-rewrite fix metadata (TRL-832)', () => {
+    const code = "import { authLayer } from '@ontrails/permits';";
+    const fix = noLegacyLayerImports.check(
+      code,
+      '/repo/apps/example/src/cli.ts'
+    )[0]?.fix;
+
+    expect(fix?.class).toBe('term-rewrite');
+    // These legacy layers were removed, not renamed: no mechanical replacement,
+    // so the fix is review-required and carries no edits. `warden --fix` must
+    // never auto-apply it; it stays reported for human migration.
+    expect(fix?.safety).toBe('review');
+    expect(fix?.edits).toBeUndefined();
+    expect(fix?.reason).toContain('authLayer');
+  });
+
   test('flags `autoIterateLayer` references in committed source', () => {
     const code = [
       "import { autoIterateLayer } from '@ontrails/cli';",

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -272,6 +272,7 @@ const builtinWardenRuleMetadataInput = {
     tier: 'source-static',
   },
   'no-legacy-layer-imports': {
+    fix: { class: 'term-rewrite', safety: 'review' },
     invariant:
       'Legacy layer exports removed across TRL-475/TRL-476 (authLayer, autoIterateLayer, dateShortcutsLayer) do not reappear in committed source.',
     lifecycle: {

--- a/packages/warden/src/rules/no-legacy-layer-imports.ts
+++ b/packages/warden/src/rules/no-legacy-layer-imports.ts
@@ -33,7 +33,7 @@
  */
 import { resolve, sep } from 'node:path';
 
-import type { WardenDiagnostic, WardenRule } from './types.js';
+import type { WardenDiagnostic, WardenFix, WardenRule } from './types.js';
 
 const RULE_NAME = 'no-legacy-layer-imports';
 
@@ -165,6 +165,23 @@ const buildMessage = (name: LegacyLayerName): string => {
 };
 
 /**
+ * Build the term-rewrite fix metadata for a legacy layer finding.
+ *
+ * These layers were removed, not renamed, so there is no mechanical
+ * replacement: the fix is review-required and carries no edits. It still
+ * advertises the transform class and migration reason so `warden --fix`
+ * reports (but never auto-applies) it and downstream regrades can route it.
+ */
+const buildFix = (name: LegacyLayerName): WardenFix => {
+  const migration = LEGACY_LAYER_MIGRATIONS[name];
+  return {
+    class: 'term-rewrite',
+    reason: `Legacy layer '${name}' was removed in ${migration.removedIn}; ${migration.guidance}. Removal has no mechanical replacement, so it needs human migration.`,
+    safety: 'review',
+  };
+};
+
+/**
  * Flags references to the removed legacy layer symbols in committed source.
  */
 export const noLegacyLayerImports: WardenRule = {
@@ -179,6 +196,7 @@ export const noLegacyLayerImports: WardenRule = {
     return [
       {
         filePath,
+        fix: buildFix(match.name),
         line: lineForOffset(sourceCode, match.index),
         message: buildMessage(match.name),
         rule: RULE_NAME,


### PR DESCRIPTION
## Summary

Makes `no-legacy-layer-imports` the first fixable Warden rule. It declares a per-rule `term-rewrite` capability and attaches per-finding `WardenFix` metadata — but with `safety: 'review'` and no edits, because the legacy layers (`authLayer`, `autoIterateLayer`, `dateShortcutsLayer`) were removed, not renamed, so there is no mechanical replacement. `warden --fix` will report but never auto-apply these.

## Changes

- `packages/warden/src/rules/no-legacy-layer-imports.ts`: per-finding `WardenFix` (`term-rewrite`, review-required, no edits) plus a per-rule capability.
- `metadata.ts`: declare the rule's fix capability.
- `no-legacy-layer-imports.test.ts` + `guide.test.ts`: assert the fix metadata and its faithful guide projection.

## Testing

Warden suite green; fix metadata appears in the full guide markdown / agent-json, not the compact rule index (no guide resync needed). CI green (8/8).

Changeset: `@ontrails/warden` patch.

---

Stack base: #626. Linear: [TRL-832](https://linear.app/outfitter/issue/TRL-832).
