### PR TITLE
docs: draft warden fix metadata adr

### DIFF
--- a/.agents/plans/2026-05-30-v1-convergence-loop/GOAL.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/GOAL.md
@@ -1,0 +1,51 @@
+# Pasteable Goal
+
+Build and submit a large Trails v1 convergence Graphite stack from the linked
+worktree at `/Users/mg/.config/codex/worktrees/trails-v1-convergence`.
+
+Use `lewis/v1-convergence-lane` as the zero-diff worktree lane and start the
+real stack at `trl-834-draft-warden-fix-metadata-adr`. Primary checkout stays
+clean on `main`.
+
+Objective: make a meaningful v1 step forward by landing Warden fix metadata
+doctrine, Warden trail output parity for fix metadata, adapter authoring as a
+paved path, and Regrade dogfood that consumes Warden-owned migration facts.
+TRL-834 must be first. Adapter package payloads such as Cloudflare/Vercel are
+out of scope.
+
+Stack:
+
+1. TRL-834 - Warden fix metadata ADR.
+2. TRL-866 - Warden diagnostic fix metadata through rule trail outputs.
+3. TRL-853 - Adapter ADR snippet import truth.
+4. TRL-861 - Adapter target metadata and catalog derivation.
+5. TRL-862 - HTTP adapter-support/testing conformance factory.
+6. TRL-863 - Shared adapter check engine.
+7. TRL-864 - Warden adapter checks plus `trails adapter check`.
+8. TRL-865 - Dogfood one first-party HTTP adapter.
+9. TRL-805 - `create.adapter` scaffolding against proven catalog/checking.
+10. TRL-836 - Regrade consumes Warden-backed `term-rewrite` metadata.
+11. TRL-850 - ADR map check only if live verification shows real drift/gap.
+12. TRL-826 - Package-source modes only if this stack proves the need.
+13. TRL-829 - Regrade ADR after evidence, not before.
+
+Rules:
+
+- Use Graphite for source-control writes. No vanilla Git commits/pushes.
+- Do not submit empty branches.
+- Do not ship `create.adapter` before the dogfood branch proves the paved path.
+- Subagents may inspect, edit assigned files, run checks, and write reports,
+  but must not run git/gt write commands or mutate Linear/PRs.
+- For review fixes, land changes on the lowest owning branch, `gt modify`,
+  restack upward, and re-run focused checks.
+- Keep PRs draft until CI and local review are clean.
+- Treat Greptile/code-review errors as blockers.
+- Add new Linear issues for real discoveries that become part of the goal.
+- Record tracker mutations, branch state, validation, reviews, and fixes in
+  `RETRO.md`.
+
+Completion condition:
+
+The stack is submitted as draft PRs, CI is checked, P0/P1/P2 local findings are
+fixed or explicitly rejected with evidence, PR bodies are useful, Linear issues
+are current, and `RETRO.md` records the final state and remaining risks.

