### PR TITLE
fix(warden): preserve fix metadata in rule trail outputs

### DIFF
--- a/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
@@ -73,6 +73,26 @@ status: active
   route change: dogfood the adapter path before shipping `create.adapter`, and
   make TRL-850 conditional unless live map drift/check evidence remains.
 
+### 2026-05-30 08:38 EDT - TRL-866 implementation slice
+
+- Started `trl-866-project-warden-diagnostic-fix-metadata-through-rule-trail`
+  above the TRL-834 ADR base.
+- Extended the Warden trail diagnostic schema with the existing structured
+  `WardenFix` shape.
+- Updated the `no-legacy-layer-imports` trail example so contract tests assert
+  the review-required `term-rewrite` fix metadata survives trail projection.
+- Added a regression proving `runWardenTrails()` preserves
+  `diagnostic.fix.class === 'term-rewrite'` and `safety === 'review'`.
+- Added a Warden patch changeset for the public output-shape fix.
+
+### 2026-05-30 08:41 EDT - TRL-866 sidecar review tightened tests
+
+- Kant reviewed diagnostic projection paths and found no blocker after the
+  schema change.
+- Folded in Kant's cheap guardrails: `formatJson()` now proves diagnostic
+  `fix` survives structured JSON, and the `trails warden` output schema fixture
+  now includes a structured fix object.
+
 ## Verification Ledger
 
 | Command | Context | Result | Notes |
@@ -86,6 +106,12 @@ status: active
 | `bun scripts/adr.ts check` | TRL-834 ADR draft | pass | 0 errors, 0 warnings. |
 | `bunx markdownlint-cli2 docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md .agents/plans/2026-05-30-v1-convergence-loop/*.md` | TRL-834 ADR + packet | pass | Initial bare-URL findings in `REFS.md` fixed; rerun clean. |
 | `git diff --check` | TRL-834 ADR + packet | pass | No whitespace findings. |
+| `bun test packages/warden/src/__tests__/trails.test.ts packages/warden/src/__tests__/no-legacy-layer-imports.test.ts` | TRL-866 Warden trail projection | pass | 175 tests passed. |
+| `bun test packages/warden/src/__tests__/trails.test.ts packages/warden/src/__tests__/no-legacy-layer-imports.test.ts packages/warden/src/__tests__/formatters.test.ts apps/trails/src/__tests__/warden.test.ts` | TRL-866 sidecar review guardrails | pass | 216 tests passed. |
+| `bun run --cwd packages/warden typecheck` | TRL-866 Warden package | pass | `tsc --noEmit` clean. |
+| `bun run --cwd apps/trails typecheck` | TRL-866 Trails app wrapper | pass | `tsc --noEmit` clean. |
+| `bun run format:check && bun run --cwd packages/warden lint` | TRL-866 formatting and Warden lint | pass | First run caught sorted-key fixture ordering; fixed and reran clean. |
+| `bunx markdownlint-cli2 .changeset/trl-866-warden-trail-fix-metadata.md .agents/plans/2026-05-30-v1-convergence-loop/RETRO.md && git diff --check` | TRL-866 docs/hygiene | pass | Markdown and whitespace clean. |
 
 ## Review Findings
 

--- a/.changeset/trl-866-warden-trail-fix-metadata.md
+++ b/.changeset/trl-866-warden-trail-fix-metadata.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Preserve diagnostic fix metadata through Warden rule trail outputs.

