### PR TITLE
chore: wire Claude session bootstrap hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,30 @@
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/bootstrap.sh claude",
+            "timeout": 300,
+            "statusMessage": "Bootstrapping Claude environment…"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "./scripts/bootstrap.sh teardown",
+            "timeout": 120,
+            "statusMessage": "Tearing down Claude environment…"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit",


### PR DESCRIPTION
## What

Adds `SessionStart` and `SessionEnd` hooks to the committed `.claude/settings.json`:

- `SessionStart` → `./scripts/bootstrap.sh claude`
- `SessionEnd` → `./scripts/bootstrap.sh teardown`

## Why

Claude Code has no `environment.toml` equivalent to Codex's `[setup]`/`[cleanup]` lifecycle. Session hooks are the official lifecycle mechanism, so this mirrors `.codex/environments/environment.toml` for local Claude Code sessions (including worktrees):

| Codex | Claude equivalent |
|---|---|
| `[setup] script = bootstrap.sh codex` | `SessionStart` → `bootstrap.sh claude` |
| `[cleanup] script = bootstrap.sh teardown` | `SessionEnd` → `bootstrap.sh teardown` |

`bootstrap.sh claude` is worktree-aware and idempotent, so running it per session self-detects the checkout (main or worktree) and does the right thing. Validated locally: exit 0, `bun install` reports "no changes" on a ready tree.

## Notes

- Unscoped matcher → `SessionEnd` runs on every session end (including `/clear`). Safe because teardown is conservative cleanup and the bootstrap is idempotent.
- Existing `PostToolUse` formatter hook is preserved.
- Lives in committed `settings.json` so the lifecycle is shared with everyone working the repo.