### PR TITLE
feat(regrade): consume warden term-rewrite metadata

### DIFF
--- a/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
+++ b/.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md
@@ -1,6 +1,6 @@
 ---
 created: "2026-05-30T12:28:00Z"
-updated: "2026-05-31T15:44:00Z"
+updated: "2026-06-01T00:00:00Z"
 status: active
 ---
 
@@ -285,6 +285,36 @@ status: active
   and #643 rejected `runConformance(adapter)` even when the owner runner
   defaulted to the declared cases factory. Fixed both and walked upward again.
 
+### 2026-05-31 17:42 EDT - TRL-836 Regrade/Warden metadata slice
+
+- Created
+  `trl-836-integrate-warden-backed-term-rewrite-regrades` above the ready
+  TRL-805 stack tip. This is a new top branch, so no lower branch was edited.
+- Regrade now derives built-in classes from Warden rules that advertise
+  `fix.class === "term-rewrite"` instead of maintaining a parallel term table.
+- The first projected class is
+  `term-rewrite:no-legacy-layer-imports`; Regrade runs the Warden rule itself,
+  routes review-required fixes to `needs-review`, and preserves the Warden fix
+  reason in the Regrade note.
+- Warden-owned safe edits can be applied generically after Regrade validates
+  spans, ordering, and overlap. Invalid or missing fix edits stay review-only.
+- `@ontrails/adapter-kit` is the actual implemented package name. The older
+  `adapter-tools` wording only remains as historical ADR discussion, not as an
+  active package or import path.
+- Tried to launch a sidecar sniff for the new Regrade slice, but the agent pool
+  was full. Covered the slice inline with focused tests, package gates, and the
+  full top-of-stack gate.
+- `bun run check` initially caught a duplicate export alias
+  (`wardenTermRewriteClasses` and `builtinRegradeClasses`). Removed the alias,
+  amended the branch, reran focused gates, then reran the full top gate clean.
+- Post-submit Codex review found one real P2 on #644: Regrade's new
+  `@ontrails/warden` dependency was missing from `bun.lock`. Ran `bun install`
+  on the owning top branch so frozen installs see the dependency.
+- A later Codex review pass found another real P2 on #644: mixed safe Warden
+  diagnostics could partly rewrite when one diagnostic lacked concrete edits.
+  Regrade now routes the whole file to review when any safe diagnostic is
+  missing edits, preserving the unfixable finding instead of hiding it.
+
 ## Verification Ledger
 
 | Command | Context | Result | Notes |
@@ -529,6 +559,15 @@ status: active
 | `bun run --cwd packages/adapter-kit lint && bun run --cwd apps/trails lint && bun run --cwd packages/warden lint` | TRL-805 final-review follow-up | pass | Adapter-kit, Trails app, and Warden lints clean. |
 | `bun run --cwd packages/adapter-kit typecheck && bun run --cwd apps/trails typecheck && bun run --cwd packages/warden typecheck` | TRL-805 final-review follow-up | pass | Adapter-kit, Trails app, and Warden typechecks clean. |
 | `bun run --cwd packages/adapter-kit build && bun run --cwd apps/trails build && bun run --cwd packages/warden build && bun run lint:ast-grep && git diff --check` | TRL-805 final-review follow-up | pass | Package builds, repo ast-grep, and whitespace checks clean. |
