### PR TITLE
docs: converge Trails documentation surfaces

### DIFF
--- a/.agents/skills/clark-survey/SKILL.md
+++ b/.agents/skills/clark-survey/SKILL.md
@@ -79,7 +79,7 @@ Compare the docs against the code:
 bun run test
 bun run typecheck
 trails warden
-trails survey --brief
+trails survey brief
 ```
 
 ### 6. Growth Without Governance

--- a/.agents/skills/clark/references/assess.md
+++ b/.agents/skills/clark/references/assess.md
@@ -14,7 +14,7 @@ Did what was built match what was planned? Compare the implemented trails, schem
 - Do examples cover the agreed happy paths and failure modes?
 - Are `composes` declarations accurate to actual composition?
 
-Run `trails warden` and `trails survey --brief` to get the current state. Do not rely on memory of what the codebase looked like before.
+Run `trails warden` and `trails survey brief` to get the current state. Do not rely on memory of what the codebase looked like before.
 
 ### 2. Architectural Alignment
 

--- a/.agents/skills/clark/references/warden-guide.md
+++ b/.agents/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 59
+- Rule count: 60
 
 ## Agent Instructions
 
@@ -74,6 +74,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `resource-declarations` (error, source/source-static, external): Resource usage is declared on the trail contract. Guidance: Keep infrastructure dependencies declared on the trail contract.
 - `resource-exists` (error, project/project-static, external): Declared resources resolve to known resource definitions. Guidance: Make declared resources resolve to authored resource definitions.
 - `resource-id-grammar` (error, source/source-static, external): Resource identifiers stay out of the scope separator grammar.
+- `resource-mock-coverage` (warn, source/source-static, external): Resource definitions declare a mock factory or an explicit unmockable reason. Guidance: Make each resource declare a test mock or an explicit unmockable reason.
 - `static-resource-accessor-preference` (warn, all/source-static, advisory): Trail logic should prefer static resource helpers over dynamic accessors. Guidance: Use statically scoped resource helpers when the resource definition is already available.
 
 ### Results

--- a/.agents/skills/trails-adrs/SKILL.md
+++ b/.agents/skills/trails-adrs/SKILL.md
@@ -70,11 +70,11 @@ bun scripts/adr.ts fix --yes
 # Validate format and consistency
 bun scripts/adr.ts check
 
-# Regenerate decision-map.json
+# Regenerate decision maps and draft index
 bun scripts/adr.ts map
 ```
 
-The script handles file creation, git moves, title/slug/number updates, index rebuilding, decision map generation, and cross-reference updates.
+The script handles file creation, git moves, title/slug/number updates, index rebuilding, decision map generation for numbered and draft ADRs, and cross-reference updates.
 
 For manual ADR management without the script, see [assets/adr-management.md](assets/adr-management.md).
 
@@ -102,7 +102,8 @@ Examples:
 - Accepted: `docs/adr/NNNN-slug.md`
 - Drafts: `docs/adr/drafts/YYYYMMDD-slug.md`
 - Index: `docs/adr/README.md`
-- Decision map: `docs/adr/decision-map.json`
+- Accepted decision map: `docs/adr/decision-map.json`
+- Draft decision map: `docs/adr/drafts/decision-map.json`
 - Tenets: `docs/tenets.md` — the governing design principles. ADRs must be consistent with the tenets.
 
 ## Statuses

--- a/.agents/skills/trails-adrs/assets/adr-management.md
+++ b/.agents/skills/trails-adrs/assets/adr-management.md
@@ -17,7 +17,7 @@ Manual instructions for ADR lifecycle operations when the `../scripts/adr.ts` sc
 4. Update the title: `# ADR: Title` → `# ADR-NNNN: Title`
 5. Add a row to the index table in `docs/adr/README.md`
 6. Update any other ADRs that reference this one as "(draft)" to use the numbered link
-7. Regenerate `docs/adr/decision-map.json` if it exists
+7. If the script is available, regenerate `docs/adr/decision-map.json`, `docs/adr/drafts/decision-map.json`, and `docs/adr/drafts/README.md`
 
 ## Demoting a numbered ADR
 
@@ -60,4 +60,4 @@ Rules:
 
 ## Decision map
 
-`docs/adr/decision-map.json` is a generated JSON file that catalogs all ADRs (numbered and drafts) with their metadata. Regenerate it after any structural changes. The script's `map` command handles this automatically.
+`docs/adr/decision-map.json` catalogs accepted ADR metadata, while `docs/adr/drafts/decision-map.json` catalogs draft ADR metadata. The script's `map` command regenerates both maps and the generated draft index.

