### PR TITLE
feat(adapter-kit): expose adapter checks

### DIFF
--- a/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
@@ -106,7 +106,7 @@ status: active
 
 - Started `trl-861-define-adapter-target-metadata-and-catalog-derivation`
   above the adapter conformance snippet branch.
-- Added private internal `@ontrails/adapter-kit` package for read-only
+- Added internal `@ontrails/adapter-kit` package for read-only
   `trails.adapterTargets` catalog derivation.
 - Added first-party metadata to `@ontrails/http` and `@ontrails/store`; HTTP
   advertises the target and placements only, while Store also advertises its
@@ -157,7 +157,7 @@ status: active
 ### 2026-05-30 09:20 EDT - TRL-863 shared adapter check engine
 
 - Started `trl-863-build-shared-adapter-check-engine` above TRL-862.
-- Added `checkAdapters()` to private `@ontrails/adapter-kit` as the shared
+- Added `checkAdapters()` to internal `@ontrails/adapter-kit` as the shared
   predicate engine for future Warden and local `adapter.check` projections.
 - Kept adapter metadata minimal: extracted adapter packages author only
   `trails.adapter.target`; the engine derives placement from workspace path,
@@ -184,6 +184,17 @@ status: active
   real static and dynamic import coverage.
 - Added regressions for line-comment, block-comment, string-literal, and
   type-only false positives, plus a dynamic import positive case.
+
+### 2026-05-31 00:00 EDT - TRL-864 review fixes
+
+- Follow-up review threads found that Warden's `advisory` tier accidentally
+  enabled adapter checks without `--adapter-check`, and the Trails
+  `adapter.check` output bridge did not honor the global `--jsonl` shorthand.
+- Kept adapter checks opt-in for Warden by requiring `adapterCheck` explicitly.
+- Treated `jsonl` like `json` and `--output jsonl` so the generic structured
+  output path, not the human adapter report bridge, owns line-delimited output.
+- Updated Warden and Trails adapter-check fixtures to create the source file
+  their package export maps claim exists after the stricter export-target check.
 
 ## Verification Ledger
 
@@ -277,6 +288,15 @@ status: active
 | `bun run --cwd packages/adapter-kit lint` | TRL-876 nested type-query follow-up | pass | Oxlint clean. |
 | `bun run --cwd packages/adapter-kit typecheck` | TRL-876 nested type-query follow-up | pass | `tsc --noEmit` clean. |
 | `bunx markdownlint-cli2 .changeset/trl-863-adapter-check-engine.md` | TRL-863 changeset follow-up | pass | Branch-local adapter-kit changeset markdown clean. |
+| `bun test packages/warden/src/__tests__/adapter-check.test.ts packages/warden/src/__tests__/cli.test.ts apps/trails/src/__tests__/adapter-check.test.ts` | TRL-864 review-thread follow-up | pass | 54 tests passed, covering explicit adapter-check opt-in, `--jsonl`, and repaired export-map fixtures. |
+| `bun run --cwd packages/warden typecheck && bun run --cwd apps/trails typecheck` | TRL-864 review-thread follow-up | pass | Warden and Trails typechecks clean. |
+| `bun run --cwd packages/warden lint && bun run --cwd apps/trails lint` | TRL-864 review-thread follow-up | pass | Oxlint clean for both packages. |
+| `bun run format:check` | TRL-864 review-thread follow-up | pass | Full Ultracite check clean after formatting the touched adapter-check surface. |
+| `git diff --check` | TRL-864 review-thread follow-up | pass | No whitespace findings. |
+| `bun test packages/warden/src/__tests__/cli.test.ts` | TRL-864 pre-push fixture follow-up | pass | 47 Warden CLI tests passed after making the adapter-check opt-in fixture explicitly opt in. |
+| `bun test apps/trails/src/__tests__/adapter-check.test.ts` | TRL-864 env output follow-up | pass | 6 Trails adapter-check tests passed, including `TRAILS_JSON=1` and `TRAILS_JSONL=1` structured-output handling. |
+| `bun run --cwd apps/trails lint` | TRL-864 env output follow-up | pass | Oxlint clean after making env restore explicit. |
+| `bun run --cwd apps/trails typecheck` | TRL-864 env output follow-up | pass | `tsc --noEmit` clean. |
 
 ## Review Findings
 
@@ -317,6 +337,22 @@ Another #639 follow-up found nested TS type-query imports such as
 evidence, and that the exported adapter-kit check API needed a branch-local
 changeset. The scanner now treats annotated generic type positions as erased
 imports, and TRL-863 carries its own `@ontrails/adapter-kit` patch changeset.
+
+Follow-up review threads on #640 found that advisory Warden runs were no longer
+pure advisory-rule runs because adapter checks were implicitly attached, and that
+`trails adapter check --jsonl` still printed the human report. Warden now runs
+adapter checks only behind explicit adapter opt-in, while the Trails CLI bridge
+defers both `--jsonl` and `--output jsonl` to the structured output path.
+
+Pre-push later caught that the Warden opt-in regression fixture no longer
+produced adapter-check diagnostics after unannotated adapters became out of
+scope. The fixture now declares `trails.adapter` explicitly so the test proves
+opt-in execution instead of relying on old unannotated-adapter behavior.
+
+A later #640 review found that `trails adapter check` skipped human output for
+structured flags but ignored the repo-wide topo env selectors. The adapter-check
+result bridge now delegates to `deriveOutputMode()`, so `TRAILS_JSON=1` and
+`TRAILS_JSONL=1` behave like the corresponding flags.
 
 ## Open Risks
 

--- a/.changeset/trl-864-adapter-check-surfaces.md
+++ b/.changeset/trl-864-adapter-check-surfaces.md
@@ -1,0 +1,9 @@
+---
+"@ontrails/adapter-kit": patch
+"@ontrails/trails": patch
+"@ontrails/warden": patch
+---
+
+Expose the shared adapter readiness engine through Warden's opt-in
+`--adapter-check` diagnostics and the local `trails adapter check` authoring
+workflow.

--- a/apps/trails/__tests__/examples.test.ts
+++ b/apps/trails/__tests__/examples.test.ts
@@ -11,6 +11,7 @@ import { app } from '../src/app.js';
 const trailsWorkspaceDir = resolve(import.meta.dir, '..', '.trails');
 const trailsGitignorePath = join(trailsWorkspaceDir, '.gitignore');
 const trailsWorkspaceSubdirs = ['cache', 'state'] as const;