+| `bun test packages/regrade/src/downstream/__tests__/report.test.ts` | TRL-836 Regrade/Warden metadata slice | pass | 16 focused Regrade report tests passed, including Warden-backed review routing. |
+| `bun run --cwd packages/regrade lint && bun run --cwd packages/regrade typecheck && bun run --cwd packages/regrade build && bun run --cwd packages/regrade test` | TRL-836 Regrade package | pass | Regrade lint, typecheck, build, and 35 package tests passed. |
+| `bun test packages/warden/src/__tests__/no-legacy-layer-imports.test.ts packages/warden/src/__tests__/warden-rule-metadata.test.ts packages/warden/src/__tests__/guide.test.ts` | TRL-836 Warden metadata dependency | pass | 25 Warden tests passed for the consumed rule metadata surface. |
+| `bun run changeset:check && bun run lint:ast-grep && git diff --check` | TRL-836 release and structural hygiene | pass | Changeset gate passed; Regrade is private, and repo ast-grep plus whitespace checks stayed clean. |
+| `bun run build && bun run test && bun run check && bun run publish:check && git status --short --branch && git diff --check` | TRL-836 top pre-submit gate | pass | Full workspace build, tests, check, public package pack checks, clean status, and whitespace check passed after removing the duplicate export alias. |
+| `bun install --frozen-lockfile` | TRL-836 lockfile review follow-up | pass | Frozen install accepted the updated Regrade dependency entry in `bun.lock`. |
+| `bun run build && bun run test && bun run check && bun run publish:check && git status --short --branch && git diff --check` | TRL-836 lockfile review follow-up | pass | Full workspace build, tests, check, public package pack checks, status, and whitespace checks passed after the lockfile fix. |
+| `bun test packages/regrade/src/downstream/__tests__/report.test.ts && bun run --cwd packages/regrade lint && bun run --cwd packages/regrade typecheck && git diff --check` | TRL-836 missing-edit review follow-up | pass | Regrade now routes mixed safe Warden diagnostics with missing edits to review; 17 focused tests passed. |
+| `bun run build && bun run test && bun run check && bun run publish:check && git diff --check` | TRL-836 missing-edit review follow-up | pass | Full workspace build, tests, check, public package pack checks, and whitespace check passed after the missing-edit review fix. |
 
 ## Remote PR Ledger
 
