### PR TITLE
fix(testing): stabilize composed example errors

### DIFF
--- a/.changeset/testing-compose-error-injection.md
+++ b/.changeset/testing-compose-error-injection.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/testing": patch
+---
+
+Construct declared Trails error classes when `testComposes` injects composed trail error examples.

--- a/packages/testing/src/__tests__/all.test.ts
+++ b/packages/testing/src/__tests__/all.test.ts
@@ -1,5 +1,11 @@
 import { afterAll, describe, expect, mock, test } from 'bun:test';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join, resolve } from 'node:path';
 
 import { contour, Result, trail, topo } from '@ontrails/core';
@@ -276,6 +282,7 @@ const runGeneratedEstablishedSuite = (): {
   readonly output: string;
 } => {
   const dir = repoTempDir();
+  const reportFile = join(dir, 'testAllEstablished-surfaces.junit.xml');
   const testFile = join(dir, 'testAllEstablished-surfaces.test.ts');
 
   mkdirSync(dir, { recursive: true });
@@ -305,15 +312,24 @@ testAllEstablished(topo('established-topo', { show }));
 
   try {
     const proc = Bun.spawnSync({
-      cmd: ['bun', 'test', testFile],
+      cmd: [
+        'bun',
+        'test',
+        testFile,
+        '--reporter=junit',
+        `--reporter-outfile=${reportFile}`,
+      ],
       cwd: resolve(import.meta.dir, '..', '..', '..'),
       stderr: 'pipe',
       stdout: 'pipe',
     });
+    const report = existsSync(reportFile)
+      ? readFileSync(reportFile, 'utf8')
+      : '';
 
     return {
       exitCode: proc.exitCode,
-      output: `${proc.stdout.toString()}\n${proc.stderr.toString()}`,
+      output: `${proc.stdout.toString()}\n${proc.stderr.toString()}\n${report}`,
     };
   } finally {
     rmSync(dir, { force: true, recursive: true });

--- a/packages/testing/src/__tests__/composes.test.ts
+++ b/packages/testing/src/__tests__/composes.test.ts
@@ -1,7 +1,13 @@
 import { describe } from 'bun:test';
 
 import type { AnyTrail, TrailContext } from '@ontrails/core';
-import { InternalError, Result, resource, trail } from '@ontrails/core';
+import {
+  AlreadyExistsError,
+  InternalError,
+  Result,
+  resource,
+  trail,
+} from '@ontrails/core';
 import { z } from 'zod';
 
 import { testComposes } from '../composes.js';
@@ -137,7 +143,7 @@ describe('testComposes: injectFromExample', () => {
     [
       {
         description: 'inject duplicate error from add trail example',
-        expectErr: Error,
+        expectErr: AlreadyExistsError,
         expectErrMessage: 'AlreadyExistsError',
         injectFromExample: { 'entity.add': 'duplicate' },
         input: { name: 'Alpha', relatedTo: 'Beta' },

--- a/packages/testing/src/composes.ts
+++ b/packages/testing/src/composes.ts
@@ -29,6 +29,7 @@ import {
   assertSchemaMatch,
 } from './assertions.js';
 import { mergeResourceOverrides, mergeTestContext } from './context.js';
+import { createErrorFromName } from './errors.js';
 import type { ComposeScenario } from './types.js';
 
 type TestingExecuteTrailOptions = ExecuteTrailOptions & {
@@ -146,7 +147,7 @@ const tryInjectError = (
       )
     );
   }
-  return Result.err(new Error(errorName));
+  return Result.err(createErrorFromName(errorName));
 };
 
 const executeFromMap = (

--- a/packages/testing/src/errors.ts
+++ b/packages/testing/src/errors.ts
@@ -1,0 +1,47 @@
+import {
+  errorClasses,
+  InternalError,
+  RetryExhaustedError,
+  TrailsError,
+} from '@ontrails/core';
+
+type ErrorConstructor = new (...args: never[]) => Error;
+type MessageErrorConstructor = new (message: string) => Error;
+
+const ERROR_CLASS_BY_NAME = new Map<string, ErrorConstructor>([
+  ...errorClasses.map(
+    (entry) => [entry.name, entry.ctor as ErrorConstructor] as const
+  ),
+  ['TrailsError', TrailsError as unknown as ErrorConstructor],
+]);
+
+/**
+ * Resolve an error class name string to the actual constructor.
+ * Falls back to generic Error if the name is not in the core taxonomy.
+ */
+export const resolveErrorClass = (name: string): ErrorConstructor =>
+  ERROR_CLASS_BY_NAME.get(name) ?? (Error as ErrorConstructor);
+
+/**
+ * Create an error instance for an authored example error name.
+ */
+export const createErrorFromName = (name: string): Error => {
+  if (name === 'TrailsError') {
+    return new InternalError(name);
+  }
+
+  const entry = errorClasses.find((candidate) => candidate.name === name);
+  if (entry === undefined) {
+    return new Error(name);
+  }
+
+  if (entry.name === 'RetryExhaustedError') {
+    return new RetryExhaustedError(new InternalError(name), {
+      attempts: 1,
+      detour: 'testComposes',
+    });
+  }
+
+  const ErrorClass = entry.ctor as unknown as MessageErrorConstructor;
+  return new ErrorClass(name);
+};

--- a/packages/testing/src/examples.ts
+++ b/packages/testing/src/examples.ts
@@ -21,26 +21,10 @@ import type {
 } from '@ontrails/core';
 
 import {
-  AlreadyExistsError,
-  AmbiguousError,
-  AssertionError,
-  AuthError,
   buildComposeValidationSchema,
-  CancelledError,
-  ConflictError,
-  DerivationError,
-  InternalError,
-  NetworkError,
-  NotFoundError,
-  PermissionError,
-  PermitError,
-  RateLimitError,
-  RetryExhaustedError,
   executeTrail,
   parseTrailIdVersionReference,
   Result,
-  TimeoutError,
-  TrailsError,
   ValidationError,
   validateInput,
 } from '@ontrails/core';
@@ -65,44 +49,12 @@ import {
   isDerivedExample,
 } from './effective-examples.js';
 import type { TrailExampleTarget } from './effective-examples.js';
+import { resolveErrorClass } from './errors.js';
 import { withSignalAssertions } from './signals.js';
 
 type TestingExecuteTrailOptions = ExecuteTrailOptions & {
   readonly validationSchema?: ReturnType<typeof buildComposeValidationSchema>;
 };
-
-// ---------------------------------------------------------------------------
-// Error class name -> constructor map
-// ---------------------------------------------------------------------------
-
-const ERROR_MAP: Record<string, new (...args: never[]) => Error> = {
-  AlreadyExistsError: AlreadyExistsError as new (...args: never[]) => Error,
-  AmbiguousError: AmbiguousError as new (...args: never[]) => Error,
-  AssertionError: AssertionError as new (...args: never[]) => Error,
-  AuthError: AuthError as new (...args: never[]) => Error,
-  CancelledError: CancelledError as new (...args: never[]) => Error,
-  ConflictError: ConflictError as new (...args: never[]) => Error,
-  DerivationError: DerivationError as new (...args: never[]) => Error,
-  InternalError: InternalError as new (...args: never[]) => Error,
-  NetworkError: NetworkError as new (...args: never[]) => Error,
-  NotFoundError: NotFoundError as new (...args: never[]) => Error,
-  PermissionError: PermissionError as new (...args: never[]) => Error,
-  PermitError: PermitError as new (...args: never[]) => Error,
-  RateLimitError: RateLimitError as new (...args: never[]) => Error,
-  RetryExhaustedError: RetryExhaustedError as unknown as new (
-    ...args: never[]
-  ) => Error,
-  TimeoutError: TimeoutError as new (...args: never[]) => Error,
-  TrailsError: TrailsError as unknown as new (...args: never[]) => Error,
-  ValidationError: ValidationError as new (...args: never[]) => Error,
-};
-
-/**
- * Resolve an error class name string to the actual constructor.
- * Falls back to generic Error if the name is not in the core taxonomy.
- */
-const resolveErrorClass = (name: string): new (...args: never[]) => Error =>
-  ERROR_MAP[name] ?? (Error as new (...args: never[]) => Error);
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary
- Reuses a shared testing helper to resolve declared Trails error classes from authored examples.
- Makes `testComposes` inject real declared Trails errors instead of generic `Error` instances.
- Stabilizes the established surface-suite assertion by reading child-suite JUnit output instead of Bun console formatting.

## Verification
- bun run --cwd packages/testing test
- bun run --cwd packages/testing typecheck
- bun run --cwd packages/testing lint
- bun run check
- Graphite pre-push hook passed during stack submit

## Notes
- Submitted as draft while hosted CI/review catches up.