### PR TITLE
fix(warden): handle packed draft owner files

### DIFF
--- a/.changeset/packed-warden-draft-prefix.md
+++ b/.changeset/packed-warden-draft-prefix.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Avoid draft-marker false positives when a packed Warden install scans the Trails framework source tree from a different package location.

--- a/packages/warden/src/__tests__/draft-rules-context.test.ts
+++ b/packages/warden/src/__tests__/draft-rules-context.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { resolve } from 'node:path';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { draftFileMarking } from '../rules/draft-file-marking.js';
@@ -20,6 +22,40 @@ const WARDEN_DRAFT_PATH = resolve(
 /** Any file outside the two framework files — exemption must NOT apply here. */
 const NORMAL_FILE = 'packages/example/src/ordinary.ts';
 
+const createFrameworkPackageFixture = (
+  packageName: string
+): {
+  readonly draftPath: string;
+  readonly rootDir: string;
+} => {
+  const sanitizedName = packageName.replaceAll(/[^a-z0-9-]/g, '-');
+  const rootDir = mkdtempSync(
+    join(tmpdir(), `warden-draft-framework-test-${sanitizedName}-`)
+  );
+  const draftPath = join(rootDir, 'src', 'draft.ts');
+
+  mkdirSync(join(rootDir, 'src'), { recursive: true });
+  writeFileSync(
+    join(rootDir, 'package.json'),
+    JSON.stringify({ name: packageName })
+  );
+  writeFileSync(draftPath, '');
+
+  return { draftPath, rootDir };
+};
+
+const withTempPackageFixture = <T>(
+  packageName: string,
+  fn: (path: string) => T
+): T => {
+  const { draftPath, rootDir } = createFrameworkPackageFixture(packageName);
+  try {
+    return fn(draftPath);
+  } finally {
+    rmSync(rootDir, { force: true, recursive: true });
+  }
+};
+
 describe('draft-file-marking context-awareness', () => {
   test('ignores framework DRAFT_ID_PREFIX in packages/core/src/draft.ts', () => {
     const code = `export const DRAFT_ID_PREFIX = '_draft.';\n`;
@@ -29,6 +65,29 @@ describe('draft-file-marking context-awareness', () => {
   test('ignores framework DRAFT_FILE_PREFIX in packages/warden/src/draft.ts', () => {
     const code = `export const DRAFT_FILE_PREFIX = '_draft.';\n`;
     expect(draftFileMarking.check(code, WARDEN_DRAFT_PATH)).toEqual([]);
+  });
+
+  test('ignores framework DRAFT_ID_PREFIX in a @ontrails/core package root from a different install path', () => {
+    withTempPackageFixture('@ontrails/core', (path) => {
+      const code = `export const DRAFT_ID_PREFIX = '_draft.';\n`;
+      expect(draftFileMarking.check(code, path)).toEqual([]);
+    });
+  });
+
+  test('ignores framework DRAFT_FILE_PREFIX in a @ontrails/warden package root from a different install path', () => {
+    withTempPackageFixture('@ontrails/warden', (path) => {
+      const code = `export const DRAFT_FILE_PREFIX = '_draft.';\n`;
+      expect(draftFileMarking.check(code, path)).toEqual([]);
+    });
+  });
+
+  test('still reports draft IDs in src/draft.ts for non-framework package roots', () => {
+    withTempPackageFixture('@not-ontrails/package', (path) => {
+      const code = `export const DRAFT_ID_PREFIX = '_draft.leak';\n`;
+      const diagnostics = draftFileMarking.check(code, path);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+    });
   });
 
   test('fires when DRAFT_ID_PREFIX is reused in a non-framework file (false-negative closed)', () => {
@@ -102,6 +161,29 @@ describe('draft-visible-debt context-awareness', () => {
   test('ignores framework DRAFT_FILE_PREFIX in packages/warden/src/draft.ts', () => {
     const code = `export const DRAFT_FILE_PREFIX = '_draft.';\n`;
     expect(draftVisibleDebt.check(code, WARDEN_DRAFT_PATH)).toEqual([]);
+  });
+
+  test('ignores framework DRAFT_ID_PREFIX in a @ontrails/core package root from a different install path', () => {
+    withTempPackageFixture('@ontrails/core', (path) => {
+      const code = `export const DRAFT_ID_PREFIX = '_draft.';\n`;
+      expect(draftVisibleDebt.check(code, path)).toEqual([]);
+    });
+  });
+
+  test('ignores framework DRAFT_FILE_PREFIX in a @ontrails/warden package root from a different install path', () => {
+    withTempPackageFixture('@ontrails/warden', (path) => {
+      const code = `export const DRAFT_FILE_PREFIX = '_draft.';\n`;
+      expect(draftVisibleDebt.check(code, path)).toEqual([]);
+    });
+  });
+
+  test('still reports draft IDs in src/draft.ts for non-framework package roots', () => {
+    withTempPackageFixture('@not-ontrails/package', (path) => {
+      const code = `export const DRAFT_ID_PREFIX = '_draft.leak';\n`;
+      const diagnostics = draftVisibleDebt.check(code, path);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('warn');
+    });
   });
 
   test('fires when DRAFT_ID_PREFIX is reused in a non-framework file (false-negative closed)', () => {

--- a/packages/warden/src/rules/ast.ts
+++ b/packages/warden/src/rules/ast.ts
@@ -5,7 +5,8 @@
  * walker and helpers for finding blaze bodies.
  */
 
-import { resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { DRAFT_ID_PREFIX, intentValues } from '@ontrails/core';
@@ -260,6 +261,60 @@ export const FRAMEWORK_DRAFT_PREFIX_CONSTANT_NAMES: ReadonlySet<string> =
  */
 const FRAMEWORK_DRAFT_PREFIX_LITERAL = DRAFT_ID_PREFIX;
 
+interface PackageJsonWithName {
+  readonly name: string;
+}
+
+const FRAMEWORK_DRAFT_PREFIX_PACKAGES: ReadonlySet<string> = new Set([
+  '@ontrails/core',
+  '@ontrails/warden',
+]);
+
+const isPackageJsonWithName = (value: unknown): value is PackageJsonWithName =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as { name?: unknown }).name === 'string';
+
+const readPackageJsonName = (packageJsonPath: string): string | null => {
+  try {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    return isPackageJsonWithName(parsed) ? parsed.name : null;
+  } catch {
+    return null;
+  }
+};
+
+const frameworkDraftPackageRoot = (filePath: string): string | null => {
+  const resolvedPath = resolve(filePath);
+  if (basename(resolvedPath) !== 'draft.ts') {
+    return null;
+  }
+
+  const sourceDir = dirname(resolvedPath);
+  if (basename(sourceDir) !== 'src') {
+    return null;
+  }
+
+  const packageRoot = dirname(sourceDir);
+  if (!existsSync(join(packageRoot, 'package.json'))) {
+    return null;
+  }
+
+  return packageRoot;
+};
+
+/** Fallback exemption when framework files are consumed from a different install path. */
+const isFrameworkDraftPrefixSourceFile = (filePath: string): boolean => {
+  const root = frameworkDraftPackageRoot(filePath);
+  if (!root) {
+    return false;
+  }
+  const packageName = readPackageJsonName(join(root, 'package.json'));
+  return (
+    packageName !== null && FRAMEWORK_DRAFT_PREFIX_PACKAGES.has(packageName)
+  );
+};
+
 /**
  * Absolute paths of the two framework files allowed to declare the
  * draft-prefix constants. Anchored against the rule module's own URL so the
@@ -285,8 +340,8 @@ const FRAMEWORK_DRAFT_CONSTANT_FILES: ReadonlySet<string> = new Set([
  * constants.
  *
  * Exemption is gated on all three of:
- *   1. The file's absolute path matches one of the two framework files that
- *      actually define these constants.
+ *   1. The file is one of the two known framework draft files, or its package
+ *      root `package.json` name is `@ontrails/core` or `@ontrails/warden`.
  *   2. The declaration name is `DRAFT_ID_PREFIX` or `DRAFT_FILE_PREFIX`.
  *   3. The string literal value is exactly `'_draft.'`.
  *
@@ -299,7 +354,11 @@ export const collectFrameworkDraftPrefixConstantOffsets = (
 ): ReadonlySet<number> => {
   const offsets = new Set<number>();
 
-  if (!FRAMEWORK_DRAFT_CONSTANT_FILES.has(resolve(filePath))) {
+  const resolvedPath = resolve(filePath);
+  if (
+    !FRAMEWORK_DRAFT_CONSTANT_FILES.has(resolvedPath) &&
+    !isFrameworkDraftPrefixSourceFile(resolvedPath)
+  ) {
     return offsets;
   }
 


### PR DESCRIPTION
## Summary
- Fixes Warden draft-file marking for packed first-party packages whose owner file is package-local `src/draft.ts`.
- Narrows the exemption to exact package-owner draft marker files.
- Adds focused regression coverage plus the required changeset.

## Verification
- bun run --cwd packages/warden test
- bun run --cwd packages/warden typecheck
- bun run --cwd packages/warden lint
- bun run check
- bun run publish:check
- bun run dogfood:packed
- Graphite pre-push hook passed during stack submit

## Notes
- Submitted as draft while hosted CI/review catches up.