--- a/.agents/plans/2026-05-30-v1-convergence-loop/PLAN.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/PLAN.md
@@ -1,0 +1,181 @@
+---
+created: "2026-05-30T12:28:00Z"
+updated: "2026-05-30T12:28:00Z"
+status: active
+owner: Lewis
+linear:
+  - TRL-834
+  - TRL-866
+  - TRL-853
+  - TRL-861
+  - TRL-862
+  - TRL-863
+  - TRL-864
+  - TRL-865
+  - TRL-805
+  - TRL-836
+  - TRL-850
+  - TRL-826
+  - TRL-829
+---
+
+# V1 Convergence Loop
+
+## Objective
+
+Build one reviewable Graphite stack that moves Trails toward a stronger v1
+state by connecting three compounding lanes:
+
+1. Warden fix metadata doctrine.
+2. Warden's trail-shaped diagnostic outputs preserving the same fix facts.
+3. Adapter authoring as a paved path.
+4. Regrade consuming Warden-owned migration facts once the Warden projection is
+   true.
+
+This is a build loop, not just a checklist. Each branch should improve the
+next branch's footing, and each review pass should feed fixes back into the
+lowest owning branch.
+
+## Stack Lane
+
+- Primary checkout stays clean on `main`.
+- Execution worktree:
+  `/Users/mg/.config/codex/worktrees/trails-v1-convergence`
+- Zero-diff lane branch:
+  `lewis/v1-convergence-lane`
+- First stack branch:
+  `trl-834-draft-warden-fix-metadata-adr`
+
+The lane branch exists only so the linked worktree has a real Graphite branch.
+Do not submit the zero-diff lane branch unless we intentionally add work to it.
+
+## Branch Order
+
+| Order | Issue | Branch | Purpose |
+| --- | --- | --- | --- |
+| 1 | TRL-834 | `trl-834-draft-warden-fix-metadata-adr` | ADR for Warden fix metadata before Regrade consumes it. |
+| 2 | TRL-866 | `trl-866-project-warden-diagnostic-fix-metadata-through-rule-trail` | Preserve diagnostic `fix` metadata through Warden rule trail outputs. |
+| 3 | TRL-853 | `trl-853-draft-adr-conformance-snippet-calls-runconformance-without` | Stabilize adapter ADR snippet truth before implementation relies on it. |
+| 4 | TRL-861 | `trl-861-define-adapter-target-metadata-and-catalog-derivation` | Adapter target metadata and read-only catalog derivation. |
+| 5 | TRL-862 | `trl-862-add-http-adapter-authoring-support-and-conformance-factory` | HTTP owner authoring bundle and conformance factory. |
+| 6 | TRL-863 | `trl-863-build-shared-adapter-check-engine` | One shared adapter check engine. |
+| 7 | TRL-864 | `trl-864-expose-adapter-checks-through-warden-and-trails-adapter` | Warden and `trails adapter check` projections over the same engine. |
+| 8 | TRL-865 | `trl-865-dogfood-adapter-authoring-path-on-a-first-party-http-adapter` | First-party HTTP adapter dogfood. |
+| 9 | TRL-805 | `trl-805-trails-create-adapter-scaffold-adapter-packages-against-the` | `create.adapter` scaffolding after dogfood proves the path. |
+| 10 | TRL-836 | `trl-836-integrate-warden-backed-term-rewrite-regrades` | Regrade consumes Warden-backed `term-rewrite` metadata. |
+| 11 | TRL-850 | `trl-850-regenerate-stale-adr-decision-map-and-enforce-consistency-in` | Conditional: only if a real map drift/check gap remains. |
+| 12 | TRL-826 | `trl-826-prove-regrade-package-source-modes` | Conditional: package-source modes only if this stack proves the need. |
+| 13 | TRL-829 | `trl-829-draft-regrade-adr-from-tracer-evidence` | Conditional: Regrade ADR after evidence, not before. |
+
+The bottom ten are expected. TRL-850, TRL-826, and TRL-829 are conditional:
+keep them in scope only if live verification says they are still justified;
+otherwise update Linear and defer with a clear note.
+
+## Non-Goals
+
+- Do not build Cloudflare, Vercel, webhook, scheduler, or provider adapters in
+  this stack.
+- Do not make adapter tooling public before dogfood evidence supports the
+  shape.
+- Do not duplicate Warden-owned migration facts inside Regrade.
+- Do not ship `create.adapter` before a real adapter dogfood pass proves the
+  catalog, conformance, and check loop.
+- Do not submit empty branches.
+- Do not use `gt absorb`.
+- Do not merge or queue merge without Matt explicitly asking.
+
+## Source-Control Rules
+
+- Use Graphite for source-control writes:
+  `gt create`, `gt modify`, `gt restack`, `gt submit`.
+- Use read-only Git commands freely for inspection.
+- Before every `gt modify`, run `git branch --show-current`.
+- For review fixes, check out the lowest owning branch, apply the fix there,
+  `gt modify`, `gt restack`, then walk upward with focused checks.
+- Subagents must not run git/gt write commands or mutate PRs/Linear.
+- Keep PRs draft until CI and local review are clean.
+
+## Linear Rules
+
+- Keep every in-scope issue current.
+- If a bug is discovered and it belongs in the stack, create or update a
+  focused Linear issue immediately and add it to this packet.
+- If implementation diverges from an issue description, leave a Linear comment
+  explaining the divergence.
+- Do not mark issues Done until their PRs merge.
+
+## Review Loop
+
+Run local review from the stack tip before submission, and repeat until the
+latest pass is clean or P3-only.
+
+Minimum review lanes:
+
+- Doctrine and ADR fit: tenets, lexicon, decision map, doc truth.
+- Adapter authoring: metadata/catalog, package boundaries, conformance shape,
+  CLI/Warden projection consistency.
+- Regrade/Warden integration: no parallel mapping database, `NeedsReview`
+  routing, provenance and validation.
+- Test and release hygiene: changesets, export maps, docs examples, generated
+  guides, package boundaries.
+
+Review output must use:
+
+```markdown
+Overall score: n/5
+
+Summary:
+<one short prose judgment>
+
+Findings:
+- P0/P1/P2/P3 - <file:line> - <finding>
+  Prompt To Fix With AI:
+  <concise fix prompt>
+
+No-findings statement:
+<what was inspected and what residual risk remains>
+```
+
+Fix all P0/P1/P2. P3 can be fixed if cheap or recorded with a reason.
+
+## Validation Ladder
+
+Use the smallest relevant checks per branch, then broaden at the tip.
+
+Likely focused checks:
+
+- `bun scripts/adr.ts map`
+- `bun scripts/adr.ts check`
+- `bun test packages/warden/src/__tests__/fix.test.ts`
+- `bun test packages/warden/src/__tests__/guide.test.ts`
+- `bun test packages/regrade/src/downstream/__tests__/report.test.ts`
+- `bun test apps/trails/src/__tests__/*.test.ts`
+- package-local `bun run typecheck`
+
+Tip checks before submission:
+
+- `bun run lint`
+- `bun run lint:ast-grep`
+- `bun run format:check`
+- `bun run typecheck`
+- `bun run test`
+- `bun run build`
+- `bun run check`
+- `bun run publish:check`
+- `git diff --check`
+
+If Warden guides or skill/agent projections change:
+
+- `bun run warden:agents:sync`
+- `bun run warden:skills:sync`
+- `bun run warden:agents:check`
+- `bun run warden:skills:check`
+
+## Submission Plan
+
+1. Submit the full stack as draft with `gt submit --stack --draft`.
+2. Patch PR bodies with context, changes, verification, risks, and Linear links.
+3. Wait for CI.
+4. Keep PRs draft until CI and local review are clean.
+5. Mark ready only after no P0/P1/P2 local findings remain and CI is green.
+6. Capture CI and bot-review state in `RETRO.md`.

