### PR TITLE
feat(adapter-kit): add shared adapter check engine

### DIFF
--- a/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
@@ -1,6 +1,6 @@
 ---
 created: "2026-05-30T12:28:00Z"
-updated: "2026-05-30T12:51:00Z"
+updated: "2026-05-30T17:45:00Z"
 status: active
 ---
 
@@ -68,7 +68,7 @@ status: active
   coverage, and consume Warden metadata without recreating Warden's safe-edit
   applicator or a parallel term table.
 - Beauvoir confirmed Hono is the strongest HTTP dogfood candidate and warned
-  that conformance must stay owner-owned, not inside adapter tooling.
+  that conformance must stay owner-owned, not inside adapter kit.
 - Clark ruled the doctrine coherent but too broad as first sketched; accepted
   route change: dogfood the adapter path before shipping `create.adapter`, and
   make TRL-850 conditional unless live map drift/check evidence remains.
@@ -154,6 +154,37 @@ status: active
 - Updated the HTTP README and README snippet harness so the public testing
   subpath example typechecks.
 
+### 2026-05-30 09:20 EDT - TRL-863 shared adapter check engine
+
+- Started `trl-863-build-shared-adapter-check-engine` above TRL-862.
+- Added `checkAdapters()` to private `@ontrails/adapter-kit` as the shared
+  predicate engine for future Warden and local `adapter.check` projections.
+- Kept adapter metadata minimal: extracted adapter packages author only
+  `trails.adapter.target`; the engine derives placement from workspace path,
+  export-map facts from `package.json`, dependency direction from manifests,
+  and conformance coverage from owner `testingImport` imports in test files.
+- Added structured diagnostics for missing/invalid adapter metadata, unknown
+  targets, unsupported placements, bad package export maps, dependency-boundary
+  violations, missing owner conformance facts, missing adapter conformance
+  imports, and runtime imports/dependencies on `@ontrails/adapter-kit`.
+- Read-only live repo check currently reports the expected pre-dogfood debt:
+  `@ontrails/commander`, `@ontrails/drizzle`, `@ontrails/hono`, and
+  `@ontrails/vite` are extracted adapter packages without
+  `trails.adapter.target` metadata. TRL-864 must not blindly turn this on as a
+  hard CI gate before TRL-865 dogfoods the shape.
+
+### 2026-05-30 13:45 EDT - TRL-876 review fix on TRL-863
+
+- Codex review and a focused subagent sniff found that the TRL-863 adapter
+  check engine accepted raw source text matches for conformance imports, so a
+  comment or string literal could suppress `missing-conformance`.
+- Created TRL-876 under TRL-863 to track the review bug.
+- Fixed the owning branch by replacing the raw regex with a small import
+  scanner that ignores comments, strings, and type-only imports while preserving
+  real static and dynamic import coverage.
+- Added regressions for line-comment, block-comment, string-literal, and
+  type-only false positives, plus a dynamic import positive case.
+
 ## Verification Ledger
 
 | Command | Context | Result | Notes |
@@ -218,6 +249,34 @@ status: active
 | `bun run --cwd packages/http lint` | TRL-862 review-thread follow-up | pass | Oxlint clean. |
 | `bun run lint:ast-grep` | TRL-862 pre-push follow-up | pass | Native redaction error kept behind a helper so the repo-wide `Result.err(new Error(...))` structural rule stays clean. |
 | `bun run --cwd packages/http typecheck && bun run --cwd packages/http build` | TRL-862 pre-push follow-up | pass | HTTP typecheck and build clean after the helper extraction. |