--- a/.agents/skills/trails-adrs/scripts/adr.ts
+++ b/.agents/skills/trails-adrs/scripts/adr.ts
@@ -10,7 +10,7 @@
  *   update   — change title, slug, status, or number of an ADR
  *   check    — validate ADR format and consistency
  *   fix      — auto-fix common issues (number padding, cross-refs)
- *   map      — regenerate decision-map.json
+ *   map      — regenerate decision maps and draft index
  *
  * Usage:
  *   bun .claude/skills/trails-adrs/scripts/adr.ts create --title "My Decision" --slug my-decision

--- a/.agents/skills/trails-adrs/scripts/lib/cli.ts
+++ b/.agents/skills/trails-adrs/scripts/lib/cli.ts
@@ -76,7 +76,7 @@ Commands:
   update    Change title, slug, status, or number of an ADR
   check     Validate ADR format and consistency
   fix       Auto-fix common issues (number padding, cross-refs)
-  map       Regenerate decision-map.json
+  map       Regenerate decision maps and draft index
 
 Options:
   --title <title>           ADR title (create, update)

--- a/.agents/skills/trails-adrs/scripts/lib/decision-map.ts
+++ b/.agents/skills/trails-adrs/scripts/lib/decision-map.ts
@@ -264,6 +264,8 @@ const buildDraftsIndex = (
     '# Draft ADRs',
     '',
     'Proposed decisions under discussion. Promoted to `docs/adr/` when accepted.',
+    '',
+    'Draft map: `docs/adr/drafts/decision-map.json`; numbered map: `docs/adr/decision-map.json`.',
   ];
 
   // Group by YYYY-MM from created date

--- a/.changeset/boundary-tsdoc.md
+++ b/.changeset/boundary-tsdoc.md
@@ -1,0 +1,8 @@
+---
+'@ontrails/commander': patch
+'@ontrails/hono': patch
+'@ontrails/pino': patch
+'@ontrails/vite': patch
+---
+
+Add missing TSDoc for public adapter and sink boundary types.

--- a/.changeset/wayfinder-shell.md
+++ b/.changeset/wayfinder-shell.md
@@ -1,7 +1,11 @@
 ---
+'@ontrails/observe': patch
+'@ontrails/topographer': patch
 '@ontrails/wayfinder': major
 ---
 
-Scaffold the empty `@ontrails/wayfinder` package shell. Reserves the namespace and gives the v0 wayfinding trails a clean home; no trails ship yet. v0 catalog is specified in the wayfinding draft ADR (`docs/adr/drafts/20260503-wayfinding.md`).
+Scaffold the empty `@ontrails/wayfinder` package shell and remove draft ADR
+anchors from public source comments. Reserves the namespace and gives future
+wayfinding trails a clean home; no trails ship yet.
 
 The `major` bump keeps the package in lockstep with the rest of the `@ontrails/*` workspace: with `initialVersions: "0.1.0"` in `.changeset/pre.json`, a `major` bump computes `1.0.0` on `changeset pre exit`, matching the other framework packages that carry `major` bumps in earlier changesets (`api-simplification-beta4`, `topo-store-relocation`).

--- a/.claude/agents/maintainer.md
+++ b/.claude/agents/maintainer.md
@@ -35,7 +35,7 @@ You are a subagent. You may read and write files, but you must NOT perform any g
 
 ## Memory
 
-Use `.claude/agent-memory/maintainer/` to build persistent knowledge about the ADR landscape across sessions. Write each memory as a separate `.md` file with frontmatter, and index it in `MEMORY.md`.
+Use `.agents/memory/decisions.md` to build persistent knowledge about the ADR landscape across sessions. Append each memory as a dated markdown section with enough source anchors to stay auditable.
 
 ### What to remember
 
@@ -56,13 +56,10 @@ Use `.claude/agent-memory/maintainer/` to build persistent knowledge about the A
 ### Memory format
 
 ```markdown
----
-name: theme-name
-description: one-line hook for relevance matching
-type: decision-graph | style-feedback | theme | cross-cutting | draft-status | reference
----
+### YYYY-MM-DD Brief topic
+
+**Type:** decision-graph | style-feedback | theme | cross-cutting | draft-status | reference
+**Hook:** one-line relevance hook
 
 Content. For style feedback, include **Why:** and **How to apply:** lines.
 ```
-
-Index each file in `MEMORY.md` with a one-line entry: `- [Title](file.md) — hook`

