### PR TITLE
chore: add provider bootstrap modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,8 @@ Use Graphite for source control operations.
 - We use Conventional Commits.
 - Keep PRs small, isolate mechanical changes when possible, and keep PRs in draft until CI is green.
 - Treat a Greptile error comment (`Greptile encountered an error while reviewing this PR`) as a blocker, not as a completed review.
-- When performing fixes across stacked branches, always do so from the top most branch and use `gt absorb -a`
+- When performing fixes across stacked branches, prefer the owning branch: check it out, make the focused fix there, `gt modify`, restack, and verify upward. Use `gt absorb -a` only when the stack owner explicitly chooses a top-branch absorption workflow.
+- For Codex/Crew worktree farming, the worker worktree must have a real branch checked out. `gt create` does not work from detached `HEAD`. A zero-diff Graphite-tracked base branch under `main` is acceptable as the worker lane base; workers may create child branches from that lane and hold before submit.
 
 ## Subagent Rules
 

--- a/scripts/__tests__/bootstrap.test.ts
+++ b/scripts/__tests__/bootstrap.test.ts
@@ -34,11 +34,13 @@ describe('bootstrap dispatcher', () => {
     expect(parseBootstrapArgs(['--force'])).toEqual({
       command: 'repo',
       force: true,
+      provider: undefined,
       update: false,
     });
     expect(parseBootstrapArgs(['--update'])).toEqual({
       command: 'repo',
       force: false,
+      provider: undefined,
       update: true,
     });
   });
@@ -47,11 +49,37 @@ describe('bootstrap dispatcher', () => {
     expect(parseBootstrapArgs(['agent', '--update'])).toEqual({
       command: 'agent',
       force: false,
+      provider: undefined,
       update: true,
+    });
+    expect(parseBootstrapArgs(['codex'])).toEqual({
+      command: 'codex',
+      force: false,
+      provider: 'codex',
+      update: false,
+    });
+    expect(parseBootstrapArgs(['claude'])).toEqual({
+      command: 'claude',
+      force: false,
+      provider: 'claude',
+      update: false,
     });
     expect(parseBootstrapArgs(['doctor'])).toEqual({
       command: 'doctor',
       force: false,
+      provider: undefined,
+      update: false,
+    });
+    expect(parseBootstrapArgs(['teardown'])).toEqual({
+      command: 'teardown',
+      force: false,
+      provider: undefined,
+      update: false,
+    });
+    expect(parseBootstrapArgs(['sweep'])).toEqual({
+      command: 'sweep',
+      force: false,
+      provider: undefined,
       update: false,
     });
   });
@@ -65,7 +93,9 @@ describe('bootstrap dispatcher', () => {
     });
 
     expect(proc.exitCode).toBe(0);
-    expect(proc.stdout.toString()).toContain('repo|agent|doctor|sweep');
+    expect(proc.stdout.toString()).toContain(
+      'repo|agent|codex|claude|doctor|teardown'
+    );
   });
 });
 
@@ -155,6 +185,28 @@ describe('bootstrap repo policy', () => {
     }
   });
 
+  test('provider-specific root resolution prefers the requested provider', () => {
+    const config = loadBootstrapConfig();
+    const codexRoot = makeRepoRoot();
+    const claudeRoot = makeRepoRoot();
+    try {
+      expect(
+        resolveRepoRoot(
+          tmpdir(),
+          {
+            CLAUDE_PROJECT_DIR: claudeRoot,
+            CODEX_WORKTREE_PATH: codexRoot,
+          } as NodeJS.ProcessEnv,
+          config,
+          'claude'
+        )
+      ).toBe(claudeRoot);
+    } finally {
+      rmSync(codexRoot, { force: true, recursive: true });
+      rmSync(claudeRoot, { force: true, recursive: true });
+    }
+  });
+
   test('root resolution accepts CLAUDECODE when it carries a repo path', () => {
     const config = loadBootstrapConfig();
     const claudeRoot = makeRepoRoot();
@@ -203,5 +255,11 @@ describe('bootstrap repo policy', () => {
     expect(() => resolveCleanupTarget(repoRoot, '../outside')).toThrow(
       'outside repo'
     );
+  });
+
+  test('teardown cleanup includes current trails state paths', () => {
+    const config = loadBootstrapConfig();
+    expect(config.cleanup.files).toContain('.trails/state/trails.db');
+    expect(config.cleanup.files).toContain('.trails/state/tracing.db');
   });
 });

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,7 +3,7 @@
 # bootstrap.sh — cold-start trampoline for Trails repo lifecycle commands.
 #
 # Usage:
-#   ./scripts/bootstrap.sh [repo|agent|doctor|sweep] [--force] [--update]
+#   ./scripts/bootstrap.sh [repo|agent|codex|claude|doctor|teardown] [--force] [--update]
 #   ./scripts/bootstrap.sh --force   # legacy alias for repo --force
 #   ./scripts/bootstrap.sh --update  # legacy alias for repo --update
 
