### PR TITLE
docs(mcp): add public API examples

### DIFF
--- a/.changeset/mcp-annotations-example.md
+++ b/.changeset/mcp-annotations-example.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/mcp": patch
+---
+
+Add a public API example for MCP `deriveAnnotations` annotation derivation.

--- a/.changeset/mcp-meta-key-examples.md
+++ b/.changeset/mcp-meta-key-examples.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/mcp": patch
+---
+
+Add public API examples for the MCP tool metadata keys.

--- a/.changeset/mcp-progress-callback-example.md
+++ b/.changeset/mcp-progress-callback-example.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/mcp": patch
+---
+
+Add a public API example for the MCP progress callback bridge.

--- a/packages/mcp/src/annotations.ts
+++ b/packages/mcp/src/annotations.ts
@@ -25,6 +25,26 @@ export interface McpAnnotations {
  *
  * Only sets hints that are explicitly declared on the trail.
  * Omitted hints let the MCP SDK use its defaults.
+ *
+ * @example
+ * ```ts
+ * import { deriveAnnotations } from '@ontrails/mcp';
+ *
+ * const annotations = deriveAnnotations({
+ *   intent: 'read',
+ *   idempotent: true,
+ *   description: 'Show account',
+ * });
+ *
+ * // read intent -> readOnlyHint, idempotent -> idempotentHint, description -> title.
+ * annotations.readOnlyHint === true;
+ * annotations.idempotentHint === true;
+ * annotations.title === 'Show account';
+ *
+ * // destroy intent -> destructiveHint.
+ * const destroyAnnotations = deriveAnnotations({ intent: 'destroy' });
+ * destroyAnnotations.destructiveHint === true;
+ * ```
  */
 export const deriveAnnotations = (
   trail: Pick<

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -45,8 +45,28 @@ import { deriveAnnotations } from './annotations.js';
 import { createMcpProgressCallback } from './progress.js';
 import { deriveToolName } from './tool-name.js';
 
+/**
+ * Metadata key used for structured trail examples on derived MCP tools.
+ *
+ * @example
+ * ```ts
+ * import { MCP_TOOL_EXAMPLES_META_KEY } from '@ontrails/mcp';
+ *
+ * const examples = tool._meta?.[MCP_TOOL_EXAMPLES_META_KEY];
+ * ```
+ */
 export const MCP_TOOL_EXAMPLES_META_KEY = 'ontrails/examples';
 
+/**
+ * Metadata key used for public Trails error projections on MCP tool errors.
+ *
+ * @example
+ * ```ts
+ * import { MCP_TOOL_ERROR_META_KEY } from '@ontrails/mcp';
+ *
+ * const error = result._meta?.[MCP_TOOL_ERROR_META_KEY];
+ * ```
+ */
 export const MCP_TOOL_ERROR_META_KEY = 'ontrails/error';
 
 // ---------------------------------------------------------------------------

--- a/packages/mcp/src/progress.ts
+++ b/packages/mcp/src/progress.ts
@@ -54,6 +54,28 @@ const progressHandlers: Record<
  *
  * Returns `undefined` if the MCP client did not provide a progressToken
  * (meaning no progress reporting was requested).
+ *
+ * @example
+ * ```ts
+ * import { createMcpProgressCallback, type McpExtra } from '@ontrails/mcp';
+ *
+ * const extra: McpExtra = {
+ *   progressToken: 'token-123',
+ *   sendProgress: async (current, total) => {
+ *     console.log(`progress ${current}/${total}`);
+ *   },
+ * };
+ *
+ * const progress = createMcpProgressCallback(extra);
+ * if (progress !== undefined) {
+ *   progress({
+ *     current: 0,
+ *     ts: new Date().toISOString(),
+ *     total: 1,
+ *     type: 'start',
+ *   });
+ * }
+ * ```
  */
 export const createMcpProgressCallback = (
   extra: McpExtra


### PR DESCRIPTION
## Summary
- Adds public `@example` coverage for MCP progress callback helpers.
- Adds examples for MCP annotations and metadata key helpers.
- Includes changeset coverage for the MCP package documentation surface.

## Verification
- bun run docs:api-examples
- bun run --cwd packages/mcp test
- bun run --cwd packages/mcp typecheck
- bun run --cwd packages/mcp lint
- bun run check
- Graphite pre-push hook passed during stack submit

## Notes
- Submitted as draft while hosted CI/review catches up.