--- a/.claude/skills/clark-survey/SKILL.md
+++ b/.claude/skills/clark-survey/SKILL.md
@@ -71,7 +71,7 @@ Compare the docs against the code:
 bun run test
 bun run typecheck
 trails warden
-trails survey --brief
+trails survey brief
 ```
 
 ### 6. Growth Without Governance

--- a/.claude/skills/clark/references/assess.md
+++ b/.claude/skills/clark/references/assess.md
@@ -14,7 +14,7 @@ Did what was built match what was planned? Compare the implemented trails, schem
 - Do examples cover the agreed happy paths and failure modes?
 - Are `composes` declarations accurate to actual composition?
 
-Run `trails warden` and `trails survey --brief` to get the current state. Do not rely on memory of what the codebase looked like before.
+Run `trails warden` and `trails survey brief` to get the current state. Do not rely on memory of what the codebase looked like before.
 
 ### 2. Architectural Alignment
 

--- a/.claude/skills/trails-adrs/SKILL.md
+++ b/.claude/skills/trails-adrs/SKILL.md
@@ -63,11 +63,11 @@ bun scripts/adr.ts fix --yes
 # Validate format and consistency
 bun scripts/adr.ts check
 
-# Regenerate decision-map.json
+# Regenerate decision maps and draft index
 bun scripts/adr.ts map
 ```
 
-The script handles file creation, git moves, title/slug/number updates, index rebuilding, decision map generation, and cross-reference updates.
+The script handles file creation, git moves, title/slug/number updates, index rebuilding, decision map generation for numbered and draft ADRs, and cross-reference updates.
 
 For manual ADR management without the script, see [assets/adr-management.md](assets/adr-management.md).
 
@@ -95,7 +95,8 @@ Examples:
 - Accepted: `docs/adr/NNNN-slug.md`
 - Drafts: `docs/adr/drafts/YYYYMMDD-slug.md`
 - Index: `docs/adr/README.md`
-- Decision map: `docs/adr/decision-map.json`
+- Accepted decision map: `docs/adr/decision-map.json`
+- Draft decision map: `docs/adr/drafts/decision-map.json`
 - Tenets: `docs/tenets.md` — the governing design principles. ADRs must be consistent with the tenets.
 
 ## Statuses

--- a/.claude/skills/trails-adrs/assets/adr-management.md
+++ b/.claude/skills/trails-adrs/assets/adr-management.md
@@ -17,7 +17,7 @@ Manual instructions for ADR lifecycle operations when the `../scripts/adr.ts` sc
 4. Update the title: `# ADR: Title` → `# ADR-NNNN: Title`
 5. Add a row to the index table in `docs/adr/README.md`
 6. Update any other ADRs that reference this one as "(draft)" to use the numbered link
-7. Regenerate `docs/adr/decision-map.json` if it exists
+7. If the script is available, regenerate `docs/adr/decision-map.json`, `docs/adr/drafts/decision-map.json`, and `docs/adr/drafts/README.md`
 
 ## Demoting a numbered ADR
 
@@ -60,4 +60,4 @@ Rules:
 
 ## Decision map
 
-`docs/adr/decision-map.json` is a generated JSON file that catalogs all ADRs (numbered and drafts) with their metadata. Regenerate it after any structural changes. The script's `map` command handles this automatically.
+`docs/adr/decision-map.json` catalogs accepted ADR metadata, while `docs/adr/drafts/decision-map.json` catalogs draft ADR metadata. The script's `map` command regenerates both maps and the generated draft index.

--- a/.claude/skills/trails-adrs/scripts/adr.ts
+++ b/.claude/skills/trails-adrs/scripts/adr.ts
@@ -10,7 +10,7 @@
  *   update   — change title, slug, status, or number of an ADR
  *   check    — validate ADR format and consistency
  *   fix      — auto-fix common issues (number padding, cross-refs)
- *   map      — regenerate decision-map.json
+ *   map      — regenerate decision maps and draft index
  *
  * Usage:
  *   bun .claude/skills/trails-adrs/scripts/adr.ts create --title "My Decision" --slug my-decision

--- a/.claude/skills/trails-adrs/scripts/lib/cli.ts
+++ b/.claude/skills/trails-adrs/scripts/lib/cli.ts
@@ -76,7 +76,7 @@ Commands:
   update    Change title, slug, status, or number of an ADR
   check     Validate ADR format and consistency
   fix       Auto-fix common issues (number padding, cross-refs)