--- a/apps/trails/src/__tests__/warden.test.ts
+++ b/apps/trails/src/__tests__/warden.test.ts
@@ -304,6 +304,11 @@ describe('trails warden', () => {
       diagnostics: [
         {
           filePath: 'src/trails/entity.ts',
+          fix: {
+            class: 'term-rewrite',
+            reason: 'Retired term needs a reviewed migration.',
+            safety: 'review',
+          },
           guidance: {
             docs: [{ label: 'Trail Rules', path: 'AGENTS.md#trail-rules' }],
             summary: 'Convert thrown failures in blazes into Result.err().',

--- a/packages/warden/src/__tests__/formatters.test.ts
+++ b/packages/warden/src/__tests__/formatters.test.ts
@@ -19,6 +19,11 @@ const reportWithDiagnostics: WardenReport = {
   diagnostics: [
     {
       filePath: 'packages/core/src/result.ts',
+      fix: {
+        class: 'term-rewrite',
+        reason: 'Retired term needs a reviewed migration.',
+        safety: 'review',
+      },
       guidance: {
         commands: ['bun test packages/core'],
         docs: [{ label: 'Trail Rules', path: 'AGENTS.md#trail-rules' }],
@@ -121,6 +126,16 @@ describe('formatJson', () => {
       summary: 'Convert thrown failures in blazes into Result.err().',
     });
     expect(parsed.diagnostics[1].guidance).toBeUndefined();
+  });
+
+  test('exposes diagnostic fix metadata as structured JSON', () => {
+    const parsed = JSON.parse(formatJson(reportWithDiagnostics));
+    expect(parsed.diagnostics[0].fix).toMatchObject({
+      class: 'term-rewrite',
+      reason: 'Retired term needs a reviewed migration.',
+      safety: 'review',
+    });
+    expect(parsed.diagnostics[1].fix).toBeUndefined();
   });
 
   test('includes null drift when absent', () => {

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { testAll } from '@ontrails/testing';
 
+import { runWardenTrails } from '../trails/run.js';
 import { diagnosticSchema } from '../trails/schema.js';
 import { wardenTopo } from '../trails/topo.js';
 
@@ -46,6 +47,23 @@ describe('wardenTopo', () => {
     ).toBe(true);
   });
 
+  test('diagnostic schema accepts structured fix metadata', () => {
+    expect(
+      diagnosticSchema.safeParse({
+        filePath: 'src/trail.ts',
+        fix: {
+          class: 'term-rewrite',
+          reason: 'Retired term needs a reviewed migration.',
+          safety: 'review',
+        },
+        line: 1,
+        message: 'Retired term used.',
+        rule: 'no-legacy-layer-imports',
+        severity: 'error',
+      }).success
+    ).toBe(true);
+  });
+
   test('diagnostic schema accepts label-only guidance links', () => {
     expect(
       diagnosticSchema.safeParse({
@@ -60,5 +78,23 @@ describe('wardenTopo', () => {
         severity: 'error',
       }).success
     ).toBe(true);
+  });
+
+  test('rule trail execution preserves diagnostic fix metadata', async () => {
+    const diagnostics = await runWardenTrails(
+      '/repo/apps/example/src/cli.ts',
+      "import { authLayer } from '@ontrails/permits';\n"
+    );
+
+    const diagnostic = diagnostics.find(
+      (entry) => entry.rule === 'no-legacy-layer-imports'
+    );
+
+    expect(diagnostic?.fix).toMatchObject({
+      class: 'term-rewrite',
+      safety: 'review',
+    });
+    expect(diagnostic?.fix?.reason).toContain('authLayer');
+    expect(diagnostic?.fix?.edits).toBeUndefined();
   });
 });

--- a/packages/warden/src/trails/no-legacy-layer-imports.trail.ts
+++ b/packages/warden/src/trails/no-legacy-layer-imports.trail.ts
@@ -16,6 +16,12 @@ export const noLegacyLayerImportsTrail = wrapRule({
         diagnostics: [
           {
             filePath: 'apps/example/src/cli.ts',
+            fix: {
+              class: 'term-rewrite',
+              reason:
+                "Legacy layer 'authLayer' was removed in TRL-475; Permit enforcement is intrinsic to executeTrail. Removal has no mechanical replacement, so it needs human migration.",
+              safety: 'review',
+            },
             line: 1,
             message:
               "Legacy layer 'authLayer' was removed in TRL-475. Permit enforcement is intrinsic to executeTrail. See docs/adr/0043-layer-evolution.md.",

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -10,6 +10,7 @@ import type { Topo } from '@ontrails/core';
 import type { TopoGraph } from '@ontrails/topographer';
 import { z } from 'zod';
 import { wardenImportResolutionErrorKinds } from '../resolve.js';
+import { wardenFixClasses, wardenFixSafeties } from '../rules/metadata.js';
 
 export const guidanceLinkSchema = z.object({
   label: z.string(),
@@ -25,9 +26,24 @@ export const guidanceSchema = z.object({
   summary: z.string(),
 });
 
+export const fixEditSchema = z.object({
+  end: z.number(),
+  replacement: z.string(),
+  start: z.number(),
+});
+
+export const fixSchema = z.object({
+  class: z.enum(wardenFixClasses),
+  edits: z.array(fixEditSchema).readonly().optional(),
+  fixture: z.string().optional(),
+  reason: z.string(),
+  safety: z.enum(wardenFixSafeties),
+});
+
 /** A single diagnostic emitted by a warden rule trail. */
 export const diagnosticSchema = z.object({
   filePath: z.string().describe('File path that was analyzed'),
+  fix: fixSchema.optional().describe('Structured fix metadata'),
   guidance: guidanceSchema
     .optional()
     .describe('Structured remediation guidance'),


### PR DESCRIPTION
## Context

Second branch in the V1 convergence stack (#634-#641). This turns the Warden fix-metadata ADR into executable projection behavior.

## Changes

- Preserves structured `fix` metadata in Warden rule trail diagnostics.
- Extends the Warden diagnostic schema/fixtures to include fix payloads.
- Adds JSON formatter coverage so structured output keeps the fix object intact.

## Verification

- `bun test packages/warden/src/__tests__/trails.test.ts packages/warden/src/__tests__/no-legacy-layer-imports.test.ts packages/warden/src/__tests__/formatters.test.ts apps/trails/src/__tests__/warden.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run --cwd apps/trails typecheck`
- `bun run format:check && bun run --cwd packages/warden lint`
- `bunx markdownlint-cli2 .changeset/trl-866-warden-trail-fix-metadata.md .agents/plans/2026-05-30-v1-convergence-loop/RETRO.md && git diff --check`

## Risks

- Scope is intentionally limited to projection/schema preservation; automated fix application remains out of scope.

Closes TRL-866
