### PR TITLE
docs(cli): add public API examples

### DIFF
--- a/.changeset/cli-api-examples.md
+++ b/.changeset/cli-api-examples.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/cli": patch
+---
+
+Add `@example` coverage in CLI public API docs for flag and preset helpers so API docs tooling can verify public examples for missing exports.

--- a/.changeset/cli-utility-examples.md
+++ b/.changeset/cli-utility-examples.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/cli": patch
+---
+
+Add public API examples for CLI result, prompt, and validation helpers.

--- a/packages/cli/src/flags.ts
+++ b/packages/cli/src/flags.ts
@@ -83,6 +83,23 @@ const normalizeAliasSpec = (
   return { ...alias, value };
 };
 
+/**
+ * Resolve explicit value aliases for enum-style CLI flags.
+ *
+ * @example
+ * ```ts
+ * import { deriveCliFlagValueAliases } from '@ontrails/cli';
+ *
+ * const aliases = deriveCliFlagValueAliases({
+ *   aliases: {
+ *     json: { description: 'JSON output', name: 'json' },
+ *     jsonl: 'jsonl',
+ *   },
+ *   choices: ['text', 'json', 'jsonl'],
+ *   flagName: 'output',
+ * });
+ * ```
+ */
 export const deriveCliFlagValueAliases = ({
   aliases,
   choices,
@@ -168,6 +185,25 @@ export const deriveFlags = (
   overrides?: Readonly<Record<string, CliFieldOverride>> | undefined
 ): CliFlag[] => toFlags(deriveFields(schema, overrides), overrides);
 
+/**
+ * Normalize value aliases back onto canonical flag keys.
+ *
+ * @example
+ * ```ts
+ * import { applyCliFlagValueAliases, deriveFlags } from '@ontrails/cli';
+ * import { z } from 'zod';
+ *
+ * const flags = deriveFlags(z.object({ output: z.enum(['json', 'text']) }), {
+ *   output: { aliases: { json: 'json' } },
+ * });
+ *
+ * const normalized = applyCliFlagValueAliases(flags, {
+ *   output: 'text',
+ *   json: true,
+ * });
+ * // { output: 'json' }
+ * ```
+ */
 export const applyCliFlagValueAliases = (
   flags: readonly CliFlag[],
   parsedFlags: Readonly<Record<string, unknown>>,
@@ -224,7 +260,17 @@ export const applyCliFlagValueAliases = (
 // Presets
 // ---------------------------------------------------------------------------
 
-/** Flags for output mode selection: --output, --json, --jsonl, --quiet */
+/**
+ * Flags for output mode selection: --output, --json, --jsonl, --quiet
+ *
+ * @example
+ * ```ts
+ * import { outputModePreset } from '@ontrails/cli';
+ *
+ * const flagNames = outputModePreset().map((flag) => flag.name);
+ * // [ 'output', 'json', 'jsonl', 'quiet' ]
+ * ```
+ */
 export const outputModePreset = (): CliFlag[] => [
   {
     choices: ['text', 'json', 'jsonl'],
@@ -261,7 +307,17 @@ export const outputModePreset = (): CliFlag[] => [
   },
 ];
 
-/** Flag for working directory override: --cwd */
+/**
+ * Flag for working directory override: --cwd
+ *
+ * @example
+ * ```ts
+ * import { cwdPreset } from '@ontrails/cli';
+ *
+ * const [cwd] = cwdPreset();
+ * // cwd.name === 'cwd'
+ * ```
+ */
 export const cwdPreset = (): CliFlag[] => [
   {
     description: 'Working directory override',
@@ -272,7 +328,17 @@ export const cwdPreset = (): CliFlag[] => [
   },
 ];
 
-/** Flag for dry-run mode: --dry-run */
+/**
+ * Flag for dry-run mode: --dry-run
+ *
+ * @example
+ * ```ts
+ * import { dryRunPreset } from '@ontrails/cli';
+ *
+ * const [dryRun] = dryRunPreset();
+ * // dryRun.name === 'dry-run'
+ * ```
+ */
 export const dryRunPreset = (): CliFlag[] => [
   {
     description: 'Execute without side effects',
@@ -301,6 +367,14 @@ export const trailVersionPreset = (): CliFlag[] => [
  * the resulting trace tree to stderr after execution, and (under `--json`)
  * includes the structured `TraceRecord[]` on the stdout envelope. The flag
  * is treated as a meta flag — it never flows into trail input.
+ *
+ * @example
+ * ```ts
+ * import { tracePreset } from '@ontrails/cli';
+ *
+ * const [trace] = tracePreset();
+ * // trace.name === 'trace'
+ * ```
  */
 export const tracePreset = (): CliFlag[] => [
   {
@@ -324,6 +398,14 @@ export const tracePreset = (): CliFlag[] => [
  *
  * Mutually exclusive with `--token`; passing both surfaces a
  * `ValidationError`.
+ *
+ * @example
+ * ```ts
+ * import { permitPreset } from '@ontrails/cli';
+ *
+ * const [permit] = permitPreset();
+ * // permit.name === 'permit'
+ * ```
  */
 export const permitPreset = (): CliFlag[] => [
   {
@@ -346,6 +428,14 @@ export const permitPreset = (): CliFlag[] => [
  * Mutually exclusive with `--permit`; passing both surfaces a
  * `ValidationError`. The flag is treated as a meta flag — it never flows
  * into trail input.
+ *
+ * @example
+ * ```ts
+ * import { tokenPreset } from '@ontrails/cli';
+ *
+ * const [token] = tokenPreset();
+ * // token.name === 'token'
+ * ```
  */
 export const tokenPreset = (): CliFlag[] => [
   {
@@ -371,6 +461,14 @@ export const tokenPreset = (): CliFlag[] => [
  * `--watch` is local-development ergonomics only and is implemented in
  * the `apps/trails` binary's `run` entrypoint, not in surface-agnostic
  * trail code. Other surfaces (MCP, HTTP) ignore the flag.
+ *
+ * @example
+ * ```ts
+ * import { watchPreset } from '@ontrails/cli';
+ *
+ * const [watch] = watchPreset();
+ * // watch.name === 'watch'
+ * ```
  */
 export const watchPreset = (): CliFlag[] => [
   {
@@ -402,6 +500,14 @@ export const watchPreset = (): CliFlag[] => [
  * Mutually exclusive with `--permit` and `--token`; passing any pair
  * surfaces a `ValidationError`. The flag is treated as a meta flag — it
  * never flows into trail input.
+ *
+ * @example
+ * ```ts
+ * import { devPermitPreset } from '@ontrails/cli';
+ *
+ * const [devPermit] = devPermitPreset();
+ * // devPermit.name === 'dev-permit'
+ * ```
  */
 export const devPermitPreset = (): CliFlag[] => [
   {

--- a/packages/cli/src/on-result.ts
+++ b/packages/cli/src/on-result.ts
@@ -18,6 +18,23 @@ import { output, deriveOutputMode } from './output.js';
  *
  * @remarks Trail logic should return `Result.err(...)` instead of throwing.
  * This host-boundary throw is intentionally outside trail execution.
+ *
+ * @example
+ * ```ts
+ * import { Result } from '@ontrails/core';
+ * import { defaultOnResult, type ActionResultContext } from '@ontrails/cli';
+ *
+ * const ctx = {
+ *   args: {},
+ *   flags: { json: true },
+ *   input: {},
+ *   result: Result.ok({ id: 'example' }),
+ *   topoName: 'demo',
+ *   trail: { id: 'demo.example', kind: 'trail' },
+ * } as ActionResultContext;
+ *
+ * await defaultOnResult(ctx);
+ * ```
  */
 export const defaultOnResult = async (
   ctx: ActionResultContext

--- a/packages/cli/src/prompt.ts
+++ b/packages/cli/src/prompt.ts
@@ -29,11 +29,31 @@ export type InputResolver = (
   options?: ResolveInputOptions
 ) => Promise<Record<string, unknown>>;
 
-/** Default passthrough resolver for non-interactive execution. */
+/**
+ * Default passthrough resolver for non-interactive execution.
+ *
+ * @example
+ * ```ts
+ * import { passthroughResolver } from '@ontrails/cli';
+ *
+ * const resolved = await passthroughResolver([], { name: 'Ada' });
+ * // resolved.name === 'Ada'
+ * ```
+ */
 export const passthroughResolver: InputResolver = async (_fields, provided) =>
   await provided;
 
-/** Shared TTY check for resolver implementations. */
+/**
+ * Shared TTY check for resolver implementations.
+ *
+ * @example
+ * ```ts
+ * import { isInteractive } from '@ontrails/cli';
+ *
+ * const canPrompt = isInteractive({ isTTY: true });
+ * // canPrompt === true
+ * ```
+ */
 export const isInteractive = (options?: ResolveInputOptions): boolean =>
   options?.isTTY ?? process.stdin.isTTY ?? false;
 

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -133,6 +133,26 @@ const validateCommandFlags = (command: CliCommand): void => {
   }
 };
 
+/**
+ * Validate command paths and flag collisions before wiring a CLI adapter.
+ *
+ * @example
+ * ```ts
+ * import { validateCliCommands, type CliCommand } from '@ontrails/cli';
+ *
+ * const commands = [
+ *   {
+ *     args: [],
+ *     flags: [],
+ *     intent: 'read',
+ *     path: ['greet'],
+ *     trail: { id: 'demo.greet', kind: 'trail' } as CliCommand['trail'],
+ *   },
+ * ] satisfies CliCommand[];
+ *
+ * validateCliCommands(commands);
+ * ```
+ */
 export const validateCliCommands = (commands: readonly CliCommand[]): void => {
   for (const command of commands) {
     validateCommandPath(command);


### PR DESCRIPTION
## Summary
- Adds public `@example` coverage for CLI flag helpers.
- Adds examples for CLI result, prompt, and validation utilities.
- Includes changeset coverage for the CLI package documentation surface.

## Verification
- bun run docs:api-examples
- bun run --cwd packages/cli test
- bun run --cwd packages/cli typecheck
- bun run --cwd packages/cli lint
- bun run check
- Graphite pre-push hook passed during stack submit

## Notes
- Submitted as draft while hosted CI/review catches up.