@@ -15,17 +15,20 @@ BUN_VERSION_FILE="$REPO_ROOT/.bun-version"
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/bootstrap.sh [repo|agent|doctor|sweep] [--force] [--update]
+Usage: ./scripts/bootstrap.sh [repo|agent|codex|claude|doctor|teardown] [--force] [--update]
 
 Commands:
   repo     Make this checkout runnable (default)
   agent    Repo bootstrap plus agent lifecycle diagnostics
+  codex    Codex agent bootstrap with provider-specific root detection
+  claude   Claude agent bootstrap with provider-specific root detection
   doctor   Diagnostics only; no install, cleanup, or mutation
-  sweep    Conservative cleanup of configured runtime artifacts only
+  teardown Conservative cleanup of configured runtime artifacts only
 
 Compatibility:
   ./scripts/bootstrap.sh --force
   ./scripts/bootstrap.sh --update
+  ./scripts/bootstrap.sh sweep
 EOF
 }
 
@@ -36,7 +39,7 @@ fi
 
 SUBCOMMAND="${1:-repo}"
 case "$SUBCOMMAND" in
-  repo|agent|doctor|sweep)
+  repo|agent|codex|claude|doctor|sweep|teardown)
     shift || true
     ;;
   --force|--update)

--- a/scripts/bootstrap/config.toml
+++ b/scripts/bootstrap/config.toml
@@ -45,7 +45,7 @@ graphite_stack_max_lines = 120
 [commands.doctor]
 mutates = false
 
-[commands.sweep]
+[commands.teardown]
 mutates = true
 git_mutation_allowed = false
 
