### PR TITLE
docs(http): add public API examples

### DIFF
--- a/.changeset/http-fetch-handler-examples.md
+++ b/.changeset/http-fetch-handler-examples.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/http": patch
+---
+
+Add public API examples for the shared Web Fetch route and topo handlers.

--- a/.changeset/http-method-intent-example.md
+++ b/.changeset/http-method-intent-example.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/http": patch
+---
+
+Add a public API example for the HTTP intent method table.

--- a/packages/http/src/fetch.ts
+++ b/packages/http/src/fetch.ts
@@ -488,6 +488,21 @@ const handleWebhookRoute = async (
 
 /**
  * Build a Web Fetch handler for one framework-agnostic HTTP route.
+ *
+ * @example
+ * ```ts
+ * import { deriveHttpRoutes } from '@ontrails/http';
+ * import { createRouteHandler } from '@ontrails/http/fetch';
+ *
+ * const routes = deriveHttpRoutes(graph, { basePath: '/api' });
+ * if (routes.isErr()) throw routes.error;
+ *
+ * const route = routes.value[0];
+ * if (!route) throw new Error('No routes derived');
+ *
+ * const handle = createRouteHandler(route);
+ * const response = await handle(new Request('https://example.test/api/hello'));
+ * ```
  */
 export const createRouteHandler = (
   route: HttpRouteDefinition,
@@ -534,6 +549,16 @@ export const createRouteHandler = (
 
 /**
  * Build a Web Fetch dispatcher for all HTTP routes in a topo.
+ *
+ * @example
+ * ```ts
+ * import { createFetchHandler } from '@ontrails/http/fetch';
+ *
+ * const fetch = createFetchHandler(graph, { basePath: '/api' });
+ * const response = await fetch(
+ *   new Request('https://example.test/api/hello?name=Matt')
+ * );
+ * ```
  */
 export const createFetchHandler = (
   graph: Topo,

--- a/packages/http/src/method.ts
+++ b/packages/http/src/method.ts
@@ -6,6 +6,17 @@ export type HttpOperationMethod = Lowercase<HttpMethod>;
 
 export type InputSource = 'query' | 'body' | 'webhook';
 
+/**
+ * Owner table for projecting trail intent onto HTTP methods.
+ *
+ * @example
+ * ```ts
+ * import { httpMethodByIntent } from '@ontrails/http';
+ *
+ * const readMethod = httpMethodByIntent.read;
+ * // readMethod === 'GET'
+ * ```
+ */
 export const httpMethodByIntent = {
   destroy: 'DELETE',
   read: 'GET',


### PR DESCRIPTION
## Summary
- Adds public `@example` coverage for HTTP fetch handler helpers.
- Adds intent method projection examples.
- Includes changeset coverage for the HTTP package documentation surface.

## Verification
- bun run docs:api-examples
- bun run --cwd packages/http test
- bun run --cwd packages/http typecheck
- bun run --cwd packages/http lint
- bun run check
- Graphite pre-push hook passed during stack submit

## Notes
- Submitted as draft while hosted CI/review catches up.