--- a/.agents/plans/2026-05-30-v1-convergence-loop/REFS.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/REFS.md
@@ -1,0 +1,72 @@
+# References
+
+## Repo State
+
+- Primary checkout: `/Users/mg/Developer/outfitter/trails`
+- Execution worktree:
+  `/Users/mg/.config/codex/worktrees/trails-v1-convergence`
+- Main HEAD at setup:
+  `3205521d0504da226c8c6d39867405e02197a2dc`
+- Main commit:
+  `3205521d0 docs: record adapter authoring decision (#633)`
+
+## Live Issues
+
+| Issue | Link | Role |
+| --- | --- | --- |
+| TRL-834 | [Linear](https://linear.app/outfitter/issue/TRL-834/draft-warden-fix-metadata-adr) | Base branch, Warden fix metadata ADR. |
+| TRL-866 | [Linear](https://linear.app/outfitter/issue/TRL-866/project-warden-diagnostic-fix-metadata-through-rule-trail-outputs) | Created for this goal; Warden rule trail fix metadata projection. |
+| TRL-853 | [Linear](https://linear.app/outfitter/issue/TRL-853/draft-adr-conformance-snippet-calls-runconformance-without-importing) | Adapter ADR snippet fix. |
+| TRL-861 | [Linear](https://linear.app/outfitter/issue/TRL-861/define-adapter-target-metadata-and-catalog-derivation) | Created for this goal; adapter metadata/catalog. |
+| TRL-862 | [Linear](https://linear.app/outfitter/issue/TRL-862/add-http-adapter-authoring-support-and-conformance-factory) | Created for this goal; HTTP owner bundle. |
+| TRL-863 | [Linear](https://linear.app/outfitter/issue/TRL-863/build-shared-adapter-check-engine) | Created for this goal; shared adapter check engine. |
+| TRL-864 | [Linear](https://linear.app/outfitter/issue/TRL-864/expose-adapter-checks-through-warden-and-trails-adapter-check) | Created for this goal; Warden/local projections. |
+| TRL-865 | [Linear](https://linear.app/outfitter/issue/TRL-865/dogfood-adapter-authoring-path-on-a-first-party-http-adapter) | Created for this goal; first-party dogfood. |
+| TRL-805 | [Linear](https://linear.app/outfitter/issue/TRL-805/trails-create-adapter-scaffold-adapter-packages-against-the-adapter) | Retargeted from `add.adapter` to `create.adapter`. |
+| TRL-836 | [Linear](https://linear.app/outfitter/issue/TRL-836/integrate-warden-backed-term-rewrite-regrades) | Regrade consumes Warden metadata. |
+| TRL-850 | [Linear](https://linear.app/outfitter/issue/TRL-850/regenerate-stale-adr-decision-map-and-enforce-consistency-in-pre-push) | Conditional ADR map drift/check work. |
+| TRL-826 | [Linear](https://linear.app/outfitter/issue/TRL-826/prove-regrade-package-source-modes) | Conditional package-source mode proof. |
+| TRL-829 | [Linear](https://linear.app/outfitter/issue/TRL-829/draft-regrade-adr-from-tracer-evidence) | Conditional Regrade ADR after evidence. |
+
+## Doctrine And Docs
+
+- `AGENTS.md` - repo workflow, Graphite, subagent, Warden guide, release rules.
+- `.agents/plans/PLANNING.md` - goal packet, review loop, validation ladder.
+- `/Users/mg/.agents/skills/goal-planning/references/code-review.md` - P0-P3
+  review model and review output contract.
+- `.agents/skills/trails-adrs/SKILL.md` - ADR authoring rules and `scripts/adr.ts`
+  workflow.
+- `docs/tenets.md` - governing tenets.
+- `docs/lexicon.md` - terminology.
+- `docs/architecture.md` - contract-first architecture.
+- `docs/adr/0000-core-premise.md` - core premise.
+- `docs/adr/0001-naming-conventions.md` - naming conventions.
+- `docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md` - adapter
+  authoring doctrine this stack implements.
+
+## Key Code Surfaces
+
+- `packages/warden/src/rules/types.ts` - `WardenFix`,
+  `WardenFixCapability`, and diagnostic shape.
+- `packages/warden/src/fix.ts` - safe fix application substrate.
+- `packages/warden/src/cli.ts` - `--fix` execution path and report summary.
+- `packages/warden/src/guide.ts` - guide projection of fix capability.
+- `packages/warden/src/rules/metadata.ts` - rule manifest metadata.
+- `packages/warden/src/rules/no-legacy-layer-imports.ts` - current
+  `term-rewrite` fix metadata.
+- `packages/warden/src/trails/schema.ts` - Warden rule trail diagnostic schema;
+  TRL-866 must preserve diagnostic fix metadata here before TRL-836 consumes it.
+- `packages/regrade/src/downstream/report.ts` - current preview
+  `term-rewrite` transform class and downstream report path.
+- `packages/regrade/src/downstream/collect.ts` - downstream source collection.
+- `packages/http/package.json` - HTTP public export map.
+- `packages/store/package.json` - existing `adapter-support` and testing
+  precedent.
+- `apps/trails/src/trails/create*` - create/scaffold command family.
+
+## Subagents
+
+- Dewey: Warden fix metadata ADR source map.
+- Beauvoir: Adapter authoring substrate map.
+- Planck: Regrade/Warden `term-rewrite` integration map.
+- Clark: doctrine and stack-order review.

--- a/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
@@ -1,0 +1,102 @@
+---
+created: "2026-05-30T12:28:00Z"
+updated: "2026-05-30T12:28:00Z"
+status: active
+---
+
+# Retro
+
+## Running Log
+
+### 2026-05-30 08:18 EDT - Live state refreshed
+
+- Primary checkout `/Users/mg/Developer/outfitter/trails` was clean on `main`.
+- `main`, `origin/main`, and remote `refs/heads/main` all resolved to
+  `3205521d0504da226c8c6d39867405e02197a2dc`.
+- `gh pr list --state open` returned no open PRs.
+- Existing worktree `/Users/mg/.config/codex/worktrees/4241/trails` remained a
+  stale detached checkout and was not used for execution.
+
+### 2026-05-30 08:21 EDT - Worktree lane created
+
+- Created zero-diff Graphite branch `lewis/v1-convergence-lane` under `main`.
+- Returned primary checkout to `main`.
+- Added linked worktree:
+  `/Users/mg/.config/codex/worktrees/trails-v1-convergence`.
+- Verified linked worktree is on `lewis/v1-convergence-lane` and Graphite sees
+  it above `main`.
+
+### 2026-05-30 08:24 EDT - Worktree bootstrapped
+
+- Ran `./scripts/bootstrap.sh codex`.
+- Result: Bun compatible, linked worktree detected, dependencies installed
+  locally, optional tools present, Graphite stack printed.
+- Verified `node_modules` exists in the worktree and `git status` is clean.
+
+### 2026-05-30 08:26 EDT - Linear scope updated
+
+- Created TRL-861: adapter target metadata and catalog derivation.
+- Created TRL-862: HTTP adapter authoring support and conformance factory.
+- Created TRL-863: shared adapter check engine.
+- Created TRL-864: Warden and `trails adapter check` projections.
+- Created TRL-865: dogfood adapter authoring path on a first-party HTTP
+  adapter.
+- Retargeted TRL-805 from stale `add.adapter` wording to `create.adapter`.
+
+### 2026-05-30 08:27 EDT - First branch started
+
+- Created `trl-834-draft-warden-fix-metadata-adr` above
+  `lewis/v1-convergence-lane`.
+- Marked TRL-834 In Progress.
+- Added a Linear start comment with branch and worktree details.
+
+### 2026-05-30 08:28 EDT - Subagent sidecars launched
+
+- Dewey: Warden fix metadata ADR source map.
+- Beauvoir: adapter authoring substrate and branch-slice map.
+- Planck: Regrade consuming Warden-backed `term-rewrite` metadata.
+- Clark: doctrine and stack-order review.
+
+### 2026-05-30 08:31 EDT - Sidecar findings folded into route
+
+- Dewey found a Warden doctrine gap: `WardenDiagnostic.fix` exists, but the
+  Warden rule trail diagnostic schema omits `fix`, so trail-shaped outputs can
+  drop metadata that raw-rule paths preserve.
+- Created TRL-866 to project diagnostic fix metadata through Warden rule trail
+  outputs before TRL-836 depends on the data.
+- Planck found TRL-836 should keep Regrade source collection, especially `.tsx`
+  coverage, and consume Warden metadata without recreating Warden's safe-edit
+  applicator or a parallel term table.
+- Beauvoir confirmed Hono is the strongest HTTP dogfood candidate and warned
+  that conformance must stay owner-owned, not inside adapter tooling.
+- Clark ruled the doctrine coherent but too broad as first sketched; accepted
+  route change: dogfood the adapter path before shipping `create.adapter`, and
+  make TRL-850 conditional unless live map drift/check evidence remains.
+
+## Verification Ledger
+
+| Command | Context | Result | Notes |
+| --- | --- | --- | --- |
+| `git status --short --branch` | Primary checkout setup | pass | Clean on `main`. |
+| `gt ls` | Primary checkout setup | pass | Graphite only saw `main` before lane creation. |
+| `git ls-remote origin refs/heads/main` | Primary checkout setup | pass | Remote main matched local `HEAD`. |
+| `gh pr list --state open --json ...` | Primary checkout setup | pass | No open PRs returned. |
+| `./scripts/bootstrap.sh codex` | New worktree | pass | Dependencies installed locally; linked worktree diagnostics printed. |
+| `git status --short --branch` | New worktree after bootstrap | pass | Clean on `lewis/v1-convergence-lane`. |
+| `bun scripts/adr.ts check` | TRL-834 ADR draft | pass | 0 errors, 0 warnings. |
+| `bunx markdownlint-cli2 docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md .agents/plans/2026-05-30-v1-convergence-loop/*.md` | TRL-834 ADR + packet | pass | Initial bare-URL findings in `REFS.md` fixed; rerun clean. |
+| `git diff --check` | TRL-834 ADR + packet | pass | No whitespace findings. |
+
+## Review Findings
+
+No local review pass has run yet.
+
+## Open Risks
+
+- TRL-850 may already be partially stale if the adapter ADR merge refreshed the
+  decision map. Verify before cutting its branch.
+- TRL-826 and TRL-829 are conditional. Keep them only if this stack produces
+  enough implementation evidence.
+- Adapter tooling package name is intentionally unsettled until implementation
+  proves whether `adapter-tools` or another name better communicates internal
+  tooling rather than central authority.

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -175,6 +175,11 @@
           "fromPath": "docs/adr/drafts/20260406-documentation-structure.md"
         },
         {
+          "context": "- [ADR-0000: Core Premise](../0000-core-premise.md) - Warden is the governance",
+          "from": "20260530",
+          "fromPath": "docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md"
+        },
+        {
           "context": "- **[ADR-0000: Core Premise](./adr/0000-core-premise.md)** — Why contracts, why Result, why derive",
           "from": "index",
           "fromPath": "docs/index.md"
@@ -701,6 +706,11 @@
           "context": "- [ADR-0007: Governance as Trails](0007-governance-as-trails.md) - Warden",
           "from": "0038",
           "fromPath": "docs/adr/0038-typed-signal-emission.md"
+        },
+        {
+          "context": "before runtime, and [ADR-0007](../0007-governance-as-trails.md) made that",
+          "from": "20260530",
+          "fromPath": "docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md"
         },
         {
           "context": "- **[ADR-0007: Governance as Trails](./adr/0007-governance-as-trails.md)** — Warden rules are trails, AST-based analysis",
@@ -2218,6 +2228,11 @@
           "fromPath": "docs/adr/0037-owner-first-authority.md"
         },
         {
+          "context": "[ADR-0036](../0036-warden-rules-ship-only-as-trails.md) tightened the public",
+          "from": "20260530",
+          "fromPath": "docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md"
+        },
+        {
           "context": "Use it with [Warden](../warden.md), [ADR-0036](../adr/0036-warden-rules-ship-only-as-trails.md), and [ADR-0037](../adr/0037-owner-first-authority.md).",
           "from": "warden-rules",
           "fromPath": "docs/contributing/warden-rules.md"
@@ -2245,6 +2260,11 @@
           "context": "- [ADR-0037: Owner-First Authority](0037-owner-first-authority.md) — release",
           "from": "0047",
           "fromPath": "docs/adr/0047-stable-release-line-discipline.md"
+        },
+        {
+          "context": "- [ADR-0037: Owner-First Authority](../0037-owner-first-authority.md) - Warden",
+          "from": "20260530",
+          "fromPath": "docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md"
         },
         {
           "context": "Use it with [Warden](../warden.md), [ADR-0036](../adr/0036-warden-rules-ship-only-as-trails.md), and [ADR-0037](../adr/0037-owner-first-authority.md).",
@@ -2454,6 +2474,11 @@
           "context": "- [ADR-0043: Layer Evolution](../0043-layer-evolution.md) -- layers gain input schemas; the compiled library trailhead must project layer inputs alongside trail inputs",
           "from": "20260401",
           "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
+        },
+        {
+          "context": "the layer exports retired by [ADR-0043](../0043-layer-evolution.md).",
+          "from": "20260530",
+          "fromPath": "docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md"
         },
         {
           "context": "Source code, including TSDoc, inline comments, runtime strings, error messages, and log payloads, should reference accepted ADRs by stable number, such as `docs/adr/0043-layer-evolution.md`. It should",

--- a/docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md
+++ b/docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md
@@ -1,0 +1,195 @@
+---
+slug: fixes-are-warden-diagnostic-metadata
+title: Fixes are Warden diagnostic metadata
+status: draft
+created: 2026-05-30
+updated: 2026-05-30
+owners: ['[galligan](https://github.com/galligan)']
+depends_on: [0, 7, 36, 37, 43]
+---
+
+# ADR: Fixes are Warden diagnostic metadata
+
+## Context
+
+Warden is the governance arm of Trails. It is where drift becomes visible before runtime, and [ADR-0007](../0007-governance-as-trails.md) made that governance trail-shaped instead of a parallel lint system. Later, [ADR-0036](../0036-warden-rules-ship-only-as-trails.md) tightened the public shape: rules ship through Warden's trail and registry surfaces, not as a second raw-rule API.
+
+Fixability creates the same drift risk in a new place. Once Warden can say "this source is wrong," the next tempting move is to build a separate table of "how to fix it" somewhere else: a Regrade migration database, a CLI-specific rewrite list, a guide scraper, or a prose-only convention. That route splits detection from repair. The rule that knows why a finding exists would no longer own the structured facts needed to repair or route it.
+
+That split is especially dangerous for Regrade. Regrade needs Warden's rename-class facts, starting with `term-rewrite`, but it must not become a second Warden. Warden owns detection, rule identity, severity, and governance. Regrade owns application to a target codebase, provenance, validation, and review routing. If Regrade authors its own migration facts for Warden-detected drift, the two systems will disagree by construction.
+
+The first implemented proof already points the right way:
+
+- `WardenDiagnostic` carries optional `fix` metadata.
+- `WardenRuleMetadata` carries optional rule-level fix capability.
+- `WardenFix` distinguishes a transform class, safety level, concrete edits,
+  reason, and fixture pointer.
+- The guide/manifest projection exposes rule-level fix availability.
+- `warden --fix` applies only safe edits and leaves review-required fixes
+  reported.
+- `no-legacy-layer-imports` emits review-required `term-rewrite` metadata for
+  the layer exports retired by [ADR-0043](../0043-layer-evolution.md).
+
+This ADR ratifies that direction before Regrade consumes the data.
+
+## Decision
+
+Fix metadata belongs with Warden diagnostics and rule metadata.
+
+The detecting rule owns the fix facts because the detecting rule is the only artifact that knows the matched invariant, source span, safety posture, and migration reason at the moment a finding is created. Other systems may consume those facts, but they do not re-author them.
+
+### Fixability has three states
+
+Warden findings are one of three shapes:
+
+1. **Detection-only.** The rule can explain the violation but does not claim a
+   structured fix. No `fix` appears on the diagnostic.
+2. **Review-required fix.** The rule understands the migration class and
+   reason, but the change needs human judgement. The diagnostic carries
+   `fix.safety: 'review'` and no safe edits. Warden reports it and never
+   rewrites it.
+3. **Safe fix.** The rule can provide deterministic source edits. The
+   diagnostic carries `fix.safety: 'safe'` plus concrete half-open edits.
+   `warden --fix` may apply them.
+
+This avoids a false binary where "fixable" implies "auto-apply." Review routing is a first-class fix outcome.
+
+### Rule capability and finding edits are separate
+
+Rule metadata advertises capability:
+
+```ts
+fix: { class: 'term-rewrite', safety: 'review' }
+```
+
+Diagnostic metadata carries the concrete finding:
+
+```ts
+fix: {
+  class: 'term-rewrite',
+  safety: 'review',
+  reason: 'Legacy layer ... has no mechanical replacement.'
+}
+```
+
+The rule-level capability feeds `warden guide`, manifests, agent guides, and rule catalogs. It says "this rule can emit fixes of this class." The diagnostic metadata says "this specific finding has this migration reason and, when safe, these exact edits."
+
+Concrete edits do not live on rule metadata because a rule-level declaration does not know the source span. Prose guidance does not substitute for diagnostic metadata because prose is not a stable integration contract.
+
+Diagnostic fix metadata must survive Warden's trail-shaped outputs. A rule trail output that strips `fix` recreates the parallel-surface drift [ADR-0036](../0036-warden-rules-ship-only-as-trails.md) was written to remove: raw-rule consumers would see richer facts than trail consumers. If a diagnostic has structured fix metadata, every supported Warden diagnostic projection must either carry it or explicitly document why that projection is summary-only.
+
+### Safe fixes are deterministic source edits
+
+A safe Warden fix is a set of half-open string-index edits into the exact source text that Warden analyzed. The applicator applies edits last-to-first, rejects non-safe-integer offsets, rejects out-of-bounds spans, and rejects overlap.
+
+Safety means more than "the replacement is obvious." A safe fix must be:
+
+- deterministic from the analyzed source;
+- scoped to the scanned file set;
+- expressible without semantic judgement;
+- test-covered with before/after source; and
+- safe to omit from the final diagnostic count once applied.
+
+If those conditions are not true, the finding stays review-required.
+
+### `term-rewrite` is a transform class, not a migration database
+
+`term-rewrite` names the class of mechanical or review-routed term migrations. It is durable vocabulary for routing. It is not a side database of old-to-new terms, and it is not Regrade-owned policy.
+
+For a removed symbol with no mechanical replacement, Warden emits `term-rewrite` with `safety: 'review'` and a reason. For a future renamed term with deterministic spans, Warden may emit `term-rewrite` with `safety: 'safe'` and edits. Regrade can consume both as one transform family: safe edits become rewrite candidates; review-only findings become `NeedsReview`; absence of a finding is no-op.
+
+### Regrade consumes, validates, and routes
+
+Regrade must not duplicate Warden's fix metadata. It can:
+
+- run Warden or consume Warden-produced diagnostics that preserve `fix`;
+- select diagnostics by `fix.class`;
+- apply safe edits through the same semantics Warden uses;
+- record package/source provenance;
+- validate the result; and
+- route review-required or ambiguous findings to `NeedsReview`.
+
+Regrade does not own rule detection, severity, migration facts, or old-to-new term tables for Warden-detected drift.
+
+This means Warden fix metadata blocks rename-class Regrade integration. It does not block the literal transform-trail tracer, downstream source collection, or other Regrade substrate that does not depend on Warden-authored migration facts.
+
+### Manifests expose capability, not hidden behavior
+
+Agent-facing guide output and manifests must expose rule-level fix capability when it exists. That lets agents discover which rules can produce fix metadata without manufacturing diagnostics or scraping docs. Concrete edits still appear only in diagnostics from a real run.
+
+This is the same "one write, many reads" doctrine applied to governance repair: the rule author writes structured facts once, and Warden CLI output, guide surfaces, Regrade, and future agents consume the same authored facts.
+
+## Non-goals
+
+- Defining a public third-party fix plugin API.
+- Creating a general codemod engine.
+- Making Regrade a Warden replacement.
+- Guaranteeing every Warden rule has a fix.
+- Claiming review-required fixes are safe to apply automatically.
+- Deciding Regrade package-source modes or the final Regrade ADR shape.
+
+## Consequences
+
+### Positive
+
+- Warden remains the source of truth for governance findings and their repair
+  metadata.
+- Regrade can consume Warden facts without inventing a parallel migration
+  database.
+- Agents can discover fix capability through manifests instead of parsing prose.
+- Safe source edits are constrained enough to trust in `warden --fix`.
+- Review-required migrations become visible structured work instead of failed
+  auto-fixes.
+
+### Tradeoffs
+
+- Rule authors must do more than emit a message when a finding is fixable: they
+  must decide safety, class, reason, and tests.
+- Fix metadata expands Warden's public-ish diagnostic shape, so compatibility
+  discipline matters.
+- The first `term-rewrite` cases may be review-routed even when a human can see
+  an obvious edit. That is acceptable until the rule can prove deterministic
+  spans.
+
+### Risks
+
+- **Safety inflation.** A rule might mark an edit safe because it is usually
+  right. Mitigation: safe fixes require deterministic spans and regression
+  tests; otherwise use `review`.
+- **Class sprawl.** Every migration could ask for a new class. Mitigation:
+  classes route behavior and must earn multiple consumers. Start with
+  `term-rewrite`.
+- **Regrade drift.** Regrade could quietly add its own mappings for convenience.
+  Mitigation: TRL-836 must consume Warden-owned metadata, and local review
+  should reject parallel mapping tables.
+- **Projection drift.** A raw Warden rule path might preserve diagnostic fixes
+  while a Warden trail path drops them. Mitigation: diagnostic `fix` is part of
+  the supported Warden diagnostic shape; TRL-866 closes the current rule-trail
+  projection gap before TRL-836 depends on it.
+
+## Non-decisions
+
+- Whether future fix classes are needed beyond `term-rewrite`.
+- Whether project-local Warden rules can expose custom fix classes.
+- Whether a future public manifest has a stronger versioned compatibility
+  contract.
+- Whether Regrade eventually persists review items as contours.
+- The exact Regrade integration path for `.tsx` scanning and downstream roots.
+  Regrade still owns source collection and package provenance.
+
+## References
+
+- [ADR-0000: Core Premise](../0000-core-premise.md) - Warden is the governance
+  arm of the contract-first model.
+- [ADR-0007: Governance as Trails](../0007-governance-as-trails.md) - Warden
+  rules follow the same trail-shaped model they enforce.
+- [ADR-0036: Warden rules ship only as trails](../0036-warden-rules-ship-only-as-trails.md)
+  - Warden's public rule shape stays canonical.
+- [ADR-0037: Owner-First Authority](../0037-owner-first-authority.md) - Warden
+  rules own their detection and fix facts; consumers derive from those facts.
+- [ADR-0043: Layer Evolution](../0043-layer-evolution.md) - source of the
+  retired legacy layer exports used by the first `term-rewrite` metadata.
+- TRL-830 - Define Warden fix metadata and safe fix execution.
+- TRL-834 - Draft Warden fix metadata ADR.
+- TRL-866 - Project Warden diagnostic fix metadata through rule trail outputs.
+- TRL-836 - Integrate Warden-backed `term-rewrite` regrades.

--- a/docs/adr/drafts/README.md
+++ b/docs/adr/drafts/README.md
@@ -37,3 +37,5 @@ Proposed decisions under discussion. Promoted to `docs/adr/` when accepted.
   - depends on [ADR-0010: Trails-Native Infrastructure Pattern](../0010-native-infrastructure.md), [ADR-0047: Stable Release Line Discipline](../0047-stable-release-line-discipline.md), [ADR-0048: Trail Versioning v3](../0048-trail-versioning-v3.md)
 - [Adapter authoring as a paved path](20260528-adapter-authoring-as-a-paved-path.md)
   - depends on [ADR-0029: Adapter Extraction and Composition Around Core Contracts](../0029-connector-extraction-and-the-with-packaging-model.md)
+- [Fixes are Warden diagnostic metadata](20260530-fixes-are-warden-diagnostic-metadata.md)
+  - depends on [ADR-0000: Core Premise — Contract-First, Surface-Agnostic Design](../0000-core-premise.md), [ADR-0007: Governance as Trails with AST-Based Analysis](../0007-governance-as-trails.md), [ADR-0036: Warden rules ship only as trails](../0036-warden-rules-ship-only-as-trails.md), [ADR-0037: Owner-First Authority](../0037-owner-first-authority.md), [ADR-0043: Layer Evolution](../0043-layer-evolution.md)

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -238,6 +238,19 @@
       "superseded_by": null,
       "title": "Adapter authoring as a paved path",
       "updated": "2026-05-28"
+    },
+    {
+      "created": "2026-05-30",
+      "depends_on": ["0", "7", "36", "37", "43"],
+      "inbound": [],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md",
+      "slug": "fixes-are-warden-diagnostic-metadata",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "Fixes are Warden diagnostic metadata",
+      "updated": "2026-05-30"
     }
   ],
   "version": 1


### PR DESCRIPTION
## Context

Bottom branch in the V1 convergence stack (#634-#641). It records the doctrine for Warden fixes before the implementation branch projects that metadata through rule trail outputs.

## Changes

- Adds a draft ADR for treating Warden fixes as diagnostic metadata.
- Updates the draft ADR index and decision maps.
- Commits the V1 convergence packet/retro references used to run this stack.

## Verification

- `bun scripts/adr.ts check`
- `bunx markdownlint-cli2 docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md .agents/plans/2026-05-30-v1-convergence-loop/*.md`
- `git diff --check`

## Risks

- ADR remains draft doctrine; implementation lands in the next branch.

Closes TRL-834
