### PR TITLE
feat(warden): wire safe warden fixes through CLI

### DIFF
--- a/.changeset/trl-833-warden-safe-fix-cli.md
+++ b/.changeset/trl-833-warden-safe-fix-cli.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/warden": minor
+"@ontrails/trails": patch
+---
+
+Add `warden --fix` to apply safe source fixes. The executor applies only `safety: 'safe'` edits last-to-first, re-reading and rewriting affected files, while review-required, edit-less, and topo diagnostics stay reported but unapplied. The report surfaces applied, changed-file, and skipped counts.
+
+Expose `fix` through the Trails app wrapper and mark the `warden` trail as write intent with explicit public access because `fix: true` mutates source files while the local governance command remains directly runnable.

--- a/apps/trails/src/__tests__/warden.test.ts
+++ b/apps/trails/src/__tests__/warden.test.ts
@@ -177,6 +177,14 @@ const writeAllDepthWarningFixture = (dir: string): void => {
 };
 
 describe('trails warden', () => {
+  test('declares write intent because --fix can mutate source files', () => {
+    expect(wardenTrail.intent).toBe('write');
+  });
+
+  test('declares public permit access for the local governance command', () => {
+    expect(wardenTrail.permit).toBe('public');
+  });
+
   test('projects final Warden flags into the shared command surface', () => {
     const args = buildWardenCommandArgs({
       apps: ['trails', 'demo'],
@@ -186,6 +194,7 @@ describe('trails warden', () => {
       drafts: 'include',
       excludeDrafts: true,
       failOn: 'error',
+      fix: true,
       format: 'summary',
       github: true,
       includeDrafts: false,
@@ -209,6 +218,7 @@ describe('trails warden', () => {
       '--cached',
       '--exclude-drafts',
       '--no-lock-mutation',
+      '--fix',
       '--apps',
       'trails,demo',
     ]);
@@ -307,6 +317,7 @@ describe('trails warden', () => {
       ],
       drift: null,
       errorCount: 1,
+      fixes: undefined,
       formatted: 'Result: FAIL',
       passed: false,
       warnCount: 0,
@@ -341,6 +352,7 @@ describe('trails warden', () => {
     expect(raw.stderr).toBe('');
     expect(raw.stdout).toContain('Usage: warden [options]');
     expect(raw.stdout).toContain('--depth <value>');
+    expect(raw.stdout).toContain('--fix');
     expect(raw.stdout).not.toContain('Warden Report');
   });
 

--- a/apps/trails/src/trails/warden.ts
+++ b/apps/trails/src/trails/warden.ts
@@ -40,6 +40,7 @@ const wardenInputSchema = z.object({
     .default(false)
     .describe('Alias for --drafts exclude'),
   failOn: z.enum(wardenFailOnValues).optional().describe('Failure threshold'),
+  fix: z.boolean().default(false).describe('Apply safe source fixes'),
   format: z.enum(wardenFormatValues).optional().describe('Output format'),
   github: z.boolean().default(false).describe('Alias for --format github'),
   includeDrafts: z
@@ -129,6 +130,7 @@ export const buildWardenCommandArgs = (
     pushValue(args, '--drafts', input.drafts);
   }
   pushFlag(args, input.noLockMutation, '--no-lock-mutation');
+  pushFlag(args, input.fix, '--fix');
   pushValue(args, '--config-path', input.configPath);
   pushApps(args, input.apps);
 
@@ -153,6 +155,7 @@ export const wardenTrail = trail('warden', {
       diagnostics: [...report.diagnostics],
       drift: report.drift,
       errorCount: report.errorCount,
+      fixes: report.fixes,
       formatted: result.output,
       passed: report.passed,
       warnCount: report.warnCount,
@@ -174,7 +177,7 @@ export const wardenTrail = trail('warden', {
     },
   ],
   input: wardenInputSchema,
-  intent: 'read',
+  intent: 'write',
   output: z.object({
     diagnostics: z.array(
       diagnosticSchema.extend({ topoName: z.string().optional() })
@@ -188,8 +191,16 @@ export const wardenTrail = trail('warden', {
       })
       .nullable(),
     errorCount: z.number(),
+    fixes: z
+      .object({
+        applied: z.number(),
+        filesChanged: z.number(),
+        skipped: z.number(),
+      })
+      .optional(),
     formatted: z.string(),
     passed: z.boolean(),
     warnCount: z.number(),
   }),
+  permit: 'public',
 });

--- a/packages/warden/bin/warden.ts
+++ b/packages/warden/bin/warden.ts
@@ -13,6 +13,7 @@ Options:
   --apps, -a <names>           Comma-delimited Trails app names
   --config-path <path>         Path to trails.config.* file
   --root-dir <path>            Project root to inspect
+  --fix                        Apply safe source fixes
   --depth <value>              source, project, topo, or all
   --fail-on <value>            error or warning
   --format <value>             summary, github, or json

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -17,8 +17,16 @@ import {
 } from '@ontrails/topographer';
 import { z } from 'zod';
 
-import { formatWardenReport, runWarden } from '../cli.js';
-import type { TopoAwareWardenRule, WardenDiagnostic } from '../rules/types.js';
+import {
+  applySafeFixesToFiles,
+  formatWardenReport,
+  runWarden,
+} from '../cli.js';
+import type {
+  TopoAwareWardenRule,
+  WardenDiagnostic,
+  WardenRule,
+} from '../rules/types.js';
 
 const DEV_PERMIT_FLAG = ['--dev', '-permit'].join('');
 
@@ -95,6 +103,61 @@ const throwDiagnosticFilePaths = (
     .filter((diagnostic) => diagnostic.rule === 'no-throw-in-implementation')
     .map((diagnostic) => diagnostic.filePath)
     .toSorted();
+
+const safeRenameDiagnostic = (filePath: string): WardenDiagnostic => ({
+  filePath,
+  fix: {
+    class: 'term-rewrite',
+    edits: [{ end: 12, replacement: 'ping', start: 6 }],
+    reason: 'safe rename',
+    safety: 'safe',
+  },
+  line: 1,
+  message: 'safe rename',
+  rule: 'synthetic-safe-fix',
+  severity: 'warn',
+});
+
+const buildSyntheticSafeSourceRule = (): WardenRule => ({
+  check: (sourceCode, filePath) => {
+    const start = sourceCode.indexOf('signal');
+    if (start === -1) {
+      return [];
+    }
+    return [
+      {
+        filePath,
+        fix: {
+          class: 'term-rewrite',
+          edits: [
+            {
+              end: start + 'signal'.length,
+              replacement: 'ping',
+              start,
+            },
+          ],
+          reason: 'safe rename',
+          safety: 'safe',
+        },
+        line: 1,
+        message: 'safe rename',
+        rule: 'synthetic-safe-fix',
+        severity: 'warn',
+      },
+    ];
+  },
+  description: 'synthetic safe source fix rule',
+  metadata: {
+    concern: 'general',
+    depth: 'source',
+    invariant: 'synthetic safe source fix test hook',
+    lifecycle: { retireWhen: 'test helper', state: 'temporary' },
+    scope: 'temporary',
+    tier: 'source-static',
+  },
+  name: 'synthetic-safe-fix',
+  severity: 'warn',
+});
 
 describe('runWarden basics', () => {
   test('produces a report with diagnostics for bad code', async () => {
@@ -1087,6 +1150,245 @@ describe('runWarden draft markers', () => {
       );
 
       expect(hasDraftFileMarkingWarn).toBe(true);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('applySafeFixesToFiles', () => {
+  test('rewrites a file with a safe edit and reports applied counts', async () => {
+    const dir = makeTempDir();
+    try {
+      const filePath = join(dir, 'entity.ts');
+      writeFileSync(filePath, 'const signal = 1;');
+      const diagnostic: WardenDiagnostic = {
+        filePath,
+        fix: {
+          class: 'term-rewrite',
+          edits: [{ end: 12, replacement: 'ping', start: 6 }],
+          reason: 'rename signal to ping',
+          safety: 'safe',
+        },
+        line: 1,
+        message: 'rename signal',
+        rule: 'synthetic-safe-fix',
+        severity: 'warn',
+      };
+
+      const summary = await applySafeFixesToFiles([diagnostic], {
+        allowedFilePaths: [filePath],
+        rootDir: dir,
+      });
+
+      expect(summary).toMatchObject({
+        applied: 1,
+        filesChanged: 1,
+        skipped: 0,
+      });
+      expect(summary.appliedDiagnostics).toEqual([diagnostic]);
+      expect(readFileSync(filePath, 'utf8')).toBe('const ping = 1;');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('leaves review-only and edit-less fixes unapplied and counted as skipped', async () => {
+    const dir = makeTempDir();
+    try {
+      const safePath = join(dir, 'safe.ts');
+      const reviewPath = join(dir, 'review.ts');
+      writeFileSync(safePath, 'const signal = 1;');
+      writeFileSync(reviewPath, 'const legacy = 1;');
+
+      const safe: WardenDiagnostic = {
+        filePath: safePath,
+        fix: {
+          class: 'term-rewrite',
+          edits: [{ end: 12, replacement: 'ping', start: 6 }],
+          reason: 'safe rename',
+          safety: 'safe',
+        },
+        line: 1,
+        message: 'safe rename',
+        rule: 'synthetic-safe-fix',
+        severity: 'warn',
+      };
+      const review: WardenDiagnostic = {
+        filePath: reviewPath,
+        fix: {
+          class: 'term-rewrite',
+          reason: 'needs human migration',
+          safety: 'review',
+        },
+        line: 1,
+        message: 'needs review',
+        rule: 'synthetic-review-fix',
+        severity: 'error',
+      };
+      const noFix: WardenDiagnostic = {
+        filePath: reviewPath,
+        line: 1,
+        message: 'no fix metadata',
+        rule: 'synthetic-no-fix',
+        severity: 'warn',
+      };
+
+      const summary = await applySafeFixesToFiles([safe, review, noFix], {
+        allowedFilePaths: [safePath, reviewPath],
+        rootDir: dir,
+      });
+
+      expect(summary).toMatchObject({
+        applied: 1,
+        filesChanged: 1,
+        skipped: 1,
+      });
+      expect(summary.appliedDiagnostics).toEqual([safe]);
+      // The review-targeted file is never read or written.
+      expect(readFileSync(reviewPath, 'utf8')).toBe('const legacy = 1;');
+      expect(readFileSync(safePath, 'utf8')).toBe('const ping = 1;');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('skips safe diagnostics outside the root and scan set', async () => {
+    const dir = makeTempDir();
+    const outside = makeTempDir();
+    try {
+      const safePath = join(dir, 'safe.ts');
+      const unscannedPath = join(dir, 'unscanned.ts');
+      const outsidePath = join(outside, 'outside.ts');
+      writeFileSync(safePath, 'const signal = 1;');
+      writeFileSync(unscannedPath, 'const signal = 1;');
+      writeFileSync(outsidePath, 'const signal = 1;');
+
+      const summary = await applySafeFixesToFiles(
+        [
+          safeRenameDiagnostic(safePath),
+          safeRenameDiagnostic(unscannedPath),
+          safeRenameDiagnostic(outsidePath),
+        ],
+        {
+          allowedFilePaths: [safePath],
+          rootDir: dir,
+        }
+      );
+
+      expect(summary).toMatchObject({
+        applied: 1,
+        filesChanged: 1,
+        skipped: 2,
+      });
+      expect(summary.appliedDiagnostics).toEqual([
+        safeRenameDiagnostic(safePath),
+      ]);
+      expect(readFileSync(safePath, 'utf8')).toBe('const ping = 1;');
+      expect(readFileSync(unscannedPath, 'utf8')).toBe('const signal = 1;');
+      expect(readFileSync(outsidePath, 'utf8')).toBe('const signal = 1;');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+      rmSync(outside, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('runWarden --fix wiring', () => {
+  test('omits the fix summary when fix is not requested', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'legacy.ts'),
+        '// references authLayer in a note'
+      );
+
+      const report = await runWarden({ rootDir: dir, tier: 'source-static' });
+
+      expect(report.fixes).toBeUndefined();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('removes applied safe diagnostics from the final report', async () => {
+    const dir = makeTempDir();
+    try {
+      const filePath = join(dir, 'safe.ts');
+      writeFileSync(filePath, 'const signal = 1;');
+
+      const report = await runWarden({
+        extraSourceRules: [buildSyntheticSafeSourceRule()],
+        fix: true,
+        lock: 'skip',
+        rootDir: dir,
+      });
+
+      expect(readFileSync(filePath, 'utf8')).toBe('const ping = 1;');
+      expect(report.fixes).toEqual({
+        applied: 1,
+        filesChanged: 1,
+        skipped: 0,
+      });
+      expect(report.diagnostics.map((entry) => entry.rule)).not.toContain(
+        'synthetic-safe-fix'
+      );
+      expect(report.warnCount).toBe(0);
+      expect(report.errorCount).toBe(0);
+      expect(report.passed).toBe(true);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('blocks drift evidence after safe fixes change source', async () => {
+    const dir = makeTempDir();
+    try {
+      const filePath = join(dir, 'safe.ts');
+      writeFileSync(filePath, 'const signal = 1;');
+
+      const report = await runWarden({
+        extraSourceRules: [buildSyntheticSafeSourceRule()],
+        fix: true,
+        rootDir: dir,
+      });
+
+      expect(readFileSync(filePath, 'utf8')).toBe('const ping = 1;');
+      expect(report.diagnostics.map((entry) => entry.rule)).not.toContain(
+        'synthetic-safe-fix'
+      );
+      expect(report.drift?.blockedReason).toBe(
+        'Source fixes were applied; rerun Warden to refresh drift evidence.'
+      );
+      expect(report.passed).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('reports review-only legacy fixes as skipped without touching source', async () => {
+    const dir = makeTempDir();
+    try {
+      const filePath = join(dir, 'legacy.ts');
+      const source = '// references authLayer in a note';
+      writeFileSync(filePath, source);
+
+      const report = await runWarden({
+        fix: true,
+        rootDir: dir,
+        tier: 'source-static',
+      });
+
+      const legacyDiagnostics = report.diagnostics.filter(
+        (diagnostic) => diagnostic.rule === 'no-legacy-layer-imports'
+      );
+      expect(legacyDiagnostics.length).toBeGreaterThan(0);
+      expect(report.fixes).toBeDefined();
+      expect(report.fixes?.applied).toBe(0);
+      expect(report.fixes?.filesChanged).toBe(0);
+      expect(report.fixes?.skipped).toBeGreaterThanOrEqual(1);
+      // Review-only fixes never rewrite source.
+      expect(readFileSync(filePath, 'utf8')).toBe(source);
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/warden/src/__tests__/command.test.ts
+++ b/packages/warden/src/__tests__/command.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -60,6 +66,15 @@ describe('parseWardenCommandArgs', () => {
       'Invalid --format value "xml". Expected one of: summary, github, json.'
     );
   });
+
+  test('parses --fix as a boolean flag', () => {
+    expect(parseWardenCommandArgs(['--fix']).fix).toBe(true);
+    expect(parseWardenCommandArgs(['--fix']).diagnostics).toEqual([]);
+  });
+
+  test('defaults --fix to false when absent', () => {
+    expect(parseWardenCommandArgs([]).fix).toBe(false);
+  });
 });
 
 describe('runWardenCommand', () => {
@@ -78,6 +93,89 @@ describe('runWardenCommand', () => {
           (diagnostic) => diagnostic.rule === 'topo-load'
         )
       ).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('--fix threads through to the runner and reports review-only fixes as skipped', async () => {
+    const dir = makeTempDir();
+    try {
+      const filePath = join(dir, 'legacy.ts');
+      const source = '// references authLayer in a note';
+      writeFileSync(filePath, source);
+
+      const result = await runWardenCommand({
+        args: ['--fix', '--depth', 'source', '--lock', 'skip'],
+        cwd: dir,
+        env: {},
+      });
+
+      expect(result.report.fixes).toBeDefined();
+      expect(result.report.fixes?.applied).toBe(0);
+      expect(result.report.fixes?.filesChanged).toBe(0);
+      expect(result.report.fixes?.skipped).toBeGreaterThanOrEqual(1);
+      expect(result.output).toContain('**Fixes:** 0 applied, 0 files changed,');
+      // Review-only legacy fixes never rewrite source.
+      expect(readFileSync(filePath, 'utf8')).toBe(source);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('omits the fix summary when --fix is not passed', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'legacy.ts'),
+        '// references authLayer in a note'
+      );
+
+      const result = await runWardenCommand({
+        args: ['--depth', 'source', '--lock', 'skip'],
+        cwd: dir,
+        env: {},
+      });
+
+      expect(result.report.fixes).toBeUndefined();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('--fix JSON output includes the fix summary', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(
+        join(dir, 'legacy.ts'),
+        '// references authLayer in a note'
+      );
+
+      const result = await runWardenCommand({
+        args: [
+          '--fix',
+          '--format',
+          'json',
+          '--depth',
+          'source',
+          '--lock',
+          'skip',
+        ],
+        cwd: dir,
+        env: {},
+      });
+      const output = JSON.parse(result.output) as {
+        readonly fixes?: {
+          readonly applied: number;
+          readonly filesChanged: number;
+          readonly skipped: number;
+        };
+      };
+
+      expect(output.fixes).toEqual(result.report.fixes);
+      expect(output.fixes?.applied).toBe(0);
+      expect(output.fixes?.filesChanged).toBe(0);
+      expect(output.fixes?.skipped).toBeGreaterThanOrEqual(1);
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/warden/src/__tests__/fix.test.ts
+++ b/packages/warden/src/__tests__/fix.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, test } from 'bun:test';
+
+import { applySafeFixesToSource } from '../fix.js';
+import type { WardenDiagnostic } from '../rules/index.js';
+
+const baseDiagnostic = (
+  overrides: Partial<WardenDiagnostic>
+): WardenDiagnostic => ({
+  filePath: 'entity.ts',
+  line: 1,
+  message: 'test diagnostic',
+  rule: 'test-rule',
+  severity: 'error',
+  ...overrides,
+});
+
+describe('applySafeFixesToSource', () => {
+  test('applies a safe source edit and reports it as applied', () => {
+    const source = 'const signal = 1;';
+    const diagnostic = baseDiagnostic({
+      fix: {
+        class: 'term-rewrite',
+        edits: [{ end: 12, replacement: 'ping', start: 6 }],
+        reason: 'rename signal to ping',
+        safety: 'safe',
+      },
+    });
+
+    const result = applySafeFixesToSource(source, [diagnostic]);
+
+    expect(result.changed).toBe(true);
+    expect(result.patched).toBe('const ping = 1;');
+    expect(result.applied).toHaveLength(1);
+    expect(result.skipped).toHaveLength(0);
+  });
+
+  test('leaves a review-required fix untouched and still reported', () => {
+    const source = `import { authLayer } from '@ontrails/core';`;
+    const diagnostic = baseDiagnostic({
+      fix: {
+        class: 'term-rewrite',
+        reason: 'legacy layer removed; needs human migration',
+        safety: 'review',
+      },
+    });
+
+    const result = applySafeFixesToSource(source, [diagnostic]);
+
+    expect(result.changed).toBe(false);
+    expect(result.patched).toBe(source);
+    expect(result.applied).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.fix?.safety).toBe('review');
+  });
+
+  test('treats a diagnostic with no fix as skipped', () => {
+    const source = 'const x = 1;';
+    const result = applySafeFixesToSource(source, [baseDiagnostic({})]);
+    expect(result.changed).toBe(false);
+    expect(result.applied).toHaveLength(0);
+    expect(result.skipped).toHaveLength(1);
+  });
+
+  test('applies multiple safe edits last-to-first across one source', () => {
+    const source = 'aaa bbb ccc';
+    const diagnostic = baseDiagnostic({
+      fix: {
+        class: 'term-rewrite',
+        edits: [
+          { end: 3, replacement: 'XXXX', start: 0 },
+          { end: 11, replacement: 'Z', start: 8 },
+        ],
+        reason: 'two independent rewrites',
+        safety: 'safe',
+      },
+    });
+
+    const result = applySafeFixesToSource(source, [diagnostic]);
+
+    // Both spans applied; the earlier offset stays valid because edits run
+    // right-to-left.
+    expect(result.patched).toBe('XXXX bbb Z');
+    expect(result.changed).toBe(true);
+  });
+
+  test('applies offsets as JavaScript string indices after multibyte text', () => {
+    const source = 'const label = "café"; const signal = 1;';
+    const start = source.indexOf('signal');
+    const diagnostic = baseDiagnostic({
+      fix: {
+        class: 'term-rewrite',
+        edits: [{ end: start + 'signal'.length, replacement: 'ping', start }],
+        reason: 'rename signal to ping',
+        safety: 'safe',
+      },
+    });
+
+    const result = applySafeFixesToSource(source, [diagnostic]);
+
+    expect(result.patched).toBe('const label = "café"; const ping = 1;');
+    expect(result.changed).toBe(true);
+  });
+
+  test('applies safe edits while skipping review fixes in the same file', () => {
+    const source = 'const signal = 1;';
+    const safe = baseDiagnostic({
+      fix: {
+        class: 'term-rewrite',
+        edits: [{ end: 12, replacement: 'ping', start: 6 }],
+        reason: 'safe rename',
+        safety: 'safe',
+      },
+    });
+    const review = baseDiagnostic({
+      fix: {
+        class: 'term-rewrite',
+        reason: 'needs review',
+        safety: 'review',
+      },
+    });
+
+    const result = applySafeFixesToSource(source, [safe, review]);
+
+    expect(result.patched).toBe('const ping = 1;');
+    expect(result.applied).toHaveLength(1);
+    expect(result.skipped).toHaveLength(1);
+  });
+
+  test('throws on out-of-bounds edits rather than corrupting source', () => {
+    const diagnostic = baseDiagnostic({
+      fix: {
+        class: 'term-rewrite',
+        edits: [{ end: 999, replacement: 'x', start: 0 }],
+        reason: 'bad span',
+        safety: 'safe',
+      },
+    });
+    expect(() => applySafeFixesToSource('short', [diagnostic])).toThrow();
+  });
+
+  test.each([
+    {
+      edit: { end: 1, replacement: 'x', start: Number.NaN },
+      name: 'NaN start',
+    },
+    {
+      edit: { end: Number.POSITIVE_INFINITY, replacement: 'x', start: 0 },
+      name: 'infinite end',
+    },
+    {
+      edit: { end: 2, replacement: 'x', start: 0.5 },
+      name: 'fractional start',
+    },
+  ])('throws on $name offsets rather than corrupting source', ({ edit }) => {
+    const diagnostic = baseDiagnostic({
+      fix: {
+        class: 'term-rewrite',
+        edits: [edit],
+        reason: 'bad span',
+        safety: 'safe',
+      },
+    });
+
+    expect(() => applySafeFixesToSource('abc', [diagnostic])).toThrow(
+      /safe integer offsets/
+    );
+  });
+
+  test('throws on overlapping safe edits rather than corrupting source', () => {
+    const diagnostic = baseDiagnostic({
+      fix: {
+        class: 'term-rewrite',
+        // [0, 5) and [3, 8) overlap; applied last-to-first, the later edit's
+        // end (8) crosses the earlier edit's start, which must throw.
+        edits: [
+          { end: 5, replacement: 'A', start: 0 },
+          { end: 8, replacement: 'B', start: 3 },
+        ],
+        reason: 'overlapping spans',
+        safety: 'safe',
+      },
+    });
+    expect(() => applySafeFixesToSource('0123456789', [diagnostic])).toThrow(
+      /overlaps/
+    );
+  });
+});

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -5,7 +5,7 @@
  * and returns a structured report.
  */
 
-import { resolve } from 'node:path';
+import { isAbsolute, relative, resolve } from 'node:path';
 
 import type { Topo } from '@ontrails/core';
 import { deriveTopoGraph } from '@ontrails/topographer';
@@ -23,6 +23,7 @@ import type {
 } from './config.js';
 import { resolveWardenConfig } from './config.js';
 import { isDraftMarkedFile } from './draft.js';
+import { applySafeFixesToSource, hasSafeFixEdits } from './fix.js';
 import type { DriftResult } from './drift.js';
 import { checkDrift } from './drift.js';
 import {
@@ -85,6 +86,13 @@ export interface WardenRunOptions {
   readonly drafts?: EffectiveWardenConfig['drafts'] | undefined;
   /** Failure threshold used to compute `report.passed`. */
   readonly failOn?: WardenFailOn | undefined;
+  /**
+   * Apply safe source fixes among the run's diagnostics, writing changed files.
+   *
+   * Only `safety: 'safe'` fixes with concrete edits are applied; review-required,
+   * edit-less, and topo diagnostics stay reported but unapplied.
+   */
+  readonly fix?: boolean | undefined;
   /** Output format requested by the caller. */
   readonly format?: WardenFormat | undefined;
   /** Lockfile mode requested by the caller. */
@@ -129,10 +137,34 @@ export interface WardenRunOptions {
    * when `topo` is also supplied (see `topo` remarks).
    */
   readonly extraTopoRules?: readonly TopoAwareWardenRule[] | undefined;
+  /**
+   * Extra source rules to run in addition to the built-in registry.
+   *
+   * Primarily a test hook — production callers should register durable rules
+   * via `wardenRules` in `rules/index.ts`.
+   */
+  readonly extraSourceRules?: readonly WardenRule[] | undefined;
 }
 
 /** Backwards-compatible name for older consumers. */
 export type WardenOptions = WardenRunOptions;
+
+/**
+ * Aggregate outcome of a `--fix` pass over a run's diagnostics.
+ */
+export interface WardenFixSummary {
+  /** Diagnostics whose safe fix was applied to source. */
+  readonly applied: number;
+  /** Source files rewritten with patched content. */
+  readonly filesChanged: number;
+  /** Diagnostics carrying fix metadata left unapplied (review or edit-less). */
+  readonly skipped: number;
+}
+
+export interface WardenFixApplication extends WardenFixSummary {
+  /** Diagnostics removed from the final report because their safe fix applied. */
+  readonly appliedDiagnostics: readonly WardenDiagnostic[];
+}
 
 /**
  * Result of a warden run.
@@ -152,6 +184,8 @@ export interface WardenReport {
   readonly effectiveConfig?: EffectiveWardenConfig | undefined;
   /** Resolved topo/app labels governed by this run. */
   readonly topoNames?: readonly string[] | undefined;
+  /** Safe-fix application summary, present only when a `--fix` pass ran. */
+  readonly fixes?: WardenFixSummary | undefined;
 }
 
 /**
@@ -990,11 +1024,13 @@ const lintTopo = async (
 const lintSourceFiles = (
   sourceFiles: readonly SourceFile[],
   context: ProjectContext,
+  extraSourceRules: readonly WardenRule[],
   selector: WardenRuleSelector
 ): readonly WardenDiagnostic[] => {
   const diagnostics: WardenDiagnostic[] = [];
+  const rules = [...wardenRules.values(), ...extraSourceRules];
   for (const sourceFile of sourceFiles) {
-    for (const rule of wardenRules.values()) {
+    for (const rule of rules) {
       if (
         sourceFile.kind === 'text' &&
         rule.name !== 'no-dev-permit-in-source' &&
@@ -1077,17 +1113,26 @@ const selectorIncludesTopoRules = (selector: WardenRuleSelector): boolean => {
 /**
  * Lint all files against all warden rules.
  */
+interface WardenLintResult {
+  readonly diagnostics: readonly WardenDiagnostic[];
+  readonly sourceFiles: readonly SourceFile[];
+}
+
 const lintFiles = async (
   rootDir: string,
   drafts: EffectiveWardenConfig['drafts'],
   topoTargets: readonly WardenTopoTarget[],
   extraTopoRules: readonly TopoAwareWardenRule[],
+  extraSourceRules: readonly WardenRule[],
   selector: WardenRuleSelector
-): Promise<WardenDiagnostic[]> => {
+): Promise<WardenLintResult> => {
   if (selector.tier === 'topo-aware') {
-    return [
-      ...(await lintTopoTargets(topoTargets, extraTopoRules, selector, true)),
-    ];
+    return {
+      diagnostics: [
+        ...(await lintTopoTargets(topoTargets, extraTopoRules, selector, true)),
+      ],
+      sourceFiles: [],
+    };
   }
 
   const sourceFiles = filterSourceFilesByDraftMode(
@@ -1100,7 +1145,7 @@ const lintFiles = async (
     topoTargets.map((target) => target.topo)
   );
   const allDiagnostics: WardenDiagnostic[] = [
-    ...lintSourceFiles(sourceFiles, context, selector),
+    ...lintSourceFiles(sourceFiles, context, extraSourceRules, selector),
   ];
 
   if (
@@ -1118,7 +1163,7 @@ const lintFiles = async (
     );
   }
 
-  return allDiagnostics;
+  return { diagnostics: allDiagnostics, sourceFiles };
 };
 
 const topoTargetsFromOptions = (
@@ -1270,6 +1315,101 @@ const buildCliConfigLayer = (options: WardenRunOptions): WardenConfigLayer => ({
     : { noLockMutation: options.noLockMutation }),
 });
 
+const fixSummary = (application: WardenFixApplication): WardenFixSummary => ({
+  applied: application.applied,
+  filesChanged: application.filesChanged,
+  skipped: application.skipped,
+});
+
+const filterAppliedFixDiagnostics = (
+  diagnostics: readonly WardenDiagnostic[],
+  appliedDiagnostics: readonly WardenDiagnostic[]
+): readonly WardenDiagnostic[] => {
+  if (appliedDiagnostics.length === 0) {
+    return diagnostics;
+  }
+  const applied = new Set(appliedDiagnostics);
+  return diagnostics.filter((diagnostic) => !applied.has(diagnostic));
+};
+
+const blockedDriftAfterSourceFixes = (): DriftResult => ({
+  blockedReason:
+    'Source fixes were applied; rerun Warden to refresh drift evidence.',
+  committedHash: null,
+  currentHash: 'blocked',
+  stale: true,
+});
+
+/**
+ * Apply every safe source fix among a run's diagnostics, writing patched files.
+ *
+ * Diagnostics with a safe, edit-bearing fix are grouped by file; each file is
+ * re-read so the rule's recorded offsets stay valid, patched via
+ * {@link applySafeFixesToSource}, and written back only when its source
+ * actually changed. Diagnostics that carry fix metadata but are not safe with
+ * edits (review-required or edit-less) are counted as skipped and left reported
+ * for a human or downstream regrade to resolve. Diagnostics without fix
+ * metadata — including topo diagnostics, which carry no source span — are
+ * neither applied nor counted in `skipped`.
+ */
+export const applySafeFixesToFiles = async (
+  diagnostics: readonly WardenDiagnostic[],
+  options: {
+    readonly allowedFilePaths?: ReadonlySet<string> | readonly string[];
+    readonly rootDir: string;
+  }
+): Promise<WardenFixApplication> => {
+  const rootDir = resolve(options.rootDir);
+  const allowedFilePaths =
+    options.allowedFilePaths === undefined
+      ? undefined
+      : new Set(
+          [...options.allowedFilePaths].map((filePath) => resolve(filePath))
+        );
+  const fixableByFile = new Map<string, WardenDiagnostic[]>();
+  let skipped = 0;
+  for (const diagnostic of diagnostics) {
+    if (diagnostic.fix === undefined) {
+      continue;
+    }
+    if (hasSafeFixEdits(diagnostic)) {
+      const filePath = resolve(diagnostic.filePath);
+      const rootRelativePath = relative(rootDir, filePath);
+      const insideRoot =
+        rootRelativePath.length === 0 ||
+        (!rootRelativePath.startsWith('..') && !isAbsolute(rootRelativePath));
+      if (
+        !insideRoot ||
+        (allowedFilePaths !== undefined && !allowedFilePaths.has(filePath))
+      ) {
+        skipped += 1;
+        continue;
+      }
+      const bucket = fixableByFile.get(filePath) ?? [];
+      bucket.push(diagnostic);
+      fixableByFile.set(filePath, bucket);
+    } else {
+      skipped += 1;
+    }
+  }
+
+  let applied = 0;
+  const appliedDiagnostics: WardenDiagnostic[] = [];
+  let filesChanged = 0;
+  for (const [filePath, group] of fixableByFile) {
+    const source = await Bun.file(filePath).text();
+    const result = applySafeFixesToSource(source, group);
+    applied += result.applied.length;
+    appliedDiagnostics.push(...result.applied);
+    if (result.changed) {
+      await Bun.write(filePath, result.patched);
+      filesChanged += 1;
+    }
+  }
+
+  return { applied, appliedDiagnostics, filesChanged, skipped };
+};
+
 /**
  * Run all warden checks and return a structured report.
  */
@@ -1298,39 +1438,62 @@ export const runWarden = async (
   } satisfies WardenRuleSelector;
   const runLint = shouldRunLint(options);
   const runDrift = shouldRunDrift(options, effectiveConfig);
+  const lintResult = runLint
+    ? await lintFiles(
+        rootDir,
+        effectiveConfig.drafts,
+        topoTargets,
+        options.extraTopoRules ?? [],
+        options.extraSourceRules ?? [],
+        selector
+      )
+    : { diagnostics: [], sourceFiles: [] };
 
   const rawDiagnostics = [
     ...configDiagnostics,
     ...optionDiagnostics,
-    ...(runLint
-      ? await lintFiles(
-          rootDir,
-          effectiveConfig.drafts,
-          topoTargets,
-          options.extraTopoRules ?? [],
-          selector
-        )
-      : []),
+    ...lintResult.diagnostics,
   ];
   const allDiagnostics = rawDiagnostics.map(withDiagnosticGuidance);
-  const drift = runDrift
-    ? await checkDriftForTopoTargets(rootDir, topoTargets)
-    : null;
+  const fixApplication = options.fix
+    ? await applySafeFixesToFiles(allDiagnostics, {
+        allowedFilePaths: lintResult.sourceFiles.map(
+          (sourceFile) => sourceFile.filePath
+        ),
+        rootDir,
+      })
+    : undefined;
+  const reportDiagnostics = filterAppliedFixDiagnostics(
+    allDiagnostics,
+    fixApplication?.appliedDiagnostics ?? []
+  );
+  let drift: DriftResult | null = null;
+  if (runDrift) {
+    drift =
+      fixApplication !== undefined && fixApplication.filesChanged > 0
+        ? blockedDriftAfterSourceFixes()
+        : await checkDriftForTopoTargets(rootDir, topoTargets);
+  }
 
-  const errorCount = allDiagnostics.filter(
+  const errorCount = reportDiagnostics.filter(
     (d) => d.severity === 'error'
   ).length;
-  const warnCount = allDiagnostics.filter((d) => d.severity === 'warn').length;
+  const warnCount = reportDiagnostics.filter(
+    (d) => d.severity === 'warn'
+  ).length;
   const topoNames =
     topoTargets.length > 0
       ? topoTargets.map((target) => target.name ?? target.topo.name)
       : undefined;
 
   return {
-    diagnostics: allDiagnostics,
+    diagnostics: reportDiagnostics,
     drift,
     effectiveConfig,
     errorCount,
+    ...(fixApplication === undefined
+      ? {}
+      : { fixes: fixSummary(fixApplication) }),
     passed: reportPassed({
       drift,
       errorCount,

--- a/packages/warden/src/command.ts
+++ b/packages/warden/src/command.ts
@@ -132,6 +132,7 @@ export interface ParsedWardenCommand {
   readonly cli: WardenConfigLayer;
   readonly configPath?: string | undefined;
   readonly diagnostics: readonly WardenDiagnostic[];
+  readonly fix: boolean;
   readonly prePush: boolean;
   readonly rootDir?: string | undefined;
 }
@@ -140,6 +141,7 @@ const createEmptyParsedCommand = (message: string): ParsedWardenCommand => ({
   ci: false,
   cli: {},
   diagnostics: [diagnostic({ message })],
+  fix: false,
   prePush: false,
 });
 
@@ -153,6 +155,7 @@ interface CommandParserState {
   readonly diagnostics: WardenDiagnostic[];
   readonly cli: MutableWardenConfigLayer;
   configPath?: string | undefined;
+  fix?: boolean | undefined;
   rootDir?: string | undefined;
 }
 
@@ -238,6 +241,7 @@ const parseTokens = (
         depth: { type: 'string' },
         drafts: { type: 'string' },
         'fail-on': { type: 'string' },
+        fix: { type: 'boolean' },
         format: { type: 'string' },
         lock: { type: 'string' },
         'no-lock-mutation': { type: 'boolean' },
@@ -388,6 +392,10 @@ const applyCommandOption = (
     state.configPath = value;
     return;
   }
+  if (token.name === 'fix') {
+    state.fix = true;
+    return;
+  }
   if (token.name === 'no-lock-mutation') {
     state.cli.noLockMutation = true;
     return;
@@ -443,6 +451,7 @@ export const parseWardenCommandArgs = (
     ) as WardenConfigLayer,
     configPath: state.configPath,
     diagnostics: state.diagnostics,
+    fix: state.fix ?? false,
     prePush,
     rootDir: state.rootDir,
   };
@@ -791,12 +800,14 @@ const buildRunOptions = ({
   cli,
   config,
   env,
+  fix,
   rootDir,
   topos,
 }: {
   readonly cli: WardenConfigLayer;
   readonly config?: WardenConfigInput | undefined;
   readonly env: EnvRecord;
+  readonly fix: boolean;
   readonly rootDir: string;
   readonly topos: readonly WardenTopoTarget[];
 }): WardenRunOptions => ({
@@ -806,6 +817,7 @@ const buildRunOptions = ({
     depth: cli.depth,
     drafts: cli.drafts,
     failOn: cli.failOn,
+    fix,
     format: cli.format,
     lock: cli.lock,
     noLockMutation: cli.noLockMutation,
@@ -907,6 +919,7 @@ export const runWardenCommand = async ({
       cli: parsed.cli,
       config: loadedConfig.config,
       env,
+      fix: parsed.fix,
       rootDir,
       topos: topoResolution.topos,
     })

--- a/packages/warden/src/fix.ts
+++ b/packages/warden/src/fix.ts
@@ -1,0 +1,120 @@
+/**
+ * Safe-fix execution for `warden --fix` (TRL-833).
+ *
+ * Consumes the structured {@link WardenFix} metadata a rule attaches to its
+ * diagnostics (TRL-831) and applies only the edits marked `safe`. Findings
+ * whose fix is `review`-required, or that carry no edits, are never applied —
+ * they stay reported so a human (or a downstream regrade) resolves them.
+ *
+ * The applicator is pure: it takes a file's source plus that file's
+ * diagnostics and returns the patched source plus which diagnostics were
+ * applied or skipped. The CLI layer owns reading and writing files.
+ */
+
+import type { WardenDiagnostic, WardenFixEdit } from './rules/types.js';
+
+/** A safe edit resolved from a diagnostic, ready to apply to a source string. */
+interface ResolvedEdit {
+  readonly start: number;
+  readonly end: number;
+  readonly replacement: string;
+}
+
+/**
+ * Apply a set of edits to a source string, last-to-first.
+ *
+ * Edits are applied in descending start order so earlier offsets stay valid as
+ * later spans are spliced. Overlapping edits are a programming error in the
+ * rule that produced them; this throws rather than silently corrupt source.
+ */
+const applyEdits = (source: string, edits: readonly ResolvedEdit[]): string => {
+  for (const edit of edits) {
+    if (!Number.isSafeInteger(edit.start) || !Number.isSafeInteger(edit.end)) {
+      throw new RangeError(
+        `Fix edit [${String(edit.start)}, ${String(edit.end)}) must use safe integer offsets.`
+      );
+    }
+  }
+
+  const ordered = [...edits].toSorted(
+    (left, right) => right.start - left.start
+  );
+  let result = source;
+  let lastStart = Number.POSITIVE_INFINITY;
+  for (const edit of ordered) {
+    if (edit.start < 0 || edit.end > source.length || edit.start > edit.end) {
+      throw new RangeError(
+        `Fix edit [${edit.start}, ${edit.end}) is out of bounds for source of length ${source.length}.`
+      );
+    }
+    if (edit.end > lastStart) {
+      throw new RangeError(
+        `Fix edit [${edit.start}, ${edit.end}) overlaps a later edit starting at ${lastStart}.`
+      );
+    }
+    result =
+      result.slice(0, edit.start) + edit.replacement + result.slice(edit.end);
+    lastStart = edit.start;
+  }
+  return result;
+};
+
+/** Whether a diagnostic carries an applicable safe fix with concrete edits. */
+export const hasSafeFixEdits = (
+  diagnostic: WardenDiagnostic
+): diagnostic is WardenDiagnostic & {
+  readonly fix: { readonly edits: readonly WardenFixEdit[] };
+} =>
+  diagnostic.fix?.safety === 'safe' &&
+  diagnostic.fix.edits !== undefined &&
+  diagnostic.fix.edits.length > 0;
+
+/** Result of applying safe fixes to a single file's source. */
+export interface WardenFileFixResult {
+  /** Source after applying every safe edit; unchanged when none applied. */
+  readonly patched: string;
+  /** Whether any edit was applied (i.e. `patched` differs from input). */
+  readonly changed: boolean;
+  /** Diagnostics whose safe fix was applied. */
+  readonly applied: readonly WardenDiagnostic[];
+  /** Diagnostics left reported (review-required, or no safe edits). */
+  readonly skipped: readonly WardenDiagnostic[];
+}
+
+/**
+ * Apply the safe fixes among a file's diagnostics to its source.
+ *
+ * Pure and filesystem-free. Only `safety: 'safe'` fixes with edits are applied;
+ * everything else is returned in `skipped`. Edits from all applicable
+ * diagnostics are pooled and applied last-to-first in one pass.
+ */
+export const applySafeFixesToSource = (
+  source: string,
+  diagnostics: readonly WardenDiagnostic[]
+): WardenFileFixResult => {
+  const applied: WardenDiagnostic[] = [];
+  const skipped: WardenDiagnostic[] = [];
+  const edits: ResolvedEdit[] = [];
+
+  for (const diagnostic of diagnostics) {
+    if (hasSafeFixEdits(diagnostic)) {
+      applied.push(diagnostic);
+      for (const edit of diagnostic.fix.edits) {
+        edits.push({
+          end: edit.end,
+          replacement: edit.replacement,
+          start: edit.start,
+        });
+      }
+    } else {
+      skipped.push(diagnostic);
+    }
+  }
+
+  if (edits.length === 0) {
+    return { applied, changed: false, patched: source, skipped };
+  }
+
+  const patched = applyEdits(source, edits);
+  return { applied, changed: patched !== source, patched, skipped };
+};

--- a/packages/warden/src/formatters.ts
+++ b/packages/warden/src/formatters.ts
@@ -60,6 +60,7 @@ export const formatJson = (report: WardenReport): string => {
     {
       diagnostics: report.diagnostics,
       drift: report.drift,
+      fixes: report.fixes,
       passed: report.passed,
       summary,
     },
@@ -150,6 +151,16 @@ const driftSection = (drift: WardenReport['drift']): readonly string[] => {
   ];
 };
 
+/** Render safe-fix counts when a fix pass was requested. */
+const fixSummaryLine = (fixes: WardenReport['fixes']): readonly string[] => {
+  if (fixes === undefined) {
+    return [];
+  }
+  return [
+    `**Fixes:** ${String(fixes.applied)} applied, ${String(fixes.filesChanged)} files changed, ${String(fixes.skipped)} skipped`,
+  ];
+};
+
 /**
  * Produce a concise markdown summary suitable for a GitHub job summary or PR comment.
  *
@@ -164,6 +175,7 @@ export const formatSummary = (report: WardenReport): string => {
     '## Warden Report',
     '',
     `**Result: ${result}** | ${String(report.errorCount)} errors, ${String(report.warnCount)} warnings`,
+    ...fixSummaryLine(report.fixes),
     ...severitySection('Errors', errors),
     ...severitySection('Warnings', warnings),
     ...driftSection(report.drift),


### PR DESCRIPTION
## Summary

Implements `warden --fix` for safe source edits. A pure executor applies only `safety: 'safe'` fixes that carry concrete edits (last-to-first, throwing on overlap or out-of-bounds rather than corrupting source); review-required, edit-less, and topo diagnostics stay reported but unapplied. The CLI wires the flag end to end and the report carries applied / changed-file / skipped counts.

## Changes

- `packages/warden/src/fix.ts`: `applySafeFixesToSource` executor (plus an exported `hasSafeFixEdits` selector so selection stays single-sourced).
- `packages/warden/src/cli.ts`: `WardenRunOptions.fix`, `WardenFixSummary`, `WardenReport.fixes`, and `applySafeFixesToFiles` (group by file, re-read via `Bun.file().text()`, write changed files via `Bun.write`); `runWarden` runs the pass only when `--fix` is set.
- `packages/warden/src/command.ts`: parse the boolean `--fix` flag and thread it `runWardenCommand` → `buildRunOptions` → `runWarden`.
- Tests: executor unit tests (incl. overlap and out-of-bounds), `applySafeFixesToFiles` file I/O, and `--fix` CLI/command coverage (safe-apply via a synthetic diagnostic; review-only path via the real `no-legacy-layer-imports` rule).

## Testing

Warden suite green (985 tests). No built-in rule emits a safe fix yet, so the end-to-end safe-apply path is covered with a synthetic diagnostic while the review path runs through the real rule. CI green (8/8).

Changeset: `@ontrails/warden` minor.

---

Stack tip. Stack base: #627. Linear: [TRL-833](https://linear.app/outfitter/issue/TRL-833).