+| `bunx ultracite check packages/http/src/__tests__/testing.test.ts` | TRL-862 hosted CI fix | pass | Formatting and lint clean for the touched test file. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts packages/adapter-kit/src/__tests__/catalog.test.ts` | TRL-863 adapter check engine | pass | 17 tests passed. |
+| `bun run --cwd packages/adapter-kit typecheck` | TRL-863 adapter check engine | pass | `tsc --noEmit` clean. |
+| `bun run --cwd packages/adapter-kit lint` | TRL-863 adapter check engine | pass | Oxlint clean. |
+| `bunx tsc -p packages/adapter-kit/tsconfig.tests.json --noEmit` | TRL-863 adapter check engine | pass | Test tsconfig typecheck clean. |
+| `bun run --cwd packages/adapter-kit build` | TRL-863 adapter check engine | pass | `tsc -b` clean. |
+| `bunx ultracite check packages/adapter-kit/src/check.ts packages/adapter-kit/src/__tests__/check.test.ts packages/adapter-kit/src/index.ts` | TRL-863 formatting | pass | Formatter initially found two files; `ultracite fix` applied formatting and rerun passed. |
+| `bun -e "import { checkAdapters } from './packages/adapter-kit/src/check.ts'; ..."` | TRL-863 live repo smoke | pass | Reported 2 targets, 0 subjects, and 4 expected `missing-adapter-metadata` diagnostics for current extracted adapters. |
+| `bun run typecheck` | TRL-863 workspace integration | pass | 24 package typechecks passed. |
+| `bun run lint` | TRL-863 workspace integration | pass | 25 lint tasks passed. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts` | TRL-876 review fix | pass | 14 focused adapter-check tests passed, including comment/string/type-only import regressions. |
+| `bun run --cwd packages/adapter-kit test` | TRL-876 review fix | pass | 22 adapter-kit tests passed. |
+| `bun run --cwd packages/adapter-kit lint` | TRL-876 review fix | pass | Oxlint clean. |
+| `bun run --cwd packages/adapter-kit typecheck` | TRL-876 review fix | pass | `tsc --noEmit` clean. |
+| `git diff --check` | TRL-876 review fix | pass | No whitespace findings. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts` | TRL-876 inline type-import follow-up | pass | 16 focused adapter-check tests passed after adding the inline `import { type ... }` regression and mixed value/type positive case. |
+| `bun run --cwd packages/adapter-kit lint` | TRL-876 inline type-import follow-up | pass | First run caught helper ordering via `no-use-before-define`; helper moved and rerun passed. |
+| `bun run --cwd packages/adapter-kit typecheck` | TRL-876 inline type-import follow-up | pass | `tsc --noEmit` clean. |
+| `git diff --check` | TRL-876 inline type-import follow-up | pass | No whitespace findings. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts` | TRL-876 review-thread follow-up | pass | 18 focused adapter-check tests passed, including missing export targets and TS type-query import regressions. |
+| `bun run --cwd packages/adapter-kit lint` | TRL-876 review-thread follow-up | pass | Oxlint clean. |
+| `bun run --cwd packages/adapter-kit typecheck` | TRL-876 review-thread follow-up | pass | `tsc --noEmit` clean. |
+| `bun run format:check` | TRL-876 review-thread follow-up | pass | Full Ultracite check clean after formatting the touched check engine. |
+| `git diff --check` | TRL-876 review-thread follow-up | pass | No whitespace findings. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts` | TRL-876 nested type-query follow-up | pass | 18 focused adapter-check tests passed after adding a nested `Array<import(...)>` regression. |
+| `bun run --cwd packages/adapter-kit lint` | TRL-876 nested type-query follow-up | pass | Oxlint clean. |
+| `bun run --cwd packages/adapter-kit typecheck` | TRL-876 nested type-query follow-up | pass | `tsc --noEmit` clean. |
+| `bunx markdownlint-cli2 .changeset/trl-863-adapter-check-engine.md` | TRL-863 changeset follow-up | pass | Branch-local adapter-kit changeset markdown clean. |
 
 ## Review Findings
 
@@ -236,12 +295,35 @@ the repo-wide native-error structural rule. The fixture still returns a native
 `Result.err()`, preserving the redaction behavior without violating the
 syntax-level guardrail.
 
+Bacon reviewed the TRL-876 / #639 conformance import-detection bug and agreed
+the narrow fix should stay on import syntax only, leaving helper-call validation
+to the later conformance-metadata/scaffold branch. The line-comment,
+block-comment, string-literal, and type-only false positives were fixed on
+`trl-863-build-shared-adapter-check-engine`.
+
+Goodall reviewed the resubmitted #639/#643 fix and found one remaining P2:
+inline named type-only imports such as `import { type Foo } from ...` still
+counted as fallback conformance evidence. The scanner now rejects import
+clauses with only inline type bindings while preserving mixed value/type imports.
+
+Follow-up review threads on #639 found that package exports were accepted when
+their targets did not exist, TS type-query `import("...")` references counted as
+runtime conformance imports, and `skipLineComment()` stopped on the newline
+itself. The shared check engine now requires exported targets to exist, ignores
+type-query imports, and advances line-comment skips past the newline.
+
+Another #639 follow-up found nested TS type-query imports such as
+`Array<import("@ontrails/http/testing").Adapter>` still counted as conformance
+evidence, and that the exported adapter-kit check API needed a branch-local
+changeset. The scanner now treats annotated generic type positions as erased
+imports, and TRL-863 carries its own `@ontrails/adapter-kit` patch changeset.
+
 ## Open Risks
 
 - TRL-850 may already be partially stale if the adapter ADR merge refreshed the
   decision map. Verify before cutting its branch.
 - TRL-826 and TRL-829 are conditional. Keep them only if this stack produces
   enough implementation evidence.
-- Adapter tooling package name was corrected from `@ontrails/adapter-tools` to
-  private `@ontrails/adapter-kit` before landing so the package reads as the
-  adapter-authoring paved path, not a grab bag of internals.
+- Adapter tooling package name is now implemented as publishable-but-internal
+  `@ontrails/adapter-kit`; keep watching whether the name communicates tooling
+  rather than central authority as later branches consume it.

--- a/.changeset/trl-863-adapter-check-engine.md
+++ b/.changeset/trl-863-adapter-check-engine.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/adapter-kit": patch
+---
+
+Add the shared adapter readiness check engine for authoring and review workflows.

--- a/packages/adapter-kit/src/__tests__/catalog.test.ts
+++ b/packages/adapter-kit/src/__tests__/catalog.test.ts
@@ -7,14 +7,18 @@ import { deriveAdapterTargetCatalog } from '../catalog.js';
 
 const roots: string[] = [];
 
+const writeFile = (root: string, path: string, value: string): void => {
+  const filePath = join(root, path);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value);
+};
+
 const writeJson = (
   root: string,
   path: string,
   value: Record<string, unknown>
 ): void => {
-  const filePath = join(root, path);
-  mkdirSync(dirname(filePath), { recursive: true });
-  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+  writeFile(root, path, `${JSON.stringify(value, null, 2)}\n`);
 };
 
 const makeRoot = (): string => {
@@ -61,6 +65,8 @@ describe('deriveAdapterTargetCatalog', () => {
         },
       },
     });
+    writeFile(root, 'packages/store/src/adapter-support.ts', 'export {};\n');
+    writeFile(root, 'packages/store/src/testing.ts', 'export {};\n');
 
     const catalog = deriveAdapterTargetCatalog(root);
 
@@ -228,6 +234,38 @@ describe('deriveAdapterTargetCatalog', () => {
       catalog.diagnostics.every((entry) => entry.code === 'invalid-import')
     ).toBe(true);
     expect(catalog.diagnostics[0]?.message).toContain('does not export');
+  });
+
+  test('reports owner imports whose export targets do not exist', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './adapter-support': './src/missing-adapter-support.ts',
+        './testing': './src/missing-testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            supportImport: '@ontrails/http/adapter-support',
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(2);
+    expect(
+      catalog.diagnostics.every((entry) => entry.code === 'invalid-import')
+    ).toBe(true);
+    expect(catalog.diagnostics[0]?.message).toContain(
+      'missing or non-file target'
+    );
   });
 
   test('keeps extracted and subpath placements distinct and deterministic', () => {

--- a/packages/adapter-kit/src/__tests__/check.test.ts
+++ b/packages/adapter-kit/src/__tests__/check.test.ts
@@ -1,0 +1,1136 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { checkAdapters } from '../check.js';
+import type { AdapterCheckDiagnosticCode } from '../check.js';
+
+const roots: string[] = [];
+
+const writeFile = (root: string, path: string, value: string): void => {
+  const filePath = join(root, path);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value);
+};
+
+const writeJson = (
+  root: string,
+  path: string,
+  value: Record<string, unknown>
+): void => {
+  writeFile(root, path, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const makeRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'trails-adapter-check-'));
+  roots.push(root);
+  writeJson(root, 'package.json', {
+    name: 'fixture-root',
+    workspaces: ['packages/*', 'adapters/*'],
+  });
+  return root;
+};
+
+const writePackage = (
+  root: string,
+  workspacePath: string,
+  manifest: Record<string, unknown>
+): void => {
+  writeJson(root, join(workspacePath, 'package.json'), manifest);
+};
+
+const writeHttpOwner = (
+  root: string,
+  targetOverrides: Record<string, unknown> = {}
+): void => {
+  writePackage(root, 'packages/http', {
+    exports: {
+      '.': './src/index.ts',
+      './package.json': './package.json',
+      './testing': './src/testing.ts',
+    },
+    name: '@ontrails/http',
+    trails: {
+      adapterTargets: {
+        http: {
+          placements: ['extracted'],
+          testingImport: '@ontrails/http/testing',
+          ...targetOverrides,
+        },
+      },
+    },
+  });
+  writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
+};
+
+const writeHonoAdapter = (
+  root: string,
+  manifestOverrides: Record<string, unknown> = {}
+): void => {
+  writePackage(root, 'adapters/hono', {
+    dependencies: {
+      '@ontrails/core': 'workspace:^',
+      hono: '^4.7.0',
+    },
+    exports: {
+      '.': './src/index.ts',
+      './package.json': './package.json',
+    },
+    name: '@ontrails/hono',
+    peerDependencies: {
+      '@ontrails/http': 'workspace:^',
+    },
+    trails: {
+      adapter: {
+        target: 'http',
+      },
+    },
+    ...manifestOverrides,
+  });
+  writeFile(
+    root,
+    'adapters/hono/src/index.ts',
+    'export const honoAdapter = {};\n'
+  );
+};
+
+const writeHttpConformanceTest = (
+  root: string,
+  path = 'adapters/hono/src/__tests__/conformance.test.ts'
+): void => {
+  writeFile(
+    root,
+    path,
+    "import { createHttpAdapterConformanceCases } from '@ontrails/http/testing';\n\nvoid createHttpAdapterConformanceCases;\n"
+  );
+};
+
+const codes = (
+  diagnostics: readonly { readonly code: AdapterCheckDiagnosticCode }[]
+): readonly AdapterCheckDiagnosticCode[] =>
+  diagnostics.map((entry) => entry.code).toSorted();
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe('checkAdapters', () => {
+  test('accepts a valid extracted adapter package', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects).toHaveLength(1);
+    expect(report.subjects[0]).toMatchObject({
+      conformanceTestPaths: [
+        expect.stringContaining(
+          'adapters/hono/src/__tests__/conformance.test.ts'
+        ),
+      ],
+      key: '@ontrails/hono',
+      ownerPackage: '@ontrails/http',
+      packageName: '@ontrails/hono',
+      placement: 'extracted',
+      target: 'http',
+      targetKey: '@ontrails/http:http',
+      testingImport: '@ontrails/http/testing',
+    });
+  });
+
+  test('ignores extracted adapter packages until they declare target metadata', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, { trails: undefined });
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects).toEqual([]);
+    expect(report.diagnostics).toEqual([]);
+  });
+
+  test('ignores existing adapter workspaces that have not opted into adapter metadata', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    for (const packageName of [
+      '@ontrails/commander',
+      '@ontrails/drizzle',
+      '@ontrails/hono',
+      '@ontrails/vite',
+    ]) {
+      const workspaceName = packageName.replace('@ontrails/', '');
+      writePackage(root, `adapters/${workspaceName}`, {
+        exports: {
+          '.': './src/index.ts',
+          './package.json': './package.json',
+        },
+        name: packageName,
+      });
+    }
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects).toEqual([]);
+    expect(report.diagnostics).toEqual([]);
+  });
+
+  test('reports bad adapter package export maps', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, {
+      exports: {
+        '.': { types: './src/index.ts' },
+        './package.json': {},
+      },
+    });
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(codes(report.diagnostics)).toEqual([
+      'missing-package-export',
+      'missing-package-export',
+    ]);
+    expect(report.diagnostics.map((entry) => entry.message)).toEqual([
+      expect.stringContaining('export "."'),
+      expect.stringContaining('export "./package.json"'),
+    ]);
+  });
+
+  test('honors package export string shorthand for the root entrypoint', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, {
+      exports: './src/index.ts',
+    });
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-package-export',
+      packageName: '@ontrails/hono',
+    });
+    expect(report.diagnostics[0]?.message).toContain('export "./package.json"');
+  });
+
+  test('honors package export conditional shorthand for the root entrypoint', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, {
+      exports: {
+        import: './src/index.ts',
+      },
+    });
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-package-export',
+      packageName: '@ontrails/hono',
+    });
+    expect(report.diagnostics[0]?.message).toContain('export "./package.json"');
+  });
+
+  test('reports package exports that point at missing files', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, {
+      exports: {
+        '.': './src/missing.ts',
+        './package.json': './package.json',
+      },
+    });
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-package-export',
+      packageName: '@ontrails/hono',
+    });
+    expect(report.diagnostics[0]?.message).toContain('export "."');
+  });
+
+  test('reports package exports that point at directories', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, {
+      exports: {
+        '.': './src',
+        './package.json': './package.json',
+      },
+    });
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-package-export',
+      packageName: '@ontrails/hono',
+    });
+    expect(report.diagnostics[0]?.message).toContain('export "."');
+  });
+
+  test('reports dependency direction violations', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, {
+      dependencies: {
+        '@ontrails/http': 'workspace:^',
+        hono: '^4.7.0',
+      },
+      peerDependencies: {},
+    });
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(codes(report.diagnostics)).toEqual([
+      'dependency-direction',
+      'dependency-direction',
+    ]);
+    expect(
+      report.diagnostics.map((entry) => entry.message).join('\n')
+    ).toContain('runtime dependencies invert the adapter boundary');
+    expect(
+      report.diagnostics.map((entry) => entry.message).join('\n')
+    ).toContain('peerDependencies');
+  });
+
+  test('reports optional owner dependencies as runtime boundary violations', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, {
+      optionalDependencies: {
+        '@ontrails/http': 'workspace:^',
+      },
+    });
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(codes(report.diagnostics)).toEqual(['dependency-direction']);
+    expect(report.diagnostics[0]?.message).toContain(
+      'runtime dependencies invert the adapter boundary'
+    );
+  });
+
+  test('reports missing adapter conformance coverage', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores commented-out adapter conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "// import { createHttpAdapterConformanceCases } from '@ontrails/http/testing';",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores block-commented adapter conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        '/*',
+        " * import { createHttpAdapterConformanceCases } from '@ontrails/http/testing';",
+        ' */',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores string-literal adapter conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        '"from @ontrails/http/testing";',
+        '"from \'@ontrails/http/testing\'";',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores regex-literal adapter conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const importPattern = /import('@ontrails\\/http\\/testing')/;",
+        'void importPattern;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores type-only adapter conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import type { HttpAdapterConformanceAdapter } from '@ontrails/http/testing';",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores commented type-only adapter conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import /* erased */ type { HttpAdapterConformanceAdapter } from '@ontrails/http/testing';",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores inline type-only adapter conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { type HttpAdapterConformanceAdapter } from '@ontrails/http/testing';",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores inline type-only adapter conformance imports split across whitespace', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { type\n HttpAdapterConformanceAdapter } from '@ontrails/http/testing';",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores side-effect and empty adapter conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import '@ontrails/http/testing';",
+        "import {} from '@ontrails/http/testing';",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('accepts mixed value and type adapter conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { createHttpAdapterConformanceCases, type HttpAdapterConformanceAdapter } from '@ontrails/http/testing';",
+        'void createHttpAdapterConformanceCases;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts dynamic adapter conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const testing = await import('@ontrails/http/testing');",
+        'void testing.createHttpAdapterConformanceCases;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts dynamic adapter conformance imports after semicolonless type aliases', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "type Adapter = import('@ontrails/http/testing').HttpAdapterConformanceAdapter",
+        "const testing = await import('@ontrails/http/testing');",
+        "testing.runConformance({ name: '@ontrails/hono' }, testing.createHttpAdapterConformanceCases());",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts dynamic adapter conformance imports after function return types', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        'async function loadTesting(): Promise<unknown> {',
+        "  return await import('@ontrails/http/testing');",
+        '}',
+        'const testing = await loadTesting() as typeof import("@ontrails/http/testing");',
+        "testing.runConformance({ name: '@ontrails/hono' }, testing.createHttpAdapterConformanceCases());",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts dynamic adapter conformance imports in object literal values', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        'const modules = {',
+        "  testing: await import('@ontrails/http/testing'),",
+        '};',
+        'void modules.testing.createHttpAdapterConformanceCases;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts dynamic adapter conformance imports in conditional expressions', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        'const cached = undefined as unknown;',
+        'const useCached = false;',
+        "const testing = useCached ? cached : await import('@ontrails/http/testing');",
+        'void testing;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('ignores direct, type-argument, and nested type-query adapter conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "type Adapter = import('@ontrails/http/testing').HttpAdapterConformanceAdapter;",
+        "const adapter: import('@ontrails/http/testing').HttpAdapterConformanceAdapter = {} as never;",
+        "const adapters: Array<import('@ontrails/http/testing').HttpAdapterConformanceAdapter> = [];",
+        "const testing = {} as typeof import('@ontrails/http/testing');",
+        "expectTypeOf<import('@ontrails/http/testing').HttpAdapterConformanceAdapter>();",
+        "function acceptsGeneric<T extends import('@ontrails/http/testing').HttpAdapterConformanceAdapter>() {}",
+        "class ImplementsAdapter implements import('@ontrails/http/testing').HttpAdapterConformanceAdapter {}",
+        'void adapter;',
+        'void adapters;',
+        'void acceptsGeneric;',
+        'void ImplementsAdapter;',
+        'void testing;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores type-only conformance imports after semicolonless export markers', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        'export {}',
+        "import type { HttpAdapterConformanceAdapter } from '@ontrails/http/testing';",
+        'type Adapter = HttpAdapterConformanceAdapter;',
+        'const adapter = {} as Adapter;',
+        'void adapter;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores import.meta before type-only conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        'const here = import.meta.url;',
+        "import type { HttpAdapterConformanceAdapter } from '@ontrails/http/testing';",
+        'type Adapter = HttpAdapterConformanceAdapter;',
+        'const adapter = {} as Adapter;',
+        'void here;',
+        'void adapter;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores member import calls as adapter conformance imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        'const loader = { import: async (_specifier: string) => ({}) };',
+        "await loader.import('@ontrails/http/testing');",
+        "await loader . import('@ontrails/http/testing');",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores re-export-only adapter conformance files', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "export { createHttpAdapterConformanceCases } from '@ontrails/http/testing';",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('reports missing owner conformance facts', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { testingImport: undefined });
+    writeHonoAdapter(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.testingImport).toBeUndefined();
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-owner-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('reports invalid owner conformance export targets', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './package.json': './package.json',
+        './testing': './src/missing-testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeHonoAdapter(root);
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects).toEqual([]);
+    expect(report.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'invalid-import',
+        packageName: '@ontrails/http',
+        target: 'http',
+      })
+    );
+    expect(report.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'unknown-adapter-target',
+        packageName: '@ontrails/hono',
+        target: 'http',
+      })
+    );
+    expect(report.diagnostics[0]?.message).toContain(
+      'missing or non-file target'
+    );
+  });
+
+  test('reports invalid owner conformance export target directories', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './package.json': './package.json',
+        './testing': './src',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/index.ts', 'export {};\n');
+    writeHonoAdapter(root);
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects).toEqual([]);
+    expect(report.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'invalid-import',
+        packageName: '@ontrails/http',
+        target: 'http',
+      })
+    );
+    expect(report.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: 'unknown-adapter-target',
+        packageName: '@ontrails/hono',
+        target: 'http',
+      })
+    );
+    expect(report.diagnostics[0]?.message).toContain(
+      'missing or non-file target'
+    );
+  });
+
+  test('reports unsupported derived placement for a target', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { placements: ['subpath'] });
+    writeHonoAdapter(root);
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'unsupported-placement',
+      packageName: '@ontrails/hono',
+      placement: 'extracted',
+      target: 'http',
+    });
+  });
+
+  test('reports unknown adapter targets', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, {
+      trails: {
+        adapter: {
+          target: 'smtp',
+        },
+      },
+    });
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'unknown-adapter-target',
+      packageName: '@ontrails/hono',
+      target: 'smtp',
+    });
+  });
+
+  test('keeps runtime adapters from depending on adapter kit', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, {
+      dependencies: {
+        '@ontrails/adapter-kit': 'workspace:*',
+        '@ontrails/core': 'workspace:^',
+        hono: '^4.7.0',
+      },
+    });
+    writeHttpConformanceTest(root);
+    writeFile(
+      root,
+      'adapters/hono/src/index.ts',
+      "import { checkAdapters } from '@ontrails/adapter-kit';\n\nvoid checkAdapters;\n"
+    );
+
+    const report = checkAdapters(root);
+
+    expect(codes(report.diagnostics)).toEqual([
+      'tooling-boundary',
+      'tooling-boundary',
+    ]);
+  });
+
+  test('ignores regex-literal adapter-kit mentions as runtime imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeHttpConformanceTest(root);
+    writeFile(
+      root,
+      'adapters/hono/src/index.ts',
+      [
+        "const importPattern = /import('@ontrails\\/adapter-kit')/;",
+        'void importPattern;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+  });
+
+  test('counts empty named adapter-kit imports as runtime imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, {
+      dependencies: {
+        '@ontrails/adapter-kit': 'workspace:*',
+        '@ontrails/core': 'workspace:^',
+        hono: '^4.7.0',
+      },
+    });
+    writeHttpConformanceTest(root);
+    writeFile(
+      root,
+      'adapters/hono/src/index.ts',
+      "import {} from '@ontrails/adapter-kit';\n"
+    );
+
+    const report = checkAdapters(root);
+
+    expect(codes(report.diagnostics)).toEqual([
+      'tooling-boundary',
+      'tooling-boundary',
+    ]);
+  });
+
+  test('counts adapter-kit re-exports as runtime imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeHttpConformanceTest(root);
+    writeFile(
+      root,
+      'adapters/hono/src/index.ts',
+      "export { checkAdapters } from '@ontrails/adapter-kit';\n"
+    );
+
+    const report = checkAdapters(root);
+
+    expect(codes(report.diagnostics)).toEqual(['tooling-boundary']);
+  });
+
+  test('allows adapter-kit imports from adapter authoring tests', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeHttpConformanceTest(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/adapter-check.test.ts',
+      "import { checkAdapters } from '@ontrails/adapter-kit';\n\nvoid checkAdapters;\n"
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+  });
+
+  test('allows adapter-kit dev dependencies for adapter authoring tests', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, {
+      devDependencies: {
+        '@ontrails/adapter-kit': 'workspace:^',
+      },
+    });
+    writeHttpConformanceTest(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/adapter-check.test.ts',
+      "import { checkAdapters } from '@ontrails/adapter-kit';\n\nvoid checkAdapters;\n"
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+  });
+
+  test('allows adapter-kit imports from declaration test files', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, {
+      devDependencies: {
+        '@ontrails/adapter-kit': 'workspace:^',
+      },
+    });
+    writeHttpConformanceTest(root);
+    writeFile(
+      root,
+      'adapters/hono/src/public-api.test-d.ts',
+      "import { checkAdapters } from '@ontrails/adapter-kit';\n\nexport type Check = typeof checkAdapters;\n"
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+  });
+
+  test('ignores type-only adapter-kit re-exports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeHttpConformanceTest(root);
+    writeFile(
+      root,
+      'adapters/hono/src/index.ts',
+      "export type { AdapterCheckReport } from '@ontrails/adapter-kit';\n"
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+  });
+});

--- a/packages/adapter-kit/src/catalog.ts
+++ b/packages/adapter-kit/src/catalog.ts
@@ -6,7 +6,13 @@
  * private package.
  */
 
-import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
 export const adapterTargetPlacements = ['extracted', 'subpath'] as const;
@@ -86,6 +92,14 @@ const normalizeRealPath = (path: string): string => {
     return normalizePath(realpathSync(path));
   } catch {
     return normalizePath(resolve(path));
+  }
+};
+
+const pathIsFile = (path: string): boolean => {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
   }
 };
 
@@ -365,6 +379,19 @@ const missingExportDiagnostic = (
     target
   );
 
+const missingExportTargetDiagnostic = (
+  context: AdapterTargetParseContext,
+  field: 'supportImport' | 'testingImport',
+  importSpecifier: string,
+  target: string
+): AdapterTargetCatalogDiagnostic =>
+  diagnostic(
+    context,
+    'invalid-import',
+    `Adapter target "${target}" declares ${field} "${importSpecifier}", but ${context.packageName} exports that subpath to a missing or non-file target.`,
+    target
+  );
+
 const adapterTargetsRecord = (
   manifest: AdapterTargetPackageManifest
 ): Record<string, unknown> | undefined | null => {
@@ -421,25 +448,47 @@ const parseCatalogTarget = (
     ? context.exportTargets[testingImportSpecifier]
     : undefined;
 
-  if (supportImportSpecifier && !supportExportTarget) {
-    importDiagnostics.push(
-      missingExportDiagnostic(
-        context,
-        'supportImport',
-        supportImportSpecifier,
-        target
-      )
-    );
+  if (supportImportSpecifier) {
+    if (!supportExportTarget) {
+      importDiagnostics.push(
+        missingExportDiagnostic(
+          context,
+          'supportImport',
+          supportImportSpecifier,
+          target
+        )
+      );
+    } else if (!pathIsFile(supportExportTarget)) {
+      importDiagnostics.push(
+        missingExportTargetDiagnostic(
+          context,
+          'supportImport',
+          supportImportSpecifier,
+          target
+        )
+      );
+    }
   }
-  if (testingImportSpecifier && !testingExportTarget) {
-    importDiagnostics.push(
-      missingExportDiagnostic(
-        context,
-        'testingImport',
-        testingImportSpecifier,
-        target
-      )
-    );
+  if (testingImportSpecifier) {
+    if (!testingExportTarget) {
+      importDiagnostics.push(
+        missingExportDiagnostic(
+          context,
+          'testingImport',
+          testingImportSpecifier,
+          target
+        )
+      );
+    } else if (!pathIsFile(testingExportTarget)) {
+      importDiagnostics.push(
+        missingExportTargetDiagnostic(
+          context,
+          'testingImport',
+          testingImportSpecifier,
+          target
+        )
+      );
+    }
   }
   if (importDiagnostics.length > 0 || placements.placements.length === 0) {
     return { diagnostics: importDiagnostics };

--- a/packages/adapter-kit/src/check.ts
+++ b/packages/adapter-kit/src/check.ts
@@ -1,0 +1,1150 @@
+/**
+ * Shared adapter readiness checks for Warden and local author tooling.
+ *
+ * The engine reads package manifests and source files. It does not import
+ * runtime adapter packages, and runtime adapters must not import it.
+ */
+
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+} from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+
+import { deriveAdapterTargetCatalog } from './catalog.js';
+import type {
+  AdapterTargetCatalog,
+  AdapterTargetCatalogDiagnosticCode,
+  AdapterTargetCatalogEntry,
+  AdapterTargetPlacement,
+} from './catalog.js';
+
+export type AdapterCheckDiagnosticCode =
+  | AdapterTargetCatalogDiagnosticCode
+  | 'dependency-direction'
+  | 'invalid-adapter-metadata'
+  | 'missing-conformance'
+  | 'missing-owner-conformance'
+  | 'missing-package-export'
+  | 'tooling-boundary'
+  | 'unknown-adapter-target'
+  | 'unsupported-placement';
+
+export type AdapterCheckDiagnosticSeverity = 'error' | 'warn';
+
+export interface AdapterCheckDiagnostic {
+  readonly code: AdapterCheckDiagnosticCode;
+  readonly message: string;
+  readonly packageJsonPath: string;
+  readonly packageName?: string | undefined;
+  readonly placement?: AdapterTargetPlacement | undefined;
+  readonly severity: AdapterCheckDiagnosticSeverity;
+  readonly target?: string | undefined;
+}
+
+export interface AdapterCheckSubject {
+  readonly conformanceTestPaths: readonly string[];
+  readonly key: string;
+  readonly ownerPackage: string;
+  readonly packageJsonPath: string;
+  readonly packageName: string;
+  readonly packageRoot: string;
+  readonly placement: AdapterTargetPlacement;
+  readonly target: string;
+  readonly targetKey: string;
+  readonly testingImport?: string | undefined;
+}
+
+export interface AdapterCheckReport {
+  readonly diagnostics: readonly AdapterCheckDiagnostic[];
+  readonly subjects: readonly AdapterCheckSubject[];
+  readonly targets: readonly AdapterTargetCatalogEntry[];
+}
+
+interface RootManifest {
+  readonly workspaces?: unknown;
+}
+
+interface AdapterCheckPackageManifest {
+  readonly dependencies?: unknown;
+  readonly devDependencies?: unknown;
+  readonly exports?: unknown;
+  readonly name?: unknown;
+  readonly optionalDependencies?: unknown;
+  readonly peerDependencies?: unknown;
+  readonly trails?: unknown;
+}
+
+interface WorkspacePackage {
+  readonly manifest: AdapterCheckPackageManifest;
+  readonly packageJsonPath: string;
+  readonly packageRoot: string;
+  readonly workspacePath: string;
+}
+
+interface AdapterMetadata {
+  readonly target: string;
+}
+
+const adapterKitPackageName = '@ontrails/adapter-kit';
+
+const targetIdPattern = /^[a-z][a-z0-9-]*$/u;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+const normalizePath = (path: string): string => path.replaceAll('\\', '/');
+
+const normalizeRealPath = (path: string): string => {
+  try {
+    return normalizePath(realpathSync(path));
+  } catch {
+    return normalizePath(resolve(path));
+  }
+};
+
+const readJson = <T>(path: string): T | undefined => {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as T;
+  } catch {
+    return undefined;
+  }
+};
+
+const workspacePatternsFromManifest = (
+  manifest: RootManifest | undefined
+): readonly string[] => {
+  const { workspaces } = manifest ?? {};
+  if (Array.isArray(workspaces)) {
+    return workspaces.filter(
+      (pattern): pattern is string => typeof pattern === 'string'
+    );
+  }
+
+  const packages = isRecord(workspaces) ? workspaces['packages'] : undefined;
+  return Array.isArray(packages)
+    ? packages.filter(
+        (pattern): pattern is string => typeof pattern === 'string'
+      )
+    : [];
+};
+
+const workspaceDirsForPattern = (
+  rootDir: string,
+  pattern: string
+): readonly string[] => {
+  if (!pattern.endsWith('/*')) {
+    const workspaceDir = join(rootDir, pattern);
+    return existsSync(workspaceDir) ? [workspaceDir] : [];
+  }
+
+  const groupDir = join(rootDir, pattern.slice(0, -2));
+  if (!existsSync(groupDir)) {
+    return [];
+  }
+
+  return readdirSync(groupDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(groupDir, entry.name))
+    .toSorted();
+};
+
+const workspacePackages = (rootDir: string): readonly WorkspacePackage[] => {
+  const normalizedRoot = normalizeRealPath(rootDir);
+  const rootManifest = readJson<RootManifest>(
+    join(normalizedRoot, 'package.json')
+  );
+  const packages: WorkspacePackage[] = [];
+
+  for (const pattern of workspacePatternsFromManifest(rootManifest)) {
+    for (const workspaceDir of workspaceDirsForPattern(
+      normalizedRoot,
+      pattern
+    )) {
+      const packageJsonPath = join(workspaceDir, 'package.json');
+      const manifest = readJson<AdapterCheckPackageManifest>(packageJsonPath);
+      if (!manifest || typeof manifest.name !== 'string') {
+        continue;
+      }
+
+      const packageRoot = normalizeRealPath(dirname(packageJsonPath));
+      packages.push({
+        manifest,
+        packageJsonPath: normalizeRealPath(packageJsonPath),
+        packageRoot,
+        workspacePath: normalizePath(relative(normalizedRoot, packageRoot)),
+      });
+    }
+  }
+
+  return packages.toSorted((left, right) =>
+    left.workspacePath.localeCompare(right.workspacePath)
+  );
+};
+
+const resolveExportTarget = (
+  target: unknown,
+  depth = 0
+): string | undefined => {
+  if (typeof target === 'string') {
+    return target;
+  }
+  if (!isRecord(target) || depth > 8) {
+    return undefined;
+  }
+
+  for (const condition of ['bun', 'import', 'default', 'require'] as const) {
+    const resolvedTarget = resolveExportTarget(target[condition], depth + 1);
+    if (resolvedTarget) {
+      return resolvedTarget;
+    }
+  }
+  return undefined;
+};
+
+const isPackageRelativePath = (path: string): boolean =>
+  path.startsWith('./') && !normalizePath(path).includes('/../');
+
+const exportTargetIsFile = (packageRoot: string, target: string): boolean => {
+  if (!isPackageRelativePath(target)) {
+    return false;
+  }
+
+  try {
+    return statSync(resolve(packageRoot, target)).isFile();
+  } catch {
+    return false;
+  }
+};
+
+const hasResolvableExport = (
+  workspace: WorkspacePackage,
+  key: string
+): boolean => {
+  const { exports: exportsValue } = workspace.manifest;
+  if (typeof exportsValue === 'string') {
+    return (
+      key === '.' && exportTargetIsFile(workspace.packageRoot, exportsValue)
+    );
+  }
+
+  if (!isRecord(exportsValue)) {
+    return false;
+  }
+
+  if (!Object.hasOwn(exportsValue, key)) {
+    if (key !== '.') {
+      return false;
+    }
+
+    const rootTarget = resolveExportTarget(exportsValue);
+    return (
+      rootTarget !== undefined &&
+      exportTargetIsFile(workspace.packageRoot, rootTarget)
+    );
+  }
+
+  const target = resolveExportTarget(exportsValue[key]);
+  return (
+    target !== undefined && exportTargetIsFile(workspace.packageRoot, target)
+  );
+};
+
+const dependencyMap = (value: unknown): Readonly<Record<string, unknown>> =>
+  isRecord(value) ? value : {};
+
+const runtimeDependencyNames = (
+  manifest: AdapterCheckPackageManifest
+): ReadonlySet<string> =>
+  new Set([
+    ...Object.keys(dependencyMap(manifest.dependencies)),
+    ...Object.keys(dependencyMap(manifest.optionalDependencies)),
+    ...Object.keys(dependencyMap(manifest.peerDependencies)),
+  ]);
+
+const trailAdapterMetadata = (
+  manifest: AdapterCheckPackageManifest
+): AdapterMetadata | undefined | null => {
+  const trails = isRecord(manifest.trails) ? manifest.trails : undefined;
+  const adapter = trails?.['adapter'];
+  if (adapter === undefined) {
+    return undefined;
+  }
+  if (!isRecord(adapter)) {
+    return null;
+  }
+
+  const { target } = adapter;
+  return typeof target === 'string' && targetIdPattern.test(target)
+    ? { target }
+    : null;
+};
+
+const placementForWorkspace = (
+  workspacePath: string
+): AdapterTargetPlacement | undefined =>
+  workspacePath.startsWith('adapters/') ? 'extracted' : undefined;
+
+const diagnostic = (
+  packageJsonPath: string,
+  packageName: string | undefined,
+  code: AdapterCheckDiagnosticCode,
+  message: string,
+  target?: string,
+  placement?: AdapterTargetPlacement
+): AdapterCheckDiagnostic => ({
+  code,
+  message,
+  packageJsonPath,
+  ...(packageName === undefined ? {} : { packageName }),
+  ...(placement === undefined ? {} : { placement }),
+  severity: 'error',
+  ...(target === undefined ? {} : { target }),
+});
+
+const catalogDiagnostics = (
+  catalog: AdapterTargetCatalog
+): readonly AdapterCheckDiagnostic[] =>
+  catalog.diagnostics.map((entry) =>
+    diagnostic(
+      entry.packageJsonPath,
+      entry.packageName,
+      entry.code,
+      entry.message,
+      entry.target
+    )
+  );
+
+const targetEntriesByTarget = (
+  targets: readonly AdapterTargetCatalogEntry[]
+): ReadonlyMap<string, AdapterTargetCatalogEntry> =>
+  new Map(targets.map((target) => [target.target, target]));
+
+const collectSourceFiles = (dir: string): readonly string[] => {
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const visit = (current: string): void => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const child = join(current, entry.name);
+      if (entry.isDirectory()) {
+        visit(child);
+        continue;
+      }
+      if (entry.isFile() && child.endsWith('.ts')) {
+        files.push(normalizeRealPath(child));
+      }
+    }
+  };
+
+  visit(dir);
+  return files.toSorted();
+};
+
+const isIdentifierChar = (char: string | undefined): boolean =>
+  char !== undefined && /[$\w]/u.test(char);
+
+const skipWhitespace = (source: string, start: number): number => {
+  let index = start;
+  while (/\s/u.test(source[index] ?? '')) {
+    index += 1;
+  }
+  return index;
+};
+
+const previousNonWhitespaceChar = (
+  source: string,
+  start: number
+): string | undefined => {
+  let index = start - 1;
+  while (index >= 0) {
+    const char = source[index];
+    if (!/\s/u.test(char ?? '')) {
+      return char;
+    }
+    index -= 1;
+  }
+  return undefined;
+};
+
+const regexLiteralCanStartAfter = (char: string | undefined): boolean =>
+  char === undefined || /[([{:;,=!?&|+\-*%^~<>]/u.test(char);
+
+const regexLiteralCanStartAfterKeyword = (
+  source: string,
+  start: number
+): boolean =>
+  /\b(?:await|case|delete|do|else|in|instanceof|of|return|throw|typeof|void|yield)\s*$/u.test(
+    source.slice(0, start).trimEnd()
+  );
+
+const startsRegexLiteral = (source: string, start: number): boolean => {
+  if (
+    source[start] !== '/' ||
+    source.startsWith('//', start) ||
+    source.startsWith('/*', start)
+  ) {
+    return false;
+  }
+
+  const previousChar = previousNonWhitespaceChar(source, start);
+  return (
+    regexLiteralCanStartAfter(previousChar) ||
+    regexLiteralCanStartAfterKeyword(source, start)
+  );
+};
+
+const skipRegexLiteral = (source: string, start: number): number => {
+  let index = start + 1;
+  let inCharacterClass = false;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === '\\') {
+      index += 2;
+      continue;
+    }
+    if (char === '[') {
+      inCharacterClass = true;
+      index += 1;
+      continue;
+    }
+    if (char === ']' && inCharacterClass) {
+      inCharacterClass = false;
+      index += 1;
+      continue;
+    }
+    if (char === '/' && !inCharacterClass) {
+      index += 1;
+      while (/[a-z]/iu.test(source[index] ?? '')) {
+        index += 1;
+      }
+      return index;
+    }
+    index += 1;
+  }
+  return source.length;
+};
+
+const readQuotedString = (
+  source: string,
+  start: number
+): { readonly end: number; readonly value: string } | undefined => {
+  const quote = source[start];
+  if (quote !== '"' && quote !== "'") {
+    return undefined;
+  }
+
+  let index = start + 1;
+  let value = '';
+  while (index < source.length) {
+    const char = source[index];
+    if (char === '\\') {
+      value += source[index + 1] ?? '';
+      index += 2;
+      continue;
+    }
+    if (char === quote) {
+      return { end: index + 1, value };
+    }
+    value += char;
+    index += 1;
+  }
+
+  return undefined;
+};
+
+const skipBlockComment = (source: string, start: number): number => {
+  const end = source.indexOf('*/', start + 2);
+  return end === -1 ? source.length : end + 2;
+};
+
+const skipLineComment = (source: string, start: number): number => {
+  const end = source.indexOf('\n', start + 2);
+  return end === -1 ? source.length : end + 1;
+};
+
+const skipTrivia = (source: string, start: number): number => {
+  let index = skipWhitespace(source, start);
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      index = skipWhitespace(source, skipLineComment(source, index));
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      index = skipWhitespace(source, skipBlockComment(source, index));
+      continue;
+    }
+    return index;
+  }
+  return index;
+};
+
+const skipQuoted = (source: string, start: number): number => {
+  const quote = source[start];
+  let index = start + 1;
+  while (index < source.length) {
+    if (source[index] === '\\') {
+      index += 2;
+      continue;
+    }
+    if (source[index] === quote) {
+      return index + 1;
+    }
+    index += 1;
+  }
+  return source.length;
+};
+
+const skipImportScanIgnoredToken = (
+  source: string,
+  start: number
+): number | undefined => {
+  if (source.startsWith('//', start)) {
+    return skipLineComment(source, start);
+  }
+  if (source.startsWith('/*', start)) {
+    return skipBlockComment(source, start);
+  }
+
+  const char = source[start];
+  if (char === '"' || char === "'" || char === '`') {
+    return skipQuoted(source, start);
+  }
+  if (char === '/' && startsRegexLiteral(source, start)) {
+    return skipRegexLiteral(source, start);
+  }
+
+  return undefined;
+};
+
+const importClauseHasRuntimeBinding = (
+  clause: string,
+  options: { readonly emptyNamedCounts?: boolean } = {}
+): boolean => {
+  const emptyNamedCounts = options.emptyNamedCounts ?? true;
+  const uncommented = clause
+    .replaceAll(/\/\*[\s\S]*?\*\//g, ' ')
+    .replaceAll(/\/\/[^\n\r]*/g, ' ');
+  const trimmed = uncommented.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  const namedStart = trimmed.indexOf('{');
+  if (namedStart === -1) {
+    return true;
+  }
+
+  if (trimmed.slice(0, namedStart).replaceAll(',', '').trim()) {
+    return true;
+  }
+
+  const namedEnd = trimmed.indexOf('}', namedStart + 1);
+  if (namedEnd === -1) {
+    return emptyNamedCounts;
+  }
+
+  const namedBindings = trimmed
+    .slice(namedStart + 1, namedEnd)
+    .split(',')
+    .map((binding) => binding.trim())
+    .filter(Boolean);
+  if (namedBindings.length === 0) {
+    return emptyNamedCounts;
+  }
+
+  return namedBindings.some((binding) => !/^type(?:\s|$)/u.test(binding));
+};
+
+const previousStatementStart = (source: string, start: number): number => {
+  let index = start - 1;
+  while (index >= 0) {
+    if (source[index] === ';' || source[index] === '}') {
+      return index + 1;
+    }
+    index -= 1;
+  }
+  return 0;
+};
+
+const importAppearsInTypePosition = (
+  source: string,
+  start: number
+): boolean => {
+  const prefix = source
+    .slice(previousStatementStart(source, start), start)
+    .replaceAll(/\/\*[\s\S]*?\*\//g, ' ')
+    .replaceAll(/\/\/[^\n\r]*/g, ' ')
+    .trimStart();
+  const lastLineStart =
+    Math.max(prefix.lastIndexOf('\n'), prefix.lastIndexOf('\r')) + 1;
+  const lastLine = prefix.slice(lastLineStart).trimStart();
+  if (
+    /^(?:export\s+)?(?:type|interface)\b/u.test(prefix) &&
+    lastLineStart > 0 &&
+    /^(?:const|let|var|using|await|return|throw|void|yield|new)\b/u.test(
+      lastLine
+    )
+  ) {
+    return false;
+  }
+
+  if (/^(?:export\s+)?(?:type|interface)\b/u.test(prefix)) {
+    return true;
+  }
+
+  const trimmed = prefix.trimEnd();
+  const lastAssignment = prefix.lastIndexOf('=');
+  const colonLooksLikeTypeAnnotation = (colonIndex: number): boolean => {
+    const objectLiteralStart = prefix.indexOf('{', lastAssignment + 1);
+    if (objectLiteralStart !== -1 && objectLiteralStart < colonIndex) {
+      return false;
+    }
+
+    const blockStart = prefix.lastIndexOf('{');
+    if (blockStart > colonIndex) {
+      const blockTail = prefix.slice(blockStart + 1).trimStart();
+      if (
+        /^(?:const|let|var|using|await|return|throw|void|yield|new)\b/u.test(
+          blockTail
+        )
+      ) {
+        return false;
+      }
+    }
+
+    const questionIndex = prefix.indexOf('?', lastAssignment + 1);
+    return questionIndex === -1 || questionIndex > colonIndex;
+  };
+
+  if (trimmed.endsWith('<') && isIdentifierChar(trimmed.at(-2))) {
+    return true;
+  }
+
+  if (trimmed.endsWith(':')) {
+    const trailingColon = prefix.lastIndexOf(':');
+    return colonLooksLikeTypeAnnotation(trailingColon);
+  }
+
+  if (/\b(?:as|extends|implements|satisfies|typeof)\s*$/u.test(trimmed)) {
+    return true;
+  }
+
+  const annotationColon = prefix.indexOf(':', lastAssignment + 1);
+  if (annotationColon === -1) {
+    return false;
+  }
+
+  return colonLooksLikeTypeAnnotation(annotationColon);
+};
+
+const importDeclarationSpecifier = (
+  source: string,
+  start: number
+): string | undefined => {
+  let index = skipTrivia(source, start + 'import'.length);
+  if (source[index] === '.') {
+    return undefined;
+  }
+  if (
+    source.startsWith('type', index) &&
+    !isIdentifierChar(source[index + 'type'.length])
+  ) {
+    return undefined;
+  }
+  const sideEffect = readQuotedString(source, index);
+  if (sideEffect) {
+    return sideEffect.value;
+  }
+
+  if (source[index] === '(') {
+    if (importAppearsInTypePosition(source, start)) {
+      return undefined;
+    }
+    index = skipTrivia(source, index + 1);
+    return readQuotedString(source, index)?.value;
+  }
+
+  const clauseStart = index;
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      index = skipLineComment(source, index);
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      index = skipBlockComment(source, index);
+      continue;
+    }
+    const char = source[index];
+    if (char === '"' || char === "'" || char === '`') {
+      index = skipQuoted(source, index);
+      continue;
+    }
+    if (
+      source.startsWith('from', index) &&
+      !isIdentifierChar(source[index - 1]) &&
+      !isIdentifierChar(source[index + 'from'.length])
+    ) {
+      if (!importClauseHasRuntimeBinding(source.slice(clauseStart, index))) {
+        return undefined;
+      }
+      index = skipTrivia(source, index + 'from'.length);
+      return readQuotedString(source, index)?.value;
+    }
+    if (char === ';') {
+      return undefined;
+    }
+    index += 1;
+  }
+
+  return undefined;
+};
+
+const boundImportDeclarationSpecifier = (
+  source: string,
+  start: number
+): string | undefined => {
+  let index = skipTrivia(source, start + 'import'.length);
+  if (source[index] === '.') {
+    return undefined;
+  }
+  if (
+    source.startsWith('type', index) &&
+    !isIdentifierChar(source[index + 'type'.length])
+  ) {
+    return undefined;
+  }
+  if (readQuotedString(source, index)) {
+    return undefined;
+  }
+
+  if (source[index] === '(') {
+    if (importAppearsInTypePosition(source, start)) {
+      return undefined;
+    }
+    index = skipTrivia(source, index + 1);
+    return readQuotedString(source, index)?.value;
+  }
+
+  const clauseStart = index;
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      index = skipLineComment(source, index);
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      index = skipBlockComment(source, index);
+      continue;
+    }
+    const char = source[index];
+    if (char === '"' || char === "'" || char === '`') {
+      index = skipQuoted(source, index);
+      continue;
+    }
+    if (
+      source.startsWith('from', index) &&
+      !isIdentifierChar(source[index - 1]) &&
+      !isIdentifierChar(source[index + 'from'.length])
+    ) {
+      if (
+        !importClauseHasRuntimeBinding(source.slice(clauseStart, index), {
+          emptyNamedCounts: false,
+        })
+      ) {
+        return undefined;
+      }
+      index = skipTrivia(source, index + 'from'.length);
+      return readQuotedString(source, index)?.value;
+    }
+    if (char === ';') {
+      return undefined;
+    }
+    index += 1;
+  }
+
+  return undefined;
+};
+
+const reExportDeclarationSpecifier = (
+  source: string,
+  start: number
+): string | undefined => {
+  let index = skipTrivia(source, start + 'export'.length);
+  if (
+    source.startsWith('type', index) &&
+    !isIdentifierChar(source[index + 'type'.length])
+  ) {
+    return undefined;
+  }
+
+  const clauseStart = index;
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      index = skipLineComment(source, index);
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      index = skipBlockComment(source, index);
+      continue;
+    }
+    const char = source[index];
+    if (char === '"' || char === "'" || char === '`') {
+      index = skipQuoted(source, index);
+      continue;
+    }
+    if (char === '}') {
+      const next = skipTrivia(source, index + 1);
+      if (
+        !source.startsWith('from', next) ||
+        isIdentifierChar(source[next + 'from'.length])
+      ) {
+        return undefined;
+      }
+      index = next;
+      continue;
+    }
+    if (
+      source.startsWith('from', index) &&
+      !isIdentifierChar(source[index - 1]) &&
+      !isIdentifierChar(source[index + 'from'.length])
+    ) {
+      if (!importClauseHasRuntimeBinding(source.slice(clauseStart, index))) {
+        return undefined;
+      }
+      index = skipTrivia(source, index + 'from'.length);
+      return readQuotedString(source, index)?.value;
+    }
+    if (char === ';') {
+      return undefined;
+    }
+    index += 1;
+  }
+
+  return undefined;
+};
+
+const importsSpecifier = (
+  source: string,
+  specifier: string,
+  options: { includeReExports?: boolean; requireImportBinding?: boolean } = {}
+): boolean => {
+  const includeReExports = options.includeReExports ?? true;
+  const importSpecifier = options.requireImportBinding
+    ? boundImportDeclarationSpecifier
+    : importDeclarationSpecifier;
+  let index = 0;
+  while (index < source.length) {
+    const skippedIndex = skipImportScanIgnoredToken(source, index);
+    if (skippedIndex !== undefined) {
+      index = skippedIndex;
+      continue;
+    }
+
+    if (
+      source.startsWith('import', index) &&
+      !isIdentifierChar(source[index - 1]) &&
+      previousNonWhitespaceChar(source, index) !== '.' &&
+      !isIdentifierChar(source[index + 'import'.length])
+    ) {
+      if (importSpecifier(source, index) === specifier) {
+        return true;
+      }
+      index += 'import'.length;
+      continue;
+    }
+    if (
+      includeReExports &&
+      source.startsWith('export', index) &&
+      !isIdentifierChar(source[index - 1]) &&
+      !isIdentifierChar(source[index + 'export'.length])
+    ) {
+      if (reExportDeclarationSpecifier(source, index) === specifier) {
+        return true;
+      }
+      index += 'export'.length;
+      continue;
+    }
+    index += 1;
+  }
+
+  return false;
+};
+
+const pathsImporting = (
+  sourceFiles: readonly string[],
+  specifier: string,
+  options?: { includeReExports?: boolean; requireImportBinding?: boolean }
+): readonly string[] =>
+  sourceFiles.filter((filePath) =>
+    importsSpecifier(readFileSync(filePath, 'utf8'), specifier, options)
+  );
+
+const isTestFile = (filePath: string): boolean => {
+  const normalizedPath = normalizePath(filePath);
+  return (
+    normalizedPath.includes('/__tests__/') ||
+    normalizedPath.endsWith('.test.ts') ||
+    normalizedPath.endsWith('.test-d.ts')
+  );
+};
+
+const assertPackageExports = (
+  workspace: WorkspacePackage,
+  diagnostics: AdapterCheckDiagnostic[]
+): void => {
+  const packageName = workspace.manifest.name as string;
+  for (const key of ['.', './package.json'] as const) {
+    if (hasResolvableExport(workspace, key)) {
+      continue;
+    }
+    diagnostics.push(
+      diagnostic(
+        workspace.packageJsonPath,
+        packageName,
+        'missing-package-export',
+        `${packageName} must export "${key}" so adapter kit and consumers can resolve it.`
+      )
+    );
+  }
+};
+
+const assertDependencyDirection = (
+  workspace: WorkspacePackage,
+  targetEntry: AdapterTargetCatalogEntry,
+  diagnostics: AdapterCheckDiagnostic[]
+): void => {
+  const packageName = workspace.manifest.name as string;
+  const dependencies = dependencyMap(workspace.manifest.dependencies);
+  const devDependencies = dependencyMap(workspace.manifest.devDependencies);
+  const optionalDependencies = dependencyMap(
+    workspace.manifest.optionalDependencies
+  );
+  const peerDependencies = dependencyMap(workspace.manifest.peerDependencies);
+
+  if (
+    Object.hasOwn(dependencies, targetEntry.ownerPackage) ||
+    Object.hasOwn(optionalDependencies, targetEntry.ownerPackage)
+  ) {
+    diagnostics.push(
+      diagnostic(
+        workspace.packageJsonPath,
+        packageName,
+        'dependency-direction',
+        `${packageName} must peer-depend on ${targetEntry.ownerPackage}; runtime dependencies invert the adapter boundary.`,
+        targetEntry.target,
+        'extracted'
+      )
+    );
+  }
+
+  if (Object.hasOwn(devDependencies, targetEntry.ownerPackage)) {
+    diagnostics.push(
+      diagnostic(
+        workspace.packageJsonPath,
+        packageName,
+        'dependency-direction',
+        `${packageName} must not hide ${targetEntry.ownerPackage} in devDependencies; declare the owner as a peer dependency.`,
+        targetEntry.target,
+        'extracted'
+      )
+    );
+  }
+
+  if (!Object.hasOwn(peerDependencies, targetEntry.ownerPackage)) {
+    diagnostics.push(
+      diagnostic(
+        workspace.packageJsonPath,
+        packageName,
+        'dependency-direction',
+        `${packageName} must declare ${targetEntry.ownerPackage} in peerDependencies for extracted adapter placement.`,
+        targetEntry.target,
+        'extracted'
+      )
+    );
+  }
+};
+
+const assertToolingBoundary = (
+  workspace: WorkspacePackage,
+  sourceFiles: readonly string[],
+  diagnostics: AdapterCheckDiagnostic[]
+): void => {
+  const packageName = workspace.manifest.name as string;
+  if (runtimeDependencyNames(workspace.manifest).has(adapterKitPackageName)) {
+    diagnostics.push(
+      diagnostic(
+        workspace.packageJsonPath,
+        packageName,
+        'tooling-boundary',
+        `${packageName} must not depend on ${adapterKitPackageName}; adapter kit stays out of runtime adapter packages.`
+      )
+    );
+  }
+
+  const runtimeSourceFiles = sourceFiles.filter(
+    (sourceFile) => !isTestFile(sourceFile)
+  );
+  const toolingImportPaths = pathsImporting(
+    runtimeSourceFiles,
+    adapterKitPackageName
+  );
+  for (const sourcePath of toolingImportPaths) {
+    diagnostics.push(
+      diagnostic(
+        workspace.packageJsonPath,
+        packageName,
+        'tooling-boundary',
+        `${packageName} imports ${adapterKitPackageName} from ${normalizePath(relative(workspace.packageRoot, sourcePath))}; adapters must not import the adapter kit engine.`
+      )
+    );
+  }
+};
+
+const checkAdapterPackage = (
+  workspace: WorkspacePackage,
+  targetById: ReadonlyMap<string, AdapterTargetCatalogEntry>
+): {
+  readonly diagnostics: readonly AdapterCheckDiagnostic[];
+  readonly subject?: AdapterCheckSubject | undefined;
+} => {
+  const packageName = workspace.manifest.name as string;
+  const diagnostics: AdapterCheckDiagnostic[] = [];
+  const placement = placementForWorkspace(workspace.workspacePath);
+  const metadata = trailAdapterMetadata(workspace.manifest);
+
+  if (!placement || metadata === undefined) {
+    return { diagnostics: [] };
+  }
+
+  assertPackageExports(workspace, diagnostics);
+  const sourceFiles = collectSourceFiles(join(workspace.packageRoot, 'src'));
+  assertToolingBoundary(workspace, sourceFiles, diagnostics);
+
+  if (metadata === null) {
+    return {
+      diagnostics: [
+        ...diagnostics,
+        diagnostic(
+          workspace.packageJsonPath,
+          packageName,
+          'invalid-adapter-metadata',
+          `${packageName} must declare trails.adapter as an object with a kebab-case target string.`,
+          undefined,
+          placement
+        ),
+      ],
+    };
+  }
+
+  const targetEntry = targetById.get(metadata.target);
+  if (!targetEntry) {
+    return {
+      diagnostics: [
+        ...diagnostics,
+        diagnostic(
+          workspace.packageJsonPath,
+          packageName,
+          'unknown-adapter-target',
+          `${packageName} declares unknown adapter target "${metadata.target}".`,
+          metadata.target,
+          placement
+        ),
+      ],
+    };
+  }
+
+  if (!targetEntry.placements.includes(placement)) {
+    diagnostics.push(
+      diagnostic(
+        workspace.packageJsonPath,
+        packageName,
+        'unsupported-placement',
+        `${targetEntry.ownerPackage}:${targetEntry.target} does not support ${placement} adapter placement.`,
+        targetEntry.target,
+        placement
+      )
+    );
+  }
+
+  if (placement === 'extracted') {
+    assertDependencyDirection(workspace, targetEntry, diagnostics);
+  }
+
+  const { testingImport } = targetEntry;
+  const conformanceTestPaths = testingImport
+    ? pathsImporting(sourceFiles.filter(isTestFile), testingImport, {
+        includeReExports: false,
+        requireImportBinding: true,
+      })
+    : [];
+
+  if (!testingImport) {
+    diagnostics.push(
+      diagnostic(
+        workspace.packageJsonPath,
+        packageName,
+        'missing-owner-conformance',
+        `${targetEntry.ownerPackage}:${targetEntry.target} must declare testingImport before adapters can prove conformance.`,
+        targetEntry.target,
+        placement
+      )
+    );
+  } else if (conformanceTestPaths.length === 0) {
+    diagnostics.push(
+      diagnostic(
+        workspace.packageJsonPath,
+        packageName,
+        'missing-conformance',
+        `${packageName} must import ${testingImport} from a conformance test.`,
+        targetEntry.target,
+        placement
+      )
+    );
+  }
+
+  return {
+    diagnostics,
+    subject: {
+      conformanceTestPaths,
+      key: packageName,
+      ownerPackage: targetEntry.ownerPackage,
+      packageJsonPath: workspace.packageJsonPath,
+      packageName,
+      packageRoot: workspace.packageRoot,
+      placement,
+      target: targetEntry.target,
+      targetKey: targetEntry.key,
+      ...(testingImport ? { testingImport } : {}),
+    },
+  };
+};
+
+export const checkAdapters = (rootDir: string): AdapterCheckReport => {
+  const catalog = deriveAdapterTargetCatalog(rootDir);
+  const targetById = targetEntriesByTarget(catalog.targets);
+  const diagnostics: AdapterCheckDiagnostic[] = [
+    ...catalogDiagnostics(catalog),
+  ];
+  const subjects: AdapterCheckSubject[] = [];
+
+  for (const workspace of workspacePackages(rootDir)) {
+    const result = checkAdapterPackage(workspace, targetById);
+    diagnostics.push(...result.diagnostics);
+    if (result.subject) {
+      subjects.push(result.subject);
+    }
+  }
+
+  return {
+    diagnostics,
+    subjects: subjects.toSorted((left, right) =>
+      left.key.localeCompare(right.key)
+    ),
+    targets: catalog.targets,
+  };
+};

