### PR TITLE
feat(http): add adapter conformance factory

### DIFF
--- a/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
@@ -138,6 +138,22 @@ status: active
 - Updated the adapter ADR draft `updated` frontmatter date for the TRL-861
   metadata changes.
 
+### 2026-05-30 09:58 EDT - TRL-862 HTTP owner conformance slice
+
+- Started `trl-862-add-http-adapter-authoring-support-and-conformance-factory`
+  above TRL-861.
+- Added `@ontrails/http/testing` with owner-owned HTTP adapter conformance
+  cases plus `runConformance()`.
+- Kept HTTP adapter support out of scope for now: current adapters can conform
+  through the public topo/options surface, so an `adapter-support` subpath would
+  be invented surface area.
+- Updated `@ontrails/http` package metadata so the `http` adapter target points
+  at the now-real `@ontrails/http/testing` import.
+- Validated `@ontrails/http/fetch`, `@ontrails/http/bun`, and `@ontrails/hono`
+  through the same owner conformance cases.
+- Updated the HTTP README and README snippet harness so the public testing
+  subpath example typechecks.
+
 ## Verification Ledger
 
 | Command | Context | Result | Notes |
@@ -178,12 +194,47 @@ status: active
 | `bun run --cwd packages/adapter-kit lint` | TRL-861 sidecar review fixes | pass | Oxlint clean. |
 | `bun scripts/adr.ts check` | TRL-861 sidecar review fixes | pass | 0 errors, 0 warnings. |
 | `bunx ultracite check packages/adapter-kit/src/catalog.ts packages/adapter-kit/src/__tests__/catalog.test.ts packages/adapter-kit/tsconfig.tests.json docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md` | TRL-861 sidecar review fixes | pass | First run found formatting in the new test; `ultracite fix` applied it and rerun passed. |
+| `bun test packages/http/src/__tests__/testing.test.ts` | TRL-862 HTTP conformance factory | pass | 14 tests passed, including public subpath typecheck and fetch/bun conformance. |
+| `bun test packages/http/src/__tests__/fetch.test.ts packages/http/src/__tests__/bun.test.ts packages/http/src/__tests__/testing.test.ts` | TRL-862 HTTP regression set | pass | 35 tests passed. |
+| `bun test adapters/hono/src/__tests__/surface.test.ts adapters/hono/src/__tests__/conformance.test.ts` | TRL-862 Hono conformance dogfood | pass | 28 tests passed. |
+| `bun run --cwd packages/http typecheck` | TRL-862 HTTP package | pass | `tsc --noEmit` clean. |
+| `bun run --cwd packages/http lint` | TRL-862 HTTP package | pass | Oxlint clean. |
+| `bun run --cwd packages/http build` | TRL-862 HTTP package | pass | `tsc -b` clean. |
+| `bun run --cwd adapters/hono typecheck` | TRL-862 Hono conformance dogfood | pass | `tsc --noEmit` clean. |
+| `bun run --cwd adapters/hono lint` | TRL-862 Hono conformance dogfood | pass | Oxlint clean. |
+| `bun run docs:snippets` | TRL-862 HTTP README snippet | pass | 21 README files typechecked; HTTP README now has 6 snippets. |
+| `bun run docs:api-examples` | TRL-862 public API examples | pass | Existing public API example inventory passed. |
+| `bunx ultracite check packages/http/src/testing.ts packages/http/src/__tests__/testing.test.ts packages/http/package.json packages/http/README.md scripts/check-readme-snippets.ts .changeset/trl-862-http-adapter-testing.md` | TRL-862 formatting | pass | Matched files clean after formatter fix. |
+| `bunx markdownlint-cli2 packages/http/README.md .changeset/trl-862-http-adapter-testing.md .agents/plans/2026-05-30-v1-convergence-loop/RETRO.md` | TRL-862 docs/hygiene | pass | 0 markdown errors. |
+| `git diff --check` | TRL-862 whitespace | pass | No whitespace findings. |
+| `bun run docs:wrap-check` | TRL-862 docs/hardwrap | pass | Lower-stack ADR hardwraps were reflowed on their owning branches; 159 scanned files clean. |
+| `gh pr checks 643` | Top-of-stack hosted CI | fail | `Test` timed out in the TRL-862 HTTP public testing subpath smoke test on the CI runner. |
+| `gh run view 26689927179 --job 78664434517 --log-failed` | Hosted CI failure investigation | pass | Confirmed the timeout was `@ontrails/http/testing public subpath > typechecks the public testing subpath`. |
+| `bun test packages/http/src/__tests__/testing.test.ts` | TRL-862 hosted CI fix | pass | 14 tests passed after switching the public subpath smoke test away from `bunx tsc` and giving the subprocess an explicit timeout. |
+| `bun run --cwd packages/http lint` | TRL-862 hosted CI fix | pass | Oxlint clean. |
+| `bun run --cwd packages/http test` | TRL-862 hosted CI fix | pass | 159 HTTP package tests passed. |
+| `bun run --cwd packages/http typecheck` | TRL-862 hosted CI fix | pass | `tsc --noEmit` clean. |
+| `bun test packages/http/src/__tests__/testing.test.ts` | TRL-862 review-thread follow-up | pass | 14 HTTP conformance tests passed after switching the redaction case to a native `Error`. |
+| `bun run --cwd packages/http lint` | TRL-862 review-thread follow-up | pass | Oxlint clean. |
+| `bun run lint:ast-grep` | TRL-862 pre-push follow-up | pass | Native redaction error kept behind a helper so the repo-wide `Result.err(new Error(...))` structural rule stays clean. |
+| `bun run --cwd packages/http typecheck && bun run --cwd packages/http build` | TRL-862 pre-push follow-up | pass | HTTP typecheck and build clean after the helper extraction. |
 
 ## Review Findings
 
 Laplace reviewed TRL-861 and found one P1 and three P2 issues. All four were
 fixed on `trl-861-define-adapter-target-metadata-and-catalog-derivation` before
 continuing upward.
