### PR TITLE
feat(adapter-kit): derive adapter target catalog

### DIFF
--- a/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
@@ -1,6 +1,6 @@
 ---
 created: "2026-05-30T12:28:00Z"
-updated: "2026-05-30T12:28:00Z"
+updated: "2026-05-30T12:51:00Z"
 status: active
 ---
 
@@ -102,6 +102,42 @@ status: active
   `fix` survives structured JSON, and the `trails warden` output schema fixture
   now includes a structured fix object.
 
+### 2026-05-30 08:51 EDT - TRL-861 catalog substrate slice
+
+- Started `trl-861-define-adapter-target-metadata-and-catalog-derivation`
+  above the adapter conformance snippet branch.
+- Added private internal `@ontrails/adapter-kit` package for read-only
+  `trails.adapterTargets` catalog derivation.
+- Added first-party metadata to `@ontrails/http` and `@ontrails/store`; HTTP
+  advertises the target and placements only, while Store also advertises its
+  existing support and testing owner imports.
+- Kept support/testing imports optional so owners can advertise a target before
+  every authoring affordance exists. Missing means "not available yet"; the
+  tooling does not guess.
+- Added focused catalog tests for valid owner metadata, missing metadata,
+  invalid metadata, owner-local import boundaries, missing owner exports,
+  export-target derivation, and deterministic extracted/subpath placements.
+- Folded in Boole's review finding that declared support/testing imports should
+  fail when they cross owner package boundaries or are not exported by the
+  owner package.
+- Trimmed premature template/fixture/guidance fields out of the substrate; keep
+  this branch to facts derivation can prove.
+- Added a patch changeset for the public package metadata.
+
+### 2026-05-30 09:00 EDT - TRL-861 sidecar review fixes
+
+- Laplace reviewed the adapter catalog substrate and scored it 3/5 with one
+  P1 and three P2 findings.
+- Fixed the P1 by reporting `invalid-placement` for `placements: []` instead
+  of silently omitting a declared adapter target from an otherwise clean
+  catalog.
+- Tightened optional `supportImport` and `testingImport` validation so they
+  must point at owner package subpaths, not the owner package root.
+- Fixed `packages/adapter-kit/tsconfig.tests.json` so editor/test type
+  coverage includes `src/__tests__/catalog.test.ts`.
+- Updated the adapter ADR draft `updated` frontmatter date for the TRL-861
+  metadata changes.
+
 ## Verification Ledger
 
 | Command | Context | Result | Notes |
@@ -123,10 +159,31 @@ status: active
 | `bunx markdownlint-cli2 .changeset/trl-866-warden-trail-fix-metadata.md .agents/plans/2026-05-30-v1-convergence-loop/RETRO.md && git diff --check` | TRL-866 docs/hygiene | pass | Markdown and whitespace clean. |
 | `rg -n "runConformance" docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md` | TRL-853 snippet truth | pass | Confirmed the conformance snippet now imports and calls `runConformance`. |
 | `bun scripts/adr.ts check` | TRL-853 adapter ADR snippet | pass | 0 errors, 0 warnings. |