--- a/packages/adapter-kit/src/index.ts
+++ b/packages/adapter-kit/src/index.ts
@@ -1,3 +1,11 @@
+export { checkAdapters } from './check.js';
+export type {
+  AdapterCheckDiagnostic,
+  AdapterCheckDiagnosticCode,
+  AdapterCheckDiagnosticSeverity,
+  AdapterCheckReport,
+  AdapterCheckSubject,
+} from './check.js';
 export {
   adapterTargetPlacements,
   deriveAdapterTargetCatalog,


### PR DESCRIPTION
## Context

Sixth branch in the V1 convergence stack (#634-#641). This adds the shared check engine that lets Warden and local Trails CLI project the same adapter-authoring facts.

## Changes

- Adds `checkAdapters()` to internal `@ontrails/adapter-tools`.
- Derives extracted adapter placement, package exports, dependency direction, owner conformance imports, and adapter conformance test imports.
- Reports structured diagnostics for missing/invalid metadata, unknown targets, unsupported placements, package export issues, dependency-boundary issues, missing conformance facts, and runtime tooling imports.
- Adds focused tests for the diagnostic contract.

## Verification

- `bun test packages/adapter-tools/src/__tests__/check.test.ts packages/adapter-tools/src/__tests__/catalog.test.ts`
- `bun run --cwd packages/adapter-tools typecheck`
- `bun run --cwd packages/adapter-tools lint`
- `bunx tsc -p packages/adapter-tools/tsconfig.tests.json --noEmit`
- `bun run --cwd packages/adapter-tools build`
- `bunx ultracite check packages/adapter-tools/src/check.ts packages/adapter-tools/src/__tests__/check.test.ts packages/adapter-tools/src/index.ts`
- Live repo smoke: 2 targets, 0 pre-dogfood subjects, expected missing metadata diagnostics.
- `bun run typecheck`
- `bun run lint`

## Risks

- The first implementation focuses on extracted workspace adapters. Subpath adapter coverage can be added once we have a real first-party need.

Closes TRL-863