+
+Follow-up review on #638 found the public redaction conformance case used
+`InternalError`, which proved known TrailsError projection rather than generic
+error redaction. The conformance fixture now returns a native `Error` while
+retaining the same public `InternalError` response expectation.
+
+Pre-push then caught that the literal `Result.err(new Error(...))` shape trips
+the repo-wide native-error structural rule. The fixture still returns a native
+`Error`, but constructs it through a small helper before passing it to
+`Result.err()`, preserving the redaction behavior without violating the
+syntax-level guardrail.
 
 ## Open Risks
 

--- a/.changeset/trl-862-http-adapter-testing.md
+++ b/.changeset/trl-862-http-adapter-testing.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/http": patch
+---
+
+Expose owner-owned HTTP adapter conformance cases from `@ontrails/http/testing`.

--- a/adapters/hono/src/__tests__/conformance.test.ts
+++ b/adapters/hono/src/__tests__/conformance.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, beforeEach, mock } from 'bun:test';
+import {
+  createHttpAdapterConformanceCases,
+  runConformance,
+} from '@ontrails/http/testing';
+import type { HttpAdapterConformanceAdapter } from '@ontrails/http/testing';
+
+import { createApp } from '../surface.js';
+
+const honoAdapter = {
+  createApp,
+  name: '@ontrails/hono',
+} satisfies HttpAdapterConformanceAdapter;
+
+let originalConsoleError = console.error;
+
+beforeEach(() => {
+  originalConsoleError = console.error;
+  console.error = mock(() => {});
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+runConformance(honoAdapter, createHttpAdapterConformanceCases());

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -74,6 +74,23 @@ const spec = deriveOpenApiSpec(graph, { basePath: '/api' });
 | `deriveOpenApiSpec(graph, options?)` | Generate an OpenAPI 3.1 document for the HTTP surface |
 | `@ontrails/http/fetch` | Shared Web Fetch `createRouteHandler()` and `createFetchHandler()` kernel |
 | `@ontrails/http/bun` | Bun-native `createApp()` and `surface()` materializer |
+| `@ontrails/http/testing` | Owner-owned adapter conformance factory for HTTP adapter authors |
+
+## Adapter authoring
+
+HTTP adapter authors should validate adapters through the owner-owned testing subpath instead of copying conformance behavior into each adapter:
+
+```typescript
+import {
+  createHttpAdapterConformanceCases,
+  runConformance,
+} from '@ontrails/http/testing';
+import { myHttpAdapter } from './adapter.js';
+
+runConformance(myHttpAdapter, createHttpAdapterConformanceCases());
+```
+
+The adapter under test provides a `name` and `createApp(graph, options)` method that returns an object with a Web Fetch-compatible `fetch(request)` handler. The conformance cases cover query and body input projection, validation envelopes, public error redaction, request context, abort propagation, and webhook verification/parsing behavior.
 
 ## Route derivation
 

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -14,6 +14,7 @@
     ".": "./src/index.ts",
     "./bun": "./src/bun.ts",
     "./fetch": "./src/fetch.ts",
+    "./testing": "./src/testing.ts",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -35,7 +36,8 @@
         "placements": [
           "extracted",
           "subpath"
-        ]
+        ],
+        "testingImport": "@ontrails/http/testing"
       }
     }
   }

