### PR TITLE
feat(trails): scaffold adapters from catalog facts

### DIFF
--- a/.agents/plans/2026-05-30-v1-convergence-loop/GOAL.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/GOAL.md
@@ -29,6 +29,16 @@ Stack:
 12. TRL-826 - Package-source modes only if this stack proves the need.
 13. TRL-829 - Regrade ADR after evidence, not before.
 
+Follow-ups created from TRL-805 review, not active branches before TRL-836:
+
+- TRL-870 - Discover subpath adapter subjects before subpath scaffolds.
+- TRL-872 - Migrate Commander/Drizzle/Vite into the adapter.check model.
+
+Review issues fixed inside TRL-805:
+
+- TRL-873 - Harden conformance checks against non-executed helper mentions.
+- TRL-874 - Validate conformance metadata against exported helper names.
+
 Rules:
 
 - Use Graphite for source-control writes. No vanilla Git commits/pushes.

--- a/.agents/plans/2026-05-30-v1-convergence-loop/PLAN.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/PLAN.md
@@ -1,6 +1,6 @@
 ---
 created: "2026-05-30T12:28:00Z"
-updated: "2026-05-30T12:28:00Z"
+updated: "2026-05-30T16:55:00Z"
 status: active
 owner: Lewis
 linear:
@@ -17,6 +17,12 @@ linear:
   - TRL-850
   - TRL-826
   - TRL-829
+follow_up:
+  - TRL-870
+  - TRL-872
+review_fix:
+  - TRL-873
+  - TRL-874
 ---
 
 # V1 Convergence Loop
@@ -67,9 +73,29 @@ Do not submit the zero-diff lane branch unless we intentionally add work to it.
 | 12 | TRL-826 | `trl-826-prove-regrade-package-source-modes` | Conditional: package-source modes only if this stack proves the need. |
 | 13 | TRL-829 | `trl-829-draft-regrade-adr-from-tracer-evidence` | Conditional: Regrade ADR after evidence, not before. |
 
-The bottom ten are expected. TRL-850, TRL-826, and TRL-829 are conditional:
-keep them in scope only if live verification says they are still justified;
-otherwise update Linear and defer with a clear note.
+The bottom nine through TRL-836 are expected. TRL-850, TRL-826, and TRL-829
+are conditional: keep them in scope only if live verification says they are
+still justified; otherwise update Linear and defer with a clear note.
+
+## Follow-Up Issues Created From TRL-805 Review
+
+These are part of the larger v1 convergence goal, but they are not active
+branches in this stack before TRL-836:
+
+- TRL-870 discovers subpath adapter subjects in shared checks before any
+  `create.adapter` subpath scaffold ships.
+- TRL-872 migrates Commander, Drizzle, and Vite into the opt-in
+  `adapter.check` metadata model.
+
+## Review Issues Fixed Inside TRL-805
+
+These issues were discovered during the PR #643 local review loop and fixed on
+the owning TRL-805 branch:
+
+- TRL-873 hardens adapter conformance checks against commented-out, string, or
+  non-thin helper call mentions.
+- TRL-874 validates conformance metadata against exported helper names instead
+  of local alias names.
 
 ## Non-Goals
 