@@ -542,7 +581,8 @@ status: active
 | [#639](https://github.com/outfitter-dev/trails/pull/639) | `trl-863-build-shared-adapter-check-engine` | ready | green | Adds shared adapter check engine. |
 | [#640](https://github.com/outfitter-dev/trails/pull/640) | `trl-864-expose-adapter-checks-through-warden-and-trails-adapter` | ready | green | Exposes adapter checks through Warden and `trails adapter check`. |
 | [#641](https://github.com/outfitter-dev/trails/pull/641) | `trl-865-dogfood-adapter-authoring-path-on-a-first-party-http-adapter` | ready | green | Dogfoods Hono as first extracted HTTP adapter subject. |
-| [#643](https://github.com/outfitter-dev/trails/pull/643) | `trl-805-trails-create-adapter-scaffold-adapter-packages-against-the` | ready | local review fixes verified; remote CI must rerun after submit | Adds extracted `create.adapter`; subpath check discovery and remaining adapter migration split to TRL-870/TRL-872. |
+| [#643](https://github.com/outfitter-dev/trails/pull/643) | `trl-805-trails-create-adapter-scaffold-adapter-packages-against-the` | ready | green | Adds extracted `create.adapter`; subpath check discovery and remaining adapter migration split to TRL-870/TRL-872. |
+| [#644](https://github.com/outfitter-dev/trails/pull/644) | `trl-836-integrate-warden-backed-term-rewrite-regrades` | ready | green | Regrade consumes Warden-backed term-rewrite metadata; post-submit lockfile review fix was folded into this top branch. |
 
 Submitted with `gt submit --stack --draft --no-edit --no-interactive`, then
 marked ready after every PR reported green CI. Before submit, the bottom real
@@ -550,6 +590,13 @@ branch had to be reparented from the zero-diff worker lane onto `main`.
 Graphite refused to submit dependents of the empty lane branch, which confirms
 the worktree-farm base branch is useful for local farming but should not sit
 under a submitted stack.
+
+After the #644 lockfile fix, the whole stack was re-audited: all PRs were
+non-draft, no non-outdated review threads remained unresolved, top-branch
+hosted CI was green, and `gt merge --dry-run --no-interactive` reported the
+stack ready to merge. GitHub still showed upper PR merge states as `UNSTABLE`
+while Graphite mergeability caught up; treat that as queue state, not a code
+failure, unless a live check later shows a real failed status.
 
 ## Review Findings
 
@@ -670,7 +717,7 @@ remaining review risk is scope, not correctness: this stack intentionally ships
 discovery and scaffolding to TRL-870, and leaves Commander/Drizzle/Vite metadata
 migration to TRL-872.
 
-Remote review status after marking ready: GitHub CI passed on all eight PRs.
+Remote review status after marking ready: GitHub CI passed on all ten PRs.
 Greptile posted only its account/billing message ("free trial has ended") on
 each PR rather than a code review. Treat that as an unavailable review signal,
 not as a clean Greptile review and not as a code finding.
@@ -716,6 +763,21 @@ functions that default cases, and accepts typed runner variables such as
 `export const runConformance: Runner = (...)` when proving owner default-case
 coverage. The fixes were made on the owning branches, walked upward through
 PR #641, and verified again at the top before any submit.
+
+## Follow-Up Index
+
+These are the known follow-ups from this loop. They are not hidden stack
+blockers; they are the next slices or tracker cleanup needed after the stack
+lands.
+
+| Issue | Status | Follow-up |
+| --- | --- | --- |
+| TRL-870 | Deferred by design | Add adapter check coverage for subpath adapter subject discovery and subpath scaffolding before expanding `create.adapter` beyond extracted adapters. |
+| TRL-872 | Deferred by design | Migrate the remaining first-party adapter packages, especially Commander, Drizzle, and Vite, into the `trails.adapter` metadata model. |
+| TRL-875 | Fixed in stack; tracker cleanup needed | The HTTP public testing subpath CI timeout was fixed on TRL-862 by invoking local TypeScript through `process.execPath` plus `node_modules/typescript/bin/tsc` with an explicit timeout. Local HTTP gates and hosted CI are green. Connected Linear search on 2026-06-01 still showed TRL-875 In Progress, so add the fix/verification comment and move it forward after the stack lands. |
+| TRL-850 | Verify before cutting | May be stale if the adapter ADR merge refreshed the decision map; check live ADR decision-map drift before opening work. |
+| TRL-826 / TRL-829 | Conditional | Keep only if the landed adapter-authoring stack produces enough implementation evidence to justify these slices. |
+| `@ontrails/adapter-kit` naming | Watch | Implemented as publishable-but-internal adapter tooling. Keep checking whether the name communicates "adapter authoring/checking kit" rather than framework authority as more packages consume it. |
 
 ## Open Risks
 

--- a/bun.lock
+++ b/bun.lock
@@ -209,6 +209,7 @@
       "version": "1.0.0-beta.18",
       "dependencies": {
         "@ontrails/core": "workspace:^",
+        "@ontrails/warden": "workspace:^",
         "zod": "catalog:",
       },
       "devDependencies": {

--- a/packages/regrade/package.json
+++ b/packages/regrade/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@ontrails/core": "workspace:^",
+    "@ontrails/warden": "workspace:^",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { executeTrail } from '@ontrails/core';
+import type { WardenRule } from '@ontrails/warden';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -7,9 +8,11 @@ import { join } from 'node:path';
 import {
   buildRegradeReport,
   createTermRewriteClass,
+  createWardenTermRewriteClass,
   regradeReportTrail,
   runRegrade,
   selectRegradeClasses,
+  wardenTermRewriteClasses,
 } from '../report.js';
 
 const signalToPing = createTermRewriteClass({ from: 'signal', to: 'ping' });
@@ -46,6 +49,97 @@ describe('createTermRewriteClass', () => {
     const result = signalToPing.apply('// rename the signal here\n');
     expect(result.kind).toBe('rewrite');
     expect(result.nextSource).toBe('// rename the ping here\n');
+  });
+});
+
+describe('wardenTermRewriteClasses', () => {
+  test('projects Warden term-rewrite metadata into Regrade classes', () => {
+    expect(wardenTermRewriteClasses.map((cls) => cls.id)).toContain(
+      'term-rewrite:no-legacy-layer-imports'
+    );
+  });
+
+  test('routes review-required Warden term rewrites to review', () => {
+    const legacyLayerClass = wardenTermRewriteClasses.find(
+      (cls) => cls.id === 'term-rewrite:no-legacy-layer-imports'
+    );
+    expect(legacyLayerClass).toBeDefined();
+
+    const result = legacyLayerClass?.apply(
+      "import { authLayer } from '@ontrails/permits';\n",
+      { absolutePath: '/repo/src/auth.ts', path: 'src/auth.ts' }
+    );
+
+    expect(result?.kind).toBe('needs-review');
+    expect(result?.reason).toBe('warden-review-required');
+    expect(result?.nextSource).toBeUndefined();
+    expect(result?.notes.join('\n')).toContain(
+      'Removal has no mechanical replacement'
+    );
+  });
+
+  test('reports no-op when Warden finds no term-rewrite diagnostics', () => {
+    const report = buildRegradeReport({
+      classes: wardenTermRewriteClasses,
+      files: [{ path: 'src/a.ts', source: 'export const ok = true;' }],
+      root: '/repo',
+      skipped: [],
+    });
+
+    expect(report.selectedClassIds).toEqual([
+      'term-rewrite:no-legacy-layer-imports',
+    ]);
+    expect(report.matched).toBe(0);
+    expect(report.entries[0]?.outcome).toBe('no-op');
+  });
+
+  test('routes mixed safe diagnostics with missing edits to review', () => {
+    const rule = {
+      check: () => [
+        {
+          filePath: '/repo/src/auth.ts',
+          fix: {
+            class: 'term-rewrite',
+            edits: [{ end: 9, replacement: 'permit', start: 0 }],
+            reason: 'Rename one safe term.',
+            safety: 'safe',
+          },
+          line: 1,
+          message: 'Rename one safe term.',
+          rule: 'no-legacy-layer-imports',
+          severity: 'error',
+        },
+        {
+          filePath: '/repo/src/auth.ts',
+          fix: {
+            class: 'term-rewrite',
+            reason: 'Safe fix metadata was missing concrete edits.',
+            safety: 'safe',
+          },
+          line: 2,
+          message: 'Safe fix metadata was missing concrete edits.',
+          rule: 'no-legacy-layer-imports',
+          severity: 'error',
+        },
+      ],
+      description: 'Test Warden-backed term rewrites.',
+      name: 'no-legacy-layer-imports',
+      severity: 'error',
+    } satisfies WardenRule;
+    const cls = createWardenTermRewriteClass(rule);
+
+    const result = cls?.apply('authLayer();\nauthLayer();\n', {
+      absolutePath: '/repo/src/auth.ts',
+      path: 'src/auth.ts',
+    });
+
+    expect(result?.kind).toBe('needs-review');
+    expect(result?.reason).toBe('warden-fix-missing-edits');
+    expect(result?.nextSource).toBeUndefined();
+    expect(result?.notes.join('\n')).toContain('Rename one safe term.');
+    expect(result?.notes.join('\n')).toContain(
+      'Safe fix metadata was missing concrete edits.'
+    );
   });
 });
 
@@ -128,7 +222,10 @@ const writeReportFixture = (): string => {
   const root = mkdtempSync(join(tmpdir(), 'regrade-report-'));
   mkdirSync(join(root, 'src'), { recursive: true });
   mkdirSync(join(root, 'dist'), { recursive: true });
-  writeFileSync(join(root, 'src', 'a.ts'), 'export const signal = 1;\n');
+  writeFileSync(
+    join(root, 'src', 'a.ts'),
+    "import { authLayer } from '@ontrails/permits';\nexport const signal = 1;\n"
+  );
   writeFileSync(join(root, 'src', 'b.ts'), 'export const signalHandler = 2;\n');
   writeFileSync(join(root, 'dist', 'out.ts'), 'export const signal = 9;\n');
   return root;
@@ -172,13 +269,15 @@ describe('runRegrade + regradeReportTrail', () => {
         // the trail's output shape for property access.
         const value = result.value as {
           scanned: number;
+          review: number;
           selectedClassIds: string[];
           rewritten: number;
         };
         expect(value.scanned).toBe(2);
-        expect(value.rewritten).toBe(1);
+        expect(value.review).toBe(1);
+        expect(value.rewritten).toBe(0);
         expect(value.selectedClassIds).toEqual([
-          'preview.term-rewrite:signal->ping',
+          'term-rewrite:no-legacy-layer-imports',
         ]);
       }
     } finally {

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -1,5 +1,11 @@
 import type { ValidationError } from '@ontrails/core';
 import { NotFoundError, Result, trail, validateOutput } from '@ontrails/core';
+import type {
+  WardenDiagnostic,
+  WardenFixEdit,
+  WardenRule,
+} from '@ontrails/warden';
+import { getWardenRuleMetadata, wardenRules } from '@ontrails/warden';
 import { readFileSync } from 'node:fs';
 import { z } from 'zod';
 
@@ -31,6 +37,16 @@ export interface RegradeClassResult {
   readonly nextSource?: string;
   /** Human-readable notes explaining the outcome. */
   readonly notes: readonly string[];
+  /** Machine-readable reason for review outcomes. */
+  readonly reason?: string;
+}
+
+/** Source-file context passed to Regrade classes. */
+export interface RegradeClassContext {
+  /** Root-relative POSIX path. */
+  readonly path: string;
+  /** Absolute path on disk, when the caller has one. */
+  readonly absolutePath?: string;
 }
 
 /** One named, contract-aware transform. */
@@ -40,7 +56,10 @@ export interface RegradeClass {
   /** What the class does, for report and guide surfaces. */
   readonly describe: string;
   /** Apply the class to a source string. Must be pure and never throw. */
-  readonly apply: (source: string) => RegradeClassResult;
+  readonly apply: (
+    source: string,
+    context?: RegradeClassContext
+  ) => RegradeClassResult;
 }
 
 /** Which regrade classes a run should execute. */
@@ -87,6 +106,7 @@ export const createTermRewriteClass = (options: {
           notes: [
             `Found "${from}" inside larger identifiers; routed to review.`,
           ],
+          reason: 'ambiguous-match',
         };
       }
       if (matches && matches.length > 0) {
@@ -100,6 +120,126 @@ export const createTermRewriteClass = (options: {
     },
     describe: options.describe ?? `Rewrite "${from}" to "${to}".`,
     id: options.id ?? `term-rewrite:${from}->${to}`,
+  };
+};
+
+const TERM_REWRITE_FIX_CLASS = 'term-rewrite';
+
+type WardenEditApplication =
+  | { readonly ok: true; readonly nextSource: string }
+  | { readonly ok: false; readonly reason: string };
+
+const diagnosticNote = (diagnostic: WardenDiagnostic): string => {
+  const reason = diagnostic.fix?.reason ?? diagnostic.message;
+  return `${diagnostic.rule}:${diagnostic.line}: ${reason}`;
+};
+
+const wardenFilePath = (context: RegradeClassContext | undefined): string =>
+  context?.absolutePath ?? context?.path ?? '<regrade-source>';
+
+const applyWardenEdits = (
+  source: string,
+  edits: readonly WardenFixEdit[]
+): WardenEditApplication => {
+  const ordered = [...edits].toSorted((a, b) => a.start - b.start);
+  let previousEnd = 0;
+  for (const edit of ordered) {
+    if (
+      !Number.isInteger(edit.start) ||
+      !Number.isInteger(edit.end) ||
+      edit.start < 0 ||
+      edit.end < edit.start ||
+      edit.end > source.length
+    ) {
+      return { ok: false, reason: 'invalid-edit-span' };
+    }
+    if (edit.start < previousEnd) {
+      return { ok: false, reason: 'overlapping-edit-spans' };
+    }
+    previousEnd = edit.end;
+  }
+
+  let nextSource = source;
+  for (const edit of ordered.toReversed()) {
+    nextSource =
+      nextSource.slice(0, edit.start) +
+      edit.replacement +
+      nextSource.slice(edit.end);
+  }
+  return { nextSource, ok: true };
+};
+
+export const createWardenTermRewriteClass = (
+  rule: WardenRule
+): RegradeClass | null => {
+  const metadata = getWardenRuleMetadata(rule.name);
+  if (metadata?.fix?.class !== TERM_REWRITE_FIX_CLASS) {
+    return null;
+  }
+
+  return {
+    apply: (
+      source: string,
+      context?: RegradeClassContext
+    ): RegradeClassResult => {
+      const diagnostics = rule
+        .check(source, wardenFilePath(context))
+        .filter(
+          (diagnostic) => diagnostic.fix?.class === TERM_REWRITE_FIX_CLASS
+        );
+
+      if (diagnostics.length === 0) {
+        return {
+          kind: 'no-op',
+          notes: [`No Warden ${TERM_REWRITE_FIX_CLASS} diagnostics found.`],
+        };
+      }
+
+      const reviewDiagnostics = diagnostics.filter(
+        (diagnostic) => diagnostic.fix?.safety !== 'safe'
+      );
+      if (reviewDiagnostics.length > 0) {
+        return {
+          kind: 'needs-review',
+          notes: reviewDiagnostics.map(diagnosticNote),
+          reason: 'warden-review-required',
+        };
+      }
+
+      const diagnosticsMissingEdits = diagnostics.filter(
+        (diagnostic) => (diagnostic.fix?.edits?.length ?? 0) === 0
+      );
+      if (diagnosticsMissingEdits.length > 0) {
+        return {
+          kind: 'needs-review',
+          notes: diagnostics.map(diagnosticNote),
+          reason: 'warden-fix-missing-edits',
+        };
+      }
+
+      const edits = diagnostics.flatMap(
+        (diagnostic) => diagnostic.fix?.edits ?? []
+      );
+      const application = applyWardenEdits(source, edits);
+      if (!application.ok) {
+        return {
+          kind: 'needs-review',
+          notes: [
+            ...diagnostics.map(diagnosticNote),
+            `Warden fix edits could not be applied: ${application.reason}.`,
+          ],
+          reason: 'warden-fix-invalid',
+        };
+      }
+
+      return {
+        kind: 'rewrite',
+        nextSource: application.nextSource,
+        notes: diagnostics.map(diagnosticNote),
+      };
+    },
+    describe: `${rule.description} (${metadata.fix.safety} ${metadata.fix.class})`,
+    id: `${metadata.fix.class}:${rule.name}`,
   };
 };
 
@@ -170,12 +310,13 @@ export interface RegradeReport {
 const classifyFile = (
   path: string,
   source: string,
+  context: RegradeClassContext,
   selected: readonly RegradeClass[]
 ): RegradeReportEntry => {
   // First selected class that matches (rewrite or review) wins, mirroring the
   // "run one class" emphasis. No-ops fall through to a no-op entry.
   for (const cls of selected) {
-    const result = cls.apply(source);
+    const result = cls.apply(source, context);
     if (result.kind === 'rewrite') {
       return { classId: cls.id, notes: result.notes, outcome: 'rewrite', path };
     }
@@ -185,7 +326,7 @@ const classifyFile = (
         notes: result.notes,
         outcome: 'needs-review',
         path,
-        reason: 'ambiguous-match',
+        reason: result.reason ?? 'needs-review',
       };
     }
   }
@@ -198,7 +339,11 @@ const classifyFile = (
  */
 export const buildRegradeReport = (params: {
   readonly root: string;
-  readonly files: readonly { readonly path: string; readonly source: string }[];
+  readonly files: readonly {
+    readonly path: string;
+    readonly source: string;
+    readonly absolutePath?: string;
+  }[];
   readonly skipped: readonly SkippedSource[];
   readonly classes: readonly RegradeClass[];
   readonly selection?: RegradeSelection;
@@ -209,7 +354,17 @@ export const buildRegradeReport = (params: {
   );
 
   const fileEntries = params.files.map((file) =>
-    classifyFile(file.path, file.source, selected)
+    classifyFile(
+      file.path,
+      file.source,
+      {
+        ...(file.absolutePath === undefined
+          ? {}
+          : { absolutePath: file.absolutePath }),
+        path: file.path,
+      },
+      selected
+    )
   );
   const skipEntries: RegradeReportEntry[] = params.skipped.map((entry) => ({
     outcome: 'skip',
@@ -258,11 +413,12 @@ export const runRegrade = (params: {
     return null;
   }
 
-  const files: { path: string; source: string }[] = [];
+  const files: { absolutePath: string; path: string; source: string }[] = [];
   const skipped: SkippedSource[] = [...collected.skipped];
   for (const file of collected.files) {
     try {
       files.push({
+        absolutePath: file.absolutePath,
         path: file.path,
         source: readFileSync(file.absolutePath, 'utf8'),
       });
@@ -322,21 +478,18 @@ const validateRegradeReportOutput = (
   validateOutput(regradeReportOutput, report);
 
 /**
- * Preview regrade classes available to the report trail.
+ * Built-in regrade classes available to the report trail.
  *
- * This synthetic class keeps the report trail executable while the downstream
- * engine shape is still settling. It is not Warden-owned detection policy;
- * TRL-836 wires Warden-owned `term-rewrite` metadata into this set instead of
- * hand-authored preview mappings.
+ * Warden owns term detection and fix metadata. Regrade projects Warden rules
+ * that advertise `term-rewrite` capability into reportable classes and then
+ * owns application/reporting of the resulting rewrite or review outcomes.
  */
-export const previewRegradeClasses: readonly RegradeClass[] = Object.freeze([
-  createTermRewriteClass({
-    describe: 'Synthetic preview rewrite: signal -> ping',
-    from: 'signal',
-    id: 'preview.term-rewrite:signal->ping',
-    to: 'ping',
-  }),
-]);
+export const wardenTermRewriteClasses: readonly RegradeClass[] = Object.freeze(
+  [...wardenRules.values()].flatMap((rule) => {
+    const cls = createWardenTermRewriteClass(rule);
+    return cls === null ? [] : [cls];
+  })
+);
 
 /**
  * Engine trail that produces a {@link RegradeReport} for an explicit root.
@@ -348,7 +501,7 @@ export const previewRegradeClasses: readonly RegradeClass[] = Object.freeze([
 export const regradeReportTrail = trail('regrade.downstream.report', {
   blaze: (input) => {
     const report = runRegrade({
-      classes: previewRegradeClasses,
+      classes: wardenTermRewriteClasses,
       root: input.root,
       ...(input.classIds === undefined
         ? {}


### PR DESCRIPTION
## Context

TRL-836 is the next top slice in the v1 convergence stack. Warden already owns term-rewrite detection and fix metadata; Regrade should consume that metadata instead of carrying a second term table.

## What changed

- Adds `@ontrails/warden` as Regrade's private workspace dependency.
- Derives Regrade term-rewrite classes from Warden rule metadata where `fix.class === "term-rewrite"`.
- Projects `term-rewrite:no-legacy-layer-imports` from Warden into Regrade.
- Runs the Warden rule for detection, routes review-required fixes to `needs-review`, and preserves the Warden fix reason in Regrade notes.
- Applies Warden safe-edit payloads only after Regrade validates spans, ordering, and overlap; invalid/missing edits stay review-only.
- Updates the v1 convergence `RETRO.md` with the Regrade slice and verification evidence.

## Verification

- `bun test packages/regrade/src/downstream/__tests__/report.test.ts`
- `bun run --cwd packages/regrade lint`
- `bun run --cwd packages/regrade typecheck`
- `bun run --cwd packages/regrade build`
- `bun run --cwd packages/regrade test`
- `bun test packages/warden/src/__tests__/no-legacy-layer-imports.test.ts packages/warden/src/__tests__/warden-rule-metadata.test.ts packages/warden/src/__tests__/guide.test.ts`
- `bun run changeset:check`
- `bun run lint:ast-grep`
- `bun run build && bun run test && bun run check && bun run publish:check && git status --short --branch && git diff --check`
- Graphite pre-push hook passed: dead-code, format, lint, lint-ast-grep, test, typecheck, and Warden.

## Notes

Regrade is private, so this branch does not add a changeset. The first `bun run check` pass caught a duplicate export alias; that was removed before the full top gate and submit.