+| `bun test packages/adapter-kit/src/__tests__/catalog.test.ts` | TRL-861 adapter catalog | pass | 6 tests passed. |
+| `bun run --cwd packages/adapter-kit typecheck` | TRL-861 adapter catalog | pass | `tsc --noEmit` clean. |
+| `bun run --cwd packages/adapter-kit lint` | TRL-861 adapter catalog | pass | Oxlint clean. |
+| `bun run --cwd packages/adapter-kit build` | TRL-861 adapter catalog | pass | `tsc -b` clean. |
+| `bun run typecheck` | TRL-861 workspace package integration | pass | 24 package typechecks passed. |
+| `bun run lint` | TRL-861 workspace package integration | pass | 25 lint tasks passed, including Oxlint plugin build. |
+| `bun install --frozen-lockfile` | TRL-861 workspace metadata | pass | Lockfile matched new workspace package shape. |
+| `bun scripts/adr.ts check` | TRL-861 adapter ADR metadata note | pass | 0 errors, 0 warnings. |
+| `bun run oxlint-plugin:build` | TRL-861 formatter setup | pass | Private Oxlint plugin built before Ultracite. |
+| `bunx ultracite check packages/adapter-kit/src/catalog.ts packages/adapter-kit/src/__tests__/catalog.test.ts packages/adapter-kit/src/index.ts packages/adapter-kit/package.json packages/adapter-kit/tsconfig.json packages/adapter-kit/tsconfig.tests.json packages/http/package.json packages/store/package.json docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md .changeset/trl-861-adapter-target-catalog.md` | TRL-861 formatting | pass | Matched files clean. |
+| `bunx markdownlint-cli2 docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md .changeset/trl-861-adapter-target-catalog.md .agents/plans/2026-05-30-v1-convergence-loop/RETRO.md` | TRL-861 docs/hygiene | pass | 0 markdown errors. |
+| `git diff --check` | TRL-861 whitespace | pass | No whitespace findings. |
+| `bun test packages/adapter-kit/src/__tests__/catalog.test.ts` | TRL-861 sidecar review fixes | pass | 8 tests passed, including empty placements and owner-root import regressions. |
+| `bunx tsc -p packages/adapter-kit/tsconfig.tests.json --showConfig \| rg -n "catalog\\.test\\.ts\|types\|exclude\|rootDir"` | TRL-861 sidecar review fixes | pass | Confirmed `catalog.test.ts` appears in the resolved config. |
+| `bunx tsc -p packages/adapter-kit/tsconfig.tests.json --noEmit` | TRL-861 sidecar review fixes | pass | Test tsconfig typecheck clean. |
+| `bun run --cwd packages/adapter-kit typecheck` | TRL-861 sidecar review fixes | pass | Package typecheck clean. |
+| `bun run --cwd packages/adapter-kit lint` | TRL-861 sidecar review fixes | pass | Oxlint clean. |
+| `bun scripts/adr.ts check` | TRL-861 sidecar review fixes | pass | 0 errors, 0 warnings. |
+| `bunx ultracite check packages/adapter-kit/src/catalog.ts packages/adapter-kit/src/__tests__/catalog.test.ts packages/adapter-kit/tsconfig.tests.json docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md` | TRL-861 sidecar review fixes | pass | First run found formatting in the new test; `ultracite fix` applied it and rerun passed. |
 
 ## Review Findings
 
-No local review pass has run yet.
+Laplace reviewed TRL-861 and found one P1 and three P2 issues. All four were
+fixed on `trl-861-define-adapter-target-metadata-and-catalog-derivation` before
+continuing upward.
 
 ## Open Risks
 
@@ -134,6 +191,6 @@ No local review pass has run yet.
   decision map. Verify before cutting its branch.
 - TRL-826 and TRL-829 are conditional. Keep them only if this stack produces
   enough implementation evidence.
-- Adapter tooling package name is intentionally unsettled until implementation
-  proves whether `adapter-tools` or another name better communicates internal
-  tooling rather than central authority.
+- Adapter tooling package name was corrected from `@ontrails/adapter-tools` to
+  private `@ontrails/adapter-kit` before landing so the package reads as the
+  adapter-authoring paved path, not a grab bag of internals.

--- a/.changeset/trl-861-adapter-target-catalog.md
+++ b/.changeset/trl-861-adapter-target-catalog.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/http": patch
+"@ontrails/store": patch
+---
+
+Advertise first-party adapter target metadata for catalog derivation.

--- a/bun.lock
+++ b/bun.lock
@@ -117,6 +117,10 @@
         "@ontrails/warden": "workspace:^",
       },
     },