@@ -68,6 +68,12 @@ forbidden_lifecycle_commands = [
 [cleanup]
 directories = [".turbo", ".trails-tmp", ".tmp-tests", ".try"]
 files = [
+  ".trails/state/trails.db",
+  ".trails/state/trails.db-shm",
+  ".trails/state/trails.db-wal",
+  ".trails/state/tracing.db",
+  ".trails/state/tracing.db-shm",
+  ".trails/state/tracing.db-wal",
   ".trails/trails.db",
   ".trails/trails.db-shm",
   ".trails/trails.db-wal",

--- a/scripts/bootstrap/config.ts
+++ b/scripts/bootstrap/config.ts
@@ -35,7 +35,14 @@ export interface BootstrapConfig {
   };
 }
 
-export type BootstrapCommand = 'agent' | 'doctor' | 'repo' | 'sweep';
+export type BootstrapCommand =
+  | 'agent'
+  | 'claude'
+  | 'codex'
+  | 'doctor'
+  | 'repo'
+  | 'sweep'
+  | 'teardown';
 export type BunPolicy = 'compatible' | 'strict';
 
 interface RawConfig {

--- a/scripts/bootstrap/git.ts
+++ b/scripts/bootstrap/git.ts
@@ -48,6 +48,11 @@ export const printAgentGitDiagnostics = (
   console.error(
     `  branch: ${info.branch && info.branch.length > 0 ? info.branch : 'detached HEAD'}`
   );
+  if (info.branch === undefined || info.branch.length === 0) {
+    console.error(
+      '  Graphite can inspect here, but gt create requires a real checked-out branch.'
+    );
+  }
   console.error(
     '  Graphite branches and metadata are shared with the main checkout.'
   );

--- a/scripts/bootstrap/host.ts
+++ b/scripts/bootstrap/host.ts
@@ -43,6 +43,33 @@ const detectProvider = (env: NodeJS.ProcessEnv): HostProvider => {
   return 'generic';
 };
 
+const providerRootEnvVars = (
+  provider: HostProvider | undefined
+): readonly string[] => {
+  switch (provider) {
+    case 'codex': {
+      return ['CODEX_WORKTREE_PATH'];
+    }
+    case 'claude': {
+      return ['CLAUDE_PROJECT_DIR', 'CLAUDECODE'];
+    }
+    case 'factory': {
+      return ['FACTORY_PROJECT_DIR'];
+    }
+    case 'devin': {
+      return ['GITHUB_WORKSPACE'];
+    }
+    case 'generic':
+    case undefined: {
+      return [];
+    }
+    default: {
+      const exhaustive: never = provider;
+      return exhaustive;
+    }
+  }
+};
+
 export const detectHost = (
   env: NodeJS.ProcessEnv,
   config: BootstrapConfig
@@ -73,9 +100,16 @@ export const detectHost = (
 export const resolveRepoRoot = (
   cwd: string,
   env: NodeJS.ProcessEnv,
-  config: BootstrapConfig
+  config: BootstrapConfig,
+  provider?: HostProvider
 ): string => {
-  for (const name of config.root.envVars) {
+  const providerEnvVars = providerRootEnvVars(provider);
+  const orderedEnvVars = [
+    ...providerEnvVars,
+    ...config.root.envVars.filter((name) => !providerEnvVars.includes(name)),
+  ];
+
+  for (const name of orderedEnvVars) {
     const candidate = env[name];
     if (candidate !== undefined && isRepoRoot(candidate)) {
       return resolve(candidate);

--- a/scripts/bootstrap/main.ts
+++ b/scripts/bootstrap/main.ts
@@ -4,19 +4,23 @@ import { loadBootstrapConfig } from './config.js';
 import { runAgentBootstrap } from './agent.js';
 import { runDoctor } from './doctor.js';
 import { runRepoBootstrap } from './repo.js';
-import { runSweep } from './sweep.js';
+import { runTeardown } from './sweep.js';
 
 export interface ParsedBootstrapArgs {
   readonly command: BootstrapCommand;
   readonly force: boolean;
+  readonly provider: 'claude' | 'codex' | undefined;
   readonly update: boolean;
 }
 
 const COMMANDS: ReadonlySet<string> = new Set([
   'agent',
+  'claude',
+  'codex',
   'doctor',
   'repo',
   'sweep',
+  'teardown',
 ]);
 
 export const parseBootstrapArgs = (
@@ -51,22 +55,26 @@ export const parseBootstrapArgs = (
   return {
     command: command as BootstrapCommand,
     force,
+    provider: command === 'claude' || command === 'codex' ? command : undefined,
     update,
   };
 };
 
 export const printUsage = (): void => {
-  console.error(`Usage: ./scripts/bootstrap.sh [repo|agent|doctor|sweep] [--force] [--update]
+  console.error(`Usage: ./scripts/bootstrap.sh [repo|agent|codex|claude|doctor|teardown] [--force] [--update]
 
 Commands:
   repo     Make this checkout runnable (default)
   agent    Repo bootstrap plus agent lifecycle diagnostics
+  codex    Codex agent bootstrap with provider-specific root detection
+  claude   Claude agent bootstrap with provider-specific root detection
   doctor   Diagnostics only; no install, cleanup, or mutation
-  sweep    Conservative cleanup of configured runtime artifacts only
+  teardown Conservative cleanup of configured runtime artifacts only
 
 Compatibility:
   ./scripts/bootstrap.sh --force
-  ./scripts/bootstrap.sh --update`);
+  ./scripts/bootstrap.sh --update
+  ./scripts/bootstrap.sh sweep`);
 };
 
 const runMain = async (): Promise<void> => {
@@ -77,8 +85,15 @@ const runMain = async (): Promise<void> => {
 
   const config = loadBootstrapConfig();
   const parsed = parseBootstrapArgs(process.argv.slice(2));
-  const host = detectHost(process.env, config);
-  const repoRoot = resolveRepoRoot(process.cwd(), process.env, config);
+  const env =
+    parsed.provider === undefined
+      ? process.env
+      : {
+          ...process.env,
+          TRAILS_AGENT_ENV_PROVIDER: parsed.provider,
+        };
+  const host = detectHost(env, config);
+  const repoRoot = resolveRepoRoot(process.cwd(), env, config, parsed.provider);
 
   switch (parsed.command) {
     case 'repo': {
@@ -101,12 +116,24 @@ const runMain = async (): Promise<void> => {
       });
       return;
     }
+    case 'codex':
+    case 'claude': {
+      await runAgentBootstrap({
+        config,
+        force: true,
+        host,
+        repoRoot,
+        update: parsed.update,
+      });
+      return;
+    }
     case 'doctor': {
       await runDoctor(repoRoot, config, host);
       return;
     }
-    case 'sweep': {
-      runSweep(repoRoot, config);
+    case 'sweep':
+    case 'teardown': {
+      runTeardown(repoRoot, config);
       return;
     }
     default: {

--- a/scripts/bootstrap/sweep.ts
+++ b/scripts/bootstrap/sweep.ts
@@ -20,7 +20,10 @@ export const resolveCleanupTarget = (
   return target;
 };
 
-export const runSweep = (repoRoot: string, config: BootstrapConfig): void => {
+export const runTeardown = (
+  repoRoot: string,
+  config: BootstrapConfig
+): void => {
   const targets = [...config.cleanup.directories, ...config.cleanup.files].map(
     (target) => resolveCleanupTarget(repoRoot, target)
   );
@@ -35,5 +38,5 @@ export const runSweep = (repoRoot: string, config: BootstrapConfig): void => {
     removed += 1;
   }
 
-  success(`Sweep complete (${String(removed)} targets removed)`);
+  success(`Teardown complete (${String(removed)} targets removed)`);
 };


### PR DESCRIPTION
## Summary

- add `codex` and `claude` bootstrap modes that reuse agent bootstrap with provider-specific root detection
- make provider modes force a frozen Bun dependency check so linked worktrees get repo-local `node_modules` before hooks run
- add `teardown` as the cleanup lifecycle command while keeping `sweep` as a compatibility alias
- update cleanup targets for current `.trails/state/*` runtime DB paths
- document the Graphite worktree-farm branch requirement in `AGENTS.md`

## Testing

- `bun test scripts/__tests__/bootstrap.test.ts scripts/__tests__/format-staged.test.ts`
- `./scripts/bootstrap.sh codex`
- `./scripts/bootstrap.sh --help`
- `./scripts/bootstrap.sh teardown`
- `bun run format:check`
- `bun run dead-code`
- `git diff --check`

## Notes

Created as a draft PR until CI finishes green, per repo workflow.