+const repoRoot = resolve(import.meta.dir, '..', '..', '..');
 
 const resetTrailsWorkspace = (): void => {
   rmSync(trailsWorkspaceDir, { force: true, recursive: true });
@@ -29,4 +30,4 @@ afterAll(() => {
   resetTrailsWorkspace();
 });
 
-testExamples(app);
+testExamples(app, { cwd: repoRoot });

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.1.0",
+    "@ontrails/adapter-kit": "workspace:^",
     "@ontrails/cli": "workspace:^",
     "@ontrails/commander": "workspace:^",
     "@ontrails/core": "workspace:^",

--- a/apps/trails/src/__tests__/adapter-check.test.ts
+++ b/apps/trails/src/__tests__/adapter-check.test.ts
@@ -1,0 +1,346 @@
+import { deriveCliCommands } from '@ontrails/cli';
+import { Result, ValidationError } from '@ontrails/core';
+import { runWardenAdapterChecks } from '@ontrails/warden';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { app } from '../app.js';
+import { tryAdapterCheckOutput } from '../run-adapter-check.js';
+import { adapterCheckTrail } from '../trails/adapter-check.js';
+
+const roots: string[] = [];
+const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url));
+const trailsBinPath = fileURLToPath(
+  new URL('../../bin/trails.ts', import.meta.url)
+);
+const cliTimeoutMs = 30_000;
+
+interface RawCliRun {
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+const runRawCli = (
+  args: readonly string[],
+  cwd: string = repoRoot
+): RawCliRun => {
+  const command = [process.execPath, trailsBinPath, ...args];
+  const proc = Bun.spawnSync({
+    cmd: command,
+    cwd,
+    env: { ...process.env, NO_COLOR: '1' } as Record<string, string>,
+    stderr: 'pipe',
+    stdout: 'pipe',
+    timeout: cliTimeoutMs,
+  });
+  const stdout = proc.stdout.toString();
+  const stderr = proc.stderr.toString();
+  const signalCode = proc.signalCode ?? undefined;
+  if (proc.exitedDueToTimeout || signalCode !== undefined) {
+    throw new Error(
+      [
+        `Adapter check CLI subprocess ${proc.exitedDueToTimeout ? 'timed out' : 'terminated'} before producing output.`,
+        `command: ${command.join(' ')}`,
+        `cwd: ${cwd}`,
+        ...(proc.exitedDueToTimeout ? [`timeoutMs: ${cliTimeoutMs}`] : []),
+        `exitCode: ${proc.exitCode ?? 'null'}`,
+        `signal: ${signalCode ?? 'null'}`,
+        `stdout: ${stdout}`,
+        `stderr: ${stderr}`,
+      ].join('\n')
+    );
+  }
+
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stderr,
+    stdout,
+  };
+};
+
+const writeFile = (root: string, path: string, value: string): void => {
+  const filePath = join(root, path);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value);
+};
+
+const writeJson = (
+  root: string,
+  path: string,
+  value: Record<string, unknown>
+): void => {
+  writeFile(root, path, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const makeTempRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'trails-adapter-check-cli-'));
+  roots.push(root);
+  return root;
+};
+
+const makeRoot = (): string => {
+  const root = makeTempRoot();
+  writeJson(root, 'package.json', {
+    name: 'fixture-root',
+    workspaces: ['packages/*', 'adapters/*'],
+  });
+  return root;
+};
+
+const writePackage = (
+  root: string,
+  workspacePath: string,
+  manifest: Record<string, unknown>
+): void => {
+  writeJson(root, join(workspacePath, 'package.json'), manifest);
+};
+
+const writeHttpOwner = (root: string): void => {
+  writePackage(root, 'packages/http', {
+    exports: {
+      '.': './src/index.ts',
+      './package.json': './package.json',
+      './testing': './src/testing.ts',
+    },
+    name: '@ontrails/http',
+    trails: {
+      adapterTargets: {
+        http: {
+          placements: ['extracted'],
+          testingImport: '@ontrails/http/testing',
+        },
+      },
+    },
+  });
+  writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
+};
+
+const expectValidationError = (
+  result: Awaited<ReturnType<typeof adapterCheckTrail.blaze>>
+): ValidationError => {
+  expect(result.isErr()).toBe(true);
+  if (result.isOk()) {
+    throw new Error('Expected adapter.check to return Result.err');
+  }
+  expect(result.error).toBeInstanceOf(ValidationError);
+  return result.error as ValidationError;
+};
+
+const writeHonoAdapter = (
+  root: string,
+  manifestOverrides: Record<string, unknown> = {}
+): void => {
+  writePackage(root, 'adapters/hono', {
+    exports: {
+      '.': './src/index.ts',
+      './package.json': './package.json',
+    },
+    name: '@ontrails/hono',
+    peerDependencies: {
+      '@ontrails/http': 'workspace:^',
+    },
+    trails: {
+      adapter: true,
+    },
+    ...manifestOverrides,
+  });
+  writeFile(
+    root,
+    'adapters/hono/src/index.ts',
+    'export const honoAdapter = {};\n'
+  );
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe('trails adapter check', () => {
+  test('projects as a nested CLI command', () => {
+    const commands = deriveCliCommands(app);
+    if (commands.isErr()) {
+      throw commands.error;
+    }
+
+    const paths = commands.value.map((command) => command.path.join(' '));
+    expect(paths).toContain('adapter check');
+  });
+
+  test('returns the same diagnostic codes as the Warden projection', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+
+    const result = await adapterCheckTrail.blaze({ rootDir: root }, {
+      cwd: root,
+      env: {},
+    } as never);
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const localCodes = result.value.diagnostics.map((entry) => entry.code);
+    const wardenCodes = runWardenAdapterChecks(root).map((entry) => entry.code);
+
+    expect(result.value.passed).toBe(false);
+    expect(localCodes).toEqual(['invalid-adapter-metadata']);
+    expect(wardenCodes).toEqual(localCodes);
+  });
+
+  test('runs locally and exits non-zero for adapter readiness failures', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+
+    const result = runRawCli(['adapter', 'check', '--root-dir', root]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe('');
+    expect(result.stdout).toContain('## Adapter Check Report');
+    expect(result.stdout).toContain('invalid-adapter-metadata');
+  });
+
+  test('exits non-zero for adapter readiness failures under trace JSON', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+
+    const result = runRawCli([
+      'adapter',
+      'check',
+      '--root-dir',
+      root,
+      '--trace',
+      '--json',
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('adapter.check');
+    const parsed = JSON.parse(result.stdout) as {
+      readonly ok?: boolean;
+      readonly value?: { readonly passed?: boolean };
+    };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.value?.passed).toBe(false);
+  });
+
+  test('rejects missing root directories before reporting pass', async () => {
+    const root = makeRoot();
+    const missingRoot = join(root, 'missing-root');
+
+    const result = await adapterCheckTrail.blaze({ rootDir: missingRoot }, {
+      cwd: root,
+      env: {},
+    } as never);
+
+    const error = expectValidationError(result);
+    expect(error.message).toContain('rootDir does not exist');
+  });
+
+  test('rejects roots without workspace manifests before reporting pass', async () => {
+    const root = makeTempRoot();
+    writeJson(root, 'package.json', {
+      name: 'not-a-workspace-root',
+    });
+
+    const result = await adapterCheckTrail.blaze({ rootDir: root }, {
+      cwd: root,
+      env: {},
+    } as never);
+
+    const error = expectValidationError(result);
+    expect(error.message).toContain('must declare workspace packages');
+  });
+
+  test('CLI exits non-zero for missing root directories', () => {
+    const root = makeRoot();
+    const missingRoot = join(root, 'missing-root');
+
+    const result = runRawCli(['adapter', 'check', '--root-dir', missingRoot]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).not.toContain('Result: PASS');
+    expect(result.stderr).toContain('rootDir does not exist');
+  });
+
+  test('CLI exits non-zero for missing root directories under trace JSON', () => {
+    const root = makeRoot();
+    const missingRoot = join(root, 'missing-root');
+
+    const result = runRawCli([
+      'adapter',
+      'check',
+      '--root-dir',
+      missingRoot,
+      '--trace',
+      '--json',
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('adapter.check');
+    const parsed = JSON.parse(result.stdout) as {
+      readonly error?: { readonly message?: string };
+      readonly ok?: boolean;
+    };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error?.message).toContain('rootDir does not exist');
+  });
+
+  test('lets --jsonl shorthand use structured output', () => {
+    const previousExitCode = process.exitCode;
+    try {
+      process.exitCode = 0;
+
+      const handled = tryAdapterCheckOutput({
+        flags: { jsonl: true },
+        result: Result.ok({ formatted: 'adapter report', passed: false }),
+        trail: { id: 'adapter.check' },
+      } as never);
+
+      expect(handled).toBe(false);
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.exitCode = previousExitCode ?? 0;
+    }
+  });
+
+  for (const envKey of ['TRAILS_JSON', 'TRAILS_JSONL'] as const) {
+    test(`lets ${envKey}=1 use structured output`, () => {
+      const previousExitCode = process.exitCode;
+      const previousValue = process.env[envKey];
+      try {
+        process.exitCode = 0;
+        process.env[envKey] = '1';
+
+        const handled = tryAdapterCheckOutput({
+          flags: {},
+          result: Result.ok({ formatted: 'adapter report', passed: false }),
+          topoName: 'trails',
+          trail: { id: 'adapter.check' },
+        } as never);
+
+        expect(handled).toBe(false);
+        expect(process.exitCode).toBe(1);
+      } finally {
+        process.exitCode = previousExitCode ?? 0;
+        if (previousValue === undefined) {
+          if (envKey === 'TRAILS_JSON') {
+            delete process.env.TRAILS_JSON;
+          } else {
+            delete process.env.TRAILS_JSONL;
+          }
+        } else {
+          process.env[envKey] = previousValue;
+        }
+      }
+    });
+  }
+});

--- a/apps/trails/src/__tests__/warden.test.ts
+++ b/apps/trails/src/__tests__/warden.test.ts
@@ -187,6 +187,7 @@ describe('trails warden', () => {
 
   test('projects final Warden flags into the shared command surface', () => {
     const args = buildWardenCommandArgs({
+      adapterCheck: true,
       apps: ['trails', 'demo'],
       cached: true,
       ci: true,
@@ -219,6 +220,7 @@ describe('trails warden', () => {
       '--exclude-drafts',
       '--no-lock-mutation',
       '--fix',
+      '--adapter-check',
       '--apps',
       'trails,demo',
     ]);
@@ -303,6 +305,7 @@ describe('trails warden', () => {
     const parsed = wardenTrail.output.safeParse({
       diagnostics: [
         {
+          code: 'no-throw-in-implementation',
           filePath: 'src/trails/entity.ts',
           fix: {
             class: 'term-rewrite',
@@ -358,6 +361,7 @@ describe('trails warden', () => {
     expect(raw.stdout).toContain('Usage: warden [options]');
     expect(raw.stdout).toContain('--depth <value>');
     expect(raw.stdout).toContain('--fix');
+    expect(raw.stdout).toContain('--adapter-check');
     expect(raw.stdout).not.toContain('Warden Report');
   });
 

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -3,6 +3,7 @@ import { topo } from '@ontrails/core';
 import * as addSurface from './trails/add-surface.js';
 import * as addTrail from './trails/add-trail.js';
 import * as addVerify from './trails/add-verify.js';
+import * as adapterCheck from './trails/adapter-check.js';
 import * as compile from './trails/compile.js';
 import * as completions from './trails/completions.js';
 import * as completionsComplete from './trails/completions-complete.js';
@@ -48,6 +49,7 @@ export const app = topo(
   devReset,
   guide,
   draftPromote,
+  adapterCheck,
   warden,
   wardenGuide,
   create,

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -23,6 +23,10 @@ import { app } from './app.js';
 import { resolveInputWithClack } from './clack.js';
 import { getRetiredTopoCommandDiagnostic } from './retired-topo-command.js';
 import { attachCompletionsInstallCommand } from './run-completions-install.js';
+import {
+  applyAdapterCheckExitCode,
+  tryAdapterCheckOutput,
+} from './run-adapter-check.js';
 import { tryRecoverFromRunCollision } from './run-collision.js';
 import { tryExampleRunOutput } from './run-example.js';
 import { tryExamplesRunOutput } from './run-examples.js';
@@ -65,6 +69,7 @@ const buildOnResult =
     // envelope on stdout that includes the captured records under
     // `tracing`. Hand that case off before the regular chain so the
     // existing handlers do not also write to stdout.
+    applyAdapterCheckExitCode(resolvedCtx);
     if (session !== undefined && tryTraceJsonOutput(resolvedCtx, session)) {
       return;
     }
@@ -79,6 +84,9 @@ const buildOnResult =
       return;
     }
     if (tryWardenOutput(resolvedCtx)) {
+      return;
+    }
+    if (tryAdapterCheckOutput(resolvedCtx)) {
       return;
     }
     await defaultOnResult(resolvedCtx);

--- a/apps/trails/src/run-adapter-check.ts
+++ b/apps/trails/src/run-adapter-check.ts
@@ -1,0 +1,76 @@
+import type { ActionResultContext } from '@ontrails/cli';
+import { deriveOutputMode } from '@ontrails/cli';
+
+interface AdapterCheckResultValue {
+  readonly formatted: string;
+  readonly passed: boolean;
+}
+
+const isAdapterCheckResultValue = (
+  value: unknown
+): value is AdapterCheckResultValue => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate['formatted'] === 'string' &&
+    typeof candidate['passed'] === 'boolean'
+  );
+};
+
+const wantsStructuredOutput = (ctx: ActionResultContext): boolean =>
+  deriveOutputMode(ctx.flags, ctx.topoName).mode !== 'text';
+
+const isAdapterCheckTrail = (ctx: ActionResultContext): boolean =>
+  ctx.trail.id === 'adapter.check';
+
+const readAdapterCheckResultValue = (
+  ctx: ActionResultContext
+): AdapterCheckResultValue | undefined => {
+  if (!isAdapterCheckTrail(ctx) || ctx.result.isErr()) {
+    return undefined;
+  }
+
+  return isAdapterCheckResultValue(ctx.result.value)
+    ? ctx.result.value
+    : undefined;
+};
+
+export const applyAdapterCheckExitCode = (
+  ctx: ActionResultContext
+): boolean => {
+  if (!isAdapterCheckTrail(ctx)) {
+    return false;
+  }
+
+  if (ctx.result.isErr()) {
+    process.exitCode = 1;
+    return true;
+  }
+
+  const value = readAdapterCheckResultValue(ctx);
+  if (!value) {
+    return false;
+  }
+
+  process.exitCode = value.passed ? 0 : 1;
+  return true;
+};
+
+export const tryAdapterCheckOutput = (ctx: ActionResultContext): boolean => {
+  const value = readAdapterCheckResultValue(ctx);
+  if (!value) {
+    return false;
+  }
+
+  applyAdapterCheckExitCode(ctx);
+  if (wantsStructuredOutput(ctx)) {
+    return false;
+  }
+
+  if (value.formatted.length > 0) {
+    process.stdout.write(`${value.formatted}\n`);
+  }
+  return true;
+};

--- a/apps/trails/src/trails/adapter-check.ts
+++ b/apps/trails/src/trails/adapter-check.ts
@@ -1,0 +1,237 @@
+/**
+ * `adapter.check` trail -- Local adapter authoring readiness checks.
+ */
+
+import { adapterTargetPlacements, checkAdapters } from '@ontrails/adapter-kit';
+import type { AdapterCheckReport } from '@ontrails/adapter-kit';
+import { isPlainObject, Result, trail, ValidationError } from '@ontrails/core';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { z } from 'zod';
+
+import { resolveTrailRootDir } from './root-dir.js';
+
+const adapterCheckInputSchema = z.object({
+  rootDir: z.string().optional().describe('Root directory to scan'),
+});
+
+const adapterPlacementSchema = z.enum(adapterTargetPlacements);
+
+const adapterCheckDiagnosticSchema = z.object({
+  code: z.string().describe('Stable adapter diagnostic code'),
+  message: z.string(),
+  packageJsonPath: z.string(),
+  packageName: z.string().optional(),
+  placement: adapterPlacementSchema.optional(),
+  severity: z.enum(['error', 'warn']),
+  target: z.string().optional(),
+});
+
+const adapterCheckSubjectSchema = z.object({
+  conformanceTestPaths: z.array(z.string()).readonly(),
+  key: z.string(),
+  ownerPackage: z.string(),
+  packageJsonPath: z.string(),
+  packageName: z.string(),
+  packageRoot: z.string(),
+  placement: adapterPlacementSchema,
+  target: z.string(),
+  targetKey: z.string(),
+  testingImport: z.string().optional(),
+});
+
+const adapterTargetSchema = z.object({
+  key: z.string(),
+  ownerPackage: z.string(),
+  packageJsonPath: z.string(),
+  packageRoot: z.string(),
+  placements: z.array(adapterPlacementSchema).readonly(),
+  supportExportTarget: z.string().optional(),
+  supportImport: z.string().optional(),
+  target: z.string(),
+  testingExportTarget: z.string().optional(),
+  testingImport: z.string().optional(),
+});
+
+const adapterCheckOutputSchema = z.object({
+  diagnostics: z.array(adapterCheckDiagnosticSchema).readonly(),
+  formatted: z.string(),
+  passed: z.boolean(),
+  subjects: z.array(adapterCheckSubjectSchema).readonly(),
+  targets: z.array(adapterTargetSchema).readonly(),
+});
+
+const relativeToRoot = (rootDir: string, path: string): string => {
+  const normalized = relative(rootDir, path).replaceAll('\\', '/');
+  return normalized.length === 0 || normalized.startsWith('..')
+    ? path
+    : normalized;
+};
+
+const workspacePatternsFromManifest = (
+  manifest: Readonly<Record<string, unknown>>
+): readonly string[] => {
+  const { workspaces } = manifest;
+  if (Array.isArray(workspaces)) {
+    return workspaces.filter(
+      (pattern): pattern is string => typeof pattern === 'string'
+    );
+  }
+
+  const packages = isPlainObject(workspaces)
+    ? workspaces['packages']
+    : undefined;
+  return Array.isArray(packages)
+    ? packages.filter(
+        (pattern): pattern is string => typeof pattern === 'string'
+      )
+    : [];
+};
+
+const readWorkspaceManifest = (
+  packageJsonPath: string
+): Result<Readonly<Record<string, unknown>>, ValidationError> => {
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    return isPlainObject(parsed)
+      ? Result.ok(parsed)
+      : Result.err(
+          new ValidationError(
+            `adapter.check root package.json must contain a JSON object: "${packageJsonPath}"`
+          )
+        );
+  } catch (error) {
+    return Result.err(
+      new ValidationError(
+        `adapter.check could not read root package.json: "${packageJsonPath}"`,
+        error instanceof Error ? { cause: error } : undefined
+      )
+    );
+  }
+};
+
+const validateAdapterCheckRoot = (
+  rootDir: string
+): Result<void, ValidationError> => {
+  if (!existsSync(rootDir)) {
+    return Result.err(
+      new ValidationError(`adapter.check rootDir does not exist: "${rootDir}"`)
+    );
+  }
+
+  if (!statSync(rootDir).isDirectory()) {
+    return Result.err(
+      new ValidationError(
+        `adapter.check rootDir must be a directory: "${rootDir}"`
+      )
+    );
+  }
+
+  const packageJsonPath = join(rootDir, 'package.json');
+  if (!existsSync(packageJsonPath)) {
+    return Result.err(
+      new ValidationError(
+        `adapter.check rootDir must contain a package.json workspace manifest: "${packageJsonPath}"`
+      )
+    );
+  }
+
+  const manifest = readWorkspaceManifest(packageJsonPath);
+  if (manifest.isErr()) {
+    return Result.err(manifest.error);
+  }
+
+  if (workspacePatternsFromManifest(manifest.value).length === 0) {
+    return Result.err(
+      new ValidationError(
+        `adapter.check root package.json must declare workspace packages: "${packageJsonPath}"`
+      )
+    );
+  }
+
+  return Result.ok();
+};
+
+export const formatAdapterCheckReport = (
+  report: AdapterCheckReport,
+  rootDir: string
+): string => {
+  const passed = report.diagnostics.length === 0;
+  const lines = [
+    '## Adapter Check Report',
+    '',
+    `Result: ${passed ? 'PASS' : 'FAIL'}`,
+    `Targets: ${report.targets.length}`,
+    `Adapters: ${report.subjects.length}`,
+    `Diagnostics: ${report.diagnostics.length}`,
+  ];
+
+  if (report.targets.length > 0) {
+    lines.push('', '### Targets');
+    for (const target of report.targets) {
+      lines.push(
+        `- ${target.key} (${target.placements.join(', ')}) from ${relativeToRoot(rootDir, target.packageJsonPath)}`
+      );
+    }
+  }
+
+  if (report.subjects.length > 0) {
+    lines.push('', '### Adapters');
+    for (const subject of report.subjects) {
+      const conformance =
+        subject.conformanceTestPaths.length === 0
+          ? 'no conformance tests'
+          : `${subject.conformanceTestPaths.length} conformance test(s)`;
+      lines.push(
+        `- ${subject.packageName} -> ${subject.targetKey} (${subject.placement}, ${conformance})`
+      );
+    }
+  }
+
+  if (report.diagnostics.length > 0) {
+    lines.push('', '### Diagnostics');
+    for (const diagnostic of report.diagnostics) {
+      lines.push(
+        `- ${diagnostic.severity.toUpperCase()} ${diagnostic.code} ${relativeToRoot(rootDir, diagnostic.packageJsonPath)}: ${diagnostic.message}`
+      );
+    }
+  }
+
+  return lines.join('\n');
+};
+
+export const adapterCheckTrail = trail('adapter.check', {
+  blaze: (input, ctx) => {
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return rootDirResult;
+    }
+
+    const rootDir = rootDirResult.value;
+    const validRoot = validateAdapterCheckRoot(rootDir);
+    if (validRoot.isErr()) {
+      return validRoot;
+    }
+
+    const report = checkAdapters(rootDir);
+
+    return Result.ok({
+      diagnostics: [...report.diagnostics],
+      formatted: formatAdapterCheckReport(report, rootDir),
+      passed: report.diagnostics.length === 0,
+      subjects: [...report.subjects],
+      targets: [...report.targets],
+    });
+  },
+  description: 'Check adapter authoring readiness',
+  examples: [
+    {
+      input: {},
+      name: 'Check adapters in the current workspace',
+    },
+  ],
+  input: adapterCheckInputSchema,
+  intent: 'read',
+  output: adapterCheckOutputSchema,
+  permit: 'public',
+});

--- a/apps/trails/src/trails/warden.ts
+++ b/apps/trails/src/trails/warden.ts
@@ -23,6 +23,10 @@ import { resolveTrailRootDir } from './root-dir.js';
 // ---------------------------------------------------------------------------
 
 const wardenInputSchema = z.object({
+  adapterCheck: z
+    .boolean()
+    .default(false)
+    .describe('Run shared adapter authoring checks'),
   apps: z
     .array(z.string())
     .optional()
@@ -131,6 +135,7 @@ export const buildWardenCommandArgs = (
   }
   pushFlag(args, input.noLockMutation, '--no-lock-mutation');
   pushFlag(args, input.fix, '--fix');
+  pushFlag(args, input.adapterCheck, '--adapter-check');
   pushValue(args, '--config-path', input.configPath);
   pushApps(args, input.apps);
 

--- a/bun.lock
+++ b/bun.lock
@@ -77,6 +77,7 @@
       },
       "dependencies": {
         "@clack/prompts": "^1.1.0",
+        "@ontrails/adapter-kit": "workspace:^",
         "@ontrails/cli": "workspace:^",
         "@ontrails/commander": "workspace:^",
         "@ontrails/core": "workspace:^",
@@ -269,6 +270,7 @@
         "warden": "./bin/warden.ts",
       },
       "dependencies": {
+        "@ontrails/adapter-kit": "workspace:^",
         "@ontrails/cli": "workspace:^",
         "@ontrails/permits": "workspace:^",
         "@ontrails/store": "workspace:^",

--- a/docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md
+++ b/docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md
@@ -87,11 +87,11 @@ TRL-861 codifies this metadata shape: `placements` is required, while `supportIm
 
 ### The adapter kit consumes facts; it never owns adapter truth
 
-The adapter kit starts as private `@ontrails/adapter-kit`: it discovers owner targets, scaffolds extracted and subpath adapters, generates conformance tests, generates package/export skeletons, runs the shared check engine, and reports readiness. It does **not** define an `adapter()` primitive, own HTTP/store/permit/observe semantics, get imported by runtime adapters, or re-author package facts that `package.json` already states.
+The adapter kit starts as internal `@ontrails/adapter-kit`: it discovers owner targets, scaffolds extracted and subpath adapters, generates conformance tests, generates package/export skeletons, runs the shared check engine, and reports readiness. It does **not** define an `adapter()` primitive, own HTTP/store/permit/observe semantics, get imported by runtime adapters, or re-author package facts that `package.json` already states.
 
 Two structural rules keep it tooling and not truth:
 
-- **It starts private/internal — unpublished.** The CLI and Warden consume it; adapters never import it at runtime. Keeping it off the public surface is what makes "tooling, not truth" structural rather than aspirational.
+- **It starts internal, not author-facing.** The CLI and Warden consume it, so it must be publishable with those packages; runtime adapters never import it. Keeping it out of the adapter authoring surface is what makes "tooling, not truth" structural rather than aspirational.
 - **The no-import boundary is enforced, not documented.** A Warden rule asserts that runtime adapters do not import the tooling package, and that conformance cases resolve only from owner `/testing` exports — never re-defined in the tooling. This is owner-first authority, made a rule rather than a paragraph.
 
 ### Conformance is a thin call into an owner-owned dynamic factory
@@ -159,13 +159,13 @@ The user-facing commands are trails, so adapter authoring is queryable without a
 
 ### Risks
 
-- **The tooling drifts into owning adapter truth** (a primitive by stealth). Mitigation: the package stays private/unpublished, the Warden no-import rule, and the consume-not-own boundary as enforced doctrine.
+- **The tooling drifts into owning adapter truth** (a primitive by stealth). Mitigation: the package stays internal/tooling-owned, the Warden no-import rule, and the consume-not-own boundary as enforced doctrine.
 - **Conformance drifts** from the owner contract. Mitigation: generated tests are thin calls into the owner factory — cases are re-derived, never copied.
 - **Over-scoping.** Mitigation: tracer-first sequencing — prove the whole loop on one owner before fanning out.
 
 ## Non-decisions
 
-- Whether the adapter kit ever becomes public; the current package stays private.
+- Whether the adapter kit ever becomes author-facing; the current package stays internal.
 - Exact command flags.
 - How Warden scopes to a single adapter — build the shared engine first, then expose a scope without a second rule path.
 

--- a/packages/adapter-kit/package.json
+++ b/packages/adapter-kit/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@ontrails/adapter-kit",
   "version": "1.0.0-beta.18",
-  "private": true,
   "description": "Internal adapter authoring kit for Trails metadata, scaffolding, and checks.",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/adapter-kit/src/catalog.ts
+++ b/packages/adapter-kit/src/catalog.ts
@@ -3,7 +3,7 @@
  *
  * Owner packages author the few adapter facts package metadata cannot derive.
  * Tooling consumes those facts; runtime adapters must never import this
- * private package.
+ * internal tooling package.
  */
 
 import {

--- a/packages/warden/bin/warden.ts
+++ b/packages/warden/bin/warden.ts
@@ -14,6 +14,7 @@ Options:
   --config-path <path>         Path to trails.config.* file
   --root-dir <path>            Project root to inspect
   --fix                        Apply safe source fixes
+  --adapter-check              Include shared adapter authoring diagnostics
   --depth <value>              source, project, topo, or all
   --fail-on <value>            error or warning
   --format <value>             summary, github, or json

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -28,6 +28,7 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
+    "@ontrails/adapter-kit": "workspace:^",
     "@ontrails/cli": "workspace:^",
     "@ontrails/permits": "workspace:^",
     "@ontrails/store": "workspace:^",

--- a/packages/warden/src/__tests__/adapter-check.test.ts
+++ b/packages/warden/src/__tests__/adapter-check.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { runWardenAdapterChecks } from '../adapter-check.js';
+import { parseWardenCommandArgs, runWardenCommand } from '../command.js';
+
+const roots: string[] = [];
+
+const writeFile = (root: string, path: string, value: string): void => {
+  const filePath = join(root, path);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value);
+};
+
+const writeJson = (
+  root: string,
+  path: string,
+  value: Record<string, unknown>
+): void => {
+  writeFile(root, path, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const makeRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'warden-adapter-check-'));
+  roots.push(root);
+  writeJson(root, 'package.json', {
+    name: 'fixture-root',
+    workspaces: ['packages/*', 'adapters/*'],
+  });
+  return root;
+};
+
+const writePackage = (
+  root: string,
+  workspacePath: string,
+  manifest: Record<string, unknown>
+): void => {
+  writeJson(root, join(workspacePath, 'package.json'), manifest);
+};
+
+const writeHttpOwner = (root: string): void => {
+  writePackage(root, 'packages/http', {
+    exports: {
+      '.': './src/index.ts',
+      './package.json': './package.json',
+      './testing': './src/testing.ts',
+    },
+    name: '@ontrails/http',
+    trails: {
+      adapterTargets: {
+        http: {
+          placements: ['extracted'],
+          testingImport: '@ontrails/http/testing',
+        },
+      },
+    },
+  });
+  writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
+};
+
+const writeHonoAdapter = (root: string): void => {
+  writePackage(root, 'adapters/hono', {
+    exports: {
+      '.': './src/index.ts',
+      './package.json': './package.json',
+    },
+    name: '@ontrails/hono',
+    peerDependencies: {
+      '@ontrails/http': 'workspace:^',
+    },
+    trails: {
+      adapter: true,
+    },
+  });
+  writeFile(
+    root,
+    'adapters/hono/src/index.ts',
+    'export const honoAdapter = {};\n'
+  );
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe('Warden adapter checks', () => {
+  test('maps shared adapter diagnostics into Warden diagnostics', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+
+    const diagnostics = runWardenAdapterChecks(root);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      code: 'invalid-adapter-metadata',
+      rule: 'adapter-check',
+      severity: 'warn',
+    });
+    expect(diagnostics[0]?.message).toContain('trails.adapter as an object');
+  });
+
+  test('rejects missing roots before reporting a clean adapter scan', () => {
+    const root = makeRoot();
+    const missingRoot = join(root, 'missing-root');
+
+    const diagnostics = runWardenAdapterChecks(missingRoot);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      code: 'adapter-check-root',
+      filePath: missingRoot,
+      rule: 'adapter-check',
+      severity: 'error',
+    });
+    expect(diagnostics[0]?.message).toContain('rootDir does not exist');
+  });
+
+  test('threads --adapter-check into the command runner as warnings', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+
+    const parsed = parseWardenCommandArgs(['--adapter-check']);
+    expect(parsed.adapterCheck).toBe(true);
+
+    const result = await runWardenCommand({
+      args: [
+        '--adapter-check',
+        '--depth',
+        'source',
+        '--lock',
+        'skip',
+        '--format',
+        'json',
+      ],
+      cwd: root,
+      env: {},
+    });
+    const output = JSON.parse(result.output) as {
+      readonly diagnostics: readonly {
+        readonly code?: string | undefined;
+        readonly rule: string;
+        readonly severity: 'error' | 'warn';
+      }[];
+      readonly summary: {
+        readonly errors: number;
+        readonly warnings: number;
+      };
+    };
+
+    expect(result.exitCode).toBe(0);
+    expect(output.summary).toMatchObject({ errors: 0, warnings: 1 });
+    expect(output.diagnostics[0]).toMatchObject({
+      code: 'invalid-adapter-metadata',
+      rule: 'adapter-check',
+      severity: 'warn',
+    });
+  });
+
+  test('threads missing adapter-check roots into the command runner as errors', async () => {
+    const root = makeRoot();
+    const missingRoot = join(root, 'missing-root');
+
+    const result = await runWardenCommand({
+      args: [
+        '--adapter-check',
+        '--root-dir',
+        missingRoot,
+        '--depth',
+        'source',
+        '--lock',
+        'skip',
+        '--format',
+        'json',
+      ],
+      cwd: root,
+      env: {},
+    });
+    const output = JSON.parse(result.output) as {
+      readonly diagnostics: readonly {
+        readonly code?: string | undefined;
+        readonly message: string;
+        readonly rule: string;
+        readonly severity: 'error' | 'warn';
+      }[];
+      readonly summary: {
+        readonly errors: number;
+        readonly warnings: number;
+      };
+    };
+
+    expect(result.exitCode).toBe(1);
+    expect(output.summary).toMatchObject({ errors: 1, warnings: 0 });
+    expect(output.diagnostics[0]).toMatchObject({
+      code: 'adapter-check-root',
+      rule: 'adapter-check',
+      severity: 'error',
+    });
+    expect(output.diagnostics[0]?.message).toContain('rootDir does not exist');
+  });
+
+  test('--strict can fail the opt-in adapter warnings', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+
+    const result = await runWardenCommand({
+      args: [
+        '--adapter-check',
+        '--depth',
+        'source',
+        '--lock',
+        'skip',
+        '--strict',
+      ],
+      cwd: root,
+      env: {},
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.report.diagnostics[0]).toMatchObject({
+      code: 'invalid-adapter-metadata',
+      rule: 'adapter-check',
+      severity: 'warn',
+    });
+  });
+});

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -57,6 +57,42 @@ const makeTempDir = (): string => {
   return dir;
 };
 
+const writeAdapterCheckFixture = (rootDir: string): void => {
+  writeFileSync(
+    join(rootDir, 'package.json'),
+    JSON.stringify(
+      {
+        name: 'fixture-root',
+        workspaces: ['adapters/*'],
+      },
+      null,
+      2
+    )
+  );
+  mkdirSync(join(rootDir, 'adapters/hono/src'), { recursive: true });
+  writeFileSync(
+    join(rootDir, 'adapters/hono/package.json'),
+    JSON.stringify(
+      {
+        exports: {
+          '.': './src/index.ts',
+          './package.json': './package.json',
+        },
+        name: '@ontrails/hono',
+        trails: {
+          adapter: true,
+        },
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(
+    join(rootDir, 'adapters/hono/src/index.ts'),
+    'export const honoAdapter = {};\n'
+  );
+};
+
 const writeManifest = (rootDir: string, hash: string): Promise<string> =>
   writeLockManifest(
     {
@@ -559,6 +595,32 @@ export const second = contour('second', {
       expect(rules.has('prefer-schema-inference')).toBe(true);
       expect(rules.has('no-throw-in-implementation')).toBe(false);
       expect(report.drift).toBeNull();
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('advisory tier runs adapter checks only when opted in', async () => {
+    const dir = makeTempDir();
+    try {
+      writeAdapterCheckFixture(dir);
+
+      const advisoryOnly = await runWarden({
+        rootDir: dir,
+        tier: 'advisory',
+      });
+      const optedIn = await runWarden({
+        adapterCheck: true,
+        rootDir: dir,
+        tier: 'advisory',
+      });
+
+      expect(advisoryOnly.diagnostics.map((entry) => entry.rule)).not.toContain(
+        'adapter-check'
+      );
+      expect(optedIn.diagnostics.map((entry) => entry.rule)).toContain(
+        'adapter-check'
+      );
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/warden/src/__tests__/public-api.test.ts
+++ b/packages/warden/src/__tests__/public-api.test.ts
@@ -23,6 +23,8 @@ describe('@ontrails/warden public API', () => {
     );
     expect(warden.wardenRuleTiers).toContain('source-static');
     expect(warden.listWardenRuleMetadata().length).toBeGreaterThan(0);
+    expect(warden.adapterCheckRuleName).toBe('adapter-check');
+    expect(typeof warden.runWardenAdapterChecks).toBe('function');
   });
 
   test('exports the composable Warden config schema from the root entrypoint', () => {

--- a/packages/warden/src/adapter-check.ts
+++ b/packages/warden/src/adapter-check.ts
@@ -1,0 +1,136 @@
+/**
+ * Warden projection for shared adapter readiness checks.
+ *
+ * Adapter facts stay in @ontrails/adapter-kit. Warden only maps those facts
+ * into governance diagnostics and severity.
+ */
+
+import { checkAdapters } from '@ontrails/adapter-kit';
+import type { AdapterCheckDiagnostic } from '@ontrails/adapter-kit';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { WardenDiagnostic } from './rules/types.js';
+
+export const adapterCheckRuleName = 'adapter-check';
+const adapterCheckRootCode = 'adapter-check-root';
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const toWardenDiagnostic = (
+  diagnostic: AdapterCheckDiagnostic
+): WardenDiagnostic => ({
+  code: diagnostic.code,
+  filePath: diagnostic.packageJsonPath,
+  line: 1,
+  message: diagnostic.message,
+  rule: adapterCheckRuleName,
+  severity: 'warn',
+});
+
+const toRootDiagnostic = (
+  message: string,
+  filePath: string
+): WardenDiagnostic => ({
+  code: adapterCheckRootCode,
+  filePath,
+  line: 1,
+  message,
+  rule: adapterCheckRuleName,
+  severity: 'error',
+});
+
+const workspacePatternsFromManifest = (
+  manifest: Readonly<Record<string, unknown>>
+): readonly string[] => {
+  const { workspaces } = manifest;
+  if (Array.isArray(workspaces)) {
+    return workspaces.filter(
+      (pattern): pattern is string => typeof pattern === 'string'
+    );
+  }
+
+  const packages = isRecord(workspaces) ? workspaces['packages'] : undefined;
+  return Array.isArray(packages)
+    ? packages.filter(
+        (pattern): pattern is string => typeof pattern === 'string'
+      )
+    : [];
+};
+
+const validateAdapterCheckRoot = (
+  rootDir: string
+): readonly WardenDiagnostic[] => {
+  if (!existsSync(rootDir)) {
+    return [
+      toRootDiagnostic(
+        `adapter.check rootDir does not exist: "${rootDir}"`,
+        rootDir
+      ),
+    ];
+  }
+
+  if (!statSync(rootDir).isDirectory()) {
+    return [
+      toRootDiagnostic(
+        `adapter.check rootDir must be a directory: "${rootDir}"`,
+        rootDir
+      ),
+    ];
+  }
+
+  const packageJsonPath = join(rootDir, 'package.json');
+  if (!existsSync(packageJsonPath)) {
+    return [
+      toRootDiagnostic(
+        `adapter.check rootDir must contain a package.json workspace manifest: "${packageJsonPath}"`,
+        packageJsonPath
+      ),
+    ];
+  }
+
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  } catch (error) {
+    const reason = error instanceof Error ? `: ${error.message}` : '';
+    return [
+      toRootDiagnostic(
+        `adapter.check could not read root package.json: "${packageJsonPath}"${reason}`,
+        packageJsonPath
+      ),
+    ];
+  }
+
+  if (!isRecord(manifest)) {
+    return [
+      toRootDiagnostic(
+        `adapter.check root package.json must contain a JSON object: "${packageJsonPath}"`,
+        packageJsonPath
+      ),
+    ];
+  }
+
+  if (workspacePatternsFromManifest(manifest).length === 0) {
+    return [
+      toRootDiagnostic(
+        `adapter.check root package.json must declare workspace packages: "${packageJsonPath}"`,
+        packageJsonPath
+      ),
+    ];
+  }
+
+  return [];
+};
+
+export const runWardenAdapterChecks = (
+  rootDir: string
+): readonly WardenDiagnostic[] => {
+  const rootDiagnostics = validateAdapterCheckRoot(rootDir);
+  if (rootDiagnostics.length > 0) {
+    return rootDiagnostics;
+  }
+
+  return checkAdapters(rootDir).diagnostics.map(toWardenDiagnostic);
+};

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -21,6 +21,7 @@ import type {
   WardenFormat,
   WardenLockMode,
 } from './config.js';
+import { runWardenAdapterChecks } from './adapter-check.js';
 import { resolveWardenConfig } from './config.js';
 import { isDraftMarkedFile } from './draft.js';
 import { applySafeFixesToSource, hasSafeFixEdits } from './fix.js';
@@ -80,6 +81,8 @@ export interface WardenRunOptions {
   readonly config?: WardenConfigInput | undefined;
   /** CLI/config-layer app names carried through shared resolution. */
   readonly apps?: readonly string[] | undefined;
+  /** Include shared adapter authoring checks as Warden diagnostics. */
+  readonly adapterCheck?: boolean | undefined;
   /** Cumulative analysis depth for the final M1 surfaces. */
   readonly depth?: WardenDepth | undefined;
   /** Draft-state handling mode for final M1 surfaces. */
@@ -1268,6 +1271,12 @@ const checkDriftForTopoTargets = async (
 const shouldRunLint = (options: WardenRunOptions): boolean =>
   options.tier ? options.tier !== 'drift' : !options.driftOnly;
 
+const adapterDiagnosticsForRun = (
+  rootDir: string,
+  options: WardenRunOptions
+): readonly WardenDiagnostic[] =>
+  options.adapterCheck ? runWardenAdapterChecks(rootDir) : [];
+
 const shouldRunDrift = (
   options: WardenRunOptions,
   effectiveConfig: EffectiveWardenConfig
@@ -1448,11 +1457,13 @@ export const runWarden = async (
         selector
       )
     : { diagnostics: [], sourceFiles: [] };
+  const adapterDiagnostics = adapterDiagnosticsForRun(rootDir, options);
 
   const rawDiagnostics = [
     ...configDiagnostics,
     ...optionDiagnostics,
     ...lintResult.diagnostics,
+    ...adapterDiagnostics,
   ];
   const allDiagnostics = rawDiagnostics.map(withDiagnosticGuidance);
   const fixApplication = options.fix

--- a/packages/warden/src/command.ts
+++ b/packages/warden/src/command.ts
@@ -128,6 +128,7 @@ const readEnumValue = <T extends string>({
 };
 
 export interface ParsedWardenCommand {
+  readonly adapterCheck: boolean;
   readonly ci: boolean;
   readonly cli: WardenConfigLayer;
   readonly configPath?: string | undefined;
@@ -138,6 +139,7 @@ export interface ParsedWardenCommand {
 }
 
 const createEmptyParsedCommand = (message: string): ParsedWardenCommand => ({
+  adapterCheck: false,
   ci: false,
   cli: {},
   diagnostics: [diagnostic({ message })],
@@ -151,6 +153,7 @@ const tokenValue = (token: {
   typeof token.value === 'string' ? token.value : undefined;
 
 interface CommandParserState {
+  adapterCheck?: boolean | undefined;
   readonly apps: string[];
   readonly diagnostics: WardenDiagnostic[];
   readonly cli: MutableWardenConfigLayer;
@@ -235,6 +238,7 @@ const parseTokens = (
       allowPositionals: false,
       args: [...args],
       options: {
+        'adapter-check': { type: 'boolean' },
         apps: { multiple: true, short: 'a', type: 'string' },
         ci: { type: 'boolean' },
         'config-path': { type: 'string' },
@@ -388,6 +392,10 @@ const applyCommandOption = (
     state.apps.push(...splitApps(value));
     return;
   }
+  if (token.name === 'adapter-check') {
+    state.adapterCheck = true;
+    return;
+  }
   if (token.name === 'config-path') {
     state.configPath = value;
     return;
@@ -445,6 +453,7 @@ export const parseWardenCommandArgs = (
   }
 
   return {
+    adapterCheck: state.adapterCheck ?? false,
     ci,
     cli: cleanUndefined(
       state.cli as Record<string, unknown>
@@ -797,6 +806,7 @@ const effectiveConfigNeedsTopo = (depth: WardenDepth): boolean =>
   depth === 'topo' || depth === 'all';
 
 const buildRunOptions = ({
+  adapterCheck,
   cli,
   config,
   env,
@@ -804,6 +814,7 @@ const buildRunOptions = ({
   rootDir,
   topos,
 }: {
+  readonly adapterCheck: boolean;
   readonly cli: WardenConfigLayer;
   readonly config?: WardenConfigInput | undefined;
   readonly env: EnvRecord;
@@ -812,6 +823,7 @@ const buildRunOptions = ({
   readonly topos: readonly WardenTopoTarget[];
 }): WardenRunOptions => ({
   ...cleanUndefined({
+    adapterCheck,
     apps: cli.apps,
     config,
     depth: cli.depth,
@@ -916,6 +928,7 @@ export const runWardenCommand = async ({
     : { diagnostics: [], topos: [] };
   const report = await runWarden(
     buildRunOptions({
+      adapterCheck: parsed.adapterCheck,
       cli: parsed.cli,
       config: loadedConfig.config,
       env,

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -58,6 +58,12 @@ export type {
 } from './cli.js';
 export { formatWardenReport, runWarden } from './cli.js';
 
+// Adapter authoring checks
+export {
+  adapterCheckRuleName,
+  runWardenAdapterChecks,
+} from './adapter-check.js';
+
 // CLI command surface
 export type {
   ParsedWardenCommand,

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -194,6 +194,8 @@ export interface WardenRuleMetadata {
 export interface WardenDiagnostic {
   /** Rule identifier, e.g. "no-throw-in-implementation" */
   readonly rule: string;
+  /** Optional rule-local diagnostic code for checks with multiple stable findings. */
+  readonly code?: string | undefined;
   /** Severity level */
   readonly severity: WardenSeverity;
   /** Human-readable message describing the violation */

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -42,6 +42,7 @@ export const fixSchema = z.object({
 
 /** A single diagnostic emitted by a warden rule trail. */
 export const diagnosticSchema = z.object({
+  code: z.string().optional().describe('Optional rule-local diagnostic code'),
   filePath: z.string().describe('File path that was analyzed'),
   fix: fixSchema.optional().describe('Structured fix metadata'),
   guidance: guidanceSchema


### PR DESCRIPTION
## Context

Seventh branch in the V1 convergence stack (#634-#641). This exposes the shared adapter check engine through Warden and the local Trails CLI.

## Changes

- Adds Warden's opt-in `--adapter-check` projection.
- Adds local `adapter.check`, surfaced as `trails adapter check`.
- Adds an optional Warden diagnostic `code` field for adapter-check diagnostic categories.
- Makes `@ontrails/adapter-tools` publishable-but-internal so public packages can depend on it safely.
- Adds changesets for adapter-tools, Trails, and Warden.

## Verification

- `bun test packages/warden/src/__tests__/adapter-check.test.ts packages/warden/src/__tests__/command.test.ts packages/warden/src/__tests__/public-api.test.ts`
- `bun test apps/trails/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/warden.test.ts`
- Restacked focused regression set across adapter-tools, HTTP, Hono, Warden, and Trails.
- `bun packages/warden/bin/warden.ts --adapter-check --depth source --lock skip --format json`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run docs:wrap-check`
- `bun run changeset:check`
- `bun run publish:check`

## Risks

- Adapter diagnostics remain warnings by default; making them hard gates should wait until first-party adapter metadata debt is handled.

Closes TRL-864