+    "packages/adapter-kit": {
+      "name": "@ontrails/adapter-kit",
+      "version": "1.0.0-beta.18",
+    },
     "packages/cli": {
       "name": "@ontrails/cli",
       "version": "1.0.0-beta.18",
@@ -204,11 +208,11 @@
       "version": "1.0.0-beta.18",
       "dependencies": {
         "@ontrails/core": "workspace:^",
-        "@ontrails/topographer": "workspace:^",
         "zod": "catalog:",
       },
       "devDependencies": {
         "@ontrails/testing": "workspace:^",
+        "@ontrails/topographer": "workspace:^",
       },
     },
     "packages/store": {
@@ -384,6 +388,8 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@ontrails/adapter-kit": ["@ontrails/adapter-kit@workspace:packages/adapter-kit"],
 
     "@ontrails/cli": ["@ontrails/cli@workspace:packages/cli"],
 

--- a/docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md
+++ b/docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md
@@ -3,7 +3,7 @@ slug: adapter-authoring-as-a-paved-path
 title: Adapter authoring as a paved path
 status: draft
 created: 2026-05-28
-updated: 2026-05-28
+updated: 2026-05-30
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [29]
 ---
@@ -83,9 +83,11 @@ The discoverability substrate is the package manifest, which keeps discovery che
 }
 ```
 
-### Tooling consumes facts; it never owns adapter truth
+TRL-861 codifies this metadata shape: `placements` is required, while `supportImport` and `testingImport` are optional until the owner actually exports support or conformance surfaces. Optional means "not available yet," not "tooling should guess."
 
-The adapter tooling discovers owner targets, scaffolds extracted and subpath adapters, generates conformance tests, generates package/export skeletons, runs the shared check engine, and reports readiness. It does **not** define an `adapter()` primitive, own HTTP/store/permit/observe semantics, get imported by runtime adapters, or re-author package facts that `package.json` already states.
+### The adapter kit consumes facts; it never owns adapter truth
+
+The adapter kit starts as private `@ontrails/adapter-kit`: it discovers owner targets, scaffolds extracted and subpath adapters, generates conformance tests, generates package/export skeletons, runs the shared check engine, and reports readiness. It does **not** define an `adapter()` primitive, own HTTP/store/permit/observe semantics, get imported by runtime adapters, or re-author package facts that `package.json` already states.
 
 Two structural rules keep it tooling and not truth:
 
@@ -163,8 +165,7 @@ The user-facing commands are trails, so adapter authoring is queryable without a
 
 ## Non-decisions
 
-- The tooling package name (`@ontrails/adapter-kit` vs `@ontrails/adapter-tools`). Start private; settle the name in implementation. If "kit" keeps implying central authority, prefer the more explicitly tooling-shaped name.
-- The exact metadata syntax — the `package.json` `trails.adapterTargets` shape above is illustrative.
+- Whether the adapter kit ever becomes public; the current package stays private.
 - Exact command flags.
 - How Warden scopes to a single adapter — build the shared engine first, then expose a scope without a second rule path.
 

--- a/packages/adapter-kit/package.json
+++ b/packages/adapter-kit/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@ontrails/adapter-kit",
+  "version": "1.0.0-beta.18",
+  "private": true,
+  "description": "Internal adapter authoring kit for Trails metadata, scaffolding, and checks.",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  }
+}

--- a/packages/adapter-kit/src/__tests__/catalog.test.ts
+++ b/packages/adapter-kit/src/__tests__/catalog.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { deriveAdapterTargetCatalog } from '../catalog.js';
+
+const roots: string[] = [];
+
+const writeJson = (
+  root: string,
+  path: string,
+  value: Record<string, unknown>
+): void => {
+  const filePath = join(root, path);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const makeRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'trails-adapter-catalog-'));
+  roots.push(root);
+  writeJson(root, 'package.json', {
+    name: 'fixture-root',
+    workspaces: ['packages/*', 'adapters/*'],
+  });
+  return root;
+};
+
+const writePackage = (
+  root: string,
+  workspacePath: string,
+  manifest: Record<string, unknown>
+): void => {
+  writeJson(root, join(workspacePath, 'package.json'), manifest);
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe('deriveAdapterTargetCatalog', () => {
+  test('derives adapter target metadata from owner package manifests', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/store', {
+      exports: {
+        '.': './src/index.ts',
+        './adapter-support': './src/adapter-support.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/store',
+      trails: {
+        adapterTargets: {
+          store: {
+            placements: ['extracted', 'subpath'],
+            supportImport: '@ontrails/store/adapter-support',
+            testingImport: '@ontrails/store/testing',
+          },
+        },
+      },
+    });
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets).toHaveLength(1);
+    expect(catalog.targets[0]).toMatchObject({
+      key: '@ontrails/store:store',
+      ownerPackage: '@ontrails/store',
+      placements: ['extracted', 'subpath'],
+      supportImport: '@ontrails/store/adapter-support',
+      target: 'store',
+      testingImport: '@ontrails/store/testing',
+    });
+    expect(catalog.targets[0]?.supportExportTarget).toEndWith(
+      'packages/store/src/adapter-support.ts'
+    );
+    expect(catalog.targets[0]?.testingExportTarget).toEndWith(
+      'packages/store/src/testing.ts'
+    );
+  });
+
+  test('ignores packages without adapter target metadata', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/core', {
+      exports: { '.': './src/index.ts' },
+      name: '@ontrails/core',
+    });
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog).toEqual({
+      diagnostics: [],
+      targets: [],
+    });
+  });
+
+  test('reports invalid adapter target metadata without cataloging it', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: { '.': './src/index.ts' },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          'Bad Target': {
+            placements: ['extracted'],
+          },
+          http: {
+            placements: ['extracted', 'portal'],
+            supportImport: 42,
+          },
+          remote: {
+            placements: ['extracted'],
+            testingImport: '@other/http/testing',
+          },
+        },
+      },
+    });
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics.map((entry) => entry.code).toSorted()).toEqual([
+      'invalid-adapter-target',
+      'invalid-import',
+      'invalid-import',
+      'invalid-placement',
+    ]);
+  });
+
+  test('reports support and testing imports outside the owner package', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: { '.': './src/index.ts' },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            supportImport: '@ontrails/store/adapter-support',
+            testingImport: '@ontrails/testing',
+          },
+        },
+      },
+    });
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(2);
+    expect(
+      catalog.diagnostics.every((entry) => entry.code === 'invalid-import')
+    ).toBe(true);
+    expect(catalog.diagnostics[0]?.message).toContain('inside @ontrails/http');
+  });
+
+  test('reports owner root support and testing imports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: { '.': './src/index.ts' },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            supportImport: '@ontrails/http',
+            testingImport: '@ontrails/http',
+          },
+        },
+      },
+    });
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(2);
+    expect(
+      catalog.diagnostics.every((entry) => entry.code === 'invalid-import')
+    ).toBe(true);
+    expect(catalog.diagnostics[0]?.message).toContain('owner package subpath');
+  });
+
+  test('reports empty placements as invalid target metadata', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: { '.': './src/index.ts' },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: [],
+          },
+        },
+      },
+    });
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(1);
+    expect(catalog.diagnostics[0]?.code).toBe('invalid-placement');
+    expect(catalog.diagnostics[0]?.message).toContain('at least one placement');
+  });
+
+  test('reports support and testing imports missing from owner exports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: { '.': './src/index.ts' },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            supportImport: '@ontrails/http/adapter-support',
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(2);
+    expect(
+      catalog.diagnostics.every((entry) => entry.code === 'invalid-import')
+    ).toBe(true);
+    expect(catalog.diagnostics[0]?.message).toContain('does not export');
+  });
+
+  test('keeps extracted and subpath placements distinct and deterministic', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: { '.': './src/index.ts' },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['subpath', 'extracted', 'subpath'],
+          },
+        },
+      },
+    });
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets[0]?.placements).toEqual(['extracted', 'subpath']);
+  });
+
+  test('rejects duplicate target ids across owner packages', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: { '.': './src/index.ts' },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+          },
+        },
+      },
+    });
+    writePackage(root, 'packages/alt-http', {
+      exports: { '.': './src/index.ts' },
+      name: '@ontrails/alt-http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+          },
+        },
+      },
+    });
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(2);
+    expect(catalog.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'duplicate-adapter-target',
+          packageName: '@ontrails/http',
+          target: 'http',
+        }),
+        expect.objectContaining({
+          code: 'duplicate-adapter-target',
+          packageName: '@ontrails/alt-http',
+          target: 'http',
+        }),
+      ])
+    );
+  });
+});

--- a/packages/adapter-kit/src/catalog.ts
+++ b/packages/adapter-kit/src/catalog.ts
@@ -1,0 +1,557 @@
+/**
+ * Read-only adapter target catalog derivation.
+ *
+ * Owner packages author the few adapter facts package metadata cannot derive.
+ * Tooling consumes those facts; runtime adapters must never import this
+ * private package.
+ */
+
+import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+export const adapterTargetPlacements = ['extracted', 'subpath'] as const;
+
+export type AdapterTargetPlacementValue =
+  (typeof adapterTargetPlacements)[number];
+
+export type AdapterTargetPlacement = AdapterTargetPlacementValue;
+
+export interface AdapterTargetManifestEntry {
+  readonly placements: readonly AdapterTargetPlacement[];
+  readonly supportImport?: string | undefined;
+  readonly testingImport?: string | undefined;
+}
+
+export interface AdapterTargetCatalogEntry extends AdapterTargetManifestEntry {
+  readonly key: string;
+  readonly ownerPackage: string;
+  readonly packageJsonPath: string;
+  readonly packageRoot: string;
+  readonly supportExportTarget?: string | undefined;
+  readonly target: string;
+  readonly testingExportTarget?: string | undefined;
+}
+
+export type AdapterTargetCatalogDiagnosticCode =
+  | 'duplicate-adapter-target'
+  | 'invalid-adapter-target'
+  | 'invalid-adapter-targets'
+  | 'invalid-import'
+  | 'invalid-placement';
+
+export interface AdapterTargetCatalogDiagnostic {
+  readonly code: AdapterTargetCatalogDiagnosticCode;
+  readonly message: string;
+  readonly packageJsonPath: string;
+  readonly packageName?: string | undefined;
+  readonly target?: string | undefined;
+}
+
+export interface AdapterTargetCatalog {
+  readonly diagnostics: readonly AdapterTargetCatalogDiagnostic[];
+  readonly targets: readonly AdapterTargetCatalogEntry[];
+}
+
+interface RootManifest {
+  readonly workspaces?: unknown;
+}
+
+export interface AdapterTargetPackageManifest {
+  readonly exports?: unknown;
+  readonly name?: unknown;
+  readonly trails?: unknown;
+}
+
+export interface AdapterTargetParseContext {
+  readonly exportTargets: Readonly<Record<string, string>>;
+  readonly packageJsonPath: string;
+  readonly packageName: string;
+  readonly packageRoot: string;
+}
+
+interface ParsedCatalogTarget {
+  readonly diagnostics: readonly AdapterTargetCatalogDiagnostic[];
+  readonly targetEntry?: AdapterTargetCatalogEntry | undefined;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const targetIdPattern = /^[a-z][a-z0-9-]*$/u;
+
+const normalizePath = (path: string): string => path.replaceAll('\\', '/');
+
+const normalizeRealPath = (path: string): string => {
+  try {
+    return normalizePath(realpathSync(path));
+  } catch {
+    return normalizePath(resolve(path));
+  }
+};
+
+const readJson = <T>(path: string): T | undefined => {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as T;
+  } catch {
+    return undefined;
+  }
+};
+
+const workspacePatternsFromManifest = (
+  manifest: RootManifest | undefined
+): readonly string[] => {
+  const { workspaces } = manifest ?? {};
+  if (Array.isArray(workspaces)) {
+    return workspaces.filter(
+      (pattern): pattern is string => typeof pattern === 'string'
+    );
+  }
+
+  const packages = isRecord(workspaces) ? workspaces['packages'] : undefined;
+  return Array.isArray(packages)
+    ? packages.filter(
+        (pattern): pattern is string => typeof pattern === 'string'
+      )
+    : [];
+};
+
+const workspaceDirsForPattern = (
+  rootDir: string,
+  pattern: string
+): readonly string[] => {
+  if (!pattern.endsWith('/*')) {
+    const workspaceDir = join(rootDir, pattern);
+    return existsSync(workspaceDir) ? [workspaceDir] : [];
+  }
+
+  const groupDir = join(rootDir, pattern.slice(0, -2));
+  if (!existsSync(groupDir)) {
+    return [];
+  }
+
+  return readdirSync(groupDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(groupDir, entry.name))
+    .toSorted();
+};
+
+const resolveExportTarget = (
+  target: unknown,
+  depth = 0
+): string | undefined => {
+  if (typeof target === 'string') {
+    return target;
+  }
+  if (!isRecord(target) || depth > 8) {
+    return undefined;
+  }
+
+  for (const condition of ['bun', 'import', 'default', 'require'] as const) {
+    const resolvedTarget = resolveExportTarget(target[condition], depth + 1);
+    if (resolvedTarget) {
+      return resolvedTarget;
+    }
+  }
+  return undefined;
+};
+
+const exportSpecifierFromKey = (
+  packageName: string,
+  key: string
+): string | undefined => {
+  if (key === '.') {
+    return packageName;
+  }
+  if (!key.startsWith('./') || key.includes('*')) {
+    return undefined;
+  }
+  return `${packageName}/${key.slice(2)}`;
+};
+
+const normalizeExportTargets = (
+  packageRoot: string,
+  packageName: string,
+  exportsValue: unknown
+): Readonly<Record<string, string>> => {
+  if (!isRecord(exportsValue)) {
+    return {};
+  }
+
+  const targets: Record<string, string> = {};
+  for (const [key, value] of Object.entries(exportsValue)) {
+    const specifier = exportSpecifierFromKey(packageName, key);
+    const target = resolveExportTarget(value);
+    if (!specifier || !target) {
+      continue;
+    }
+    targets[specifier] = normalizeRealPath(join(packageRoot, target));
+  }
+  return targets;
+};
+
+const diagnostic = (
+  context: AdapterTargetParseContext,
+  code: AdapterTargetCatalogDiagnosticCode,
+  message: string,
+  target?: string
+): AdapterTargetCatalogDiagnostic => ({
+  code,
+  message,
+  packageJsonPath: context.packageJsonPath,
+  packageName: context.packageName,
+  ...(target === undefined ? {} : { target }),
+});
+
+const targetDiagnostic = (
+  entry: AdapterTargetCatalogEntry,
+  code: AdapterTargetCatalogDiagnosticCode,
+  message: string
+): AdapterTargetCatalogDiagnostic => ({
+  code,
+  message,
+  packageJsonPath: entry.packageJsonPath,
+  packageName: entry.ownerPackage,
+  target: entry.target,
+});
+
+const rejectDuplicateTargetIds = (
+  targets: readonly AdapterTargetCatalogEntry[]
+): {
+  readonly diagnostics: readonly AdapterTargetCatalogDiagnostic[];
+  readonly targets: readonly AdapterTargetCatalogEntry[];
+} => {
+  const entriesByTarget = new Map<string, AdapterTargetCatalogEntry[]>();
+  for (const entry of targets) {
+    entriesByTarget.set(entry.target, [
+      ...(entriesByTarget.get(entry.target) ?? []),
+      entry,
+    ]);
+  }
+
+  const duplicateTargets = new Set(
+    [...entriesByTarget.entries()]
+      .filter(([, entries]) => entries.length > 1)
+      .map(([target]) => target)
+  );
+
+  return {
+    diagnostics: [...entriesByTarget.values()]
+      .filter((entries) => entries.length > 1)
+      .flatMap((entries) =>
+        entries.map((entry) =>
+          targetDiagnostic(
+            entry,
+            'duplicate-adapter-target',
+            `Adapter target "${entry.target}" is declared by multiple owner packages; target ids must be globally unique until adapter metadata can select an owner.`
+          )
+        )
+      ),
+    targets: targets.filter((entry) => !duplicateTargets.has(entry.target)),
+  };
+};
+
+const isAdapterTargetPlacement = (
+  value: unknown
+): value is AdapterTargetPlacement =>
+  typeof value === 'string' &&
+  adapterTargetPlacements.includes(value as AdapterTargetPlacement);
+
+const normalizePlacements = (
+  value: unknown,
+  context: AdapterTargetParseContext,
+  target: string
+): {
+  readonly diagnostics: readonly AdapterTargetCatalogDiagnostic[];
+  readonly placements: readonly AdapterTargetPlacement[];
+} => {
+  if (!Array.isArray(value)) {
+    return {
+      diagnostics: [
+        diagnostic(
+          context,
+          'invalid-placement',
+          `Adapter target "${target}" must declare placements as an array.`,
+          target
+        ),
+      ],
+      placements: [],
+    };
+  }
+
+  const diagnostics: AdapterTargetCatalogDiagnostic[] = [];
+  if (value.length === 0) {
+    diagnostics.push(
+      diagnostic(
+        context,
+        'invalid-placement',
+        `Adapter target "${target}" must declare at least one placement.`,
+        target
+      )
+    );
+  }
+
+  const placements = new Set<AdapterTargetPlacement>();
+  for (const placement of value) {
+    if (isAdapterTargetPlacement(placement)) {
+      placements.add(placement);
+      continue;
+    }
+    diagnostics.push(
+      diagnostic(
+        context,
+        'invalid-placement',
+        `Adapter target "${target}" has unsupported placement ${JSON.stringify(placement)}.`,
+        target
+      )
+    );
+  }
+
+  return {
+    diagnostics,
+    placements: [...placements].toSorted(),
+  };
+};
+
+const normalizeOptionalImport = (
+  value: unknown,
+  field: 'supportImport' | 'testingImport',
+  context: AdapterTargetParseContext,
+  target: string
+): {
+  readonly diagnostics: readonly AdapterTargetCatalogDiagnostic[];
+  readonly importSpecifier?: string | undefined;
+} => {
+  if (value === undefined) {
+    return { diagnostics: [] };
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    if (!value.startsWith(`${context.packageName}/`)) {
+      return {
+        diagnostics: [
+          diagnostic(
+            context,
+            'invalid-import',
+            `Adapter target "${target}" must declare ${field} as an owner package subpath inside ${context.packageName}.`,
+            target
+          ),
+        ],
+      };
+    }
+
+    return { diagnostics: [], importSpecifier: value };
+  }
+  return {
+    diagnostics: [
+      diagnostic(
+        context,
+        'invalid-import',
+        `Adapter target "${target}" must declare ${field} as a non-empty string when present.`,
+        target
+      ),
+    ],
+  };
+};
+
+const missingExportDiagnostic = (
+  context: AdapterTargetParseContext,
+  field: 'supportImport' | 'testingImport',
+  importSpecifier: string,
+  target: string
+): AdapterTargetCatalogDiagnostic =>
+  diagnostic(
+    context,
+    'invalid-import',
+    `Adapter target "${target}" declares ${field} "${importSpecifier}", but ${context.packageName} does not export that subpath.`,
+    target
+  );
+
+const adapterTargetsRecord = (
+  manifest: AdapterTargetPackageManifest
+): Record<string, unknown> | undefined | null => {
+  const trails = isRecord(manifest.trails) ? manifest.trails : undefined;
+  const adapterTargets = trails?.['adapterTargets'];
+  if (adapterTargets === undefined) {
+    return undefined;
+  }
+  return isRecord(adapterTargets) ? adapterTargets : null;
+};
+
+const parseCatalogTarget = (
+  context: AdapterTargetParseContext,
+  target: string,
+  entry: unknown
+): ParsedCatalogTarget => {
+  if (!targetIdPattern.test(target) || !isRecord(entry)) {
+    return {
+      diagnostics: [
+        diagnostic(
+          context,
+          'invalid-adapter-target',
+          'Adapter target entries must use a kebab-case id and object value.',
+          target
+        ),
+      ],
+    };
+  }
+
+  const placements = normalizePlacements(entry['placements'], context, target);
+  const supportImport = normalizeOptionalImport(
+    entry['supportImport'],
+    'supportImport',
+    context,
+    target
+  );
+  const testingImport = normalizeOptionalImport(
+    entry['testingImport'],
+    'testingImport',
+    context,
+    target
+  );
+  const importDiagnostics = [
+    ...placements.diagnostics,
+    ...supportImport.diagnostics,
+    ...testingImport.diagnostics,
+  ];
+  const supportImportSpecifier = supportImport.importSpecifier;
+  const supportExportTarget = supportImportSpecifier
+    ? context.exportTargets[supportImportSpecifier]
+    : undefined;
+  const testingImportSpecifier = testingImport.importSpecifier;
+  const testingExportTarget = testingImportSpecifier
+    ? context.exportTargets[testingImportSpecifier]
+    : undefined;
+
+  if (supportImportSpecifier && !supportExportTarget) {
+    importDiagnostics.push(
+      missingExportDiagnostic(
+        context,
+        'supportImport',
+        supportImportSpecifier,
+        target
+      )
+    );
+  }
+  if (testingImportSpecifier && !testingExportTarget) {
+    importDiagnostics.push(
+      missingExportDiagnostic(
+        context,
+        'testingImport',
+        testingImportSpecifier,
+        target
+      )
+    );
+  }
+  if (importDiagnostics.length > 0 || placements.placements.length === 0) {
+    return { diagnostics: importDiagnostics };
+  }
+
+  return {
+    diagnostics: [],
+    targetEntry: {
+      key: `${context.packageName}:${target}`,
+      ownerPackage: context.packageName,
+      packageJsonPath: context.packageJsonPath,
+      packageRoot: context.packageRoot,
+      placements: placements.placements,
+      ...(supportImportSpecifier
+        ? {
+            ...(supportExportTarget ? { supportExportTarget } : {}),
+            supportImport: supportImportSpecifier,
+          }
+        : {}),
+      target,
+      ...(testingImportSpecifier
+        ? {
+            ...(testingExportTarget ? { testingExportTarget } : {}),
+            testingImport: testingImportSpecifier,
+          }
+        : {}),
+    },
+  };
+};
+
+export const parseAdapterTargetsFromManifest = (
+  manifest: AdapterTargetPackageManifest,
+  context: AdapterTargetParseContext
+): AdapterTargetCatalog => {
+  const adapterTargets = adapterTargetsRecord(manifest);
+  if (adapterTargets === undefined) {
+    return { diagnostics: [], targets: [] };
+  }
+  if (adapterTargets === null) {
+    return {
+      diagnostics: [
+        diagnostic(
+          context,
+          'invalid-adapter-targets',
+          '`trails.adapterTargets` must be an object keyed by adapter target id.'
+        ),
+      ],
+      targets: [],
+    };
+  }
+
+  const diagnostics: AdapterTargetCatalogDiagnostic[] = [];
+  const targets: AdapterTargetCatalogEntry[] = [];
+
+  for (const [target, entry] of Object.entries(adapterTargets).toSorted()) {
+    const parsedTarget = parseCatalogTarget(context, target, entry);
+    diagnostics.push(...parsedTarget.diagnostics);
+    if (parsedTarget.targetEntry) {
+      targets.push(parsedTarget.targetEntry);
+    }
+  }
+
+  return {
+    diagnostics,
+    targets,
+  };
+};
+
+export const deriveAdapterTargetCatalog = (
+  rootDir: string
+): AdapterTargetCatalog => {
+  const normalizedRoot = normalizeRealPath(rootDir);
+  const rootManifest = readJson<RootManifest>(
+    join(normalizedRoot, 'package.json')
+  );
+  const diagnostics: AdapterTargetCatalogDiagnostic[] = [];
+  const targets: AdapterTargetCatalogEntry[] = [];
+
+  for (const pattern of workspacePatternsFromManifest(rootManifest)) {
+    for (const workspaceDir of workspaceDirsForPattern(
+      normalizedRoot,
+      pattern
+    )) {
+      const packageJsonPath = join(workspaceDir, 'package.json');
+      const manifest = readJson<AdapterTargetPackageManifest>(packageJsonPath);
+      if (!manifest || typeof manifest.name !== 'string') {
+        continue;
+      }
+
+      const packageRoot = normalizeRealPath(dirname(packageJsonPath));
+      const parsed = parseAdapterTargetsFromManifest(manifest, {
+        exportTargets: normalizeExportTargets(
+          packageRoot,
+          manifest.name,
+          manifest.exports
+        ),
+        packageJsonPath: normalizeRealPath(packageJsonPath),
+        packageName: manifest.name,
+        packageRoot,
+      });
+      diagnostics.push(...parsed.diagnostics);
+      targets.push(...parsed.targets);
+    }
+  }
+
+  const sortedTargets = targets.toSorted((left, right) =>
+    left.key.localeCompare(right.key)
+  );
+  const uniqueTargets = rejectDuplicateTargetIds(sortedTargets);
+
+  return {
+    diagnostics: [...diagnostics, ...uniqueTargets.diagnostics],
+    targets: uniqueTargets.targets,
+  };
+};

--- a/packages/adapter-kit/src/index.ts
+++ b/packages/adapter-kit/src/index.ts
@@ -1,0 +1,16 @@
+export {
+  adapterTargetPlacements,
+  deriveAdapterTargetCatalog,
+  parseAdapterTargetsFromManifest,
+} from './catalog.js';
+export type {
+  AdapterTargetCatalog,
+  AdapterTargetCatalogDiagnostic,
+  AdapterTargetCatalogDiagnosticCode,
+  AdapterTargetCatalogEntry,
+  AdapterTargetManifestEntry,
+  AdapterTargetPackageManifest,
+  AdapterTargetParseContext,
+  AdapterTargetPlacement,
+  AdapterTargetPlacementValue,
+} from './catalog.js';

--- a/packages/adapter-kit/tsconfig.json
+++ b/packages/adapter-kit/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/packages/adapter-kit/tsconfig.tests.json
+++ b/packages/adapter-kit/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -28,5 +28,15 @@
   },
   "peerDependencies": {
     "zod": "catalog:"
+  },
+  "trails": {
+    "adapterTargets": {
+      "http": {
+        "placements": [
+          "extracted",
+          "subpath"
+        ]
+      }
+    }
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -30,5 +30,17 @@
   },
   "peerDependencies": {
     "zod": "catalog:"
+  },
+  "trails": {
+    "adapterTargets": {
+      "store": {
+        "placements": [
+          "extracted",
+          "subpath"
+        ],
+        "supportImport": "@ontrails/store/adapter-support",
+        "testingImport": "@ontrails/store/testing"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Context

Fourth branch in the V1 convergence stack (#634-#641). This creates the metadata substrate for first-party adapter targets without inventing adapter scaffolding yet.

## Changes

- Adds internal `@ontrails/adapter-tools` catalog derivation for `trails.adapterTargets` package metadata.
- Adds first-party adapter target metadata to `@ontrails/http` and `@ontrails/store`.
- Validates target IDs, placements, owner-local support/testing imports, and owner export maps.
- Adds a changeset for the affected package metadata.

## Verification

- `bun test packages/adapter-tools/src/__tests__/catalog.test.ts`
- `bun run --cwd packages/adapter-tools typecheck`
- `bun run --cwd packages/adapter-tools lint`
- `bun run --cwd packages/adapter-tools build`
- `bun run typecheck`
- `bun run lint`
- `bun install --frozen-lockfile`
- `bun scripts/adr.ts check`
- `bunx ultracite check ...`
- `bunx markdownlint-cli2 ... && git diff --check`

## Risks

- `@ontrails/adapter-tools` is intentionally internal tooling, not an author-facing API. Later branches consume it through Warden and `trails adapter check`.

Closes TRL-861