-  map       Regenerate decision-map.json
+  map       Regenerate decision maps and draft index
 
 Options:
   --title <title>           ADR title (create, update)

--- a/.claude/skills/trails-adrs/scripts/lib/decision-map.ts
+++ b/.claude/skills/trails-adrs/scripts/lib/decision-map.ts
@@ -264,6 +264,8 @@ const buildDraftsIndex = (
     '# Draft ADRs',
     '',
     'Proposed decisions under discussion. Promoted to `docs/adr/` when accepted.',
+    '',
+    'Draft map: `docs/adr/drafts/decision-map.json`; numbered map: `docs/adr/decision-map.json`.',
   ];
 
   // Group by YYYY-MM from created date

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ For direct local lint and format validation, prefer the repo scripts (`bun run l
 
 ## Project Overview
 
-Trails is an agent-native, contract-first TypeScript framework. Define a trail once with typed input, `Result` output, examples, and meta, then surface it on CLI, MCP, HTTP, or WebSocket.
+Trails is an agent-native, contract-first TypeScript framework. Define a trail once with typed input, `Result` output, examples, and meta, then surface it on CLI, MCP, or HTTP today. WebSocket is planned on the same contract-first model.
 
 The architecture is designed to make consistency easier than drift. Agents building with Trails should naturally produce aligned surfaces. Agents consuming Trails apps should be able to inspect contracts, examples, schemas, and errors at runtime without guessing.
 

--- a/adapters/commander/src/surface.ts
+++ b/adapters/commander/src/surface.ts
@@ -23,6 +23,9 @@ import { toCommander } from './to-commander.js';
 // Options
 // ---------------------------------------------------------------------------
 
+/**
+ * Options for creating Commander CLI surfaces from a Trails topo.
+ */
 export interface CreateProgramOptions extends BaseSurfaceOptions {
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
@@ -38,6 +41,9 @@ export interface CreateProgramOptions extends BaseSurfaceOptions {
   readonly version?: string | undefined;
 }
 
+/**
+ * Result returned by running the Commander surface bootstrap.
+ */
 export interface SurfaceCliResult {
   readonly exitCode: number;
 }

--- a/adapters/commander/src/to-commander.ts
+++ b/adapters/commander/src/to-commander.ts
@@ -11,6 +11,9 @@ import { Command, InvalidArgumentError, Option } from 'commander';
 // Options
 // ---------------------------------------------------------------------------
 
+/**
+ * Options used when constructing a Commander program from trail metadata.
+ */
 export interface ToCommanderOptions {
   description?: string | undefined;
   name?: string | undefined;

--- a/adapters/hono/src/surface.ts
+++ b/adapters/hono/src/surface.ts
@@ -31,6 +31,9 @@ import { handleCaughtHonoError } from './caught-error.js';
 // Options
 // ---------------------------------------------------------------------------
 
+/**
+ * Options for building a Trails HTTP app on Hono.
+ */
 export interface CreateAppOptions extends BaseSurfaceOptions {
   readonly basePath?: string | undefined;
   readonly createContext?:
@@ -50,6 +53,9 @@ interface RuntimeOptions {
   readonly maxJsonBodyBytes?: number | undefined;
 }
 
+/**
+ * Runtime handle returned by the Hono surface.
+ */
 export interface SurfaceHttpResult {
   readonly close: () => Promise<void>;
   readonly url: string;

--- a/adapters/vite/src/index.ts
+++ b/adapters/vite/src/index.ts
@@ -3,12 +3,17 @@ import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 
+/**
+ * Fetch contract consumed by the Vite adapter when converting to middleware.
+ */
 export interface FetchSurface {
   fetch(request: Request): Response | Promise<Response>;
 }
 
+/** Callback invoked when Connect middleware should continue execution. */
 export type ViteMiddlewareNext = (error?: unknown) => void;
 
+/** Connect-style middleware wrapper around a Trails fetch surface. */
 export type ViteMiddleware = (
   req: IncomingMessage,
   res: ServerResponse,

--- a/docs/adr/drafts/README.md
+++ b/docs/adr/drafts/README.md
@@ -4,6 +4,8 @@
 
 Proposed decisions under discussion. Promoted to `docs/adr/` when accepted.
 
+Draft map: `docs/adr/drafts/decision-map.json`; numbered map: `docs/adr/decision-map.json`.
+
 ## 2026-03
 
 - [Direct Trail Invocation (`trails run`)](20260331-direct-invocation.md)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -292,6 +292,20 @@ CrudOperation, CrudAccessorExpectation
 // writable store resources fire canonical scoped signals when accessed through `db.from(ctx)`.
 ```
 
+### `@ontrails/store/trails`
+
+```typescript
+crud(table, resource, options?)        // derive create/read/update/delete/list trails
+sync(options)                          // copy one source entity into a target store table
+reconcile(options)                     // upsert a versioned entity with conflict recovery
+
+CrudTrails<T>, CrudOptions<T>, CrudBlazeOverrides<T>
+SyncEndpoint<T, C>, SyncOptions<TSource, TTarget, TSourceConnection, TTargetConnection>
+SyncTransform<TSource, TTarget>
+ReconcileConflict<T>, ReconcileOptions<T, C>, ReconcileStrategy<T>
+CrudOperation, CrudAccessorExpectation
+```
+
 ### `@ontrails/store/adapter-support`
 
 ```typescript
@@ -538,7 +552,7 @@ LogtapeLoggerLike, LogtapeSinkOptions
 ```typescript
 createPinoSink(logger, options?)       // forward observe LogRecord values to a Pino-shaped logger
 
-PinoLoggerLike, PinoSinkOptions
+PinoLogMethod, PinoLoggerLike, PinoSinkOptions
 ```
 
 ## `@ontrails/tracing`

--- a/packages/observe/src/renderer.ts
+++ b/packages/observe/src/renderer.ts
@@ -6,8 +6,7 @@
  * the CLI's `--trace` flag) own the actual write to stderr. Live streaming is
  * deferred per ADR-0028; this renderer assumes the records are complete.
  *
- * The output mirrors the sample in the direct-invocation draft ADR
- * (`docs/adr/drafts/20260331-direct-invocation.md`):
+ * The output follows the trace tree shape documented in ADR-0041:
  *
  * ```
  * ● booking.confirm
@@ -26,7 +25,7 @@
  * Parallel siblings (overlapping `[startedAt, endedAt]` intervals) are
  * bracketed with `┌` / `├` / `└` and followed by a parallel summary line.
  *
- * @see {@link https://github.com/outfitter-dev/trails/blob/main/docs/adr/drafts/20260331-direct-invocation.md | Direct Invocation draft ADR}
+ * @see {@link https://github.com/outfitter-dev/trails/blob/main/docs/adr/0041-unified-observability.md | ADR-0041: Unified Observability}
  */
 
 import type { TraceRecord } from '@ontrails/core';

--- a/packages/pino/src/index.ts
+++ b/packages/pino/src/index.ts
@@ -5,6 +5,9 @@ import type { LogLevel, LogRecord, LogSink } from '@ontrails/observe';
  */
 export const pinoPackageName = '@ontrails/pino';
 
+/**
+ * Signature for a Pino-compatible logger method used when forwarding Trails records.
+ */
 export type PinoLogMethod = (
   payload: Record<string, unknown>,
   message?: string

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -1,7 +1,7 @@
 // `@ontrails/topographer` owns durable graph artifacts derived from the
 // resolved graph (per ADR-0042). The companion `@ontrails/wayfinder`
-// package ships trails over these artifacts; the v0 catalog is defined
-// in the wayfinding draft ADR at docs/adr/drafts/20260503-wayfinding.md.
+// package reserves the future trail catalog over these artifacts; no
+// wayfinding trails ship yet.
 
 // Derivation
 export { deriveTopoGraph } from './derive.js';

--- a/packages/wayfinder/README.md
+++ b/packages/wayfinder/README.md
@@ -4,8 +4,6 @@ Agent-shaped wayfinding trails over `@ontrails/topographer` artifacts.
 
 `@ontrails/wayfinder` is the public package home for trails that let agents query a Trails app's resolved topo — overviews, searches, trail details, examples — without re-deriving the graph from `grep` plus file reads.
 
-**Status: shell only.** No trails ship yet. The v0 catalog and design are captured in the wayfinding draft ADR:
-
-- [`docs/adr/drafts/20260503-wayfinding.md`](../../docs/adr/drafts/20260503-wayfinding.md)
+**Status: shell only.** No trails ship yet.
 
 This package currently exists to reserve the `@ontrails/wayfinder` namespace and give the v0 implementation a clean home. When wayfinding lands as an accepted ADR, trails such as `wayfind.overview`, `wayfind.search`, `wayfind.trail`, and `wayfind.examples` will be exported from here.

--- a/packages/wayfinder/package.json
+++ b/packages/wayfinder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ontrails/wayfinder",
   "version": "1.0.0-beta.18",
-  "description": "Agent-shaped wayfinding trails over @ontrails/topographer artifacts. v0 trails defined in the wayfinding draft ADR; package shell only — no trails ship yet.",
+  "description": "Reserved shell for future agent wayfinding trails over @ontrails/topographer artifacts; no trails ship yet.",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/wayfinder/src/index.ts
+++ b/packages/wayfinder/src/index.ts
@@ -3,16 +3,14 @@
  *
  * `@ontrails/wayfinder` is the public package home for trails that let agents
  * query a Trails app's resolved topo without re-deriving it from `grep` and
- * file reads. The v0 trail catalog (`wayfind.overview`, `wayfind.search`,
- * `wayfind.trail`, `wayfind.examples`, etc.) is specified in the wayfinding
- * draft ADR; this package currently ships as a marker only.
+ * file reads. A future catalog may include trails such as `wayfind.overview`,
+ * `wayfind.search`, `wayfind.trail`, and `wayfind.examples`; this package
+ * currently ships as a marker only.
  *
  * No trails are exported yet. The shell exists to reserve the namespace and
  * give the v0 trails a clean home when they land. Peer dependencies on
  * `@ontrails/core` and `@ontrails/topographer` are declared optional in
  * `peerDependenciesMeta` until real trails consume them.
- *
- * @see {@link https://github.com/outfitter-dev/trails/blob/main/docs/adr/drafts/20260503-wayfinding.md | Wayfinding (draft ADR)}
  */
 
 /**

--- a/scripts/__tests__/sync-skill-warden-guide.test.ts
+++ b/scripts/__tests__/sync-skill-warden-guide.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   CLAUDE_SKILL_WARDEN_GUIDE_PATH,
+  AGENTS_SKILL_WARDEN_GUIDE_PATH,
   PLUGIN_SKILL_WARDEN_GUIDE_PATH,
   SKILL_WARDEN_GUIDE_PATHS,
   isSkillWardenGuideCurrent,
@@ -15,10 +16,13 @@ describe('sync-skill-warden-guide', () => {
     expect(CLAUDE_SKILL_WARDEN_GUIDE_PATH).toBe(
       '.claude/skills/clark/references/warden-guide.md'
     );
+    expect(AGENTS_SKILL_WARDEN_GUIDE_PATH).toBe(
+      '.agents/skills/clark/references/warden-guide.md'
+    );
     expect(PLUGIN_SKILL_WARDEN_GUIDE_PATH).toBe(
       'plugin/skills/trails/references/warden-guide.md'
     );
-    expect(SKILL_WARDEN_GUIDE_PATHS).toHaveLength(2);
+    expect(SKILL_WARDEN_GUIDE_PATHS).toHaveLength(3);
     expect(guide).toStartWith('# Warden Guidance For Trails Skills');
     expect(guide).toContain(
       '- Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`'

--- a/scripts/sync-skill-warden-guide.ts
+++ b/scripts/sync-skill-warden-guide.ts
@@ -12,10 +12,13 @@ import {
 
 export const CLAUDE_SKILL_WARDEN_GUIDE_PATH =
   '.claude/skills/clark/references/warden-guide.md';
+export const AGENTS_SKILL_WARDEN_GUIDE_PATH =
+  '.agents/skills/clark/references/warden-guide.md';
 export const PLUGIN_SKILL_WARDEN_GUIDE_PATH =
   'plugin/skills/trails/references/warden-guide.md';
 export const SKILL_WARDEN_GUIDE_PATHS = [
   CLAUDE_SKILL_WARDEN_GUIDE_PATH,
+  AGENTS_SKILL_WARDEN_GUIDE_PATH,
   PLUGIN_SKILL_WARDEN_GUIDE_PATH,
 ] as const;
 


### PR DESCRIPTION
## Summary
- Updates stale agent/skill guidance, ADR tooling docs, and current surface wording.
- Removes draft-ADR anchors from current package-facing docs/source comments.
- Adds public boundary TSDoc and API reference coverage for the audited exports.

## Verification
- bun run docs:links
- bun run docs:wrap-check
- bun .claude/skills/trails-adrs/scripts/adr.ts check
- bun run docs:snippets
- bun run docs:api-examples
- bun run typecheck
- bun run lint
- bun run changeset:check
- git diff --check
- bun run check
- Graphite pre-push hook passed during submit

## Notes
- Submitted as draft while hosted CI/review catches up.
- Local restack review found no P0/P1/P2 findings.