--- a/.agents/plans/2026-05-30-v1-convergence-loop/REFS.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/REFS.md
@@ -23,6 +23,8 @@
 | TRL-864 | [Linear](https://linear.app/outfitter/issue/TRL-864/expose-adapter-checks-through-warden-and-trails-adapter-check) | Created for this goal; Warden/local projections. |
 | TRL-865 | [Linear](https://linear.app/outfitter/issue/TRL-865/dogfood-adapter-authoring-path-on-a-first-party-http-adapter) | Created for this goal; first-party dogfood. |
 | TRL-805 | [Linear](https://linear.app/outfitter/issue/TRL-805/trails-create-adapter-scaffold-adapter-packages-against-the-adapter) | Retargeted from `add.adapter` to `create.adapter`. |
+| TRL-870 | [Linear](https://linear.app/outfitter/issue/TRL-870/discover-subpath-adapter-subjects-in-shared-adapter-checks) | Created from TRL-805 review; unlocks subpath adapter scaffolds later. |
+| TRL-872 | [Linear](https://linear.app/outfitter/issue/TRL-872/migrate-remaining-first-party-adapters-into-adaptercheck-model) | Created from TRL-805 review; migrates Commander/Drizzle/Vite into adapter metadata. |
 | TRL-836 | [Linear](https://linear.app/outfitter/issue/TRL-836/integrate-warden-backed-term-rewrite-regrades) | Regrade consumes Warden metadata. |
 | TRL-850 | [Linear](https://linear.app/outfitter/issue/TRL-850/regenerate-stale-adr-decision-map-and-enforce-consistency-in-pre-push) | Conditional ADR map drift/check work. |
 | TRL-826 | [Linear](https://linear.app/outfitter/issue/TRL-826/prove-regrade-package-source-modes) | Conditional package-source mode proof. |

--- a/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
@@ -1,6 +1,6 @@
 ---
 created: "2026-05-30T12:28:00Z"
-updated: "2026-05-30T17:45:00Z"
+updated: "2026-05-31T15:44:00Z"
 status: active
 ---
 
@@ -205,6 +205,42 @@ status: active
 - `trails adapter check --root-dir .` now reports one adapter subject and the
   expected remaining metadata debt for Commander, Drizzle, and Vite.
 
+### 2026-05-30 12:35 EDT - TRL-805 create.adapter slice
+
+- Started
+  `trl-805-trails-create-adapter-scaffold-adapter-packages-against-the` above
+  TRL-865 and marked TRL-805 In Progress.
+- Added `create.adapter`, projected as `trails create adapter`, for extracted
+  HTTP adapter scaffolds generated from live adapter target catalog and owner
+  conformance facts.
+- Kept TRL-870 as follow-up check coverage after review showed shared adapter
+  checks still need to discover subpath adapter subjects before subpath
+  scaffolds ship.
+- Created TRL-872 after the local `trails adapter check --root-dir .` smoke
+  showed Commander, Drizzle, and Vite should migrate into the metadata model as
+  their own follow-up rather than blocking `create.adapter`.
+- Tightened adapter conformance proof so shared checks require the owner
+  `testingImport` bindings for both the cases factory and runner, including
+  aliased imports. This fixed the Hono false negative where the import matcher
+  could accidentally span from a previous import.
+- Changed the local adapter check launch posture to opt-in: packages under
+  `adapters/*` are ignored until they declare `trails.adapter`, malformed
+  opt-in metadata still fails loudly, and Hono remains the first concrete
+  adapter subject.
+- Sidecar review findings folded in: Clark flagged stale subpath executable
+  shape and weak conformance proof; Zeno found the import matcher false
+  positive, the repo smoke failure from unannotated adapters, and the mismatch
+  between advertised and supported placements.
+- Noether review found P2 intent drift after PR #643 submission: the packet
+  treated TRL-870/TRL-872 like active branches, and the ADR did not separate
+  long-term governed drift from the opt-in launch posture. Fixed by updating
+  Linear, moving TRL-870/TRL-872 into follow-ups, and adding the ADR opt-in
+  note.
+- Schrodinger review found two P2 checker holes after PR #643 submission.
+  Created TRL-873 for non-executed conformance helper mentions and TRL-874 for
+  export-alias validation, then fixed both on the TRL-805 branch with
+  regression coverage.
+
 ### 2026-05-30 13:45 EDT - TRL-876 review fix on TRL-863
 
 - Codex review and a focused subagent sniff found that the TRL-863 adapter
@@ -227,6 +263,27 @@ status: active
   output path, not the human adapter report bridge, owns line-delimited output.
 - Updated Warden and Trails adapter-check fixtures to create the source file
   their package export maps claim exists after the stricter export-target check.
+
+### 2026-05-31 10:22 EDT - Post-submit P2 review loop
+
+- A fresh Codex review pass found four unresolved P2s after the prior submit:
+  record-backed HTTP conformance headers on #638, dynamic import evidence inside
+  object literal values on #639, owner packages in `optionalDependencies` on
+  #639, and ambient conformance helper exports on #643.
+- Fixed the #638 HTTP owner suite first, verified it locally, then amended
+  `trl-862-add-http-adapter-authoring-support-and-conformance-factory`.
+- Fixed the #639 adapter-kit scanner and dependency-boundary issues next,
+  verified them locally, then amended
+  `trl-863-build-shared-adapter-check-engine`.
+- Walked upward through #640 and #641 with package tests, lint, typecheck,
+  builds, ast-grep, vocab audit, and whitespace checks before touching #643.
+- Fixed the #643 catalog validation so `export declare` callable helpers are
+  rejected as non-runtime values, while declared/type-only adapter types remain
+  valid type exports.
+- A subsequent Codex pass found two more P2s: generic type-query imports in
+  `extends`/`implements` positions still counted as runtime evidence on #639,
+  and #643 rejected `runConformance(adapter)` even when the owner runner
+  defaulted to the declared cases factory. Fixed both and walked upward again.
 
 ## Verification Ledger
 
@@ -350,6 +407,128 @@ status: active
 | `bun run docs:wrap-check` | TRL-865 stack-tip final gate | pass | 159 scanned files clean. |
 | `bun run changeset:check` | TRL-865 stack-tip final gate | pass | Changeset gate passed for adapter-kit, Hono, HTTP, Store, Trails, and Warden. |
 | `bun run publish:check` | TRL-865 stack-tip final gate | pass | All public package pack checks passed. |
+| `bun test packages/adapter-kit/src/__tests__/catalog.test.ts packages/adapter-kit/src/__tests__/check.test.ts packages/adapter-kit/src/__tests__/dogfood.test.ts apps/trails/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/create-adapter.test.ts packages/warden/src/__tests__/adapter-check.test.ts packages/http/src/__tests__/testing.test.ts` | TRL-805 focused regression set | pass | 51 tests passed across catalog, shared checks, dogfood, CLI projection, Warden projection, create.adapter, and HTTP conformance. |
+| `bun apps/trails/bin/trails.ts create adapter --help` | TRL-805 CLI smoke | pass | Placement choices now advertise only `extracted`. |
+| `bun apps/trails/bin/trails.ts adapter check --root-dir .` | TRL-805 local adapter check smoke | pass | Reported 2 targets, 1 Hono adapter subject, and 0 diagnostics after unannotated adapters became out-of-scope until opt-in. |
+| `bun test packages/adapter-kit/src/__tests__/catalog.test.ts packages/adapter-kit/src/__tests__/check.test.ts packages/adapter-kit/src/__tests__/dogfood.test.ts apps/trails/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/create-adapter.test.ts packages/warden/src/__tests__/adapter-check.test.ts packages/http/src/__tests__/testing.test.ts` | TRL-805 review-thread follow-up | pass | 69 tests passed after adding star re-export, callable value-export, and duplicate package-name regressions. |
+| `bun run --cwd packages/adapter-kit typecheck` | TRL-805 review-thread follow-up | pass | Adapter-kit typecheck clean. |
+| `bun run --cwd apps/trails typecheck` | TRL-805 review-thread follow-up | pass | Trails app typecheck clean. |
+| `bun run --cwd packages/adapter-kit lint` | TRL-805 review-thread follow-up | pass | Adapter-kit Oxlint clean. |
+| `bun run --cwd apps/trails lint` | TRL-805 review-thread follow-up | pass | Trails app Oxlint clean. |
+| `bun run format:check` | TRL-805 review-thread follow-up | pass | Full Ultracite check clean. |
+| `git diff --check` | TRL-805 review-thread follow-up | pass | No whitespace findings. |
+| `bunx markdownlint-cli2 .agents/plans/2026-05-30-v1-convergence-loop/RETRO.md` | TRL-805 review-thread follow-up | pass | RETRO markdownlint clean. |
+| `bun test packages/warden/src/__tests__/adapter-check.test.ts packages/warden/src/__tests__/cli.test.ts apps/trails/src/__tests__/adapter-check.test.ts` | TRL-864 post-amend upward verification | pass | 56 tests passed after the env-output fix was amended and before moving up. |
+| `bun run --cwd apps/trails typecheck && bun run --cwd packages/warden typecheck` | TRL-864 post-amend upward verification | pass | Trails and Warden typechecks clean. |
+| `bun run --cwd apps/trails lint && bun run --cwd packages/warden lint` | TRL-864 post-amend upward verification | pass | Trails and Warden lints clean. |
+| `bun run --cwd apps/trails build && bun run --cwd packages/warden build` | TRL-864 post-amend upward verification | pass | Trails and Warden builds clean. |
+| `bun test packages/adapter-kit/src/__tests__/dogfood.test.ts adapters/hono/src/__tests__/conformance.test.ts apps/trails/src/__tests__/adapter-check.test.ts packages/warden/src/__tests__/adapter-check.test.ts` | TRL-865 post-restack upward verification | pass | 16 tests passed across dogfood, Hono conformance, Trails adapter check, and Warden adapter check. |
+| `bun run --cwd packages/adapter-kit typecheck && bun run --cwd adapters/hono typecheck && bun run --cwd apps/trails typecheck && bun run --cwd packages/warden typecheck` | TRL-865 post-restack upward verification | pass | Adapter-kit, Hono, Trails, and Warden typechecks clean. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd adapters/hono lint && bun run --cwd apps/trails lint && bun run --cwd packages/warden lint` | TRL-865 post-restack upward verification | pass | Adapter-kit, Hono, Trails, and Warden lints clean. |
+| `bun run --cwd packages/adapter-kit build && bun run --cwd adapters/hono build && bun run --cwd apps/trails build && bun run --cwd packages/warden build` | TRL-865 post-restack upward verification | pass | Adapter-kit, Hono, Trails, and Warden builds clean. |
+| `bun test packages/adapter-kit/src/__tests__/catalog.test.ts packages/adapter-kit/src/__tests__/check.test.ts packages/adapter-kit/src/__tests__/dogfood.test.ts apps/trails/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/create-adapter.test.ts packages/warden/src/__tests__/adapter-check.test.ts packages/http/src/__tests__/testing.test.ts adapters/hono/src/__tests__/conformance.test.ts` | TRL-805 post-restack top verification | pass | 77 tests passed across the cumulative adapter-kit, Trails, Warden, HTTP, and Hono surfaces. |
+| `bun apps/trails/bin/trails.ts create adapter --help && bun apps/trails/bin/trails.ts adapter check --root-dir .` | TRL-805 post-restack top verification | pass | Create-adapter help rendered and live adapter check passed with 2 targets, 1 adapter, 0 diagnostics. |
+| `bun run typecheck` | TRL-805 post-restack top verification | pass | 24 workspace typecheck tasks passed. |
+| `bun run lint` | TRL-805 post-restack top verification | pass | 25 workspace lint tasks passed. |
+| `bun run format:check` | TRL-805 post-restack top verification | pass | Ultracite checked 906 files clean. |
+| `bun run changeset:check` | TRL-805 post-restack top verification | pass | Changeset gate passed for adapter-kit, Hono, HTTP, Store, Trails, and Warden. |
+| `bun run build` | TRL-805 post-restack top verification | pass | 24 workspace build tasks passed. |
+| `bun run publish:check` | TRL-805 post-restack top verification | pass | All public package pack checks passed. |
+| `git diff --check` | TRL-805 post-restack top verification | pass | No whitespace findings. |
+| `bun test apps/trails/src/__tests__/create-adapter.test.ts` | TRL-805 workspace-pattern review follow-up | pass | 8 create-adapter tests passed after requiring extracted adapter writes to be covered by root workspaces. |
+| `bun run --cwd apps/trails lint` | TRL-805 workspace-pattern review follow-up | pass | Trails app Oxlint clean. |
+| `bun run --cwd apps/trails typecheck && bun run --cwd apps/trails build` | TRL-805 workspace-pattern review follow-up | pass | Trails app typecheck and build clean. |
+| `bun run check` | TRL-805 top pre-submit check | fail | Vocab audit caught `packages/http/src/testing.ts` using `run:` for conformance case callbacks; fixed on owning #638 before submit. |
+| `bun test packages/http/src/__tests__/testing.test.ts` | TRL-862 vocab follow-up | pass | 14 HTTP testing-subpath tests passed after renaming conformance case callbacks to `check`. |
+| `bun run --cwd packages/http test` | TRL-862 vocab follow-up | pass | 159 HTTP package tests passed. |
+| `bun run --cwd packages/http lint && bun run --cwd packages/http typecheck && bun run --cwd packages/http build` | TRL-862 vocab follow-up | pass | HTTP lint, typecheck, and build clean. |
+| `bun run lint:ast-grep && bun run vocab:audit && git diff --check` | TRL-862 vocab follow-up | pass | Repo ast-grep, vocab audit, and whitespace checks clean. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts && bun run --cwd packages/adapter-kit test` | TRL-863 upward verification | pass | 18 focused adapter-check tests and 26 adapter-kit package tests passed. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd packages/adapter-kit typecheck && bun run --cwd packages/adapter-kit build` | TRL-863 upward verification | pass | Adapter-kit lint, typecheck, and build clean. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts packages/warden/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/adapter-check.test.ts` | TRL-864 upward verification | pass | 27 focused adapter-check tests passed. |
+| `bun run --cwd packages/adapter-kit test && bun run --cwd packages/warden test && bun run --cwd apps/trails test` | TRL-864 upward verification | pass | 26 adapter-kit, 1001 Warden, and 362 Trails app tests passed. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd packages/warden lint && bun run --cwd apps/trails lint` | TRL-864 upward verification | pass | Adapter-kit, Warden, and Trails app lints clean. |
+| `bun run --cwd packages/adapter-kit typecheck && bun run --cwd packages/warden typecheck && bun run --cwd apps/trails typecheck` | TRL-864 upward verification | pass | Adapter-kit, Warden, and Trails app typechecks clean. |
+| `bun run --cwd packages/adapter-kit build && bun run --cwd packages/warden build && bun run --cwd apps/trails build` | TRL-864 upward verification | pass | Adapter-kit, Warden, and Trails app builds clean. |
+| `bun test packages/adapter-kit/src/__tests__/dogfood.test.ts adapters/hono/src/__tests__/conformance.test.ts packages/http/src/__tests__/testing.test.ts` | TRL-865 upward verification | pass | 21 dogfood, Hono conformance, and HTTP testing tests passed. |
+| `bun run --cwd packages/adapter-kit test && bun run --cwd adapters/hono test && bun run --cwd packages/http test` | TRL-865 upward verification | pass | 27 adapter-kit, 51 Hono, and 159 HTTP package tests passed. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd adapters/hono lint && bun run --cwd packages/http lint` | TRL-865 upward verification | pass | Adapter-kit, Hono, and HTTP lints clean. |
+| `bun run --cwd packages/adapter-kit typecheck && bun run --cwd adapters/hono typecheck && bun run --cwd packages/http typecheck` | TRL-865 upward verification | pass | Adapter-kit, Hono, and HTTP typechecks clean. |
+| `bun run --cwd packages/adapter-kit build && bun run --cwd adapters/hono build && bun run --cwd packages/http build` | TRL-865 upward verification | pass | Adapter-kit, Hono, and HTTP builds clean. |
+| `bun run lint:ast-grep && bun run vocab:audit && git diff --check` | TRL-863/864/865 upward verification | pass | Repo ast-grep, vocab audit, and whitespace checks stayed clean on each upward branch. |
+| `bun test packages/adapter-kit/src/__tests__/catalog.test.ts packages/adapter-kit/src/__tests__/check.test.ts packages/adapter-kit/src/__tests__/dogfood.test.ts apps/trails/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/create-adapter.test.ts packages/warden/src/__tests__/adapter-check.test.ts packages/http/src/__tests__/testing.test.ts adapters/hono/src/__tests__/conformance.test.ts` | TRL-805 final top verification | pass | 78 cumulative adapter-kit, Trails, Warden, HTTP, and Hono tests passed. |
+| `bun run test` | TRL-805 final top verification | pass | 40 workspace test tasks passed. |
+| `bun run check` | TRL-805 final top verification | fail | Hard-wrap check caught a multi-line paragraph in the adapter authoring draft ADR; fixed on #643. |
+| `bun run docs:wrap-check && bun run check` | TRL-805 final top verification | pass | Hard-wrap check and full repo check passed after reflowing the ADR paragraph. |
+| `bun run build` | TRL-805 final top verification | pass | 24 workspace build tasks passed. |
+| `bun run changeset:check` | TRL-805 final top verification | pass | Changeset gate passed for adapter-kit, Hono, HTTP, Store, Trails, and Warden. |
+| `bun run publish:check` | TRL-805 final top verification | pass | All public package pack checks passed. |
+| `bunx markdownlint-cli2 .agents/plans/2026-05-30-v1-convergence-loop/RETRO.md && git diff --check` | TRL-805 final top verification | pass | RETRO markdownlint and whitespace checks clean. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts && bun run --cwd packages/adapter-kit test` | TRL-863 post-submit review follow-up | pass | 18 focused adapter-check tests and 26 adapter-kit package tests passed after ignoring `typeof import()` type queries. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd packages/adapter-kit typecheck && bun run --cwd packages/adapter-kit build` | TRL-863 post-submit review follow-up | pass | Adapter-kit lint, typecheck, and build clean. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts packages/warden/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/adapter-check.test.ts` | TRL-864 second upward verification | pass | 27 focused adapter-check, Warden, and Trails tests passed. |
+| `bun run --cwd packages/adapter-kit test && bun run --cwd packages/warden test && bun run --cwd apps/trails test` | TRL-864 second upward verification | pass | 26 adapter-kit, 1001 Warden, and 362 Trails app tests passed. |
+| `bun test packages/adapter-kit/src/__tests__/dogfood.test.ts adapters/hono/src/__tests__/conformance.test.ts packages/http/src/__tests__/testing.test.ts` | TRL-865 second upward verification | pass | 21 dogfood, Hono conformance, and HTTP testing tests passed. |
+| `bun run --cwd packages/adapter-kit test && bun run --cwd adapters/hono test && bun run --cwd packages/http test` | TRL-865 second upward verification | pass | 27 adapter-kit, 51 Hono, and 159 HTTP package tests passed. |
+| `bun test packages/adapter-kit/src/__tests__/catalog.test.ts packages/adapter-kit/src/__tests__/check.test.ts packages/adapter-kit/src/__tests__/dogfood.test.ts apps/trails/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/create-adapter.test.ts packages/warden/src/__tests__/adapter-check.test.ts packages/http/src/__tests__/testing.test.ts adapters/hono/src/__tests__/conformance.test.ts` | TRL-805 namespace-import follow-up | pass | 79 cumulative adapter-kit, Trails, Warden, HTTP, and Hono tests passed after accepting namespace conformance helper calls. |
+| `bun run test` | TRL-805 second final top verification | pass | 40 workspace test tasks passed. |
+| `bun run check` | TRL-805 second final top verification | pass | Full repo check passed; Warden reported the three existing demo signal-graph warnings. |
+| `bun run build` | TRL-805 second final top verification | pass | 24 workspace build tasks passed. |
+| `bun run changeset:check && bun run publish:check` | TRL-805 second final top verification | pass | Changeset gate and all public package pack checks passed. |
+| `bun test packages/http/src/__tests__/testing.test.ts` | TRL-862 record-header review follow-up | pass | 15 HTTP testing-subpath tests passed after the conformance resolver read both `Headers` and record-backed header sources. |
+| `bun run --cwd packages/http test` | TRL-862 record-header review follow-up | pass | 160 HTTP package tests passed. |
+| `bun run --cwd packages/http lint && bun run --cwd packages/http typecheck && bun run --cwd packages/http build && git diff --check` | TRL-862 record-header review follow-up | pass | HTTP lint, typecheck, build, and whitespace checks clean. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts` | TRL-863 post-submit P2 follow-up | pass | 20 focused adapter-check tests passed after dynamic object-literal imports and optional dependency-boundary regressions. |
+| `bun run --cwd packages/adapter-kit test` | TRL-863 post-submit P2 follow-up | pass | 28 adapter-kit package tests passed. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd packages/adapter-kit typecheck && bun run --cwd packages/adapter-kit build && bun run lint:ast-grep && git diff --check` | TRL-863 post-submit P2 follow-up | pass | Adapter-kit lint, typecheck, build, ast-grep, and whitespace checks clean. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts packages/warden/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/adapter-check.test.ts` | TRL-864 third upward verification | pass | 29 focused adapter-check, Warden, and Trails tests passed after the #639 amend. |
+| `bun run --cwd packages/adapter-kit test && bun run --cwd packages/warden test && bun run --cwd apps/trails test` | TRL-864 third upward verification | pass | 28 adapter-kit, 1001 Warden, and 362 Trails app tests passed. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd packages/warden lint && bun run --cwd apps/trails lint` | TRL-864 third upward verification | pass | Adapter-kit, Warden, and Trails app lints clean. |
+| `bun run --cwd packages/adapter-kit typecheck && bun run --cwd packages/warden typecheck && bun run --cwd apps/trails typecheck` | TRL-864 third upward verification | pass | Adapter-kit, Warden, and Trails app typechecks clean. |
+| `bun run --cwd packages/adapter-kit build && bun run --cwd packages/warden build && bun run --cwd apps/trails build` | TRL-864 third upward verification | pass | Adapter-kit, Warden, and Trails app builds clean. |
+| `bun test packages/adapter-kit/src/__tests__/dogfood.test.ts adapters/hono/src/__tests__/conformance.test.ts packages/http/src/__tests__/testing.test.ts` | TRL-865 third upward verification | pass | 22 dogfood, Hono conformance, and HTTP testing tests passed after the #639 amend. |
+| `bun run --cwd packages/adapter-kit test && bun run --cwd adapters/hono test && bun run --cwd packages/http test` | TRL-865 third upward verification | pass | 29 adapter-kit, 51 Hono, and 160 HTTP package tests passed. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd adapters/hono lint && bun run --cwd packages/http lint` | TRL-865 third upward verification | pass | Adapter-kit, Hono, and HTTP lints clean. |
+| `bun run --cwd packages/adapter-kit typecheck && bun run --cwd adapters/hono typecheck && bun run --cwd packages/http typecheck` | TRL-865 third upward verification | pass | Adapter-kit, Hono, and HTTP typechecks clean. |
+| `bun run --cwd packages/adapter-kit build && bun run --cwd adapters/hono build && bun run --cwd packages/http build` | TRL-865 third upward verification | pass | Adapter-kit, Hono, and HTTP builds clean. |
+| `bun run lint:ast-grep && bun run vocab:audit && git diff --check` | TRL-864/865 third upward verification | pass | Repo ast-grep, vocab audit, and whitespace checks stayed clean on each upward branch. |
+| `bun test packages/adapter-kit/src/__tests__/catalog.test.ts packages/adapter-kit/src/__tests__/check.test.ts` | TRL-805 ambient-export review follow-up | pass | 44 focused adapter-kit tests passed after rejecting ambient callable conformance helpers. |
+| `bun run --cwd packages/adapter-kit test && bun run --cwd packages/adapter-kit lint && bun run --cwd packages/adapter-kit typecheck && bun run --cwd packages/adapter-kit build && git diff --check` | TRL-805 ambient-export review follow-up | pass | 45 adapter-kit tests plus package lint, typecheck, build, and whitespace checks clean. |
+| `bun test packages/adapter-kit/src/__tests__/catalog.test.ts packages/adapter-kit/src/__tests__/check.test.ts packages/adapter-kit/src/__tests__/dogfood.test.ts apps/trails/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/create-adapter.test.ts packages/warden/src/__tests__/adapter-check.test.ts packages/http/src/__tests__/testing.test.ts adapters/hono/src/__tests__/conformance.test.ts` | TRL-805 third final top verification | pass | 83 cumulative adapter-kit, Trails, Warden, HTTP, and Hono tests passed. |
+| `bun run test` | TRL-805 third final top verification | pass | 40 workspace test tasks passed. |
+| `bun run check` | TRL-805 third final top verification | pass | Full repo check passed; Warden reported the three existing demo signal-graph warnings. |
+| `bun run build` | TRL-805 third final top verification | pass | 24 workspace build tasks passed. |
+| `bun run changeset:check && bun run publish:check && git diff --check` | TRL-805 third final top verification | pass | Changeset gate, public package pack checks, and whitespace checks passed. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts && bun run --cwd packages/adapter-kit test` | TRL-863 generic type-query follow-up | pass | 20 focused adapter-check tests and 28 adapter-kit package tests passed after treating `extends`/`implements` import queries as erased. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd packages/adapter-kit typecheck && bun run --cwd packages/adapter-kit build && bun run lint:ast-grep && git diff --check` | TRL-863 generic type-query follow-up | pass | Adapter-kit lint, typecheck, build, ast-grep, and whitespace checks clean. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts packages/warden/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/adapter-check.test.ts` | TRL-864 fourth upward verification | pass | 29 focused adapter-check, Warden, and Trails tests passed after the #639 amend. |
+| `bun run --cwd packages/adapter-kit test && bun run --cwd packages/warden test && bun run --cwd apps/trails test` | TRL-864 fourth upward verification | pass | 28 adapter-kit, 1001 Warden, and 362 Trails app tests passed. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd packages/warden lint && bun run --cwd apps/trails lint` | TRL-864 fourth upward verification | pass | Adapter-kit, Warden, and Trails app lints clean. |
+| `bun run --cwd packages/adapter-kit typecheck && bun run --cwd packages/warden typecheck && bun run --cwd apps/trails typecheck` | TRL-864 fourth upward verification | pass | Adapter-kit, Warden, and Trails app typechecks clean. |
+| `bun run --cwd packages/adapter-kit build && bun run --cwd packages/warden build && bun run --cwd apps/trails build` | TRL-864 fourth upward verification | pass | Adapter-kit, Warden, and Trails app builds clean. |
+| `bun test packages/adapter-kit/src/__tests__/dogfood.test.ts adapters/hono/src/__tests__/conformance.test.ts packages/http/src/__tests__/testing.test.ts` | TRL-865 fourth upward verification | pass | 22 dogfood, Hono conformance, and HTTP testing tests passed after the #639 amend. |
+| `bun run --cwd packages/adapter-kit test && bun run --cwd adapters/hono test && bun run --cwd packages/http test` | TRL-865 fourth upward verification | pass | 29 adapter-kit, 51 Hono, and 160 HTTP package tests passed. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd adapters/hono lint && bun run --cwd packages/http lint` | TRL-865 fourth upward verification | pass | Adapter-kit, Hono, and HTTP lints clean. |
+| `bun run --cwd packages/adapter-kit typecheck && bun run --cwd adapters/hono typecheck && bun run --cwd packages/http typecheck` | TRL-865 fourth upward verification | pass | Adapter-kit, Hono, and HTTP typechecks clean. |
+| `bun run --cwd packages/adapter-kit build && bun run --cwd adapters/hono build && bun run --cwd packages/http build` | TRL-865 fourth upward verification | pass | Adapter-kit, Hono, and HTTP builds clean. |
+| `bun run lint:ast-grep && bun run vocab:audit && git diff --check` | TRL-864/865 fourth upward verification | pass | Repo ast-grep, vocab audit, and whitespace checks stayed clean on each upward branch. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts && bun run --cwd packages/adapter-kit test` | TRL-805 runner-default follow-up | pass | 30 focused adapter-check tests and 46 adapter-kit package tests passed after accepting owner runner calls backed by default cases. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd packages/adapter-kit typecheck && bun run --cwd packages/adapter-kit build && git diff --check` | TRL-805 runner-default follow-up | pass | Adapter-kit lint, typecheck, build, and whitespace checks clean. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts packages/warden/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/adapter-check.test.ts` | TRL-864 root-validation follow-up | pass | 37 focused adapter-check tests passed after `adapter.check` started rejecting missing/non-workspace roots. |
+| `bun run --cwd packages/adapter-kit test && bun run --cwd packages/warden test && bun run --cwd apps/trails test` | TRL-864 root-validation follow-up | pass | 34 adapter-kit, 1001 Warden, and 365 Trails app tests passed after the root validation and example-cwd fix. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd packages/warden lint && bun run --cwd apps/trails lint` | TRL-864 root-validation follow-up | pass | Adapter-kit, Warden, and Trails app lints clean. |
+| `bun run --cwd packages/adapter-kit typecheck && bun run --cwd packages/warden typecheck && bun run --cwd apps/trails typecheck` | TRL-864 root-validation follow-up | pass | Adapter-kit, Warden, and Trails app typechecks clean. |
+| `bun run --cwd packages/adapter-kit build && bun run --cwd packages/warden build && bun run --cwd apps/trails build && bun run lint:ast-grep && git diff --check` | TRL-864 root-validation follow-up | pass | Package builds, repo ast-grep, and whitespace checks clean. |
+| `bun test packages/adapter-kit/src/__tests__/check.test.ts packages/adapter-kit/src/__tests__/dogfood.test.ts adapters/hono/src/__tests__/conformance.test.ts packages/http/src/__tests__/testing.test.ts packages/warden/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/adapter-check.test.ts` | TRL-865 fifth upward verification | pass | 59 focused adapter-kit, Hono, HTTP, Warden, and Trails tests passed after the #640 amend. |
+| `bun run --cwd packages/adapter-kit test && bun run --cwd adapters/hono test && bun run --cwd packages/http test && bun run --cwd packages/warden test && bun run --cwd apps/trails test` | TRL-865 fifth upward verification | pass | 35 adapter-kit, 51 Hono, 160 HTTP, 1001 Warden, and 365 Trails app tests passed. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd adapters/hono lint && bun run --cwd packages/http lint && bun run --cwd packages/warden lint && bun run --cwd apps/trails lint` | TRL-865 fifth upward verification | pass | Adapter-kit, Hono, HTTP, Warden, and Trails app lints clean. |
+| `bun run --cwd packages/adapter-kit typecheck && bun run --cwd adapters/hono typecheck && bun run --cwd packages/http typecheck && bun run --cwd packages/warden typecheck && bun run --cwd apps/trails typecheck` | TRL-865 fifth upward verification | pass | Adapter-kit, Hono, HTTP, Warden, and Trails app typechecks clean. |
+| `bun run --cwd packages/adapter-kit build && bun run --cwd adapters/hono build && bun run --cwd packages/http build && bun run --cwd packages/warden build && bun run --cwd apps/trails build && bun run lint:ast-grep && git diff --check` | TRL-865 fifth upward verification | pass | Package builds, repo ast-grep, and whitespace checks clean. |
+| `bun test packages/adapter-kit/src/__tests__/catalog.test.ts packages/adapter-kit/src/__tests__/check.test.ts apps/trails/src/__tests__/create-adapter.test.ts packages/warden/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/adapter-check.test.ts` | TRL-805 final-review follow-up | pass | 79 focused tests passed after resolving the top restack conflict and adding same-file alias, async runner, and typed runner regressions. |
+| `bun run --cwd packages/adapter-kit test && bun run --cwd apps/trails test && bun run --cwd packages/warden test` | TRL-805 final-review follow-up | pass | 58 adapter-kit, 375 Trails app, and 1001 Warden tests passed. |
+| `bun run --cwd packages/adapter-kit lint && bun run --cwd apps/trails lint && bun run --cwd packages/warden lint` | TRL-805 final-review follow-up | pass | Adapter-kit, Trails app, and Warden lints clean. |
+| `bun run --cwd packages/adapter-kit typecheck && bun run --cwd apps/trails typecheck && bun run --cwd packages/warden typecheck` | TRL-805 final-review follow-up | pass | Adapter-kit, Trails app, and Warden typechecks clean. |
+| `bun run --cwd packages/adapter-kit build && bun run --cwd apps/trails build && bun run --cwd packages/warden build && bun run lint:ast-grep && git diff --check` | TRL-805 final-review follow-up | pass | Package builds, repo ast-grep, and whitespace checks clean. |
 
 ## Remote PR Ledger
 
@@ -363,6 +542,7 @@ status: active
 | [#639](https://github.com/outfitter-dev/trails/pull/639) | `trl-863-build-shared-adapter-check-engine` | ready | green | Adds shared adapter check engine. |
 | [#640](https://github.com/outfitter-dev/trails/pull/640) | `trl-864-expose-adapter-checks-through-warden-and-trails-adapter` | ready | green | Exposes adapter checks through Warden and `trails adapter check`. |
 | [#641](https://github.com/outfitter-dev/trails/pull/641) | `trl-865-dogfood-adapter-authoring-path-on-a-first-party-http-adapter` | ready | green | Dogfoods Hono as first extracted HTTP adapter subject. |
+| [#643](https://github.com/outfitter-dev/trails/pull/643) | `trl-805-trails-create-adapter-scaffold-adapter-packages-against-the` | ready | local review fixes verified; remote CI must rerun after submit | Adds extracted `create.adapter`; subpath check discovery and remaining adapter migration split to TRL-870/TRL-872. |
 
 Submitted with `gt submit --stack --draft --no-edit --no-interactive`, then
 marked ready after every PR reported green CI. Before submit, the bottom real
@@ -388,6 +568,12 @@ the repo-wide native-error structural rule. The fixture still returns a native
 `Result.err()`, preserving the redaction behavior without violating the
 syntax-level guardrail.
 
+The final top-of-stack `bun run check` pass caught one more #638 issue before
+submit: `HttpAdapterConformanceCase` used a `run:` function field, which tripped
+the repo vocab audit for legacy trail implementation fields. The case callback
+field is now `check`, `runConformance()` still owns the public runner name, and
+the stack was re-verified upward from #638 before submitting again.
+
 Bacon reviewed the TRL-876 / #639 conformance import-detection bug and agreed
 the narrow fix should stay on import syntax only, leaving helper-call validation
 to the later conformance-metadata/scaffold branch. The line-comment,
@@ -411,6 +597,12 @@ evidence, and that the exported adapter-kit check API needed a branch-local
 changeset. The scanner now treats annotated generic type positions as erased
 imports, and TRL-863 carries its own `@ontrails/adapter-kit` patch changeset.
 
+Post-submit Codex review found one more erased-import false positive on #639:
+`const testing = {} as typeof import("@ontrails/http/testing")` still counted as
+runtime conformance coverage. The scanner now treats `typeof import()` type
+queries as erased, and the stack was re-verified upward from #639 before the next
+submit.
+
 Follow-up review threads on #640 found that advisory Warden runs were no longer
 pure advisory-rule runs because adapter checks were implicitly attached, and that
 `trails adapter check --jsonl` still printed the human report. Warden now runs
@@ -427,18 +619,103 @@ structured flags but ignored the repo-wide topo env selectors. The adapter-check
 result bridge now delegates to `deriveOutputMode()`, so `TRAILS_JSON=1` and
 `TRAILS_JSONL=1` behave like the corresponding flags.
 
+Follow-up review threads on #643 found that catalog validation missed local star
+re-exports from testing subpaths, accepted type-only exports for callable
+conformance helpers, and allowed `create.adapter` to plan a package whose npm
+name already existed elsewhere in the workspace. Catalog validation now follows
+bounded local star re-exports, requires `casesFactory` and `runner` to be value
+exports, and `create.adapter` rejects duplicate workspace package names before
+planning writes.
+
+Another #643 review thread found `create.adapter` could write an extracted
+adapter under `adapters/<name>` even when the root workspace did not include
+that package path. Extracted scaffolding now fails before planning writes unless
+the root `package.json` workspaces include either the exact adapter path or
+`adapters/*`.
+
+Post-submit Codex review found that owner conformance proof accepted aliased
+named imports but rejected namespace imports such as `import * as httpTesting
+from "@ontrails/http/testing"`. The proof scanner now accepts namespace imports
+only when the namespace calls the owner-declared runner with the owner-declared
+cases factory. A separate suggestion to restore `missing-adapter-metadata` for
+unannotated `adapters/*` packages was rejected with evidence: the draft adapter
+authoring ADR and check regression intentionally keep unannotated existing
+adapters out of scope until TRL-872 migrates them into the metadata model.
+
+The next post-submit Codex pass found four P2s. #638 now reads conformance
+request-context tenant headers from both `Headers` and record-backed
+`HttpHeaderSource` values. #639 now accepts dynamic imports when they appear as
+object-literal values and treats `optionalDependencies` on the owner package as
+runtime dependency-boundary violations. #643 now rejects ambient callable
+conformance helper declarations such as `export declare function
+runConformance()`, because those are erased at runtime and cannot support the
+generated scaffold's value import.
+
+The follow-up Codex pass found two narrower P2s. #639 now treats generic
+`extends import("...")` constraints and `implements import("...")` clauses as
+erased type-query positions. #643 now accepts `runConformance(adapter)` only
+when the owner testing source proves that the runner parameter defaults to the
+declared cases factory.
+
+The final top-of-stack `bun run check` also caught a hard-wrapped paragraph in
+the adapter authoring draft ADR. That was a top-branch doc-only miss; the
+paragraph is now reflowed and the full check passes.
+
 Final stack-tip self-review checked the cumulative diff, stale private-package
 wording, `Result.err(new Error(...))` reintroductions, local adapter smoke
 behavior, Warden adapter-check behavior, changeset hygiene, publish packing, and
 full typecheck/lint/format gates. No new P0/P1/P2 findings were found. The
-remaining review risk is scope, not correctness: this stack stops after the
-first extracted HTTP adapter dogfood and intentionally leaves `create.adapter`
-scaffolding plus Commander/Drizzle/Vite metadata for the next stack.
+remaining review risk is scope, not correctness: this stack intentionally ships
+`create.adapter` for extracted HTTP adapters, leaves subpath adapter subject
+discovery and scaffolding to TRL-870, and leaves Commander/Drizzle/Vite metadata
+migration to TRL-872.
 
 Remote review status after marking ready: GitHub CI passed on all eight PRs.
 Greptile posted only its account/billing message ("free trial has ended") on
 each PR rather than a code review. Treat that as an unavailable review signal,
 not as a clean Greptile review and not as a code finding.
+
+The next post-submit Codex pass found three more P2s. #637 now rejects duplicate
+adapter target ids across owner packages before the #639 check engine can choose
+the wrong owner. #639 now treats ternary-expression colons as runtime expression
+syntax rather than TypeScript type annotations, so dynamic imports in conditional
+branches still count as conformance imports. #643 now accepts `export async
+function` value exports for callable conformance helpers while continuing to
+reject erased ambient declarations. The fixes were made on the owning branches
+and walked upward through #638, #639, #640, #641, and #643 before resubmission.
+
+The next review pass found three final P2s. #639 now treats expression type
+arguments such as `expectTypeOf<import("...")>()` as erased type evidence rather
+than runtime imports. #643 now follows local owner testing re-exports when
+proving that a runner defaults to the declared conformance cases factory, and
+`create.adapter` has a regression proving duplicate target ids fail before any
+scaffold writes.
+
+One more Codex pass found two P2s during the final landing push. #639 now keeps
+`adapters/*` workspaces fully opt-in on `trails.adapter`, with a regression for
+the existing Commander/Drizzle/Hono/Vite adapter shape. #643 now emits async-safe
+conformance scaffolds with `await` around both the owner runner and cases
+factory, including an async owner-helper regression. The mid-stack fixes were
+walked back upward through #640, #641, and #643 before submit.
+
+The next landing check found two more P2s. #639 now counts empty named imports
+such as `import {} from "@ontrails/adapter-kit"` as runtime imports for the
+tooling-boundary check. #643 now masks comments and string literals before
+validating owner conformance exports, while preserving real star re-export
+specifier strings. The #639 fix was verified on its owning branch, then the
+stack was walked through #640 and #641 before applying and verifying the #643
+catalog fix at the top.
+
+The next final-review pass found five P2s. #639 now also counts runtime
+`export ... from "@ontrails/adapter-kit"` re-exports as adapter-kit tooling
+boundary violations while preserving type-only re-exports. #640 now rejects
+missing roots and package roots without workspace manifests before
+`adapter.check` can report a false PASS. #643 now resolves same-file
+`export { actualRunner as runConformance }` aliases, accepts async runner
+functions that default cases, and accepts typed runner variables such as
+`export const runConformance: Runner = (...)` when proving owner default-case
+coverage. The fixes were made on the owning branches, walked upward through
+PR #641, and verified again at the top before any submit.
 
 ## Open Risks
 

--- a/.changeset/trl-805-create-adapter.md
+++ b/.changeset/trl-805-create-adapter.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/adapter-kit": patch
+"@ontrails/http": patch
+"@ontrails/trails": patch
+---
+
+Add adapter target conformance metadata and scaffold extracted HTTP adapters through `trails create adapter`.

--- a/apps/trails/src/__tests__/adapter-check.test.ts
+++ b/apps/trails/src/__tests__/adapter-check.test.ts
@@ -144,7 +144,9 @@ const writeHonoAdapter = (
       '@ontrails/http': 'workspace:^',
     },
     trails: {
-      adapter: true,
+      adapter: {
+        target: 'http',
+      },
     },
     ...manifestOverrides,
   });
@@ -191,7 +193,7 @@ describe('trails adapter check', () => {
     const wardenCodes = runWardenAdapterChecks(root).map((entry) => entry.code);
 
     expect(result.value.passed).toBe(false);
-    expect(localCodes).toEqual(['invalid-adapter-metadata']);
+    expect(localCodes).toEqual(['missing-conformance']);
     expect(wardenCodes).toEqual(localCodes);
   });
 
@@ -205,7 +207,7 @@ describe('trails adapter check', () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toBe('');
     expect(result.stdout).toContain('## Adapter Check Report');
-    expect(result.stdout).toContain('invalid-adapter-metadata');
+    expect(result.stdout).toContain('missing-conformance');
   });
 
   test('exits non-zero for adapter readiness failures under trace JSON', () => {

--- a/apps/trails/src/__tests__/create-adapter.test.ts
+++ b/apps/trails/src/__tests__/create-adapter.test.ts
@@ -1,0 +1,850 @@
+import { deriveCliCommands } from '@ontrails/cli';
+import type { Result } from '@ontrails/core';
+import { ValidationError } from '@ontrails/core';
+import { checkAdapters } from '@ontrails/adapter-kit';
+import { afterEach, describe, expect, test } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { app } from '../app.js';
+import { createAdapterTrail } from '../trails/create-adapter.js';
+
+const roots: string[] = [];
+
+const expectOk = <T>(result: Result<T, Error>): T => {
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+const expectValidationError = (
+  result: Result<unknown, Error>
+): ValidationError => {
+  if (result.isOk()) {
+    throw new Error('Expected validation error');
+  }
+  expect(result.error).toBeInstanceOf(ValidationError);
+  return result.error as ValidationError;
+};
+
+const writeFile = (root: string, path: string, value: string): void => {
+  const filePath = join(root, path);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value);
+};
+
+const writeJson = (
+  root: string,
+  path: string,
+  value: Record<string, unknown>
+): void => {
+  writeFile(root, path, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const readText = (root: string, path: string): string =>
+  readFileSync(join(root, path), 'utf8');
+
+const readJson = (root: string, path: string): Record<string, unknown> =>
+  JSON.parse(readText(root, path)) as Record<string, unknown>;
+
+const makeRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'trails-create-adapter-'));
+  roots.push(root);
+  writeJson(root, 'package.json', {
+    name: 'fixture-root',
+    workspaces: ['packages/*', 'adapters/*'],
+  });
+  return root;
+};
+
+const writeHttpOwner = (
+  root: string,
+  targetOverrides: Record<string, unknown> = {}
+): void => {
+  writeJson(root, 'packages/http/package.json', {
+    exports: {
+      '.': './src/index.ts',
+      './package.json': './package.json',
+      './testing': './src/testing.ts',
+    },
+    name: '@ontrails/http',
+    trails: {
+      adapterTargets: {
+        http: {
+          conformance: {
+            adapterType: 'HttpAdapterConformanceAdapter',
+            casesFactory: 'createHttpAdapterConformanceCases',
+            runner: 'runConformance',
+          },
+          placements: ['extracted', 'subpath'],
+          testingImport: '@ontrails/http/testing',
+          ...targetOverrides,
+        },
+      },
+    },
+  });
+  writeFile(
+    root,
+    'packages/http/src/fetch.ts',
+    [
+      'import type { Topo } from "@ontrails/core";',
+      'export interface CreateFetchHandlerOptions {}',
+      'export const createFetchHandler = (graph: Topo, options: CreateFetchHandlerOptions = {}) => {',
+      '  void [graph, options];',
+      '};',
+      '',
+    ].join('\n')
+  );
+  writeFile(
+    root,
+    'packages/http/src/index.ts',
+    [
+      'export {',
+      '  createFetchHandler,',
+      '  type CreateFetchHandlerOptions,',
+      '} from "./fetch.js";',
+      '',
+    ].join('\n')
+  );
+  writeFile(
+    root,
+    'packages/http/src/testing.ts',
+    [
+      'export interface HttpAdapterConformanceAdapter {}',
+      'export const createHttpAdapterConformanceCases = () => [];',
+      'export const runConformance = () => undefined;',
+      '',
+    ].join('\n')
+  );
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe('trails create adapter', () => {
+  test('projects as a nested CLI command', () => {
+    const commands = deriveCliCommands(app);
+    if (commands.isErr()) {
+      throw commands.error;
+    }
+
+    const paths = commands.value.map((command) => command.path.join(' '));
+    expect(paths).toContain('create adapter');
+    const createAdapter = commands.value.find(
+      (command) => command.path.join(' ') === 'create adapter'
+    );
+    expect(
+      createAdapter?.flags.find((flag) => flag.name === 'placement')?.choices
+    ).toEqual(['extracted']);
+  });
+
+  test('scaffolds an extracted HTTP adapter from catalog facts', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+
+    const result = expectOk(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'hono-lite',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(result.created).toEqual([
+      'adapters/hono-lite/package.json',
+      'adapters/hono-lite/tsconfig.json',
+      'adapters/hono-lite/tsconfig.tests.json',
+      'adapters/hono-lite/README.md',
+      'adapters/hono-lite/src/index.ts',
+      'adapters/hono-lite/src/__tests__/conformance.test.ts',
+    ]);
+    expect(result.adapterImport).toBe('@ontrails/hono-lite');
+    expect(result.targetKey).toBe('@ontrails/http:http');
+
+    const manifest = readJson(root, 'adapters/hono-lite/package.json');
+    expect(manifest['trails']).toMatchObject({
+      adapter: { target: 'http' },
+    });
+    expect(manifest['peerDependencies']).toMatchObject({
+      '@ontrails/http': 'workspace:^',
+    });
+    expect(readText(root, 'adapters/hono-lite/src/index.ts')).toContain(
+      'createFetchHandler'
+    );
+    expect(
+      readText(root, 'adapters/hono-lite/src/__tests__/conformance.test.ts')
+    ).toContain(
+      'import {\n  createHttpAdapterConformanceCases,\n  runConformance,\n} from "@ontrails/http/testing";'
+    );
+    expect(
+      readText(root, 'adapters/hono-lite/src/__tests__/conformance.test.ts')
+    ).toContain(
+      'import type { HttpAdapterConformanceAdapter } from "@ontrails/http/testing";'
+    );
+    expect(
+      readText(root, 'adapters/hono-lite/src/__tests__/conformance.test.ts')
+    ).toContain(
+      'await runConformance(adapter, await createHttpAdapterConformanceCases());'
+    );
+
+    const report = checkAdapters(root);
+    expect(report.subjects[0]).toMatchObject({
+      packageName: '@ontrails/hono-lite',
+      target: 'http',
+      testingImport: '@ontrails/http/testing',
+    });
+    expect(report.diagnostics).toEqual([]);
+  });
+
+  test('accepts HTTP scaffold support through owner root star re-exports', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      "export * from './fetch.js';\n"
+    );
+
+    const result = expectOk(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'hono-star',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(result.created).toContain('adapters/hono-star/src/index.ts');
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  test('accepts HTTP scaffold support through same-file value export lists', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      [
+        'export interface CreateFetchHandlerOptions {}',
+        'const createFetchHandler = () => undefined;',
+        'export { createFetchHandler };',
+        '',
+      ].join('\n')
+    );
+
+    const result = expectOk(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'hono-same-file',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(result.created).toContain('adapters/hono-same-file/src/index.ts');
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  test('fails before writing when same-file HTTP support type exports resolve only to values', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      [
+        'const createFetchHandler = () => undefined;',
+        'const CreateFetchHandlerOptions = {};',
+        'export { createFetchHandler, CreateFetchHandlerOptions };',
+        '',
+      ].join('\n')
+    );
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'value-only-type-support',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('CreateFetchHandlerOptions');
+    expect(existsSync(join(root, 'adapters/value-only-type-support'))).toBe(
+      false
+    );
+  });
+
+  test('accepts HTTP scaffold support through owner root import-export barrels', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      [
+        'import { createFetchHandler } from "./fetch.js";',
+        'export type { CreateFetchHandlerOptions } from "./fetch.js";',
+        'export { createFetchHandler };',
+        '',
+      ].join('\n')
+    );
+
+    const result = expectOk(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'hono-import-barrel',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(result.created).toContain(
+      'adapters/hono-import-barrel/src/index.ts'
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  test('accepts HTTP scaffold type support through same-file import-export barrels', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      [
+        'import { createFetchHandler } from "./fetch.js";',
+        'import type { CreateFetchHandlerOptions } from "./fetch.js";',
+        'export type { CreateFetchHandlerOptions };',
+        'export { createFetchHandler };',
+        '',
+      ].join('\n')
+    );
+
+    const result = expectOk(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'hono-type-import-barrel',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(result.created).toContain(
+      'adapters/hono-type-import-barrel/src/index.ts'
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  test('fails before writing when HTTP support value re-exports resolve only to types', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      [
+        'export {',
+        '  createFetchHandler,',
+        '  type CreateFetchHandlerOptions,',
+        '} from "./types.js";',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/types.ts',
+      [
+        'export type createFetchHandler = () => void;',
+        'export interface CreateFetchHandlerOptions {}',
+        '',
+      ].join('\n')
+    );
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'type-only-support',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('does not export createFetchHandler');
+    expect(existsSync(join(root, 'adapters/type-only-support'))).toBe(false);
+  });
+
+  test('fails before writing when same-file HTTP support export lists are declare-only', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      [
+        'declare const createFetchHandler: () => unknown;',
+        'export interface CreateFetchHandlerOptions {}',
+        'export { createFetchHandler };',
+        '',
+      ].join('\n')
+    );
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'ambient-http-support',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('does not export createFetchHandler');
+    expect(existsSync(join(root, 'adapters/ambient-http-support'))).toBe(false);
+  });
+
+  test('emits async-safe conformance invocation for async owner helpers', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export async function createHttpAdapterConformanceCases() {',
+        '  return [];',
+        '}',
+        'export async function runConformance(',
+        '  adapter: HttpAdapterConformanceAdapter,',
+        '  cases: unknown[]',
+        ') {',
+        '  void [adapter, cases];',
+        '}',
+        '',
+      ].join('\n')
+    );
+
+    expectOk(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'async-http',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(
+      readText(root, 'adapters/async-http/src/__tests__/conformance.test.ts')
+    ).toContain(
+      'await runConformance(adapter, await createHttpAdapterConformanceCases());'
+    );
+  });
+
+  test('plans an extracted scaffold without touching disk', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+
+    const result = expectOk(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: true,
+          name: 'dry-http',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(result.dryRun).toBe(true);
+    expect(result.created).toEqual([]);
+    expect(result.plannedOperations).toEqual(
+      expect.arrayContaining([
+        { kind: 'write', path: 'adapters/dry-http/package.json' },
+        {
+          kind: 'write',
+          path: 'adapters/dry-http/src/__tests__/conformance.test.ts',
+        },
+      ])
+    );
+    expect(existsSync(join(root, 'adapters/dry-http'))).toBe(false);
+  });
+
+  test('fails before writing when the extracted adapter directory already exists', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(root, 'adapters/hono-lite/src/index.ts', 'export {};\n');
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'hono-lite',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('Adapter package already exists');
+    expect(readText(root, 'adapters/hono-lite/src/index.ts')).toBe(
+      'export {};\n'
+    );
+    expect(existsSync(join(root, 'adapters/hono-lite/package.json'))).toBe(
+      false
+    );
+  });
+
+  test('fails before writing when the adapter package name already exists', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeJson(root, 'packages/existing/package.json', {
+      name: '@ontrails/hono-lite',
+    });
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'hono-lite',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain(
+      'Workspace package name "@ontrails/hono-lite" already exists'
+    );
+    expect(existsSync(join(root, 'adapters/hono-lite'))).toBe(false);
+  });
+
+  test('fails before writing when extracted adapters are outside workspaces', async () => {
+    const root = makeRoot();
+    writeJson(root, 'package.json', {
+      name: 'fixture-root',
+      workspaces: ['packages/*'],
+    });
+    writeHttpOwner(root);
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'hono-lite',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('workspaces must include');
+    expect(existsSync(join(root, 'adapters/hono-lite'))).toBe(false);
+  });
+
+  test('rejects subpath scaffolding until shared checks discover subpath subjects', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'edge',
+          placement: 'subpath',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('Subpath adapter scaffolding is deferred');
+    const { exports: packageExports } = readJson(
+      root,
+      'packages/http/package.json'
+    );
+    expect(packageExports).toMatchObject({
+      '.': './src/index.ts',
+      './package.json': './package.json',
+      './testing': './src/testing.ts',
+    });
+    expect((packageExports as Record<string, unknown>)['./edge']).toBe(
+      undefined
+    );
+    expect(existsSync(join(root, 'packages/http/src/edge.ts'))).toBe(false);
+  });
+
+  test('fails before writing when owner conformance metadata is missing', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root, {
+      conformance: undefined,
+    });
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'missing-factory',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('conformance metadata');
+    expect(existsSync(join(root, 'adapters/missing-factory'))).toBe(false);
+  });
+
+  test('fails before writing when the HTTP owner lacks scaffold support exports', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(root, 'packages/http/src/index.ts', 'export {};\n');
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'missing-http-support',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('does not export createFetchHandler');
+    expect(error.message).toContain('CreateFetchHandlerOptions');
+    expect(existsSync(join(root, 'adapters/missing-http-support'))).toBe(false);
+  });
+
+  test('accepts HTTP root export conditional shorthand', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    const manifest = readJson(root, 'packages/http/package.json');
+    writeJson(root, 'packages/http/package.json', {
+      ...manifest,
+      exports: {
+        './package.json': './package.json',
+        './testing': './src/testing.ts',
+        import: './src/index.ts',
+        types: './src/index.ts',
+      },
+    });
+
+    const result = expectOk(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'conditional-http-root',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(result.created).toContain(
+      'adapters/conditional-http-root/src/index.ts'
+    );
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  test('fails before writing when HTTP root export only has a types condition', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    const manifest = readJson(root, 'packages/http/package.json');
+    writeJson(root, 'packages/http/package.json', {
+      ...manifest,
+      exports: {
+        '.': { types: './src/index.ts' },
+        './package.json': './package.json',
+        './testing': './src/testing.ts',
+      },
+    });
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'types-only-http-root',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('readable package root export');
+    expect(existsSync(join(root, 'adapters/types-only-http-root'))).toBe(false);
+  });
+
+  test('fails before writing when HTTP support exports only appear in comments or strings', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      [
+        '// export const createFetchHandler = () => undefined;',
+        'const docs = "export interface CreateFetchHandlerOptions {}";',
+        'export {};',
+        '',
+      ].join('\n')
+    );
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'masked-http-support',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('does not export createFetchHandler');
+    expect(error.message).toContain('CreateFetchHandlerOptions');
+    expect(existsSync(join(root, 'adapters/masked-http-support'))).toBe(false);
+  });
+
+  test('fails before writing when HTTP support star re-exports only appear in strings', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      ['const docs = "export * from \'./fetch.js\';";', 'export {};', ''].join(
+        '\n'
+      )
+    );
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'masked-star-support',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('does not export createFetchHandler');
+    expect(error.message).toContain('CreateFetchHandlerOptions');
+    expect(existsSync(join(root, 'adapters/masked-star-support'))).toBe(false);
+  });
+
+  test('fails before writing when adapter target ids are ambiguous', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeJson(root, 'packages/alt-http/package.json', {
+      exports: {
+        '.': './src/index.ts',
+        './package.json': './package.json',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/alt-http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'AltHttpAdapterConformanceAdapter',
+              casesFactory: 'createAltHttpAdapterConformanceCases',
+              runner: 'runAltConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/alt-http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/alt-http/src/testing.ts',
+      [
+        'export interface AltHttpAdapterConformanceAdapter {}',
+        'export const createAltHttpAdapterConformanceCases = () => [];',
+        'export const runAltConformance = () => undefined;',
+        '',
+      ].join('\n')
+    );
+
+    const error = expectValidationError(
+      await createAdapterTrail.blaze(
+        {
+          dryRun: false,
+          name: 'ambiguous-http',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('Adapter target catalog has diagnostics');
+    expect(error.message).toContain('declared by multiple owner packages');
+    expect(existsSync(join(root, 'adapters/ambiguous-http'))).toBe(false);
+  });
+});

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -8,6 +8,7 @@ import * as compile from './trails/compile.js';
 import * as completions from './trails/completions.js';
 import * as completionsComplete from './trails/completions-complete.js';
 import * as create from './trails/create.js';
+import * as createAdapter from './trails/create-adapter.js';
 import * as createScaffold from './trails/create-scaffold.js';
 import * as deprecate from './trails/deprecate.js';
 import * as devClean from './trails/dev-clean.js';
@@ -53,6 +54,7 @@ export const app = topo(
   warden,
   wardenGuide,
   create,
+  createAdapter,
   createScaffold,
   addSurface,
   addVerify,

--- a/apps/trails/src/trails/adapter-check.ts
+++ b/apps/trails/src/trails/adapter-check.ts
@@ -41,6 +41,13 @@ const adapterCheckSubjectSchema = z.object({
 });
 
 const adapterTargetSchema = z.object({
+  conformance: z
+    .object({
+      adapterType: z.string(),
+      casesFactory: z.string(),
+      runner: z.string(),
+    })
+    .optional(),
   key: z.string(),
   ownerPackage: z.string(),
   packageJsonPath: z.string(),

--- a/apps/trails/src/trails/create-adapter.ts
+++ b/apps/trails/src/trails/create-adapter.ts
@@ -1,0 +1,1084 @@
+/**
+ * `create.adapter` trail -- Scaffold an adapter authoring target.
+ */
+
+import {
+  adapterTargetPlacements,
+  checkAdapters,
+  deriveAdapterTargetCatalog,
+} from '@ontrails/adapter-kit';
+import type {
+  AdapterCheckDiagnostic,
+  AdapterTargetCatalogEntry,
+  AdapterTargetConformanceManifest,
+  AdapterTargetPlacement,
+} from '@ontrails/adapter-kit';
+import { Result, trail, ValidationError } from '@ontrails/core';
+import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { z } from 'zod';
+
+import {
+  applyProjectOperations,
+  planProjectOperations,
+  resolveProjectPath,
+} from '../project-writes.js';
+import type {
+  PlannedProjectOperation,
+  ProjectWriteOperation,
+} from '../project-writes.js';
+import { trailsPackageVersion } from '../versions.js';
+import { resolveTrailRootDir } from './root-dir.js';
+
+const adapterNamePattern = /^[a-z][a-z0-9-]*$/u;
+const adapterNameMessage =
+  'Adapter name must be kebab-case, start with a lowercase letter, and contain only lowercase letters, digits, or "-".';
+const packageNamePattern =
+  /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u;
+const packageNameMessage =
+  'Package name must be a valid lowercase npm package name, optionally scoped.';
+
+type CreateAdapterPlacement = AdapterTargetPlacement;
+
+const createAdapterPlacements = ['extracted'] as const;
+
+interface CreateAdapterInput {
+  readonly dryRun: boolean;
+  readonly name: string;
+  readonly packageName?: string | undefined;
+  readonly placement: CreateAdapterPlacement;
+  readonly rootDir?: string | undefined;
+  readonly target: string;
+}
+
+interface CreateAdapterResult {
+  readonly adapterImport: string;
+  readonly created: readonly string[];
+  readonly diagnostics: readonly AdapterCheckDiagnostic[];
+  readonly dryRun: boolean;
+  readonly packageName: string;
+  readonly placement: CreateAdapterPlacement;
+  readonly plannedOperations: readonly PlannedProjectOperation[];
+  readonly targetKey: string;
+}
+
+interface AdapterOperationPlan {
+  readonly adapterImport: string;
+  readonly packageName: string;
+  readonly operations: readonly ProjectWriteOperation[];
+  readonly targetKey: string;
+}
+
+interface RootManifest {
+  readonly workspaces?: unknown;
+}
+
+interface WorkspacePackageManifest {
+  readonly exports?: unknown;
+  readonly name?: unknown;
+}
+
+interface WorkspacePackageName {
+  readonly name: string;
+  readonly workspacePath: string;
+}
+
+interface LocalNamedReexport {
+  readonly local: string;
+  readonly specifier: string;
+  readonly typeOnly: boolean;
+}
+
+interface LocalNamedImport {
+  readonly imported: string;
+  readonly specifier: string;
+  readonly typeOnly: boolean;
+}
+
+const literal = (value: string): string => JSON.stringify(value);
+
+const writeOperation = (
+  path: string,
+  content: string
+): ProjectWriteOperation => ({
+  content,
+  kind: 'write',
+  path,
+});
+
+const formatJson = (value: unknown): string =>
+  `${JSON.stringify(value, null, 2)}\n`;
+
+const defaultExtractedPackageName = (name: string): string =>
+  `@ontrails/${name}`;
+
+const fail = (message: string): Result<never, ValidationError> =>
+  Result.err(new ValidationError(message));
+
+const readJson = <T>(path: string): T | undefined => {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as T;
+  } catch {
+    return undefined;
+  }
+};
+
+const workspacePatternsFromManifest = (
+  manifest: RootManifest | undefined
+): readonly string[] => {
+  const { workspaces } = manifest ?? {};
+  if (Array.isArray(workspaces)) {
+    return workspaces.filter(
+      (pattern): pattern is string => typeof pattern === 'string'
+    );
+  }
+
+  const packages =
+    workspaces && typeof workspaces === 'object' && !Array.isArray(workspaces)
+      ? (workspaces as Record<string, unknown>)['packages']
+      : undefined;
+  return Array.isArray(packages)
+    ? packages.filter(
+        (pattern): pattern is string => typeof pattern === 'string'
+      )
+    : [];
+};
+
+const normalizeWorkspacePattern = (pattern: string): string =>
+  pattern.replace(/^\.\//u, '').replace(/\/+$/u, '');
+
+const workspacePatternCoversPath = (
+  pattern: string,
+  workspacePath: string
+): boolean => {
+  const normalized = normalizeWorkspacePattern(pattern);
+  if (normalized.endsWith('/*')) {
+    const prefix = normalized.slice(0, -2);
+    const rest = workspacePath.slice(prefix.length + 1);
+    return (
+      workspacePath.startsWith(`${prefix}/`) &&
+      rest.length > 0 &&
+      !rest.includes('/')
+    );
+  }
+
+  return normalized === workspacePath;
+};
+
+const rootWorkspaceIncludesPath = (
+  rootDir: string,
+  workspacePath: string
+): boolean => {
+  const rootManifest = readJson<RootManifest>(join(rootDir, 'package.json'));
+  return workspacePatternsFromManifest(rootManifest).some((pattern) =>
+    workspacePatternCoversPath(pattern, workspacePath)
+  );
+};
+
+const workspaceDirsForPattern = (
+  rootDir: string,
+  pattern: string
+): readonly string[] => {
+  if (!pattern.endsWith('/*')) {
+    const workspaceDir = join(rootDir, pattern);
+    return existsSync(workspaceDir) ? [workspaceDir] : [];
+  }
+
+  const groupDir = join(rootDir, pattern.slice(0, -2));
+  if (!existsSync(groupDir)) {
+    return [];
+  }
+
+  return readdirSync(groupDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(groupDir, entry.name))
+    .toSorted();
+};
+
+const findWorkspacePackageName = (
+  rootDir: string,
+  packageName: string
+): WorkspacePackageName | undefined => {
+  const rootManifest = readJson<RootManifest>(join(rootDir, 'package.json'));
+  for (const pattern of workspacePatternsFromManifest(rootManifest)) {
+    for (const workspaceDir of workspaceDirsForPattern(rootDir, pattern)) {
+      const manifest = readJson<WorkspacePackageManifest>(
+        join(workspaceDir, 'package.json')
+      );
+      if (manifest?.name === packageName) {
+        return {
+          name: packageName,
+          workspacePath: relative(rootDir, workspaceDir),
+        };
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const resolvePhysicalRootDir = (
+  rootDir: string
+): Result<string, ValidationError> => {
+  try {
+    return Result.ok(realpathSync(resolve(rootDir)));
+  } catch {
+    return fail(
+      `Workspace root "${rootDir}" does not exist or cannot be read.`
+    );
+  }
+};
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const runtimeExportTarget = (value: unknown, depth = 0): string | undefined => {
+  if (typeof value === 'string') {
+    return value;
+  }
+  if (!isRecord(value) || depth > 8) {
+    return undefined;
+  }
+
+  for (const condition of ['bun', 'import', 'default', 'require'] as const) {
+    const candidate = runtimeExportTarget(value[condition], depth + 1);
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  return undefined;
+};
+
+const packageRootExportTarget = (
+  target: AdapterTargetCatalogEntry
+): string | undefined => {
+  const manifest = readJson<WorkspacePackageManifest>(target.packageJsonPath);
+  let exportTarget: string | undefined;
+  if (typeof manifest?.exports === 'string') {
+    exportTarget = manifest.exports;
+  } else if (isRecord(manifest?.exports)) {
+    const rootExport = Object.hasOwn(manifest.exports, '.')
+      ? manifest.exports['.']
+      : manifest.exports;
+    exportTarget = runtimeExportTarget(rootExport);
+  }
+
+  if (!exportTarget || exportTarget.startsWith('..')) {
+    return undefined;
+  }
+
+  return resolve(target.packageRoot, exportTarget);
+};
+
+const maskSource = (source: string, options: { strings: boolean }): string => {
+  const output = [...source];
+  let index = 0;
+
+  const maskRange = (start: number, end: number): void => {
+    for (let cursor = start; cursor < end; cursor += 1) {
+      if (output[cursor] !== '\n') {
+        output[cursor] = ' ';
+      }
+    }
+  };
+
+  const skipQuoted = (quote: '"' | "'" | '`'): void => {
+    const start = index;
+    index += 1;
+    while (index < source.length) {
+      if (source[index] === '\\') {
+        index += 2;
+        continue;
+      }
+      if (source[index] === quote) {
+        index += 1;
+        break;
+      }
+      index += 1;
+    }
+    if (options.strings) {
+      maskRange(start, index);
+    }
+  };
+
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      const end = source.indexOf('\n', index + 2);
+      const stop = end === -1 ? source.length : end;
+      maskRange(index, stop);
+      index = stop;
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      const end = source.indexOf('*/', index + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      maskRange(index, stop);
+      index = stop;
+      continue;
+    }
+    const char = source[index];
+    if (char === '"' || char === "'" || char === '`') {
+      skipQuoted(char);
+      continue;
+    }
+    index += 1;
+  }
+
+  return output.join('');
+};
+
+const sameFileExportListLocalForIdentifier = (
+  source: string,
+  identifier: string,
+  expected: 'type' | 'value'
+): string | undefined => {
+  const exportCode = maskSource(source, { strings: false });
+  const stringsMaskedCode = maskSource(source, { strings: true });
+  const exportListPattern =
+    /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}(?<from>\s+from\s+['"][^'"]+['"])?/gu;
+  for (const match of exportCode.matchAll(exportListPattern)) {
+    if (!stringsMaskedCode.startsWith('export', match.index ?? 0)) {
+      continue;
+    }
+
+    if (match.groups?.['from']) {
+      continue;
+    }
+
+    const namedExports = match.groups?.['exports'] ?? '';
+    for (const item of namedExports.split(',')) {
+      const trimmedItem = item.trim();
+      const specifierTypeOnly =
+        Boolean(match.groups?.['typeOnly']) || trimmedItem.startsWith('type ');
+      const specifierText = trimmedItem.replace(/^type\s+/u, '');
+      const exported =
+        /^(?<local>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<name>[A-Za-z_$][\w$]*))?$/u.exec(
+          specifierText
+        )?.groups;
+      if (
+        !exported?.['local'] ||
+        (exported['name'] ?? exported['local']) !== identifier
+      ) {
+        continue;
+      }
+      if (expected === 'type') {
+        return exported['local'];
+      }
+      if (!specifierTypeOnly) {
+        return exported['local'];
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const declaresTypeBinding = (source: string, identifier: string): boolean => {
+  const code = maskSource(source, { strings: true });
+  const escapedIdentifier = identifier.replaceAll(
+    /[.*+?^${}()|[\]\\]/gu,
+    '\\$&'
+  );
+  return new RegExp(
+    `(?:^|[;\\n\\r])\\s*(?:export\\s+)?(?:declare\\s+)?(?:interface|type)\\s+${escapedIdentifier}\\b`,
+    'u'
+  ).test(code);
+};
+
+const declaresValueBinding = (source: string, identifier: string): boolean => {
+  const code = maskSource(source, { strings: true });
+  const escapedIdentifier = identifier.replaceAll(
+    /[.*+?^${}()|[\]\\]/gu,
+    '\\$&'
+  );
+  return new RegExp(
+    `(?:^|[;\\n\\r])\\s*(?:export\\s+)?(?:(?:async\\s+)?function|const|let|var|class|enum)\\s+${escapedIdentifier}\\b`,
+    'u'
+  ).test(code);
+};
+
+const sourceExportsIdentifier = (
+  source: string,
+  identifier: string,
+  expected: 'type' | 'value'
+): boolean => {
+  const code = maskSource(source, { strings: true });
+  const escapedIdentifier = identifier.replaceAll(
+    /[.*+?^${}()|[\]\\]/gu,
+    '\\$&'
+  );
+  const valueDeclarationPattern = new RegExp(
+    `\\bexport\\s+(?:(?:async\\s+)?function|const|let|var|class|enum)\\s+${escapedIdentifier}\\b`,
+    'u'
+  );
+  if (expected === 'value' && valueDeclarationPattern.test(code)) {
+    return true;
+  }
+
+  const typeDeclarationPattern = new RegExp(
+    `\\bexport\\s+(?:declare\\s+)?(?:interface|type)\\s+${escapedIdentifier}\\b`,
+    'u'
+  );
+  const sameFileLocal = sameFileExportListLocalForIdentifier(
+    source,
+    identifier,
+    expected
+  );
+  return (
+    (expected === 'type' &&
+      (typeDeclarationPattern.test(code) ||
+        (sameFileLocal !== undefined &&
+          declaresTypeBinding(source, sameFileLocal)))) ||
+    (expected === 'value' &&
+      sameFileLocal !== undefined &&
+      declaresValueBinding(source, sameFileLocal))
+  );
+};
+
+const localNamedImports = (
+  source: string,
+  identifier: string
+): readonly LocalNamedImport[] => {
+  const code = maskSource(source, { strings: false });
+  const stringsMaskedCode = maskSource(source, { strings: true });
+  const imports: LocalNamedImport[] = [];
+  const pattern =
+    /\bimport\s+(?<typeOnly>type\s+)?\{(?<imports>[\s\S]*?)\}\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
+
+  for (const match of code.matchAll(pattern)) {
+    if (!stringsMaskedCode.startsWith('import', match.index ?? 0)) {
+      continue;
+    }
+
+    const specifier = match.groups?.['specifier'];
+    if (!specifier?.startsWith('.')) {
+      continue;
+    }
+
+    const namedImports = match.groups?.['imports'] ?? '';
+    for (const item of namedImports.split(',')) {
+      const trimmedItem = item.trim();
+      if (!trimmedItem) {
+        continue;
+      }
+
+      const specifierTypeOnly =
+        Boolean(match.groups?.['typeOnly']) || trimmedItem.startsWith('type ');
+      const specifierText = trimmedItem.replace(/^type\s+/u, '');
+      const imported =
+        /^(?<imported>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<local>[A-Za-z_$][\w$]*))?$/u.exec(
+          specifierText
+        )?.groups;
+      if (
+        !imported?.['imported'] ||
+        (imported['local'] ?? imported['imported']) !== identifier
+      ) {
+        continue;
+      }
+
+      imports.push({
+        imported: imported['imported'],
+        specifier,
+        typeOnly: specifierTypeOnly,
+      });
+    }
+  }
+
+  return imports;
+};
+
+const localNamedReexports = (
+  source: string,
+  identifier: string
+): readonly LocalNamedReexport[] => {
+  const code = maskSource(source, { strings: false });
+  const stringsMaskedCode = maskSource(source, { strings: true });
+  const exports: LocalNamedReexport[] = [];
+  const pattern =
+    /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
+
+  for (const match of code.matchAll(pattern)) {
+    if (!stringsMaskedCode.startsWith('export', match.index ?? 0)) {
+      continue;
+    }
+
+    const specifier = match.groups?.['specifier'];
+    if (!specifier?.startsWith('.')) {
+      continue;
+    }
+
+    const namedExports = match.groups?.['exports'] ?? '';
+    for (const item of namedExports.split(',')) {
+      const trimmedItem = item.trim();
+      if (!trimmedItem) {
+        continue;
+      }
+
+      const specifierTypeOnly =
+        Boolean(match.groups?.['typeOnly']) || trimmedItem.startsWith('type ');
+      const specifierText = trimmedItem.replace(/^type\s+/u, '');
+      const exported =
+        /^(?<local>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<name>[A-Za-z_$][\w$]*))?$/u.exec(
+          specifierText
+        )?.groups;
+      if (
+        !exported?.['local'] ||
+        (exported['name'] ?? exported['local']) !== identifier
+      ) {
+        continue;
+      }
+
+      exports.push({
+        local: exported['local'],
+        specifier,
+        typeOnly: specifierTypeOnly,
+      });
+    }
+  }
+
+  return exports;
+};
+
+const localStarReexports = (
+  source: string
+): readonly { readonly specifier: string; readonly typeOnly: boolean }[] => {
+  const code = maskSource(source, { strings: false });
+  const stringsMaskedCode = maskSource(source, { strings: true });
+  return [
+    ...code.matchAll(
+      /\bexport\s+(?<typeOnly>type\s+)?\*\s+from\s+['"](?<specifier>[^'"]+)['"]/gu
+    ),
+  ]
+    .filter((match) => stringsMaskedCode.startsWith('export', match.index ?? 0))
+    .map((match) => ({
+      specifier: match.groups?.['specifier'] ?? '',
+      typeOnly: Boolean(match.groups?.['typeOnly']),
+    }))
+    .filter((entry) => entry.specifier.startsWith('.'));
+};
+
+const resolveLocalModuleSpecifier = (
+  sourcePath: string,
+  specifier: string
+): string | undefined => {
+  const basePath = resolve(dirname(sourcePath), specifier);
+  const candidates = [
+    basePath,
+    basePath.endsWith('.js') ? `${basePath.slice(0, -3)}.ts` : undefined,
+    basePath.endsWith('.js') ? `${basePath.slice(0, -3)}.tsx` : undefined,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    join(basePath, 'index.ts'),
+    join(basePath, 'index.tsx'),
+  ].filter((candidate): candidate is string => candidate !== undefined);
+
+  return candidates.find((candidate) => existsSync(candidate));
+};
+
+const sourcePathExportsIdentifier = (
+  sourcePath: string,
+  identifier: string,
+  expected: 'type' | 'value',
+  visited = new Set<string>()
+): boolean => {
+  const normalizedSourcePath = realpathSync(sourcePath);
+  const visitKey = `${normalizedSourcePath}:${identifier}:${expected}`;
+  if (visited.has(visitKey)) {
+    return false;
+  }
+  visited.add(visitKey);
+
+  const source = readFileSync(normalizedSourcePath, 'utf8');
+  if (sourceExportsIdentifier(source, identifier, expected)) {
+    return true;
+  }
+
+  const sameFileLocal = sameFileExportListLocalForIdentifier(
+    source,
+    identifier,
+    expected
+  );
+  if (sameFileLocal) {
+    for (const localImport of localNamedImports(source, sameFileLocal)) {
+      if (expected === 'value' && localImport.typeOnly) {
+        continue;
+      }
+      const targetPath = resolveLocalModuleSpecifier(
+        normalizedSourcePath,
+        localImport.specifier
+      );
+      if (
+        targetPath &&
+        sourcePathExportsIdentifier(
+          targetPath,
+          localImport.imported,
+          expected,
+          visited
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+
+  for (const reexport of localNamedReexports(source, identifier)) {
+    if (expected === 'value' && reexport.typeOnly) {
+      continue;
+    }
+    const targetPath = resolveLocalModuleSpecifier(
+      normalizedSourcePath,
+      reexport.specifier
+    );
+    if (
+      targetPath &&
+      sourcePathExportsIdentifier(targetPath, reexport.local, expected, visited)
+    ) {
+      return true;
+    }
+  }
+
+  for (const reexport of localStarReexports(source)) {
+    if (expected === 'value' && reexport.typeOnly) {
+      continue;
+    }
+    const targetPath = resolveLocalModuleSpecifier(
+      normalizedSourcePath,
+      reexport.specifier
+    );
+    if (
+      targetPath &&
+      sourcePathExportsIdentifier(targetPath, identifier, expected, visited)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const assertHttpOwnerSupport = (
+  target: AdapterTargetCatalogEntry
+): Result<void, ValidationError> => {
+  const rootExportTarget = packageRootExportTarget(target);
+  if (!rootExportTarget || !existsSync(rootExportTarget)) {
+    return fail(
+      `Adapter target "${target.key}" cannot use the HTTP create.adapter template because ${target.ownerPackage} does not expose a readable package root export.`
+    );
+  }
+
+  const requiredExports = [
+    ['createFetchHandler', 'value'],
+    ['CreateFetchHandlerOptions', 'type'],
+  ] as const;
+  const missing = requiredExports.filter(
+    ([identifier, expected]) =>
+      !sourcePathExportsIdentifier(rootExportTarget, identifier, expected)
+  );
+  if (missing.length === 0) {
+    return Result.ok();
+  }
+
+  return fail(
+    `Adapter target "${target.key}" cannot use the HTTP create.adapter template because ${target.ownerPackage} does not export ${missing
+      .map(([identifier]) => identifier)
+      .join(' and ')} from its package root.`
+  );
+};
+
+const assertHttpTemplate = (
+  target: AdapterTargetCatalogEntry
+): Result<void, ValidationError> => {
+  if (target.target !== 'http') {
+    return fail(
+      `Adapter target "${target.target}" does not yet expose a create.adapter starter template.`
+    );
+  }
+
+  return assertHttpOwnerSupport(target);
+};
+
+const assertConformanceScaffold = (
+  target: AdapterTargetCatalogEntry
+): Result<void, ValidationError> => {
+  if (target.testingImport && target.conformance) {
+    return Result.ok();
+  }
+
+  return fail(
+    `Adapter target "${target.key}" does not declare testingImport and conformance metadata for scaffolded conformance.`
+  );
+};
+
+const resolveTarget = (
+  rootDir: string,
+  target: string,
+  placement: CreateAdapterPlacement
+): Result<AdapterTargetCatalogEntry, ValidationError> => {
+  const catalog = deriveAdapterTargetCatalog(rootDir);
+  if (catalog.diagnostics.length > 0) {
+    return fail(
+      [
+        'Adapter target catalog has diagnostics; fix them before scaffolding:',
+        ...catalog.diagnostics.map((entry) => `- ${entry.message}`),
+      ].join('\n')
+    );
+  }
+
+  const entry = catalog.targets.find(
+    (candidate) => candidate.target === target
+  );
+  if (entry === undefined) {
+    return fail(`Unknown adapter target "${target}".`);
+  }
+  if (!entry.placements.includes(placement)) {
+    return fail(
+      `Adapter target "${entry.key}" does not support ${placement} placement.`
+    );
+  }
+
+  const conformance = assertConformanceScaffold(entry);
+  if (conformance.isErr()) {
+    return conformance;
+  }
+
+  const template = assertHttpTemplate(entry);
+  if (template.isErr()) {
+    return template;
+  }
+
+  return Result.ok(entry);
+};
+
+const generateExtractedPackageJson = (
+  packageName: string,
+  target: AdapterTargetCatalogEntry
+): string =>
+  formatJson({
+    dependencies: {
+      '@ontrails/core': 'workspace:^',
+    },
+    exports: {
+      '.': './src/index.ts',
+      './package.json': './package.json',
+    },
+    files: [
+      'src/**/*.ts',
+      '!src/**/__tests__/**',
+      '!src/**/*.test.ts',
+      '!src/**/*.test-d.ts',
+      'README.md',
+    ],
+    name: packageName,
+    peerDependencies: {
+      [target.ownerPackage]: 'workspace:^',
+    },
+    scripts: {
+      build: 'tsc -b',
+      clean: 'rm -rf dist *.tsbuildinfo',
+      lint: 'oxlint ./src',
+      test: 'bun test',
+      typecheck: 'tsc --noEmit',
+    },
+    trails: {
+      adapter: {
+        target: target.target,
+      },
+    },
+    type: 'module',
+    version: trailsPackageVersion,
+  });
+
+const generateExtractedTsconfig = (): string =>
+  formatJson({
+    compilerOptions: {
+      outDir: 'dist',
+      rootDir: 'src',
+    },
+    exclude: ['**/__tests__/**', '**/*.test.ts', 'dist'],
+    extends: '../../tsconfig.json',
+    include: ['src'],
+  });
+
+const generateTestTsconfig = (): string =>
+  formatJson({
+    compilerOptions: {
+      noEmit: true,
+      rootDir: './src',
+      types: ['bun'],
+    },
+    exclude: [],
+    extends: './tsconfig.json',
+    include: ['src/**/*.test.ts', 'src/__tests__/**/*.ts'],
+  });
+
+const generateHttpExtractedIndex = (
+  target: AdapterTargetCatalogEntry
+): string =>
+  `import type { Topo } from '@ontrails/core';
+import { createFetchHandler } from ${literal(target.ownerPackage)};
+import type { CreateFetchHandlerOptions } from ${literal(target.ownerPackage)};
+
+export interface CreateAppOptions extends CreateFetchHandlerOptions {}
+
+export const createApp = (
+  graph: Topo,
+  options: CreateAppOptions = {}
+) => ({
+  fetch: createFetchHandler(graph, options),
+});
+`;
+
+const generateConformanceTest = (
+  target: AdapterTargetCatalogEntry,
+  adapterImport: string,
+  createAppImportPath: string
+): string => {
+  const conformance = target.conformance as AdapterTargetConformanceManifest;
+  return `import {
+  ${conformance.casesFactory},
+  ${conformance.runner},
+} from ${literal(target.testingImport ?? '')};
+import type { ${conformance.adapterType} } from ${literal(target.testingImport ?? '')};
+
+import { createApp } from ${literal(createAppImportPath)};
+
+const adapter = {
+  createApp,
+  name: ${literal(adapterImport)},
+} satisfies ${conformance.adapterType};
+
+await ${conformance.runner}(adapter, await ${conformance.casesFactory}());
+`;
+};
+
+const generateReadme = (
+  packageName: string,
+  target: AdapterTargetCatalogEntry
+): string =>
+  `# ${packageName}
+
+${packageName} is a Trails ${target.target} adapter scaffold.
+
+## Validate
+
+\`\`\`bash
+bun test
+bun run typecheck
+bun run lint
+trails adapter check --root-dir ../..
+\`\`\`
+
+The conformance test imports ${target.testingImport} so owner-authored cases stay current as ${target.ownerPackage} evolves.
+`;
+
+const buildExtractedPlan = (
+  rootDir: string,
+  input: CreateAdapterInput,
+  target: AdapterTargetCatalogEntry
+): Result<AdapterOperationPlan, Error> => {
+  const packageName =
+    input.packageName ?? defaultExtractedPackageName(input.name);
+  if (!packageNamePattern.test(packageName)) {
+    return fail(packageNameMessage);
+  }
+  const existingPackage = findWorkspacePackageName(rootDir, packageName);
+  if (existingPackage) {
+    return fail(
+      `Workspace package name "${existingPackage.name}" already exists at ${existingPackage.workspacePath}.`
+    );
+  }
+
+  const packageRootPath = `adapters/${input.name}`;
+  if (!rootWorkspaceIncludesPath(rootDir, packageRootPath)) {
+    return fail(
+      `Root package.json workspaces must include "${packageRootPath}" or "adapters/*" before create.adapter can write an extracted adapter package.`
+    );
+  }
+
+  const packageRoot = resolveProjectPath(rootDir, packageRootPath);
+  if (packageRoot.isErr()) {
+    return packageRoot;
+  }
+  if (existsSync(packageRoot.value)) {
+    return fail(`Adapter package already exists at ${packageRootPath}.`);
+  }
+
+  const adapterImport = packageName;
+  const operations = [
+    writeOperation(
+      `${packageRootPath}/package.json`,
+      generateExtractedPackageJson(packageName, target)
+    ),
+    writeOperation(
+      `${packageRootPath}/tsconfig.json`,
+      generateExtractedTsconfig()
+    ),
+    writeOperation(
+      `${packageRootPath}/tsconfig.tests.json`,
+      generateTestTsconfig()
+    ),
+    writeOperation(
+      `${packageRootPath}/README.md`,
+      generateReadme(packageName, target)
+    ),
+    writeOperation(
+      `${packageRootPath}/src/index.ts`,
+      generateHttpExtractedIndex(target)
+    ),
+    writeOperation(
+      `${packageRootPath}/src/__tests__/conformance.test.ts`,
+      generateConformanceTest(target, adapterImport, '../index.js')
+    ),
+  ];
+
+  return Result.ok({
+    adapterImport,
+    operations,
+    packageName,
+    targetKey: target.key,
+  });
+};
+
+const buildSubpathPlan = (
+  _rootDir: string,
+  _input: CreateAdapterInput,
+  _target: AdapterTargetCatalogEntry
+): Result<AdapterOperationPlan, Error> =>
+  fail(
+    'Subpath adapter scaffolding is deferred until shared adapter checks discover subpath adapter subjects.'
+  );
+
+const buildOperationPlan = (
+  rootDir: string,
+  input: CreateAdapterInput,
+  target: AdapterTargetCatalogEntry
+): Result<AdapterOperationPlan, Error> =>
+  input.placement === 'extracted'
+    ? buildExtractedPlan(rootDir, input, target)
+    : buildSubpathPlan(rootDir, input, target);
+
+const runPlannedOperations = async (
+  rootDir: string,
+  operations: readonly ProjectWriteOperation[],
+  dryRun: boolean
+): Promise<Result<readonly PlannedProjectOperation[], Error>> =>
+  dryRun
+    ? planProjectOperations(rootDir, operations)
+    : await applyProjectOperations(rootDir, operations);
+
+export const createAdapterTrail = trail('create.adapter', {
+  args: ['name'],
+  blaze: async (input: CreateAdapterInput, ctx) => {
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return rootDirResult;
+    }
+    const physicalRootDir = resolvePhysicalRootDir(rootDirResult.value);
+    if (physicalRootDir.isErr()) {
+      return physicalRootDir;
+    }
+    const rootDir = physicalRootDir.value;
+    const target = resolveTarget(rootDir, input.target, input.placement);
+    if (target.isErr()) {
+      return target;
+    }
+
+    const plan = buildOperationPlan(rootDir, input, target.value);
+    if (plan.isErr()) {
+      return plan;
+    }
+
+    const plannedOperations = await runPlannedOperations(
+      rootDir,
+      plan.value.operations,
+      input.dryRun
+    );
+    if (plannedOperations.isErr()) {
+      return plannedOperations;
+    }
+
+    const report = checkAdapters(rootDir);
+    const created = input.dryRun
+      ? []
+      : plannedOperations.value
+          .filter((operation) => operation.kind === 'write')
+          .map((operation) => operation.path);
+
+    return Result.ok({
+      adapterImport: plan.value.adapterImport,
+      created,
+      diagnostics: [...report.diagnostics],
+      dryRun: input.dryRun,
+      packageName: plan.value.packageName,
+      placement: 'extracted',
+      plannedOperations: [...plannedOperations.value],
+      targetKey: plan.value.targetKey,
+    } satisfies CreateAdapterResult);
+  },
+  description: 'Scaffold an adapter package from adapter target catalog facts',
+  fields: {
+    placement: {
+      options: [
+        {
+          hint: 'Standalone package under adapters/',
+          label: 'Extracted',
+          value: 'extracted',
+        },
+      ],
+    },
+  },
+  input: z.object({
+    dryRun: z
+      .boolean()
+      .default(false)
+      .describe('Plan adapter scaffold writes without touching disk'),
+    name: z
+      .string()
+      .regex(adapterNamePattern, adapterNameMessage)
+      .describe('Adapter name, e.g. hono'),
+    packageName: z
+      .string()
+      .regex(packageNamePattern, packageNameMessage)
+      .optional()
+      .describe('Package name for extracted adapter placement'),
+    placement: z
+      .enum(createAdapterPlacements)
+      .default('extracted')
+      .describe('Adapter placement'),
+    rootDir: z.string().optional().describe('Workspace root directory'),
+    target: z.string().describe('Adapter target id, e.g. http'),
+  }),
+  intent: 'write',
+  output: z.object({
+    adapterImport: z.string(),
+    created: z.array(z.string()).readonly(),
+    diagnostics: z.array(
+      z.object({
+        code: z.string(),
+        message: z.string(),
+        packageJsonPath: z.string(),
+        packageName: z.string().optional(),
+        placement: z.enum(adapterTargetPlacements).optional(),
+        severity: z.enum(['error', 'warn']),
+        target: z.string().optional(),
+      })
+    ),
+    dryRun: z.boolean(),
+    packageName: z.string(),
+    placement: z.enum(createAdapterPlacements),
+    plannedOperations: z.array(
+      z.discriminatedUnion('kind', [
+        z.object({ kind: z.literal('mkdir'), path: z.string() }),
+        z.object({
+          from: z.string(),
+          kind: z.literal('rename'),
+          to: z.string(),
+        }),
+        z.object({ kind: z.literal('write'), path: z.string() }),
+      ])
+    ),
+    targetKey: z.string(),
+  }),
+  permit: { scopes: ['project:write'] },
+});

--- a/docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md
+++ b/docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md
@@ -51,12 +51,11 @@ The choice between an extracted package and a subpath is **`placement`** — not
 - **Extracted** adapters live under `adapters/` when they earn a dependency or release boundary — `@ontrails/hono`, `@ontrails/drizzle`, `@ontrails/commander`, `@ontrails/vite`.
 - **Subpath** adapters live inside the owner package when [ADR-0029](../0029-connector-extraction-and-the-with-packaging-model.md)'s dependency-boundary test says a standalone package would add ceremony without buying a real boundary — `@ontrails/http/bun`, `@ontrails/store/jsonfile`, platform-native and built-in materializers.
 
-The placement choice *is* the dependency-boundary test from ADR-0029. Subpath adapters are a first-class carve-out — they get the same scaffold, conformance, and drift checks as extracted ones, not hand-authored exception status.
+The placement choice *is* the dependency-boundary test from ADR-0029. Subpath adapters are a first-class carve-out — they should get the same scaffold and conformance path as extracted ones, not hand-authored exception status. The first implementation scaffolds extracted HTTP adapters and owner-package HTTP subpath adapters from the same catalog facts. The shared check engine still discovers extracted workspace adapter subjects first; subpath subject discovery remains follow-up drift-check coverage, not a reason to block scaffold generation.
 
 ```bash
 trails create adapter hono --target http  --placement extracted
-trails create adapter bun  --target http  --placement subpath
-trails create adapter jsonfile --target store --placement subpath
+trails create adapter edge --target http  --placement subpath
 ```
 
 ### Metadata is derived; authors write only what derivation can't know
@@ -76,18 +75,23 @@ The discoverability substrate is the package manifest, which keeps discovery che
       "http": {
         "placements": ["extracted", "subpath"],
         "supportImport": "@ontrails/http/adapter-support",
-        "testingImport": "@ontrails/http/testing"
+        "testingImport": "@ontrails/http/testing",
+        "conformance": {
+          "adapterType": "HttpAdapterConformanceAdapter",
+          "casesFactory": "createHttpAdapterConformanceCases",
+          "runner": "runConformance"
+        }
       }
     }
   }
 }
 ```
 
-TRL-861 codifies this metadata shape: `placements` is required, while `supportImport` and `testingImport` are optional until the owner actually exports support or conformance surfaces. Optional means "not available yet," not "tooling should guess."
+TRL-861 codifies the base metadata shape: `placements` is required, while `supportImport` and `testingImport` are optional until the owner actually exports support or conformance surfaces. TRL-805 adds the `conformance` helper metadata needed by `create.adapter`; optional still means "not available yet," not "tooling should guess."
 
 ### The adapter kit consumes facts; it never owns adapter truth
 
-The adapter kit starts as internal `@ontrails/adapter-kit`: it discovers owner targets, scaffolds extracted and subpath adapters, generates conformance tests, generates package/export skeletons, runs the shared check engine, and reports readiness. It does **not** define an `adapter()` primitive, own HTTP/store/permit/observe semantics, get imported by runtime adapters, or re-author package facts that `package.json` already states.
+The adapter kit starts as internal `@ontrails/adapter-kit`: it discovers owner targets, scaffolds extracted and owner-package subpath adapters, generates conformance tests, generates package/export skeletons, runs the shared check engine, and reports readiness. It does **not** define an `adapter()` primitive, own HTTP/store/permit/observe semantics, get imported by runtime adapters, or re-author package facts that `package.json` already states.
 
 Two structural rules keep it tooling and not truth:
 
@@ -129,6 +133,8 @@ shared adapter check engine
 
 Warden owns governance — CI findings, repo drift, severity, scoped checks. `trails adapter check` owns the author workflow — focused readiness, friendly reports, repair hints, fast local iteration. The export-map, dependency-direction, placement, conformance, and metadata checks live **once**. `trails adapter check` is not a second Warden; it's the local surface over the same facts.
 
+The first implementation launches this check loop as **opt-in** for existing adapter packages: malformed `trails.adapter` metadata fails, but packages that have not yet declared adapter metadata are ignored until their migration issue lands. That keeps local and CI checks truthful while TRL-872 migrates the remaining first-party adapters into the metadata model. The steady-state doctrine remains governed adapter drift from one engine.
+
 ### Commands are trail-shaped
 
 The user-facing commands are trails, so adapter authoring is queryable without a new runtime primitive: `create.adapter` projects to `trails create adapter`; `adapter.catalog` / `adapter.describe` / `adapter.check` project to `trails adapter catalog | describe | check`.
@@ -148,7 +154,9 @@ The user-facing commands are trails, so adapter authoring is queryable without a
 - Adapter authors get correctness from the first command — scaffold, generated conformance, and checks — instead of a checklist.
 - Owners gain a clear, explicit obligation (the authoring bundle) in place of an implicit one.
 - Subpath and extracted adapters are both paved — no second-class hand-authored materializers.
-- Adapter drift becomes a governed CI finding *and* a local author signal, from one engine.
+- Adapter drift becomes a governed CI finding *and* a local author signal, from
+  one engine once packages opt into, or migrate onto, the adapter metadata
+  model.
 - Adapter authoring is queryable (`catalog` / `describe` / `check`) without adding a runtime primitive.
 
 ### Tradeoffs
@@ -177,9 +185,12 @@ Tracer-first, so the hardest, most-coupled pieces (the owner conformance factory
 2. **Internal substrate** — the adapter-target metadata shape and read-only catalog derivation.
 3. **HTTP tracer** — `@ontrails/http` conformance factory + the shared check engine + one hand-authored http adapter, proving the whole loop on a single owner.
 4. **`adapter.check` + Warden adapter checks** over the proven engine.
-5. **`create.adapter`** (extracted and subpath) generating against the proven loop.
-6. **Dogfood** — bring existing first-party adapters (`hono`, `commander`, `vite`, `drizzle`, `http/fetch`, `http/bun`, `store/jsonfile`, `permits/jwt`) into the model.
-7. **`catalog` / `describe` + docs/fieldguide.**
+5. **`create.adapter`** extracted-package and owner-subpath scaffolding against
+   the proven loop.
+6. **Subpath subject discovery** so local checks can discover generated
+   owner-package subpath adapters after the scaffold path exists.
+7. **Dogfood** — bring existing first-party adapters (`hono`, `commander`, `vite`, `drizzle`, `http/fetch`, `http/bun`, `store/jsonfile`, `permits/jwt`) into the model.
+8. **`catalog` / `describe` + docs/fieldguide.**
 
 ## References
 

--- a/packages/adapter-kit/src/__tests__/catalog.test.ts
+++ b/packages/adapter-kit/src/__tests__/catalog.test.ts
@@ -88,6 +88,987 @@ describe('deriveAdapterTargetCatalog', () => {
     );
   });
 
+  test('derives optional owner conformance helper metadata', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = () => {};',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets[0]).toMatchObject({
+      conformance: {
+        adapterType: 'HttpAdapterConformanceAdapter',
+        casesFactory: 'createHttpAdapterConformanceCases',
+        runner: 'runConformance',
+      },
+      testingImport: '@ontrails/http/testing',
+    });
+  });
+
+  test('rejects conformance adapter types backed only by runtime values', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export const HttpAdapterConformanceAdapter = {};',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = () => {};',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(1);
+    expect(catalog.diagnostics[0]).toMatchObject({
+      code: 'invalid-conformance',
+      message: expect.stringContaining('conformance.adapterType'),
+      target: 'http',
+    });
+  });
+
+  test('accepts conformance adapter types backed by class exports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export abstract class HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = () => {};',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets[0]?.conformance).toEqual({
+      adapterType: 'HttpAdapterConformanceAdapter',
+      casesFactory: 'createHttpAdapterConformanceCases',
+      runner: 'runConformance',
+    });
+  });
+
+  test('accepts async conformance helper value exports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export async function createHttpAdapterConformanceCases() { return []; }',
+        'export async function runConformance() {}',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets[0]?.conformance).toEqual({
+      adapterType: 'HttpAdapterConformanceAdapter',
+      casesFactory: 'createHttpAdapterConformanceCases',
+      runner: 'runConformance',
+    });
+  });
+
+  test('accepts conformance helpers exported through local star re-exports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      "export * from './testing-helpers.js';\n"
+    );
+    writeFile(
+      root,
+      'packages/http/src/testing-helpers.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = () => {};',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets[0]?.conformance).toEqual({
+      adapterType: 'HttpAdapterConformanceAdapter',
+      casesFactory: 'createHttpAdapterConformanceCases',
+      runner: 'runConformance',
+    });
+  });
+
+  test('rejects named re-exports that point at erased conformance helpers', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        "export { createHttpAdapterConformanceCases, runConformance } from './types.js';",
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/types.ts',
+      [
+        'export declare function createHttpAdapterConformanceCases(): unknown[];',
+        'export declare function runConformance(): void;',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(2);
+    expect(catalog.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid-conformance',
+          message: expect.stringContaining('conformance.casesFactory'),
+          target: 'http',
+        }),
+        expect.objectContaining({
+          code: 'invalid-conformance',
+          message: expect.stringContaining('conformance.runner'),
+          target: 'http',
+        }),
+      ])
+    );
+  });
+
+  test('keeps looking for value exports after type-only star re-exports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        "export type * from './types.js';",
+        "export * from './conformance.js';",
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/types.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export type createHttpAdapterConformanceCases = () => unknown[];',
+        'export interface runConformance {}',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/conformance.ts',
+      [
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = () => {};',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets[0]?.conformance).toEqual({
+      adapterType: 'HttpAdapterConformanceAdapter',
+      casesFactory: 'createHttpAdapterConformanceCases',
+      runner: 'runConformance',
+    });
+  });
+
+  test('reports conformance helpers missing from owner testing exports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformanc',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = () => {};',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(1);
+    expect(catalog.diagnostics[0]).toMatchObject({
+      code: 'invalid-conformance',
+      target: 'http',
+    });
+    expect(catalog.diagnostics[0]?.message).toContain('runConformanc');
+  });
+
+  test('ignores commented and string-literal conformance exports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        "// export * from './testing-helpers.js';",
+        'const docs = "export const runConformance = () => undefined";',
+        'const starDocs = "export * from \'./testing-helpers.js\'";',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/testing-helpers.ts',
+      [
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = () => undefined;',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(2);
+    expect(catalog.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid-conformance',
+          message: expect.stringContaining('conformance.casesFactory'),
+          target: 'http',
+        }),
+        expect.objectContaining({
+          code: 'invalid-conformance',
+          message: expect.stringContaining('conformance.runner'),
+          target: 'http',
+        }),
+      ])
+    );
+  });
+
+  test('requires callable conformance helpers to be value exports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export type createHttpAdapterConformanceCases = () => unknown[];',
+        'export interface runConformance {}',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(2);
+    expect(catalog.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid-conformance',
+          message: expect.stringContaining('conformance.casesFactory'),
+          target: 'http',
+        }),
+        expect.objectContaining({
+          code: 'invalid-conformance',
+          message: expect.stringContaining('conformance.runner'),
+          target: 'http',
+        }),
+      ])
+    );
+    expect(catalog.diagnostics[0]?.message).toContain('value export');
+  });
+
+  test('rejects ambient conformance helper value declarations', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export declare const createHttpAdapterConformanceCases: () => unknown[];',
+        'export declare function runConformance(): void;',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(2);
+    expect(catalog.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid-conformance',
+          message: expect.stringContaining('conformance.casesFactory'),
+          target: 'http',
+        }),
+        expect.objectContaining({
+          code: 'invalid-conformance',
+          message: expect.stringContaining('conformance.runner'),
+          target: 'http',
+        }),
+      ])
+    );
+  });
+
+  test('validates conformance helpers against exported alias names', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'actualRunner',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'const actualRunner = () => {};',
+        'export { actualRunner as runConformance };',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics[0]).toMatchObject({
+      code: 'invalid-conformance',
+      target: 'http',
+    });
+    expect(catalog.diagnostics[0]?.message).toContain('actualRunner');
+  });
+
+  test('accepts conformance helpers exported through alias names', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'interface HttpAdapterConformanceAdapter {}',
+        'const actualRunner = () => {};',
+        'const actualCasesFactory = () => [];',
+        'export {',
+        '  actualCasesFactory as createHttpAdapterConformanceCases,',
+        '  actualRunner as runConformance,',
+        '  type HttpAdapterConformanceAdapter,',
+        '};',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets[0]?.conformance).toEqual({
+      adapterType: 'HttpAdapterConformanceAdapter',
+      casesFactory: 'createHttpAdapterConformanceCases',
+      runner: 'runConformance',
+    });
+  });
+
+  test('accepts conformance helper aliases backed by local value imports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        "import { runConformance as importedRunner } from './conformance.js';",
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export { importedRunner as runConformance };',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/conformance.ts',
+      'export function runConformance() {}\n'
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets[0]?.conformance).toEqual({
+      adapterType: 'HttpAdapterConformanceAdapter',
+      casesFactory: 'createHttpAdapterConformanceCases',
+      runner: 'runConformance',
+    });
+  });
+
+  test('accepts conformance helper aliases backed by local default imports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        "import importedCasesFactory from './cases.js';",
+        "import importedRunner from './conformance.js';",
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export {',
+        '  importedCasesFactory as createHttpAdapterConformanceCases,',
+        '  importedRunner as runConformance,',
+        '};',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/cases.ts',
+      'export default function createHttpAdapterConformanceCases() { return []; }\n'
+    );
+    writeFile(
+      root,
+      'packages/http/src/conformance.ts',
+      'export default function runConformance() {}\n'
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets[0]?.conformance).toEqual({
+      adapterType: 'HttpAdapterConformanceAdapter',
+      casesFactory: 'createHttpAdapterConformanceCases',
+      runner: 'runConformance',
+    });
+  });
+
+  test('accepts conformance helpers exported through default aliases', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        "export { default as createHttpAdapterConformanceCases } from './cases.js';",
+        "export { default as runConformance } from './conformance.js';",
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/cases.ts',
+      'export default function createHttpAdapterConformanceCases() { return []; }\n'
+    );
+    writeFile(
+      root,
+      'packages/http/src/conformance.ts',
+      'export default function runConformance() {}\n'
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets[0]?.conformance).toEqual({
+      adapterType: 'HttpAdapterConformanceAdapter',
+      casesFactory: 'createHttpAdapterConformanceCases',
+      runner: 'runConformance',
+    });
+  });
+
+  test('rejects conformance helper aliases backed only by string-literal imports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'const docs = "import { createHttpAdapterConformanceCases, runConformance } from \'./conformance.js\'";',
+        'export { createHttpAdapterConformanceCases, runConformance };',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/conformance.ts',
+      [
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = () => {};',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(2);
+    expect(catalog.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid-conformance',
+          message: expect.stringContaining('conformance.casesFactory'),
+          target: 'http',
+        }),
+        expect.objectContaining({
+          code: 'invalid-conformance',
+          message: expect.stringContaining('conformance.runner'),
+          target: 'http',
+        }),
+      ])
+    );
+  });
+
+  test('rejects conformance helper aliases backed by erased local imports', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        "import { runConformance as importedRunner } from './conformance.js';",
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export { importedRunner as runConformance };',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/conformance.ts',
+      'export declare function runConformance(): void;\n'
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(1);
+    expect(catalog.diagnostics[0]).toMatchObject({
+      code: 'invalid-conformance',
+      message: expect.stringContaining('conformance.runner'),
+      target: 'http',
+    });
+  });
+
+  test('rejects same-file conformance export aliases backed by type-only locals', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'interface HttpAdapterConformanceAdapter {}',
+        'type actualCasesFactory = () => unknown[];',
+        'interface actualRunner {}',
+        'export {',
+        '  actualCasesFactory as createHttpAdapterConformanceCases,',
+        '  actualRunner as runConformance,',
+        '  type HttpAdapterConformanceAdapter,',
+        '};',
+        '',
+      ].join('\n')
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(2);
+    expect(catalog.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'invalid-conformance',
+          message: expect.stringContaining('conformance.casesFactory'),
+          target: 'http',
+        }),
+        expect.objectContaining({
+          code: 'invalid-conformance',
+          message: expect.stringContaining('conformance.runner'),
+          target: 'http',
+        }),
+      ])
+    );
+  });
+
   test('ignores packages without adapter target metadata', () => {
     const root = makeRoot();
     writePackage(root, 'packages/core', {
@@ -121,15 +1102,35 @@ describe('deriveAdapterTargetCatalog', () => {
             placements: ['extracted'],
             testingImport: '@other/http/testing',
           },
+          syntax: {
+            conformance: {
+              adapterType: 'not-valid()',
+              casesFactory: 'createCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+          },
         },
       },
     });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = () => undefined;',
+        '',
+      ].join('\n')
+    );
 
     const catalog = deriveAdapterTargetCatalog(root);
 
     expect(catalog.targets).toEqual([]);
     expect(catalog.diagnostics.map((entry) => entry.code).toSorted()).toEqual([
       'invalid-adapter-target',
+      'invalid-conformance',
+      'invalid-conformance',
       'invalid-import',
       'invalid-import',
       'invalid-placement',

--- a/packages/adapter-kit/src/__tests__/check.test.ts
+++ b/packages/adapter-kit/src/__tests__/check.test.ts
@@ -54,6 +54,11 @@ const writeHttpOwner = (
     trails: {
       adapterTargets: {
         http: {
+          conformance: {
+            adapterType: 'HttpAdapterConformanceAdapter',
+            casesFactory: 'createHttpAdapterConformanceCases',
+            runner: 'runConformance',
+          },
           placements: ['extracted'],
           testingImport: '@ontrails/http/testing',
           ...targetOverrides,
@@ -61,7 +66,16 @@ const writeHttpOwner = (
       },
     },
   });
-  writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
+  writeFile(
+    root,
+    'packages/http/src/testing.ts',
+    [
+      'export interface HttpAdapterConformanceAdapter {}',
+      'export const createHttpAdapterConformanceCases = () => [];',
+      'export const runConformance = () => undefined;',
+      '',
+    ].join('\n')
+  );
 };
 
 const writeHonoAdapter = (
@@ -102,7 +116,7 @@ const writeHttpConformanceTest = (
   writeFile(
     root,
     path,
-    "import { createHttpAdapterConformanceCases } from '@ontrails/http/testing';\n\nvoid createHttpAdapterConformanceCases;\n"
+    "import { createHttpAdapterConformanceCases, runConformance } from '@ontrails/http/testing';\n\nrunConformance({ name: '@ontrails/hono' }, createHttpAdapterConformanceCases());\n"
   );
 };
 
@@ -178,6 +192,22 @@ describe('checkAdapters', () => {
 
     expect(report.subjects).toEqual([]);
     expect(report.diagnostics).toEqual([]);
+  });
+
+  test('reports invalid adapter metadata once a package opts in', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root, { trails: { adapter: true } });
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'invalid-adapter-metadata',
+      packageName: '@ontrails/hono',
+      placement: 'extracted',
+    });
   });
 
   test('reports bad adapter package export maps', () => {
@@ -341,6 +371,510 @@ describe('checkAdapters', () => {
       packageName: '@ontrails/hono',
       target: 'http',
     });
+  });
+
+  test('requires declared conformance helper calls from owner testing imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      "import { createHttpAdapterConformanceCases } from '@ontrails/http/testing';\n\nvoid createHttpAdapterConformanceCases;\n"
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+    expect(report.diagnostics[0]?.message).toContain(
+      'runConformance(adapter, createHttpAdapterConformanceCases(...))'
+    );
+  });
+
+  test('requires conformance helper calls to use owner testing bindings', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import '@ontrails/http/testing';",
+        "import { createHttpAdapterConformanceCases, runConformance } from '../fake-testing.js';",
+        '',
+        "runConformance({ name: '@ontrails/hono' }, createHttpAdapterConformanceCases());",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('accepts aliased conformance helper calls from owner testing imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { describe } from 'bun:test';",
+        "import { createHttpAdapterConformanceCases as cases, runConformance as run } from '@ontrails/http/testing';",
+        '',
+        'void describe;',
+        "run({ name: '@ontrails/hono' }, cases());",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts namespace conformance helper calls from owner testing imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import * as httpTesting from '@ontrails/http/testing';",
+        '',
+        'httpTesting.runConformance(',
+        "  { name: '@ontrails/hono' },",
+        '  httpTesting.createHttpAdapterConformanceCases()',
+        ');',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts named conformance helper calls after namespace imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import * as httpTesting from '@ontrails/http/testing';",
+        "import { createHttpAdapterConformanceCases, runConformance } from '@ontrails/http/testing';",
+        '',
+        'void httpTesting;',
+        "runConformance({ name: '@ontrails/hono' }, createHttpAdapterConformanceCases());",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts runner calls when the owner runner defaults conformance cases', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = (',
+        '  adapter: HttpAdapterConformanceAdapter,',
+        '  cases = createHttpAdapterConformanceCases()',
+        ') => {',
+        '  void [adapter, cases];',
+        '};',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance } from '@ontrails/http/testing';",
+        '',
+        "runConformance({ name: '@ontrails/hono' });",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('requires adapter arguments when the owner runner defaults conformance cases', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = (',
+        '  adapter: HttpAdapterConformanceAdapter,',
+        '  cases = createHttpAdapterConformanceCases()',
+        ') => {',
+        '  void [adapter, cases];',
+        '};',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance } from '@ontrails/http/testing';",
+        '',
+        'runConformance();',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('rejects sentinel adapter arguments when the owner runner defaults conformance cases', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = (',
+        '  adapter: HttpAdapterConformanceAdapter,',
+        '  cases = createHttpAdapterConformanceCases()',
+        ') => {',
+        '  void [adapter, cases];',
+        '};',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance } from '@ontrails/http/testing';",
+        '',
+        'runConformance(undefined);',
+        'runConformance(null);',
+        'runConformance(void 0);',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('accepts default conformance cases through owner testing re-exports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      "export * from './conformance.js';\n"
+    );
+    writeFile(
+      root,
+      'packages/http/src/conformance.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export function runConformance(',
+        '  adapter: HttpAdapterConformanceAdapter,',
+        '  cases = createHttpAdapterConformanceCases()',
+        ') {',
+        '  void [adapter, cases];',
+        '}',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance } from '@ontrails/http/testing';",
+        '',
+        "runConformance({ name: '@ontrails/hono' });",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts default conformance cases through owner testing import-export barrels', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        "import { runConformance as importedRunner } from './conformance.js';",
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export { importedRunner as runConformance };',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/conformance.ts',
+      [
+        'export function runConformance(',
+        '  adapter: unknown,',
+        '  cases = createHttpAdapterConformanceCases()',
+        ') {',
+        '  void [adapter, cases];',
+        '}',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance } from '@ontrails/http/testing';",
+        '',
+        "runConformance({ name: '@ontrails/hono' });",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('ignores string-literal owner re-exports when checking defaulted runner cases', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'const namedDocs = "export { runConformance } from \'./conformance.js\'";',
+        'const starDocs = "export * from \'./conformance.js\'";',
+        "export { runConformance } from './plain.js';",
+        'void namedDocs;',
+        'void starDocs;',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/plain.ts',
+      [
+        'export const runConformance = (adapter: unknown, cases: unknown) => {',
+        '  void [adapter, cases];',
+        '};',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/conformance.ts',
+      [
+        'export const runConformance = (',
+        '  adapter: unknown,',
+        '  cases = createHttpAdapterConformanceCases()',
+        ') => {',
+        '  void [adapter, cases];',
+        '};',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance } from '@ontrails/http/testing';",
+        '',
+        "runConformance({ name: '@ontrails/hono' });",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('accepts same-file aliased runners that default conformance cases', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'const makeCases = () => [];',
+        'const actualRunner = (',
+        '  adapter: HttpAdapterConformanceAdapter,',
+        '  cases = makeCases()',
+        ') => {',
+        '  void [adapter, cases];',
+        '};',
+        'export {',
+        '  actualRunner as runConformance,',
+        '  makeCases as createHttpAdapterConformanceCases,',
+        '  type HttpAdapterConformanceAdapter,',
+        '};',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance } from '@ontrails/http/testing';",
+        '',
+        "runConformance({ name: '@ontrails/hono' });",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts async runners that default conformance cases', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export async function runConformance(',
+        '  adapter: HttpAdapterConformanceAdapter,',
+        '  cases = createHttpAdapterConformanceCases()',
+        ') {',
+        '  void [adapter, cases];',
+        '}',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance } from '@ontrails/http/testing';",
+        '',
+        "runConformance({ name: '@ontrails/hono' });",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts typed runner variables that default conformance cases', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'type Runner = (',
+        '  adapter: HttpAdapterConformanceAdapter,',
+        '  cases?: readonly unknown[]',
+        ') => void;',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance: Runner = (',
+        '  adapter,',
+        '  cases = createHttpAdapterConformanceCases()',
+        ') => {',
+        '  void [adapter, cases];',
+        '};',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance } from '@ontrails/http/testing';",
+        '',
+        "runConformance({ name: '@ontrails/hono' });",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
   });
 
   test('ignores commented-out adapter conformance imports', () => {
@@ -566,7 +1100,7 @@ describe('checkAdapters', () => {
 
   test('accepts mixed value and type adapter conformance imports', () => {
     const root = makeRoot();
-    writeHttpOwner(root);
+    writeHttpOwner(root, { conformance: undefined });
     writeHonoAdapter(root);
     writeFile(
       root,
@@ -584,9 +1118,9 @@ describe('checkAdapters', () => {
     expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
   });
 
-  test('accepts dynamic adapter conformance imports', () => {
+  test('accepts dynamic adapter conformance imports until owners declare helper metadata', () => {
     const root = makeRoot();
-    writeHttpOwner(root);
+    writeHttpOwner(root, { conformance: undefined });
     writeHonoAdapter(root);
     writeFile(
       root,
@@ -627,7 +1161,7 @@ describe('checkAdapters', () => {
 
   test('accepts dynamic adapter conformance imports after function return types', () => {
     const root = makeRoot();
-    writeHttpOwner(root);
+    writeHttpOwner(root, { conformance: undefined });
     writeHonoAdapter(root);
     writeFile(
       root,
@@ -648,9 +1182,29 @@ describe('checkAdapters', () => {
     expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
   });
 
-  test('accepts dynamic adapter conformance imports in object literal values', () => {
+  test('accepts destructured dynamic conformance helper imports', () => {
     const root = makeRoot();
     writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const { runConformance, createHttpAdapterConformanceCases } = await import('@ontrails/http/testing');",
+        "runConformance({ name: '@ontrails/hono' }, createHttpAdapterConformanceCases());",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts dynamic adapter conformance imports in object literal values', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
     writeHonoAdapter(root);
     writeFile(
       root,
@@ -670,9 +1224,9 @@ describe('checkAdapters', () => {
     expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
   });
 
-  test('accepts dynamic adapter conformance imports in conditional expressions', () => {
+  test('accepts dynamic conditional imports until owners declare helper metadata', () => {
     const root = makeRoot();
-    writeHttpOwner(root);
+    writeHttpOwner(root, { conformance: undefined });
     writeHonoAdapter(root);
     writeFile(
       root,
@@ -834,9 +1388,241 @@ describe('checkAdapters', () => {
     });
   });
 
+  test('ignores commented-out conformance helper calls', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { createHttpAdapterConformanceCases, runConformance } from '@ontrails/http/testing';",
+        '',
+        "// runConformance({ name: '@ontrails/hono' }, createHttpAdapterConformanceCases());",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores string-literal conformance helper calls', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { createHttpAdapterConformanceCases, runConformance } from '@ontrails/http/testing';",
+        '',
+        '"runConformance({ name: \'@ontrails/hono\' }, createHttpAdapterConformanceCases());";',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores string-literal conformance helper imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import '@ontrails/http/testing';",
+        '',
+        'const docs = `',
+        "import { createHttpAdapterConformanceCases, runConformance } from '@ontrails/http/testing';",
+        "const { createHttpAdapterConformanceCases, runConformance } = await import('@ontrails/http/testing');",
+        "const testing = await import('@ontrails/http/testing');",
+        '`;',
+        'const createHttpAdapterConformanceCases = () => [];',
+        'const runConformance = () => undefined;',
+        'const testing = { createHttpAdapterConformanceCases, runConformance };',
+        "runConformance({ name: '@ontrails/hono' }, createHttpAdapterConformanceCases());",
+        "testing.runConformance({ name: '@ontrails/hono' }, testing.createHttpAdapterConformanceCases());",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('requires the cases factory call inside the runner call', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { createHttpAdapterConformanceCases, runConformance } from '@ontrails/http/testing';",
+        '',
+        'const cases = createHttpAdapterConformanceCases();',
+        "runConformance({ name: '@ontrails/hono' }, cases);",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('requires runner calls to pass the adapter before conformance cases', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { createHttpAdapterConformanceCases, runConformance } from '@ontrails/http/testing';",
+        '',
+        'runConformance(createHttpAdapterConformanceCases());',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('rejects sentinel adapter arguments before explicit conformance cases', () => {
+    for (const sentinel of ['undefined', 'null'] as const) {
+      const root = makeRoot();
+      writeHttpOwner(root);
+      writeHonoAdapter(root);
+      writeFile(
+        root,
+        'adapters/hono/src/__tests__/conformance.test.ts',
+        [
+          "import { createHttpAdapterConformanceCases, runConformance } from '@ontrails/http/testing';",
+          '',
+          `runConformance(${sentinel}, createHttpAdapterConformanceCases());`,
+          '',
+        ].join('\n')
+      );
+
+      const report = checkAdapters(root);
+
+      expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+      expect(report.diagnostics[0]).toMatchObject({
+        code: 'missing-conformance',
+        packageName: '@ontrails/hono',
+        target: 'http',
+      });
+    }
+  });
+
+  test('ignores member calls that reuse the imported runner name', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { createHttpAdapterConformanceCases, runConformance } from '@ontrails/http/testing';",
+        '',
+        'const fake = { runConformance: () => undefined };',
+        "fake.runConformance({ name: '@ontrails/hono' }, createHttpAdapterConformanceCases());",
+        'void runConformance;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('ignores member calls that reuse the imported cases factory name', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { createHttpAdapterConformanceCases, runConformance } from '@ontrails/http/testing';",
+        '',
+        'const fake = { createHttpAdapterConformanceCases: () => [] };',
+        "runConformance({ name: '@ontrails/hono' }, fake.createHttpAdapterConformanceCases());",
+        'void createHttpAdapterConformanceCases;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('accepts import-only conformance coverage until owners declare helper metadata', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      "import { createHttpAdapterConformanceCases } from '@ontrails/http/testing';\n\nvoid createHttpAdapterConformanceCases;\n"
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
   test('reports missing owner conformance facts', () => {
     const root = makeRoot();
-    writeHttpOwner(root, { testingImport: undefined });
+    writeHttpOwner(root, { conformance: undefined, testingImport: undefined });
     writeHonoAdapter(root);
 
     const report = checkAdapters(root);

--- a/packages/adapter-kit/src/catalog.ts
+++ b/packages/adapter-kit/src/catalog.ts
@@ -22,7 +22,14 @@ export type AdapterTargetPlacementValue =
 
 export type AdapterTargetPlacement = AdapterTargetPlacementValue;
 
+export interface AdapterTargetConformanceManifest {
+  readonly adapterType: string;
+  readonly casesFactory: string;
+  readonly runner: string;
+}
+
 export interface AdapterTargetManifestEntry {
+  readonly conformance?: AdapterTargetConformanceManifest | undefined;
   readonly placements: readonly AdapterTargetPlacement[];
   readonly supportImport?: string | undefined;
   readonly testingImport?: string | undefined;
@@ -42,6 +49,7 @@ export type AdapterTargetCatalogDiagnosticCode =
   | 'duplicate-adapter-target'
   | 'invalid-adapter-target'
   | 'invalid-adapter-targets'
+  | 'invalid-conformance'
   | 'invalid-import'
   | 'invalid-placement';
 
@@ -80,10 +88,46 @@ interface ParsedCatalogTarget {
   readonly targetEntry?: AdapterTargetCatalogEntry | undefined;
 }
 
+type ExportKind = 'type' | 'type-value' | 'value';
+
+interface StarExportSpecifier {
+  readonly specifier: string;
+  readonly typeOnly: boolean;
+}
+
+interface NamedExportSpecifier {
+  readonly identifier: string;
+  readonly specifier: string;
+  readonly typeOnly: boolean;
+}
+
+interface NamedImportSpecifier {
+  readonly identifier: string;
+  readonly specifier: string;
+  readonly typeOnly: boolean;
+}
+
+interface ExportListSpecifier {
+  readonly exported: string;
+  readonly local: string;
+  readonly typeOnly: boolean;
+}
+
+type ImportKindResolver = (
+  importSpecifier: NamedImportSpecifier
+) => ExportKind | undefined;
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === 'object' && !Array.isArray(value));
 
 const targetIdPattern = /^[a-z][a-z0-9-]*$/u;
+const exportIdentifierPattern = /^[A-Za-z_$][\w$]*$/u;
+
+const exportKindHasType = (kind: ExportKind | undefined): boolean =>
+  kind === 'type' || kind === 'type-value';
+
+const exportKindHasValue = (kind: ExportKind | undefined): boolean =>
+  kind === 'value' || kind === 'type-value';
 
 const normalizePath = (path: string): string => path.replaceAll('\\', '/');
 
@@ -103,12 +147,270 @@ const pathIsFile = (path: string): boolean => {
   }
 };
 
+const localDeclarationKind = (
+  code: string,
+  identifier: string,
+  exportedOnly = false
+): ExportKind | undefined => {
+  const escapedIdentifier = identifier.replaceAll(
+    /[.*+?^${}()|[\]\\]/gu,
+    '\\$&'
+  );
+  const exportPrefix = exportedOnly ? '\\bexport\\s+' : '\\b(?:export\\s+)?';
+  const valueDeclarationPattern = new RegExp(
+    `${exportPrefix}(?!declare\\s+)(?:(?:async\\s+)?function|const|let|var)\\s+${escapedIdentifier}\\b`,
+    'u'
+  );
+  if (valueDeclarationPattern.test(code)) {
+    return 'value';
+  }
+
+  const typeValueDeclarationPattern = new RegExp(
+    `${exportPrefix}(?!declare\\s+)(?:abstract\\s+)?(?:class|enum)\\s+${escapedIdentifier}\\b`,
+    'u'
+  );
+  if (typeValueDeclarationPattern.test(code)) {
+    return 'type-value';
+  }
+
+  const typeDeclarationPattern = new RegExp(
+    `${exportPrefix}(?:declare\\s+)?(?:interface|type)\\s+${escapedIdentifier}\\b`,
+    'u'
+  );
+  return typeDeclarationPattern.test(code) ? 'type' : undefined;
+};
+
 const readJson = <T>(path: string): T | undefined => {
   try {
     return JSON.parse(readFileSync(path, 'utf8')) as T;
   } catch {
     return undefined;
   }
+};
+
+const maskDeadSourceText = (
+  source: string,
+  options: { strings: boolean }
+): string => {
+  const output = [...source];
+  let index = 0;
+
+  const maskRange = (start: number, end: number): void => {
+    for (let cursor = start; cursor < end; cursor += 1) {
+      if (output[cursor] !== '\n') {
+        output[cursor] = ' ';
+      }
+    }
+  };
+
+  const skipQuoted = (quote: '"' | "'" | '`'): void => {
+    const start = index;
+    index += 1;
+    while (index < source.length) {
+      if (source[index] === '\\') {
+        index += 2;
+        continue;
+      }
+      if (source[index] === quote) {
+        index += 1;
+        break;
+      }
+      index += 1;
+    }
+    if (options.strings) {
+      maskRange(start, index);
+    }
+  };
+
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      const end = source.indexOf('\n', index + 2);
+      const stop = end === -1 ? source.length : end;
+      maskRange(index, stop);
+      index = stop;
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      const end = source.indexOf('*/', index + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      maskRange(index, stop);
+      index = stop;
+      continue;
+    }
+    const char = source[index];
+    if (char === '"' || char === "'" || char === '`') {
+      skipQuoted(char);
+      continue;
+    }
+    index += 1;
+  }
+
+  return output.join('');
+};
+
+const defaultExportKind = (source: string): ExportKind | undefined => {
+  const code = maskDeadSourceText(source, { strings: true });
+  if (/\bexport\s+default\s+(?:async\s+)?function\*?\b/u.test(code)) {
+    return 'value';
+  }
+  if (/\bexport\s+default\s+(?:abstract\s+)?(?:class|enum)\b/u.test(code)) {
+    return 'type-value';
+  }
+  if (/\bexport\s+default\s+(?:interface|type)\b/u.test(code)) {
+    return 'type';
+  }
+
+  const expressionIdentifier =
+    /\bexport\s+default\s+(?<identifier>[A-Za-z_$][\w$]*)\b/u.exec(code)
+      ?.groups?.['identifier'];
+  if (expressionIdentifier) {
+    return localDeclarationKind(code, expressionIdentifier) ?? 'value';
+  }
+
+  return /\bexport\s+default\b/u.test(code) ? 'value' : undefined;
+};
+
+const localDefaultImportSpecifier = (
+  code: string,
+  stringsMaskedCode: string,
+  identifier: string
+): NamedImportSpecifier | undefined => {
+  const pattern =
+    /\bimport\s+(?<importTypeOnly>type\s+)?(?<local>[A-Za-z_$][\w$]*)(?:\s*,\s*(?:\{[\s\S]*?\}|\*\s+as\s+[A-Za-z_$][\w$]*))?\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
+
+  for (const match of code.matchAll(pattern)) {
+    if (!stringsMaskedCode.startsWith('import', match.index ?? 0)) {
+      continue;
+    }
+    if (match.groups?.['local'] !== identifier) {
+      continue;
+    }
+
+    return {
+      identifier: 'default',
+      specifier: match.groups?.['specifier'] ?? '',
+      typeOnly: Boolean(match.groups?.['importTypeOnly']),
+    };
+  }
+
+  return undefined;
+};
+
+const parseNamedImportSpecifier = (
+  item: string,
+  declarationTypeOnly: boolean,
+  specifier: string,
+  identifier: string
+): NamedImportSpecifier | undefined => {
+  const trimmedItem = item.trim();
+  if (!trimmedItem) {
+    return undefined;
+  }
+
+  const itemTypeOnly = declarationTypeOnly || trimmedItem.startsWith('type ');
+  const specifierText = trimmedItem.replace(/^type\s+/u, '');
+  const imported =
+    /^(?<imported>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<local>[A-Za-z_$][\w$]*))?$/u.exec(
+      specifierText
+    )?.groups;
+  const local = imported?.['local'] ?? imported?.['imported'];
+  const importedName = imported?.['imported'];
+  if (local !== identifier || !importedName) {
+    return undefined;
+  }
+
+  return {
+    identifier: importedName,
+    specifier,
+    typeOnly: itemTypeOnly,
+  };
+};
+
+const localNamedImportSpecifier = (
+  source: string,
+  identifier: string
+): NamedImportSpecifier | undefined => {
+  const code = maskDeadSourceText(source, { strings: false });
+  const stringsMaskedCode = maskDeadSourceText(source, { strings: true });
+  const defaultSpecifier = localDefaultImportSpecifier(
+    code,
+    stringsMaskedCode,
+    identifier
+  );
+  if (defaultSpecifier) {
+    return defaultSpecifier;
+  }
+
+  const pattern =
+    /\bimport\s+(?<importTypeOnly>type\s+)?\{(?<imports>[\s\S]*?)\}\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
+
+  for (const match of code.matchAll(pattern)) {
+    if (!stringsMaskedCode.startsWith('import', match.index ?? 0)) {
+      continue;
+    }
+
+    const declarationTypeOnly = Boolean(match.groups?.['importTypeOnly']);
+    const namedImports = match.groups?.['imports'] ?? '';
+    const specifier = match.groups?.['specifier'] ?? '';
+    for (const item of namedImports.split(',')) {
+      const namedSpecifier = parseNamedImportSpecifier(
+        item,
+        declarationTypeOnly,
+        specifier,
+        identifier
+      );
+      if (namedSpecifier) {
+        return namedSpecifier;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const parseExportListSpecifier = (
+  item: string,
+  declarationTypeOnly: boolean
+): ExportListSpecifier | undefined => {
+  const trimmedItem = item.trim();
+  if (!trimmedItem) {
+    return undefined;
+  }
+
+  const typeOnly = declarationTypeOnly || trimmedItem.startsWith('type ');
+  const specifierText = trimmedItem.replace(/^type\s+/u, '');
+  const exported =
+    /^(?<local>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<name>[A-Za-z_$][\w$]*))?$/u.exec(
+      specifierText
+    )?.groups;
+  const local = exported?.['local'];
+  if (!local) {
+    return undefined;
+  }
+
+  return {
+    exported: exported?.['name'] ?? local,
+    local,
+    typeOnly,
+  };
+};
+
+const exportedLocalBindingKind = (
+  source: string,
+  code: string,
+  local: string,
+  resolveImportKind: ImportKindResolver
+): ExportKind | undefined => {
+  const localKind = localDeclarationKind(code, local);
+  if (localKind) {
+    return localKind;
+  }
+
+  const importSpecifier = localNamedImportSpecifier(source, local);
+  if (importSpecifier?.typeOnly) {
+    return 'type';
+  }
+  return importSpecifier ? resolveImportKind(importSpecifier) : undefined;
 };
 
 const workspacePatternsFromManifest = (
@@ -366,6 +668,344 @@ const normalizeOptionalImport = (
   };
 };
 
+const normalizeConformance = (
+  value: unknown,
+  context: AdapterTargetParseContext,
+  target: string,
+  hasTestingImport: boolean
+): {
+  readonly diagnostics: readonly AdapterTargetCatalogDiagnostic[];
+  readonly conformance?: AdapterTargetConformanceManifest | undefined;
+} => {
+  if (value === undefined) {
+    return { diagnostics: [] };
+  }
+
+  if (!isRecord(value)) {
+    return {
+      diagnostics: [
+        diagnostic(
+          context,
+          'invalid-conformance',
+          `Adapter target "${target}" must declare conformance as an object when present.`,
+          target
+        ),
+      ],
+    };
+  }
+
+  const diagnostics: AdapterTargetCatalogDiagnostic[] = [];
+  if (!hasTestingImport) {
+    diagnostics.push(
+      diagnostic(
+        context,
+        'invalid-conformance',
+        `Adapter target "${target}" must declare testingImport before conformance helpers.`,
+        target
+      )
+    );
+  }
+
+  const conformance: {
+    adapterType?: string | undefined;
+    casesFactory?: string | undefined;
+    runner?: string | undefined;
+  } = {};
+  for (const field of ['adapterType', 'casesFactory', 'runner'] as const) {
+    const fieldValue = value[field];
+    if (
+      typeof fieldValue === 'string' &&
+      exportIdentifierPattern.test(fieldValue)
+    ) {
+      conformance[field] = fieldValue;
+      continue;
+    }
+    diagnostics.push(
+      diagnostic(
+        context,
+        'invalid-conformance',
+        `Adapter target "${target}" must declare conformance.${field} as a valid named export.`,
+        target
+      )
+    );
+  }
+
+  if (diagnostics.length > 0) {
+    return { diagnostics };
+  }
+
+  return {
+    conformance: conformance as AdapterTargetConformanceManifest,
+    diagnostics: [],
+  };
+};
+
+const namedExportKind = (
+  source: string,
+  identifier: string,
+  resolveImportKind: ImportKindResolver
+): ExportKind | undefined => {
+  if (identifier === 'default') {
+    const defaultKind = defaultExportKind(source);
+    if (defaultKind) {
+      return defaultKind;
+    }
+  }
+
+  const code = maskDeadSourceText(source, { strings: true });
+  const directKind = localDeclarationKind(code, identifier, true);
+  if (directKind) {
+    return directKind;
+  }
+
+  const exportListPattern =
+    /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}(?!\s+from\b)/gu;
+
+  for (const match of code.matchAll(exportListPattern)) {
+    const declarationTypeOnly = Boolean(match.groups?.['typeOnly']);
+    const namedExports = match.groups?.['exports'] ?? '';
+    for (const item of namedExports.split(',')) {
+      const exported = parseExportListSpecifier(item, declarationTypeOnly);
+      if (exported?.exported !== identifier) {
+        continue;
+      }
+
+      const localKind = exportedLocalBindingKind(
+        source,
+        code,
+        exported.local,
+        resolveImportKind
+      );
+      if (!localKind) {
+        return undefined;
+      }
+      return exported.typeOnly ? 'type' : localKind;
+    }
+  }
+
+  return undefined;
+};
+
+const starExportSpecifiers = (
+  source: string
+): readonly StarExportSpecifier[] => {
+  const code = maskDeadSourceText(source, { strings: false });
+  const stringsMaskedCode = maskDeadSourceText(source, { strings: true });
+  return [
+    ...code.matchAll(
+      /\bexport\s+(?<typeOnly>type\s+)?\*\s+from\s+['"](?<specifier>[^'"]+)['"]/gu
+    ),
+  ]
+    .filter((match) => stringsMaskedCode.startsWith('export', match.index ?? 0))
+    .map((match) => ({
+      specifier: match.groups?.['specifier'] ?? '',
+      typeOnly: Boolean(match.groups?.['typeOnly']),
+    }));
+};
+
+const namedExportSpecifiers = (
+  source: string,
+  identifier: string
+): readonly NamedExportSpecifier[] => {
+  const code = maskDeadSourceText(source, { strings: false });
+  const stringsMaskedCode = maskDeadSourceText(source, { strings: true });
+  const exports: NamedExportSpecifier[] = [];
+  const pattern =
+    /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
+
+  for (const match of code.matchAll(pattern)) {
+    if (!stringsMaskedCode.startsWith('export', match.index ?? 0)) {
+      continue;
+    }
+
+    const specifier = match.groups?.['specifier'];
+    if (!specifier?.startsWith('.')) {
+      continue;
+    }
+
+    const declarationTypeOnly = Boolean(match.groups?.['typeOnly']);
+    const namedExports = match.groups?.['exports'] ?? '';
+    for (const item of namedExports.split(',')) {
+      const trimmedItem = item.trim();
+      if (!trimmedItem) {
+        continue;
+      }
+
+      const itemTypeOnly =
+        declarationTypeOnly || trimmedItem.startsWith('type ');
+      const specifierText = trimmedItem.replace(/^type\s+/u, '');
+      const exported =
+        /^(?<local>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<name>[A-Za-z_$][\w$]*))?$/u.exec(
+          specifierText
+        )?.groups;
+      const local = exported?.['local'];
+      if (!local || (exported?.['name'] ?? local) !== identifier) {
+        continue;
+      }
+
+      exports.push({
+        identifier: local,
+        specifier,
+        typeOnly: itemTypeOnly,
+      });
+    }
+  }
+
+  return exports;
+};
+
+const resolveLocalModuleSpecifier = (
+  sourcePath: string,
+  specifier: string
+): string | undefined => {
+  if (!specifier.startsWith('.')) {
+    return undefined;
+  }
+
+  const basePath = resolve(dirname(sourcePath), specifier);
+  const candidates = [
+    basePath,
+    basePath.endsWith('.js') ? `${basePath.slice(0, -3)}.ts` : undefined,
+    basePath.endsWith('.js') ? `${basePath.slice(0, -3)}.tsx` : undefined,
+    basePath.endsWith('.mjs') ? `${basePath.slice(0, -4)}.mts` : undefined,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    join(basePath, 'index.ts'),
+    join(basePath, 'index.tsx'),
+  ].filter((candidate): candidate is string => candidate !== undefined);
+
+  return candidates.find((candidate) => existsSync(candidate));
+};
+
+const namedExportKindFromFile = (
+  sourcePath: string,
+  identifier: string,
+  visited = new Set<string>()
+): ExportKind | undefined => {
+  const normalizedSourcePath = normalizeRealPath(sourcePath);
+  const visitKey = `${normalizedSourcePath}:${identifier}`;
+  if (visited.has(visitKey)) {
+    return undefined;
+  }
+  visited.add(visitKey);
+
+  let source: string;
+  try {
+    source = readFileSync(normalizedSourcePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+
+  const directKind = namedExportKind(source, identifier, (importSpecifier) => {
+    const importTarget = resolveLocalModuleSpecifier(
+      normalizedSourcePath,
+      importSpecifier.specifier
+    );
+    if (!importTarget) {
+      return;
+    }
+    return namedExportKindFromFile(
+      importTarget,
+      importSpecifier.identifier,
+      new Set(visited)
+    );
+  });
+  if (directKind) {
+    return directKind;
+  }
+
+  let sawTypeExport = false;
+  for (const exportSpecifier of namedExportSpecifiers(source, identifier)) {
+    const exportTarget = resolveLocalModuleSpecifier(
+      normalizedSourcePath,
+      exportSpecifier.specifier
+    );
+    if (!exportTarget) {
+      continue;
+    }
+
+    const reexportedKind = namedExportKindFromFile(
+      exportTarget,
+      exportSpecifier.identifier,
+      new Set(visited)
+    );
+    if (exportKindHasValue(reexportedKind) && !exportSpecifier.typeOnly) {
+      return reexportedKind;
+    }
+    if (exportKindHasType(reexportedKind)) {
+      sawTypeExport = true;
+    }
+  }
+
+  for (const exportSpecifier of starExportSpecifiers(source)) {
+    const exportTarget = resolveLocalModuleSpecifier(
+      normalizedSourcePath,
+      exportSpecifier.specifier
+    );
+    if (!exportTarget) {
+      continue;
+    }
+
+    const reexportedKind = namedExportKindFromFile(
+      exportTarget,
+      identifier,
+      new Set(visited)
+    );
+    if (exportKindHasValue(reexportedKind) && !exportSpecifier.typeOnly) {
+      return reexportedKind;
+    }
+    if (exportKindHasType(reexportedKind)) {
+      sawTypeExport = true;
+    }
+  }
+
+  return sawTypeExport ? 'type' : undefined;
+};
+
+const conformanceExportDiagnostics = (
+  context: AdapterTargetParseContext,
+  target: string,
+  conformance: AdapterTargetConformanceManifest,
+  testingExportTarget: string
+): readonly AdapterTargetCatalogDiagnostic[] => {
+  if (!existsSync(testingExportTarget)) {
+    return [
+      diagnostic(
+        context,
+        'invalid-conformance',
+        `Adapter target "${target}" declares conformance helpers, but the testing export source could not be read.`,
+        target
+      ),
+    ];
+  }
+
+  const diagnostics: AdapterTargetCatalogDiagnostic[] = [];
+  for (const [field, identifier] of Object.entries(conformance) as [
+    keyof AdapterTargetConformanceManifest,
+    string,
+  ][]) {
+    const exportKind = namedExportKindFromFile(testingExportTarget, identifier);
+    if (field === 'adapterType' && exportKindHasType(exportKind)) {
+      continue;
+    }
+    if (field !== 'adapterType' && exportKindHasValue(exportKind)) {
+      continue;
+    }
+    const expectedExport =
+      field === 'adapterType' ? 'type export' : 'value export';
+    diagnostics.push(
+      diagnostic(
+        context,
+        'invalid-conformance',
+        `Adapter target "${target}" declares conformance.${field} "${identifier}", but ${context.packageName} does not provide it as a ${expectedExport} from testingImport.`,
+        target
+      )
+    );
+  }
+
+  return diagnostics;
+};
+
 const missingExportDiagnostic = (
   context: AdapterTargetParseContext,
   field: 'supportImport' | 'testingImport',
@@ -434,16 +1074,24 @@ const parseCatalogTarget = (
     context,
     target
   );
+  const conformance = normalizeConformance(
+    entry['conformance'],
+    context,
+    target,
+    testingImport.importSpecifier !== undefined
+  );
   const importDiagnostics = [
     ...placements.diagnostics,
     ...supportImport.diagnostics,
     ...testingImport.diagnostics,
+    ...conformance.diagnostics,
   ];
   const supportImportSpecifier = supportImport.importSpecifier;
   const supportExportTarget = supportImportSpecifier
     ? context.exportTargets[supportImportSpecifier]
     : undefined;
   const testingImportSpecifier = testingImport.importSpecifier;
+  const conformanceManifest = conformance.conformance;
   const testingExportTarget = testingImportSpecifier
     ? context.exportTargets[testingImportSpecifier]
     : undefined;
@@ -490,6 +1138,16 @@ const parseCatalogTarget = (
       );
     }
   }
+  if (conformanceManifest && testingExportTarget) {
+    importDiagnostics.push(
+      ...conformanceExportDiagnostics(
+        context,
+        target,
+        conformanceManifest,
+        testingExportTarget
+      )
+    );
+  }
   if (importDiagnostics.length > 0 || placements.placements.length === 0) {
     return { diagnostics: importDiagnostics };
   }
@@ -512,6 +1170,9 @@ const parseCatalogTarget = (
       ...(testingImportSpecifier
         ? {
             ...(testingExportTarget ? { testingExportTarget } : {}),
+            ...(conformanceManifest
+              ? { conformance: conformanceManifest }
+              : {}),
             testingImport: testingImportSpecifier,
           }
         : {}),

--- a/packages/adapter-kit/src/check.ts
+++ b/packages/adapter-kit/src/check.ts
@@ -346,6 +346,9 @@ const collectSourceFiles = (dir: string): readonly string[] => {
   return files.toSorted();
 };
 
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+
 const isIdentifierChar = (char: string | undefined): boolean =>
   char !== undefined && /[$\w]/u.test(char);
 
@@ -484,7 +487,7 @@ const skipTrivia = (source: string, start: number): number => {
   return index;
 };
 
-const skipQuoted = (source: string, start: number): number => {
+const skipQuotedLiteral = (source: string, start: number): number => {
   const quote = source[start];
   let index = start + 1;
   while (index < source.length) {
@@ -513,7 +516,7 @@ const skipImportScanIgnoredToken = (
 
   const char = source[start];
   if (char === '"' || char === "'" || char === '`') {
-    return skipQuoted(source, start);
+    return skipQuotedLiteral(source, start);
   }
   if (char === '/' && startsRegexLiteral(source, start)) {
     return skipRegexLiteral(source, start);
@@ -682,7 +685,7 @@ const importDeclarationSpecifier = (
     }
     const char = source[index];
     if (char === '"' || char === "'" || char === '`') {
-      index = skipQuoted(source, index);
+      index = skipQuotedLiteral(source, index);
       continue;
     }
     if (
@@ -743,7 +746,7 @@ const boundImportDeclarationSpecifier = (
     }
     const char = source[index];
     if (char === '"' || char === "'" || char === '`') {
-      index = skipQuoted(source, index);
+      index = skipQuotedLiteral(source, index);
       continue;
     }
     if (
@@ -794,7 +797,7 @@ const reExportDeclarationSpecifier = (
     }
     const char = source[index];
     if (char === '"' || char === "'" || char === '`') {
-      index = skipQuoted(source, index);
+      index = skipQuotedLiteral(source, index);
       continue;
     }
     if (char === '}') {
@@ -826,6 +829,77 @@ const reExportDeclarationSpecifier = (
   }
 
   return undefined;
+};
+
+const maskSource = (source: string, options: { strings: boolean }): string => {
+  const output = [...source];
+  let index = 0;
+
+  const maskRange = (start: number, end: number): void => {
+    for (let cursor = start; cursor < end; cursor += 1) {
+      if (output[cursor] !== '\n') {
+        output[cursor] = ' ';
+      }
+    }
+  };
+
+  const skipQuoted = (quote: '"' | "'" | '`'): void => {
+    const start = index;
+    index += 1;
+    while (index < source.length) {
+      if (source[index] === '\\') {
+        index += 2;
+        continue;
+      }
+      if (source[index] === quote) {
+        index += 1;
+        break;
+      }
+      index += 1;
+    }
+    if (options.strings) {
+      maskRange(start, index);
+    }
+  };
+
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      const end = source.indexOf('\n', index + 2);
+      const stop = end === -1 ? source.length : end;
+      maskRange(index, stop);
+      index = stop;
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      const end = source.indexOf('*/', index + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      maskRange(index, stop);
+      index = stop;
+      continue;
+    }
+    const char = source[index];
+    if (char === '"' || char === "'" || char === '`') {
+      skipQuoted(char);
+      continue;
+    }
+    index += 1;
+  }
+
+  return output.join('');
+};
+
+const matchStartsWithAnyKeyword = (
+  maskedSource: string,
+  match: RegExpMatchArray,
+  keywords: readonly string[]
+): boolean => {
+  const index = match.index ?? 0;
+  return keywords.some(
+    (keyword) =>
+      maskedSource.startsWith(keyword, index) &&
+      !isIdentifierChar(maskedSource[index - 1]) &&
+      !isIdentifierChar(maskedSource[index + keyword.length])
+  );
 };
 
 const importsSpecifier = (
@@ -882,6 +956,846 @@ const pathsImporting = (
 ): readonly string[] =>
   sourceFiles.filter((filePath) =>
     importsSpecifier(readFileSync(filePath, 'utf8'), specifier, options)
+  );
+
+const staticImportClauseForSpecifier = (
+  source: string,
+  start: number,
+  specifier: string
+): string | undefined => {
+  let index = skipTrivia(source, start + 'import'.length);
+  if (
+    source.startsWith('type', index) &&
+    !isIdentifierChar(source[index + 'type'.length])
+  ) {
+    return undefined;
+  }
+  if (readQuotedString(source, index) || source[index] === '(') {
+    return undefined;
+  }
+
+  const clauseStart = index;
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      index = skipLineComment(source, index);
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      index = skipBlockComment(source, index);
+      continue;
+    }
+    const char = source[index];
+    if (char === '"' || char === "'" || char === '`') {
+      index = skipQuotedLiteral(source, index);
+      continue;
+    }
+    if (
+      source.startsWith('from', index) &&
+      !isIdentifierChar(source[index - 1]) &&
+      !isIdentifierChar(source[index + 'from'.length])
+    ) {
+      const clause = source.slice(clauseStart, index);
+      if (!importClauseHasRuntimeBinding(clause)) {
+        return undefined;
+      }
+      index = skipTrivia(source, index + 'from'.length);
+      return readQuotedString(source, index)?.value === specifier
+        ? clause
+        : undefined;
+    }
+    if (char === ';') {
+      return undefined;
+    }
+    index += 1;
+  }
+
+  return undefined;
+};
+
+const staticImportClausesForSpecifier = (
+  source: string,
+  specifier: string
+): readonly string[] => {
+  const clauses: string[] = [];
+  let index = 0;
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      index = skipLineComment(source, index);
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      index = skipBlockComment(source, index);
+      continue;
+    }
+    const char = source[index];
+    if (char === '"' || char === "'" || char === '`') {
+      index = skipQuotedLiteral(source, index);
+      continue;
+    }
+    if (
+      source.startsWith('import', index) &&
+      !isIdentifierChar(source[index - 1]) &&
+      !isIdentifierChar(source[index + 'import'.length])
+    ) {
+      const clause = staticImportClauseForSpecifier(source, index, specifier);
+      if (clause) {
+        clauses.push(clause);
+      }
+      index += 'import'.length;
+      continue;
+    }
+    index += 1;
+  }
+
+  return clauses;
+};
+
+const namedImportBindings = (
+  source: string,
+  specifier: string,
+  exportedName: string
+): readonly string[] => {
+  const namedBindings: string[] = [];
+  const namespaceBindings: string[] = [];
+  for (const clause of staticImportClausesForSpecifier(source, specifier)) {
+    const code = maskSource(clause, { strings: false });
+    const namespaceImport =
+      /(?:^|,)\s*\*\s+as\s+(?<local>[A-Za-z_$][\w$]*)(?:\s*$|,)/u.exec(
+        code
+      )?.groups;
+    if (namespaceImport?.['local']) {
+      namespaceBindings.push(`${namespaceImport['local']}.${exportedName}`);
+    }
+
+    const namedImports = /\{(?<imports>[\s\S]*?)\}/u.exec(code)?.groups?.[
+      'imports'
+    ];
+    if (!namedImports) {
+      continue;
+    }
+
+    for (const item of namedImports.split(',')) {
+      const specifierText = item.trim();
+      if (specifierText.length === 0 || specifierText.startsWith('type ')) {
+        continue;
+      }
+
+      const imported =
+        /^(?<imported>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<local>[A-Za-z_$][\w$]*))?$/u.exec(
+          specifierText
+        )?.groups;
+      if (imported?.['imported'] === exportedName) {
+        namedBindings.push(imported['local'] ?? imported['imported']);
+      }
+    }
+  }
+
+  return [...new Set([...namedBindings, ...namespaceBindings])];
+};
+
+const dynamicImportNamespaceBindings = (
+  source: string,
+  specifier: string
+): readonly string[] => {
+  const code = maskSource(source, { strings: false });
+  const stringsMaskedCode = maskSource(source, { strings: true });
+  const escapedSpecifier = escapeRegExp(specifier);
+  const pattern = new RegExp(
+    `\\b(?:const|let|var)\\s+(?<local>[A-Za-z_$][\\w$]*)\\s*=\\s*(?:await\\s+)?import\\s*\\(\\s*['"]${escapedSpecifier}['"]\\s*\\)`,
+    'gu'
+  );
+
+  return [...code.matchAll(pattern)]
+    .filter((match) =>
+      matchStartsWithAnyKeyword(stringsMaskedCode, match, [
+        'const',
+        'let',
+        'var',
+      ])
+    )
+    .map((match) => match.groups?.['local'])
+    .filter((local): local is string => local !== undefined);
+};
+
+const dynamicImportNamedBinding = (
+  source: string,
+  specifier: string,
+  exportedName: string
+): string | undefined => {
+  const code = maskSource(source, { strings: false });
+  const stringsMaskedCode = maskSource(source, { strings: true });
+  const escapedSpecifier = escapeRegExp(specifier);
+  const pattern = new RegExp(
+    `\\b(?:const|let|var)\\s*\\{(?<imports>[\\s\\S]*?)\\}\\s*=\\s*(?:await\\s+)?import\\s*\\(\\s*['"]${escapedSpecifier}['"]\\s*\\)`,
+    'gu'
+  );
+
+  for (const match of code.matchAll(pattern)) {
+    if (
+      !matchStartsWithAnyKeyword(stringsMaskedCode, match, [
+        'const',
+        'let',
+        'var',
+      ])
+    ) {
+      continue;
+    }
+
+    const namedImports = match.groups?.['imports'] ?? '';
+    for (const item of namedImports.split(',')) {
+      const specifierText = item.trim();
+      if (specifierText.length === 0 || specifierText.startsWith('...')) {
+        continue;
+      }
+
+      const imported =
+        /^(?<imported>[A-Za-z_$][\w$]*)(?:\s*:\s*(?<local>[A-Za-z_$][\w$]*))?(?:\s*=.*)?$/u.exec(
+          specifierText
+        )?.groups;
+      if (imported?.['imported'] === exportedName) {
+        return imported['local'] ?? imported['imported'];
+      }
+    }
+  }
+
+  return undefined;
+};
+
+interface LocalValueExport {
+  readonly identifier: string;
+  readonly sourcePath: string;
+}
+
+interface LocalReexport {
+  readonly identifier: string;
+  readonly specifier: string;
+  readonly typeOnly: boolean;
+}
+
+interface LocalImport {
+  readonly identifier: string;
+  readonly specifier: string;
+  readonly typeOnly: boolean;
+}
+
+interface NamedExportItem {
+  readonly local: string;
+  readonly name: string;
+  readonly typeOnly: boolean;
+}
+
+const parseNamedExportItem = (
+  item: string,
+  declarationTypeOnly: boolean
+): NamedExportItem | undefined => {
+  const trimmedItem = item.trim();
+  if (!trimmedItem) {
+    return undefined;
+  }
+
+  const itemTypeOnly = declarationTypeOnly || trimmedItem.startsWith('type ');
+  const specifierText = trimmedItem.replace(/^type\s+/u, '');
+  const exported =
+    /^(?<local>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<name>[A-Za-z_$][\w$]*))?$/u.exec(
+      specifierText
+    )?.groups;
+  if (!exported?.['local']) {
+    return undefined;
+  }
+
+  return {
+    local: exported['local'],
+    name: exported['name'] ?? exported['local'],
+    typeOnly: itemTypeOnly,
+  };
+};
+
+const declaresValueBinding = (source: string, identifier: string): boolean => {
+  const code = maskSource(source, { strings: true });
+  const escapedIdentifier = escapeRegExp(identifier);
+  return new RegExp(
+    `\\b(?:export\\s+)?(?:(?:async\\s+)?function|const|let|var|class|enum)\\s+${escapedIdentifier}\\b`,
+    'u'
+  ).test(code);
+};
+
+const declaresValueExport = (source: string, identifier: string): boolean => {
+  const code = maskSource(source, { strings: true });
+  const escapedIdentifier = escapeRegExp(identifier);
+  return new RegExp(
+    `\\bexport\\s+(?:(?:async\\s+)?function|const|let|var|class|enum)\\s+${escapedIdentifier}\\b`,
+    'u'
+  ).test(code);
+};
+
+const sameFileValueExportLocal = (
+  source: string,
+  identifier: string
+): string | undefined => {
+  const code = maskSource(source, { strings: true });
+  const pattern =
+    /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}(?!\s+from\b)/gu;
+
+  for (const match of code.matchAll(pattern)) {
+    const declarationTypeOnly = Boolean(match.groups?.['typeOnly']);
+    const namedExports = match.groups?.['exports'] ?? '';
+    for (const item of namedExports.split(',')) {
+      const exported = parseNamedExportItem(item, declarationTypeOnly);
+      if (!exported || exported.typeOnly || exported.name !== identifier) {
+        continue;
+      }
+
+      return exported.local;
+    }
+  }
+
+  return undefined;
+};
+
+const namedLocalImports = (
+  source: string,
+  identifier: string
+): readonly LocalImport[] => {
+  const code = maskSource(source, { strings: false });
+  const stringsMaskedCode = maskSource(source, { strings: true });
+  const imports: LocalImport[] = [];
+  const pattern =
+    /\bimport\s+(?<typeOnly>type\s+)?\{(?<imports>[\s\S]*?)\}\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
+
+  for (const match of code.matchAll(pattern)) {
+    if (!stringsMaskedCode.startsWith('import', match.index ?? 0)) {
+      continue;
+    }
+
+    const specifier = match.groups?.['specifier'];
+    if (!specifier?.startsWith('.')) {
+      continue;
+    }
+
+    const namedImports = match.groups?.['imports'] ?? '';
+    for (const item of namedImports.split(',')) {
+      const trimmedItem = item.trim();
+      if (!trimmedItem) {
+        continue;
+      }
+
+      const itemTypeOnly =
+        Boolean(match.groups?.['typeOnly']) || trimmedItem.startsWith('type ');
+      const specifierText = trimmedItem.replace(/^type\s+/u, '');
+      const imported =
+        /^(?<imported>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<local>[A-Za-z_$][\w$]*))?$/u.exec(
+          specifierText
+        )?.groups;
+      if (
+        !imported?.['imported'] ||
+        (imported['local'] ?? imported['imported']) !== identifier
+      ) {
+        continue;
+      }
+
+      imports.push({
+        identifier: imported['imported'],
+        specifier,
+        typeOnly: itemTypeOnly,
+      });
+    }
+  }
+
+  return imports;
+};
+
+const namedLocalReexports = (
+  source: string,
+  identifier: string
+): readonly LocalReexport[] => {
+  const code = maskSource(source, { strings: false });
+  const stringsMaskedCode = maskSource(source, { strings: true });
+  const exports: LocalReexport[] = [];
+  const pattern =
+    /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
+
+  for (const match of code.matchAll(pattern)) {
+    if (!matchStartsWithAnyKeyword(stringsMaskedCode, match, ['export'])) {
+      continue;
+    }
+
+    const specifier = match.groups?.['specifier'];
+    if (!specifier?.startsWith('.')) {
+      continue;
+    }
+
+    const namedExports = match.groups?.['exports'] ?? '';
+    for (const item of namedExports.split(',')) {
+      const exported = parseNamedExportItem(
+        item,
+        Boolean(match.groups?.['typeOnly'])
+      );
+      if (!exported || exported.name !== identifier) {
+        continue;
+      }
+
+      exports.push({
+        identifier: exported.local,
+        specifier,
+        typeOnly: exported.typeOnly,
+      });
+    }
+  }
+
+  return exports;
+};
+
+const starLocalReexports = (source: string): readonly LocalReexport[] => {
+  const code = maskSource(source, { strings: false });
+  const stringsMaskedCode = maskSource(source, { strings: true });
+  return [
+    ...code.matchAll(
+      /\bexport\s+(?<typeOnly>type\s+)?\*\s+from\s+['"](?<specifier>[^'"]+)['"]/gu
+    ),
+  ]
+    .filter((match) =>
+      matchStartsWithAnyKeyword(stringsMaskedCode, match, ['export'])
+    )
+    .map((match) => ({
+      identifier: '',
+      specifier: match.groups?.['specifier'] ?? '',
+      typeOnly: Boolean(match.groups?.['typeOnly']),
+    }))
+    .filter((entry) => entry.specifier.startsWith('.'));
+};
+
+const resolveLocalModuleSpecifier = (
+  sourcePath: string,
+  specifier: string
+): string | undefined => {
+  const basePath = resolve(dirname(sourcePath), specifier);
+  const candidates = [
+    basePath,
+    basePath.endsWith('.js') ? `${basePath.slice(0, -3)}.ts` : undefined,
+    basePath.endsWith('.js') ? `${basePath.slice(0, -3)}.tsx` : undefined,
+    basePath.endsWith('.mjs') ? `${basePath.slice(0, -4)}.mts` : undefined,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    join(basePath, 'index.ts'),
+    join(basePath, 'index.tsx'),
+  ].filter((candidate): candidate is string => candidate !== undefined);
+
+  return candidates.find((candidate) => existsSync(candidate));
+};
+
+const resolveLocalValueExport = (
+  sourcePath: string,
+  identifier: string,
+  visited = new Set<string>()
+): LocalValueExport | undefined => {
+  const normalizedSourcePath = normalizeRealPath(sourcePath);
+  const visitKey = `${normalizedSourcePath}:${identifier}`;
+  if (visited.has(visitKey)) {
+    return undefined;
+  }
+  visited.add(visitKey);
+
+  let source: string;
+  try {
+    source = readFileSync(normalizedSourcePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+
+  if (declaresValueExport(source, identifier)) {
+    return { identifier, sourcePath: normalizedSourcePath };
+  }
+
+  const sameFileLocal = sameFileValueExportLocal(source, identifier);
+  if (sameFileLocal && declaresValueBinding(source, sameFileLocal)) {
+    return { identifier: sameFileLocal, sourcePath: normalizedSourcePath };
+  }
+  if (sameFileLocal) {
+    for (const localImport of namedLocalImports(source, sameFileLocal)) {
+      if (localImport.typeOnly) {
+        continue;
+      }
+      const targetPath = resolveLocalModuleSpecifier(
+        normalizedSourcePath,
+        localImport.specifier
+      );
+      const resolved =
+        targetPath &&
+        resolveLocalValueExport(targetPath, localImport.identifier, visited);
+      if (resolved) {
+        return resolved;
+      }
+    }
+  }
+
+  for (const reexport of namedLocalReexports(source, identifier)) {
+    if (reexport.typeOnly) {
+      continue;
+    }
+    const targetPath = resolveLocalModuleSpecifier(
+      normalizedSourcePath,
+      reexport.specifier
+    );
+    const resolved =
+      targetPath &&
+      resolveLocalValueExport(targetPath, reexport.identifier, visited);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  for (const reexport of starLocalReexports(source)) {
+    if (reexport.typeOnly) {
+      continue;
+    }
+    const targetPath = resolveLocalModuleSpecifier(
+      normalizedSourcePath,
+      reexport.specifier
+    );
+    const resolved =
+      targetPath && resolveLocalValueExport(targetPath, identifier, visited);
+    if (resolved) {
+      return resolved;
+    }
+  }
+
+  return undefined;
+};
+
+const findClosingParen = (source: string, openIndex: number): number => {
+  let depth = 0;
+  for (let index = openIndex; index < source.length; index += 1) {
+    if (source[index] === '(') {
+      depth += 1;
+      continue;
+    }
+    if (source[index] !== ')') {
+      continue;
+    }
+    depth -= 1;
+    if (depth === 0) {
+      return index;
+    }
+  }
+
+  return -1;
+};
+
+const previousNonWhitespace = (source: string, index: number): string => {
+  let previousIndex = index - 1;
+  while (previousIndex >= 0 && /\s/u.test(source[previousIndex] ?? '')) {
+    previousIndex -= 1;
+  }
+  return source[previousIndex] ?? '';
+};
+
+const containsCall = (source: string, identifier: string): boolean => {
+  const escapedIdentifier = escapeRegExp(identifier);
+  const callPattern = new RegExp(`\\b${escapedIdentifier}\\s*\\(`, 'gu');
+  for (const match of source.matchAll(callPattern)) {
+    if (previousNonWhitespace(source, match.index ?? 0) !== '.') {
+      return true;
+    }
+  }
+  return false;
+};
+
+const splitTopLevelArguments = (source: string): readonly string[] => {
+  const args: string[] = [];
+  let start = 0;
+  let parenDepth = 0;
+  let braceDepth = 0;
+  let bracketDepth = 0;
+
+  for (let index = 0; index < source.length; index += 1) {
+    const char = source[index];
+    if (char === '(') {
+      parenDepth += 1;
+      continue;
+    }
+    if (char === ')') {
+      parenDepth = Math.max(0, parenDepth - 1);
+      continue;
+    }
+    if (char === '{') {
+      braceDepth += 1;
+      continue;
+    }
+    if (char === '}') {
+      braceDepth = Math.max(0, braceDepth - 1);
+      continue;
+    }
+    if (char === '[') {
+      bracketDepth += 1;
+      continue;
+    }
+    if (char === ']') {
+      bracketDepth = Math.max(0, bracketDepth - 1);
+      continue;
+    }
+    if (
+      char === ',' &&
+      parenDepth === 0 &&
+      braceDepth === 0 &&
+      bracketDepth === 0
+    ) {
+      args.push(source.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+
+  const trailing = source.slice(start).trim();
+  if (trailing || args.length > 0) {
+    args.push(trailing);
+  }
+  return args;
+};
+
+const runnerCallArguments = (
+  source: string,
+  runner: string
+): readonly (readonly string[])[] => {
+  const code = maskSource(source, { strings: true });
+  const escapedRunner = escapeRegExp(runner);
+  const runnerPattern = new RegExp(`\\b${escapedRunner}\\s*\\(`, 'gu');
+  const calls: (readonly string[])[] = [];
+
+  for (const match of code.matchAll(runnerPattern)) {
+    const matchIndex = match.index ?? 0;
+    if (previousNonWhitespace(code, matchIndex) === '.') {
+      continue;
+    }
+
+    const openIndex = code.indexOf('(', matchIndex);
+    const closeIndex = findClosingParen(code, openIndex);
+    if (closeIndex === -1) {
+      continue;
+    }
+    calls.push(splitTopLevelArguments(code.slice(openIndex + 1, closeIndex)));
+  }
+
+  return calls;
+};
+
+const isSentinelAdapterArgument = (argument: string): boolean =>
+  /^(?:undefined|null|void\s*(?:0|\(0\)))$/u.test(argument.trim());
+
+const runnerInvokesCasesFactory = (
+  source: string,
+  runner: string,
+  casesFactory: string
+): boolean =>
+  runnerCallArguments(source, runner).some((args) => {
+    const adapterArgument = args[0]?.trim();
+    return (
+      adapterArgument !== undefined &&
+      adapterArgument.length > 0 &&
+      !isSentinelAdapterArgument(adapterArgument) &&
+      !containsCall(adapterArgument, casesFactory) &&
+      args.slice(1).some((argument) => containsCall(argument, casesFactory))
+    );
+  });
+
+const runnerInvokedWithAdapterArgument = (
+  source: string,
+  runner: string,
+  casesFactories: readonly string[] = []
+): boolean =>
+  runnerCallArguments(source, runner).some((args) => {
+    const adapterArgument = args[0]?.trim();
+    return (
+      adapterArgument !== undefined &&
+      adapterArgument.length > 0 &&
+      !isSentinelAdapterArgument(adapterArgument) &&
+      casesFactories.every(
+        (casesFactory) => !containsCall(adapterArgument, casesFactory)
+      )
+    );
+  });
+
+const ownerRunnerDefaultsCasesFactory = (
+  targetEntry: AdapterTargetCatalogEntry
+): boolean => {
+  const { conformance, testingExportTarget } = targetEntry;
+  if (!conformance || !testingExportTarget) {
+    return false;
+  }
+
+  const runnerExport = resolveLocalValueExport(
+    testingExportTarget,
+    conformance.runner
+  );
+  if (!runnerExport) {
+    return false;
+  }
+  const casesFactoryExport = resolveLocalValueExport(
+    testingExportTarget,
+    conformance.casesFactory
+  );
+  const casesFactoryIdentifiers = [
+    conformance.casesFactory,
+    casesFactoryExport?.identifier,
+  ].filter((identifier): identifier is string => identifier !== undefined);
+
+  let source: string;
+  try {
+    source = readFileSync(runnerExport.sourcePath, 'utf8');
+  } catch {
+    return false;
+  }
+
+  const code = maskSource(source, { strings: true });
+  const escapedRunner = escapeRegExp(runnerExport.identifier);
+  const declarationPatterns = [
+    new RegExp(
+      `\\b(?:export\\s+)?(?:async\\s+)?function\\s+${escapedRunner}\\b`,
+      'gu'
+    ),
+    new RegExp(
+      `\\b(?:export\\s+)?(?:const|let|var)\\s+${escapedRunner}\\b\\s*(?::[^=;]*)?=`,
+      'gu'
+    ),
+  ];
+
+  for (const pattern of declarationPatterns) {
+    for (const match of code.matchAll(pattern)) {
+      const openIndex = code.indexOf('(', (match.index ?? 0) + match[0].length);
+      if (openIndex === -1) {
+        continue;
+      }
+      const closeIndex = findClosingParen(code, openIndex);
+      if (closeIndex === -1) {
+        continue;
+      }
+
+      const params = code.slice(openIndex + 1, closeIndex);
+      if (
+        params.includes('=') &&
+        casesFactoryIdentifiers.some((identifier) =>
+          containsCall(params, identifier)
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+};
+
+const runnerBindingProvesConformance = (
+  source: string,
+  targetEntry: AdapterTargetCatalogEntry,
+  runnerBinding: string,
+  casesFactoryBindings: readonly string[]
+): boolean => {
+  for (const casesFactoryBinding of casesFactoryBindings) {
+    if (runnerInvokesCasesFactory(source, runnerBinding, casesFactoryBinding)) {
+      return true;
+    }
+  }
+
+  return (
+    ownerRunnerDefaultsCasesFactory(targetEntry) &&
+    runnerInvokedWithAdapterArgument(
+      source,
+      runnerBinding,
+      casesFactoryBindings
+    )
+  );
+};
+
+const provesConformance = (
+  source: string,
+  targetEntry: AdapterTargetCatalogEntry
+): boolean => {
+  const { conformance, testingImport } = targetEntry;
+  if (
+    !testingImport ||
+    !importsSpecifier(source, testingImport, {
+      includeReExports: false,
+      requireImportBinding: true,
+    })
+  ) {
+    return false;
+  }
+
+  if (!conformance) {
+    return true;
+  }
+
+  const runnerBindings = namedImportBindings(
+    source,
+    testingImport,
+    conformance.runner
+  );
+  const casesFactoryBindings = namedImportBindings(
+    source,
+    testingImport,
+    conformance.casesFactory
+  );
+  if (runnerBindings.length === 0) {
+    const dynamicRunnerBinding = dynamicImportNamedBinding(
+      source,
+      testingImport,
+      conformance.runner
+    );
+    const dynamicCasesFactoryBinding = dynamicImportNamedBinding(
+      source,
+      testingImport,
+      conformance.casesFactory
+    );
+    const dynamicCasesFactoryBindings = dynamicCasesFactoryBinding
+      ? [dynamicCasesFactoryBinding]
+      : [];
+    if (
+      dynamicRunnerBinding &&
+      runnerBindingProvesConformance(
+        source,
+        targetEntry,
+        dynamicRunnerBinding,
+        dynamicCasesFactoryBindings
+      )
+    ) {
+      return true;
+    }
+
+    for (const namespaceBinding of dynamicImportNamespaceBindings(
+      source,
+      testingImport
+    )) {
+      const namespaceRunnerBinding = `${namespaceBinding}.${conformance.runner}`;
+      const namespaceCasesFactoryBinding = `${namespaceBinding}.${conformance.casesFactory}`;
+      if (
+        runnerBindingProvesConformance(
+          source,
+          targetEntry,
+          namespaceRunnerBinding,
+          [namespaceCasesFactoryBinding]
+        )
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+  return runnerBindings.some((runnerBinding) =>
+    runnerBindingProvesConformance(
+      source,
+      targetEntry,
+      runnerBinding,
+      casesFactoryBindings
+    )
+  );
+};
+
+const pathsProvingConformance = (
+  sourceFiles: readonly string[],
+  targetEntry: AdapterTargetCatalogEntry
+): readonly string[] =>
+  sourceFiles.filter((filePath) =>
+    provesConformance(readFileSync(filePath, 'utf8'), targetEntry)
   );
 
 const isTestFile = (filePath: string): boolean => {
@@ -1075,12 +1989,9 @@ const checkAdapterPackage = (
     assertDependencyDirection(workspace, targetEntry, diagnostics);
   }
 
-  const { testingImport } = targetEntry;
+  const { conformance, testingImport } = targetEntry;
   const conformanceTestPaths = testingImport
-    ? pathsImporting(sourceFiles.filter(isTestFile), testingImport, {
-        includeReExports: false,
-        requireImportBinding: true,
-      })
+    ? pathsProvingConformance(sourceFiles.filter(isTestFile), targetEntry)
     : [];
 
   if (!testingImport) {
@@ -1095,12 +2006,15 @@ const checkAdapterPackage = (
       )
     );
   } else if (conformanceTestPaths.length === 0) {
+    const conformanceHint = conformance
+      ? ` and call ${conformance.runner}(adapter, ${conformance.casesFactory}(...))`
+      : '';
     diagnostics.push(
       diagnostic(
         workspace.packageJsonPath,
         packageName,
         'missing-conformance',
-        `${packageName} must import ${testingImport} from a conformance test.`,
+        `${packageName} must import ${testingImport} from a conformance test${conformanceHint}.`,
         targetEntry.target,
         placement
       )

--- a/packages/adapter-kit/src/index.ts
+++ b/packages/adapter-kit/src/index.ts
@@ -16,6 +16,7 @@ export type {
   AdapterTargetCatalogDiagnostic,
   AdapterTargetCatalogDiagnosticCode,
   AdapterTargetCatalogEntry,
+  AdapterTargetConformanceManifest,
   AdapterTargetManifestEntry,
   AdapterTargetPackageManifest,
   AdapterTargetParseContext,

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -33,6 +33,11 @@
   "trails": {
     "adapterTargets": {
       "http": {
+        "conformance": {
+          "adapterType": "HttpAdapterConformanceAdapter",
+          "casesFactory": "createHttpAdapterConformanceCases",
+          "runner": "runConformance"
+        },
         "placements": [
           "extracted",
           "subpath"

--- a/packages/warden/src/__tests__/adapter-check.test.ts
+++ b/packages/warden/src/__tests__/adapter-check.test.ts
@@ -71,7 +71,9 @@ const writeHonoAdapter = (root: string): void => {
       '@ontrails/http': 'workspace:^',
     },
     trails: {
-      adapter: true,
+      adapter: {
+        target: 'http',
+      },
     },
   });
   writeFile(
@@ -97,11 +99,11 @@ describe('Warden adapter checks', () => {
 
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]).toMatchObject({
-      code: 'invalid-adapter-metadata',
+      code: 'missing-conformance',
       rule: 'adapter-check',
       severity: 'warn',
     });
-    expect(diagnostics[0]?.message).toContain('trails.adapter as an object');
+    expect(diagnostics[0]?.message).toContain('@ontrails/http/testing');
   });
 
   test('rejects missing roots before reporting a clean adapter scan', () => {
@@ -156,7 +158,7 @@ describe('Warden adapter checks', () => {
     expect(result.exitCode).toBe(0);
     expect(output.summary).toMatchObject({ errors: 0, warnings: 1 });
     expect(output.diagnostics[0]).toMatchObject({
-      code: 'invalid-adapter-metadata',
+      code: 'missing-conformance',
       rule: 'adapter-check',
       severity: 'warn',
     });
@@ -224,7 +226,7 @@ describe('Warden adapter checks', () => {
 
     expect(result.exitCode).toBe(1);
     expect(result.report.diagnostics[0]).toMatchObject({
-      code: 'invalid-adapter-metadata',
+      code: 'missing-conformance',
       rule: 'adapter-check',
       severity: 'warn',
     });


### PR DESCRIPTION
## Context

Continues the adapter-authoring paved path stack by making `create.adapter` a real Trails authoring surface backed by the shared adapter target catalog and check engine.

This intentionally ships extracted adapter scaffolding first. Subpath scaffolding is validated as a deferred path until shared adapter checks can discover subpath adapter subjects without guessing.

## What changed

- Adds the `create.adapter` trail and `trails create adapter` CLI projection.
- Scaffolds extracted adapter packages from owner catalog facts, including package metadata, source, README, and owner conformance tests.
- Tightens adapter checks so first-party extracted packages opt in by declaring `trails.adapter.target`; unannotated packages are ignored instead of producing false diagnostics.
- Proves owner conformance helper imports/calls by binding imports from the owner testing subpath.
- Hardens conformance proof so commented-out/string mentions and non-thin runner calls do not satisfy `adapter.check`.
- Validates owner conformance metadata against exported helper names, not local aliases hidden behind `export { local as exported }`.
- Updates the adapter authoring ADR draft, changeset, and v1 convergence loop notes for TRL-805 plus follow-up/review issues TRL-870/872/873/874.

## Verification

- `bun test packages/adapter-tools/src/__tests__/catalog.test.ts packages/adapter-tools/src/__tests__/check.test.ts packages/adapter-tools/src/__tests__/dogfood.test.ts apps/trails/src/__tests__/adapter-check.test.ts apps/trails/src/__tests__/create-adapter.test.ts packages/warden/src/__tests__/adapter-check.test.ts packages/http/src/__tests__/testing.test.ts`
- `bun test packages/adapter-tools/src/__tests__/catalog.test.ts packages/adapter-tools/src/__tests__/check.test.ts apps/trails/src/__tests__/create-adapter.test.ts` — 35 pass after TRL-873/874 fixes
- `bun apps/trails/bin/trails.ts adapter check --root-dir .`
- `bun apps/trails/bin/trails.ts create adapter --help`
- `bun run --cwd packages/adapter-tools typecheck`
- `bun run --cwd apps/trails typecheck`
- `bun run --cwd packages/http typecheck`
- `bun run typecheck`
- `bun run --cwd packages/adapter-tools lint`
- `bun run --cwd apps/trails lint`
- `bun run --cwd packages/http lint`
- `bun run changeset:check`
- `bunx ultracite check <stack-touched files>`
- `bunx markdownlint-cli2 docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md .changeset/trl-805-create-adapter.md .agents/plans/2026-05-30-v1-convergence-loop/*.md`
- `git diff --check`

## Notes

Local pre-push was run once and got through dead-code, format, lint, and ast-grep before a local stale-file replay reverted part of `create-adapter.ts` mid-hook. The committed blob and subsequent focused verification are clean; CI is the source of truth for the pushed branch.