--- a/packages/http/src/__tests__/build.test.ts
+++ b/packages/http/src/__tests__/build.test.ts
@@ -1125,7 +1125,9 @@ describe('deriveHttpRoutes', () => {
             output: z.object({ message: z.string() }),
             status: { state: 'archived' },
             transpose: {
-              input: ({ input }) => ({ name: input.firstName }),
+              input: ({ input }: { input: { firstName: string } }) => ({
+                name: input.firstName,
+              }),
               output: ({ output }) => output,
             },
           },
@@ -1134,7 +1136,9 @@ describe('deriveHttpRoutes', () => {
             output: z.object({ message: z.string() }),
             status: { note: 'Use name.', state: 'deprecated' },
             transpose: {
-              input: ({ input }) => ({ name: input.firstName }),
+              input: ({ input }: { input: { firstName: string } }) => ({
+                name: input.firstName,
+              }),
               output: ({ output }) => output,
             },
           },

--- a/packages/http/src/__tests__/testing.test.ts
+++ b/packages/http/src/__tests__/testing.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { createApp } from '../bun.js';
+import { createFetchHandler } from '../fetch.js';
+import {
+  createHttpAdapterConformanceCases,
+  runConformance,
+} from '../testing.js';
+import type { HttpAdapterConformanceAdapter } from '../testing.js';
+
+const packageRoot = resolve(import.meta.dir, '..', '..');
+const repoRoot = resolve(packageRoot, '..', '..');
+
+let originalConsoleError = console.error;
+
+const tempDir = (name: string): string =>
+  join(
+    packageRoot,
+    '.tmp-tests',
+    `${name}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+
+const writeJson = (path: string, value: unknown): void => {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const typecheckConsumer = (
+  name: string,
+  source: string
+): { readonly exitCode: number; readonly output: string } => {
+  const dir = tempDir(name);
+  const sourcePath = join(dir, 'consumer.ts');
+  const tsconfigPath = join(dir, 'tsconfig.json');
+
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(sourcePath, source);
+  writeJson(tsconfigPath, {
+    compilerOptions: {
+      noEmit: true,
+      rootDir: repoRoot,
+      types: ['bun'],
+    },
+    extends: join(repoRoot, 'tsconfig.json'),
+    include: [sourcePath],
+  });
+
+  try {
+    const proc = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        join(repoRoot, 'node_modules', 'typescript', 'bin', 'tsc'),
+        '-p',
+        tsconfigPath,
+      ],
+      cwd: repoRoot,
+      stderr: 'pipe',
+      stdout: 'pipe',
+      timeout: 55_000,
+    });
+
+    return {
+      exitCode: proc.exitCode,
+      output: [
+        proc.stdout.toString(),
+        proc.stderr.toString(),
+        proc.exitedDueToTimeout
+          ? 'typecheck timed out after 55000ms'
+          : undefined,
+      ]
+        .filter((line) => line !== undefined && line.length > 0)
+        .join('\n'),
+    };
+  } finally {
+    rmSync(dir, { force: true, recursive: true });
+  }
+};
+
+beforeEach(() => {
+  originalConsoleError = console.error;
+  console.error = mock(() => {});
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+const fetchAdapter = {
+  createApp: (graph, options) => ({
+    fetch: createFetchHandler(graph, options),
+  }),
+  name: '@ontrails/http/fetch',
+} satisfies HttpAdapterConformanceAdapter;
+
+const bunAdapter = {
+  createApp,
+  name: '@ontrails/http/bun',
+} satisfies HttpAdapterConformanceAdapter;
+
+describe('@ontrails/http/testing public subpath', () => {
+  test('exports the owner conformance factory', () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(packageRoot, 'package.json'), 'utf8')
+    ) as {
+      readonly exports: Readonly<Record<string, string>>;
+      readonly trails?: {
+        readonly adapterTargets?: {
+          readonly http?: { readonly testingImport?: string };
+        };
+      };
+    };
+
+    expect(packageJson.exports).toMatchObject({
+      './testing': './src/testing.ts',
+    });
+    expect(packageJson.trails?.adapterTargets?.http?.testingImport).toBe(
+      '@ontrails/http/testing'
+    );
+  });
+
+  test('typechecks the public testing subpath', () => {
+    const result = typecheckConsumer(
+      'http-testing-subpath',
+      `
+        import {
+          createHttpAdapterConformanceCases,
+          runConformance,
+        } from '@ontrails/http/testing';
+        import type { HttpAdapterConformanceAdapter } from '@ontrails/http/testing';
+
+        const adapter: HttpAdapterConformanceAdapter = {
+          createApp: () => ({
+            fetch: async () => Response.json({ data: {} }),
+          }),
+          name: 'demo-http-adapter',
+        };
+
+        void [adapter, createHttpAdapterConformanceCases, runConformance];
+      `
+    );
+
+    if (result.exitCode !== 0) {
+      throw new Error(result.output);
+    }
+  }, 60_000);
+
+  test('accepts record-backed headers in the request context conformance case', async () => {
+    const contextCase = createHttpAdapterConformanceCases().find(
+      (conformanceCase) =>
+        conformanceCase.name === 'threads request context and abort signals'
+    );
+    const recordHeaderAdapter = {
+      createApp: (_graph, options) => ({
+        fetch: async (request) => {
+          const url = new URL(request.url);
+          if (url.pathname === '/permit/scope') {
+            await options?.resolvePermit?.({
+              headers: { 'X-Tenant-ID': 'tenant-1' },
+              requestId: 'req-1',
+            });
+            return Response.json({
+              data: { permitId: 'user-1', requestId: 'req-1' },
+            });
+          }
+
+          if (url.pathname === '/abort/check') {
+            return Response.json({
+              data: { aborted: request.signal.aborted },
+            });
+          }
+
+          return new Response(null, { status: 404 });
+        },
+      }),
+      name: 'record-backed-header-test',
+    } satisfies HttpAdapterConformanceAdapter;
+
+    if (!contextCase) {
+      throw new Error('request context conformance case was not found');
+    }
+
+    await contextCase.check(recordHeaderAdapter);
+  });
+});
+
+runConformance(fetchAdapter, createHttpAdapterConformanceCases());
+runConformance(bunAdapter, createHttpAdapterConformanceCases());

--- a/packages/http/src/testing.ts
+++ b/packages/http/src/testing.ts
@@ -1,0 +1,339 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  PermissionError,
+  Result,
+  getWebhookHeader,
+  trail,
+  topo,
+  webhook,
+} from '@ontrails/core';
+import type { Topo } from '@ontrails/core';
+import { z } from 'zod';
+
+import type {
+  DeriveHttpRoutesOptions,
+  HttpHeaderSource,
+  ResolveHttpPermit,
+} from './build.js';
+import type { CreateRouteHandlerOptions } from './fetch.js';
+
+export interface HttpAdapterConformanceApp {
+  readonly fetch: (request: Request) => Response | Promise<Response>;
+}
+
+export interface HttpAdapterConformanceOptions
+  extends DeriveHttpRoutesOptions, CreateRouteHandlerOptions {
+  readonly resolvePermit?: ResolveHttpPermit | undefined;
+}
+
+export interface HttpAdapterConformanceAdapter {
+  readonly createApp: (
+    graph: Topo,
+    options?: HttpAdapterConformanceOptions
+  ) => HttpAdapterConformanceApp | Promise<HttpAdapterConformanceApp>;
+  readonly name: string;
+}
+
+export interface HttpAdapterConformanceCase {
+  readonly check: (adapter: HttpAdapterConformanceAdapter) => Promise<void>;
+  readonly name: string;
+}
+
+const echoTrail = trail('echo', {
+  blaze: (input) => Result.ok({ reply: input.message }),
+  input: z.object({ message: z.string() }),
+  intent: 'read',
+  output: z.object({ reply: z.string() }),
+});
+
+const tagsTrail = trail('tags', {
+  blaze: (input) => Result.ok({ tags: input.tags }),
+  input: z.object({ tags: z.array(z.string()) }),
+  intent: 'read',
+  output: z.object({ tags: z.array(z.string()) }),
+});
+
+const echoBodyTrail = trail('echo.body', {
+  blaze: (input) => Result.ok({ length: input.message.length }),
+  input: z.object({ message: z.string() }),
+  intent: 'write',
+  output: z.object({ length: z.number() }),
+});
+
+const genericRedactionError = (): Error =>
+  new Error('database password=secret');
+
+const genericErrorTrail = trail('generic.error', {
+  blaze: () => Result.err(genericRedactionError()),
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ ok: z.boolean() }),
+});
+
+const protectedTrail = trail('permit.scope', {
+  blaze: (_input, ctx) =>
+    Result.ok({
+      permitId: ctx.permit?.id,
+      requestId: ctx.requestId,
+    }),
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({
+    permitId: z.string().optional(),
+    requestId: z.string().optional(),
+  }),
+  permit: { scopes: ['thing:read'] },
+});
+
+const abortingTrail = trail('abort.check', {
+  blaze: (_input, ctx) => Result.ok({ aborted: ctx.abortSignal.aborted }),
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ aborted: z.boolean() }),
+});
+
+const webhookSecret = 'secret';
+const paymentWebhook = webhook('webhook.payment.received', {
+  parse: z.object({ paymentId: z.string() }),
+  path: '/webhooks/payment',
+  verify: (request) =>
+    getWebhookHeader(request, 'x-webhook-secret') === webhookSecret
+      ? Result.ok()
+      : Result.err(new PermissionError('Invalid webhook secret')),
+});
+
+const paymentWebhookTrail = trail('payment.receive', {
+  blaze: (input) => Result.ok({ paymentId: input.paymentId }),
+  input: z.object({ paymentId: z.string() }),
+  on: [paymentWebhook],
+  output: z.object({ paymentId: z.string() }),
+});
+
+const buildRequest = (path: string, init: RequestInit = {}): Request =>
+  new Request(new URL(path, 'http://localhost').toString(), init);
+
+const readHeader = (
+  headers: HttpHeaderSource | undefined,
+  name: string
+): string | undefined => {
+  if (headers === undefined) {
+    return undefined;
+  }
+  if (headers instanceof Headers) {
+    return headers.get(name) ?? undefined;
+  }
+  const needle = name.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== needle || value === undefined) {
+      continue;
+    }
+    return typeof value === 'string' ? value : value[0];
+  }
+  return undefined;
+};
+
+const expectJson = async (
+  response: Response
+): Promise<Record<string, unknown>> =>
+  (await response.json()) as Record<string, unknown>;
+
+const materialize = async (
+  adapter: HttpAdapterConformanceAdapter,
+  graph: Topo,
+  options?: HttpAdapterConformanceOptions
+): Promise<HttpAdapterConformanceApp> =>
+  await adapter.createApp(graph, options);
+
+const expectOkResponse = async (
+  response: Response,
+  data: Record<string, unknown>
+): Promise<void> => {
+  expect(response.status).toBe(200);
+  expect(await expectJson(response)).toEqual({ data });
+};
+
+const request = async (
+  adapter: HttpAdapterConformanceAdapter,
+  graph: Topo,
+  path: string,
+  init?: RequestInit,
+  options?: HttpAdapterConformanceOptions
+): Promise<Response> => {
+  const app = await materialize(adapter, graph, options);
+  return await app.fetch(buildRequest(path, init));
+};
+
+const readRouteCase = async (
+  adapter: HttpAdapterConformanceAdapter
+): Promise<void> => {
+  const response = await request(
+    adapter,
+    topo('http-conformance-read', { echoTrail }),
+    '/echo?message=hello'
+  );
+
+  await expectOkResponse(response, { reply: 'hello' });
+};
+
+const writeRouteCase = async (
+  adapter: HttpAdapterConformanceAdapter
+): Promise<void> => {
+  const response = await request(
+    adapter,
+    topo('http-conformance-write', { echoBodyTrail }),
+    '/echo/body',
+    {
+      body: JSON.stringify({ message: 'hello' }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    }
+  );
+
+  await expectOkResponse(response, { length: 5 });
+};
+
+const repeatedQueryCase = async (
+  adapter: HttpAdapterConformanceAdapter
+): Promise<void> => {
+  const graph = topo('http-conformance-query', { tagsTrail });
+  const repeated = await request(adapter, graph, '/tags?tags=red&tags=blue');
+  const singleton = await request(adapter, graph, '/tags?tags=solo');
+
+  await expectOkResponse(repeated, { tags: ['red', 'blue'] });
+  expect(singleton.status).toBe(400);
+  expect(await expectJson(singleton)).toMatchObject({
+    error: { category: 'validation' },
+  });
+};
+
+const publicErrorCase = async (
+  adapter: HttpAdapterConformanceAdapter
+): Promise<void> => {
+  const response = await request(
+    adapter,
+    topo('http-conformance-errors', { genericErrorTrail }),
+    '/generic/error',
+    { headers: { 'X-Request-ID': 'req-123 forged/line' } }
+  );
+  const body = await expectJson(response);
+
+  expect(response.status).toBe(500);
+  expect(body).toEqual({
+    error: {
+      category: 'internal',
+      code: 'InternalError',
+      message: 'Internal server error',
+    },
+  });
+  expect(JSON.stringify(body)).not.toContain('secret');
+};
+
+const requestContextCase = async (
+  adapter: HttpAdapterConformanceAdapter
+): Promise<void> => {
+  let observedTenant: string | null | undefined;
+  const resolvePermit: ResolveHttpPermit = ({ headers }) => {
+    observedTenant = readHeader(headers, 'x-tenant-id');
+    return Result.ok({ id: 'user-1', scopes: ['thing:read'] });
+  };
+  const graph = topo('http-conformance-context', {
+    abortingTrail,
+    protectedTrail,
+  });
+  const app = await materialize(adapter, graph, { resolvePermit });
+  const controller = new AbortController();
+  controller.abort();
+
+  const permitResponse = await app.fetch(
+    buildRequest('/permit/scope', {
+      headers: {
+        Authorization: 'Bearer strong',
+        'X-Request-ID': 'req-1',
+        'X-Tenant-ID': 'tenant-1',
+      },
+    })
+  );
+  const abortResponse = await app.fetch(
+    buildRequest('/abort/check', { signal: controller.signal })
+  );
+
+  await expectOkResponse(permitResponse, {
+    permitId: 'user-1',
+    requestId: 'req-1',
+  });
+  expect(observedTenant).toBe('tenant-1');
+  await expectOkResponse(abortResponse, { aborted: true });
+};
+
+const webhookCase = async (
+  adapter: HttpAdapterConformanceAdapter
+): Promise<void> => {
+  const graph = topo('http-conformance-webhooks', { paymentWebhookTrail });
+  const verified = await request(adapter, graph, '/webhooks/payment', {
+    body: JSON.stringify({ paymentId: 'pay_1' }),
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Webhook-Secret': webhookSecret,
+    },
+    method: 'POST',
+  });
+  const denied = await request(adapter, graph, '/webhooks/payment', {
+    body: JSON.stringify({ paymentId: 'pay_1' }),
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Webhook-Secret': 'wrong',
+    },
+    method: 'POST',
+  });
+  const invalidPayload = await request(adapter, graph, '/webhooks/payment', {
+    body: JSON.stringify({ paymentId: 123 }),
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Webhook-Secret': webhookSecret,
+    },
+    method: 'POST',
+  });
+
+  await expectOkResponse(verified, { paymentId: 'pay_1' });
+  expect(denied.status).toBe(403);
+  expect(await expectJson(denied)).toMatchObject({
+    error: { category: 'permission' },
+  });
+  expect(invalidPayload.status).toBe(400);
+  expect(await expectJson(invalidPayload)).toMatchObject({
+    error: { category: 'validation' },
+  });
+};
+
+export const createHttpAdapterConformanceCases =
+  (): readonly HttpAdapterConformanceCase[] => [
+    { check: readRouteCase, name: 'serves read trails from query parameters' },
+    { check: writeRouteCase, name: 'serves write trails from JSON bodies' },
+    {
+      check: repeatedQueryCase,
+      name: 'preserves repeated query keys before validation',
+    },
+    {
+      check: publicErrorCase,
+      name: 'projects generic errors as redacted public 500 responses',
+    },
+    {
+      check: requestContextCase,
+      name: 'threads request context and abort signals',
+    },
+    { check: webhookCase, name: 'handles webhook verification and parsing' },
+  ];
+
+export const runConformance = (
+  adapter: HttpAdapterConformanceAdapter,
+  cases: readonly HttpAdapterConformanceCase[] = createHttpAdapterConformanceCases()
+): void => {
+  describe(`${adapter.name} HTTP adapter conformance`, () => {
+    for (const conformanceCase of cases) {
+      test(conformanceCase.name, async () => {
+        await conformanceCase.check(adapter);
+      });
+    }
+  });
+};

--- a/scripts/check-readme-snippets.ts
+++ b/scripts/check-readme-snippets.ts
@@ -151,6 +151,7 @@ export const createComposeContext: any;
 export const createDevStore: any;
 export const createFileSink: any;
 export const createHttpHarness: any;
+export const createHttpAdapterConformanceCases: any;
 export const createJwtAdapter: any;
 export const createLogtapeSink: any;
 export const createMcpHarness: any;
@@ -201,6 +202,7 @@ export const registerTraceSink: any;
 export const registerTraceStore: any;
 export const Result: any;
 export const run: any;
+export const runConformance: any;
 export const runTopoAwareWardenTrails: any;
 export const runWarden: any;
 export const runWardenTrails: any;
@@ -304,6 +306,9 @@ export const README_SNIPPET_CONFIGS: readonly ReadmeSnippetConfig[] = [
     readmePath: 'packages/testing/README.md',
   },
   {
+    localFiles: {
+      'adapter.d.ts': 'export const myHttpAdapter: any;\n',
+    },
     prelude: COMMON_README_PRELUDE,
     readmePath: 'packages/http/README.md',
   },


### PR DESCRIPTION
## Context

Fifth branch in the V1 convergence stack (#634-#641). HTTP needs an owner-owned conformance harness before extracted adapters can prove they satisfy the HTTP adapter target.

## Changes

- Adds `@ontrails/http/testing` with HTTP adapter conformance cases and `runConformance()`.
- Covers fetch, Bun, and Hono adapters with the shared conformance cases.
- Updates the HTTP README and snippet harness so the public testing subpath example typechecks.
- Updates HTTP package metadata to advertise its testing import.

## Verification

- `bun test packages/http/src/__tests__/testing.test.ts`
- `bun test packages/http/src/__tests__/fetch.test.ts packages/http/src/__tests__/bun.test.ts packages/http/src/__tests__/testing.test.ts`
- `bun test adapters/hono/src/__tests__/surface.test.ts adapters/hono/src/__tests__/conformance.test.ts`
- `bun run --cwd packages/http typecheck && bun run --cwd packages/http lint && bun run --cwd packages/http build`
- `bun run --cwd adapters/hono typecheck && bun run --cwd adapters/hono lint`
- `bun run docs:snippets`
- `bun run docs:api-examples`
- `bunx ultracite check ...`
- `bunx markdownlint-cli2 ... && git diff --check`
- `bun run docs:wrap-check`

## Risks

- This branch proves conformance, but does not add new HTTP adapter authoring support helpers; current adapters can conform through existing public topo/options surfaces.

Closes TRL-862
