### PR TITLE
fix(core): reject unsupported marker schema checks

### DIFF
--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/GOAL.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/GOAL.md
@@ -1,0 +1,47 @@
+---
+created: "2026-06-01T17:30:00-04:00"
+updated: "2026-06-01T17:47:00-04:00"
+status: staged-outside-worktree
+eventual_repo_packet: ".agents/plans/2026-06-01-agent-trust-stable-cutover-integrity"
+---
+
+# Goal Prompt
+
+Paste this into the executor once the packet has been copied into the dedicated
+execution worktree.
+
+````text
+/goal
+
+Use the current delegated Codex worktree as cwd. First run `pwd -P` and treat
+that resolved path as authoritative. Do not execute from the coordinator's
+primary worktree.
+
+You are executing the Trails Agent Trust / Stable Cutover Integrity stack. First read `.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/{PLAN.md,REFS.md,RETRO.md}` plus `AGENTS.md`, `docs/adr/0048-trail-versioning-v3.md`, and `.agents/plans/PLANNING.md`.
+
+Objective: build one Graphite stack that makes Trails' trust loop reliable for agents/release reviewers: no silent version-marker semantic collisions; Warden catches unsupported marker schemas early; `trails doctor` reports actionable pending-force evidence; Regrade preserves Warden scan-target truth; adapter catalog wildcard exports work; capstone is a read-only checkpoint verdict over existing evidence.
+
+Preflight before any write: run `git status --short`, `git diff --stat`, `git worktree list --porcelain`, `gt log --no-interactive`, and open-PR query. This cwd must be a dedicated worktree on a real Graphite-tracked branch, preferably first branch `trl-772-make-version-markers-account-for-or-reject-zod-validation`; do not proceed from detached HEAD. Do not run `gt sync` unless explicitly authorized after live-state inspection.
+
+Stack order: TRL-772, TRL-773, TRL-770, TRL-769, conditional TRL-771, TRL-878, TRL-877, conditional TRL-872, then a tracked/read-only checkpoint verdict branch only after creating/choosing its Linear issue or confirming a non-issue branch with Matt. Use exact Linear branch names and `gt create` for children. Use Graphite for source-control writes; stage specific files before `gt modify -c -m`. Do not use `gt absorb`. Dry-run `gt submit --stack --draft --restack --no-edit --no-interactive` before real submit. Do not merge, queue, publish, or mutate registry state. Subagents must not run git/gt/PR/Linear write commands.
+
+Critical boundary: the checkpoint first slice is read-only and evidence-based. It must not mutate git, Graphite, GitHub, Linear, source files, lockfiles, generated artifacts, or run broad shell gates as its own behavior. Verdict vocabulary is separate from rule severity: pass/caution/block/reroute.
+
+Loop: report checkpoint, files changed, commands run with results, remaining work, blocker status, and next checkpoint. Keep `RETRO.md` current after meaningful changes, review rounds, verification, PR submission, ready-for-review, and handoff. Final completion is invalid unless `RETRO.md` has final branch/PR/review/CI/verification/forbidden-action state.
+
+Validation: use narrow tests per branch, then broaden at the tip. Expected focused checks include version-marker, topographer derive, Warden trail-versioning rules, Trails doctor/version lifecycle/survey, Regrade report, adapter-kit catalog/check, Warden adapter-check, and Trails adapter-check tests. Before draft submission run lint, lint:ast-grep, format:check, typecheck, test, build, check, publish:check, and git diff --check unless a skipped check is explicitly justified in `RETRO.md`. Run ADR and Warden guide sync/check commands when those surfaces change.
+
+Stop and ask if main/Linear/PR state invalidates the order, TRL-772 requires broad Zod support rather than bounded rejection, checkpoint pressure wants mutation/autofix/shell-runner behavior, TRL-771 sprawls into broad exception governance, P0/P1/P2 review debt remains after four post-ready turns, or secrets/production/publish/merge actions are needed.
+````
+
+## Copy-In Step
+
+Before using the prompt, copy the staged packet into the execution worktree:
+
+```bash
+pwd -P
+mkdir -p .agents/plans/2026-06-01-agent-trust-stable-cutover-integrity
+cp -R /Users/mg/.agents/plans/trails/2026-06-01-agent-trust-stable-cutover-integrity/. .agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/
+```
+
+After that copy, the in-worktree packet becomes the active source of truth.

--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/PLAN.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/PLAN.md
@@ -1,0 +1,429 @@
+---
+created: "2026-06-01T17:30:00-04:00"
+updated: "2026-06-01T17:47:00-04:00"
+status: staged-outside-worktree
+owner: Lewis
+eventual_repo_packet: ".agents/plans/2026-06-01-agent-trust-stable-cutover-integrity"
+linear:
+  - TRL-772
+  - TRL-773
+  - TRL-770
+  - TRL-769
+  - TRL-771
+  - TRL-878
+  - TRL-877
+  - TRL-872
+---
+
+# Agent Trust / Stable Cutover Integrity
+
+## Packet Status
+
+This packet is intentionally staged outside the Trails worktree at:
+
+`/Users/mg/.agents/plans/trails/2026-06-01-agent-trust-stable-cutover-integrity`
+
+The eventual in-repo packet destination is:
+
+`.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/`
+
+Do not treat this home-level packet as source already committed to Trails. When
+execution starts in a dedicated worktree, copy the packet wholesale into the
+execution worktree, then commit it on the lowest branch in the implementation
+stack or on the first branch that makes the packet load-bearing.
+
+## Objective
+
+Build one ambitious but coherent Graphite stack that makes Trails' trust loop
+reliable enough for agents and release reviewers:
+
+1. Version markers must not silently collide for semantically different
+   contracts.
+2. Warden must catch unsupported version-marker schemas before graph derivation
+   fails.
+3. `trails doctor` must provide actionable stable-cutover evidence, especially
+   pending force events.
+4. Regrade must consume Warden truth without bypassing Warden's target filter.
+5. Adapter catalog derivation must stay trustworthy before more adapters opt
+   into `adapter.check`.
+6. The capstone should be a first read-only checkpoint verdict over existing
+   evidence, not an autofix or source-control mutation platform.
+
+The result should feel like a single product lane: "Can an agent trust this
+repo state?" The answer should be grounded in Warden, doctor, Regrade, adapter
+checks, CI, review state, and the durable `RETRO.md`.
+
+## Live Starting State
+
+Verified on 2026-06-01:
+
+- Primary cwd: `/Users/mg/Developer/outfitter/trails`.
+- Git: clean `main`, tracking `origin/main`.
+- Current commit: `ed5926bdd docs: converge Trails documentation surfaces (#645)`.
+- Graphite: `main` only.
+- Open GitHub PRs: none.
+- Remaining worktree besides primary: Clark at
+  `/Users/mg/Developer/outfitter/trails/.claude/worktrees/clark` on
+  `worktree-clark`.
+
+## Stack Order
+
+| Order | Issue | Branch | Purpose |
+| --- | --- | --- | --- |
+| 1 | TRL-772 | `trl-772-make-version-markers-account-for-or-reject-zod-validation` | Decide and implement bounded marker behavior for validation checks that currently collide. |
+| 2 | TRL-773 | `trl-773-align-marker-schema-unsupported-warden-coverage-with-runtime` | Bring Warden's `marker-schema-unsupported` coverage up to the runtime marker subset. |
+| 3 | TRL-770 | `trl-770-make-trails-doctor-pending-force-output-complete-and` | Make `trails doctor` count and report entry-level and graph-level force events. |
+| 4 | TRL-769 | `trl-769-document-pending-force-stable-cutover-gate` | Update release docs once doctor has actionable pending-force output. |
+| 5 | TRL-771 | `trl-771-define-accepted-exception-semantics-for-pending-force-events` | Conditional: only if implementation needs structured accepted-exception semantics before the checkpoint verdict. |
+| 6 | TRL-878 | `trl-878-apply-warden-scan-target-filtering-to-regrade` | Keep Regrade's Warden-backed route aligned with Warden's own scan-target exclusions. |
+| 7 | TRL-877 | `trl-877-resolve-wildcard-export-keys-in-catalog-derivation` | Fix adapter catalog export-pattern support before more adapter subjects opt in. |
+| 8 | TRL-872 | `trl-872-migrate-remaining-first-party-adapters-into-adaptercheck` | Conditional: migrate Commander/Vite/Drizzle only after catalog truth is solid and owner targets are explicit. |
+| 9 | New or explicit non-Linear branch | TBD | Read-only checkpoint verdict over existing Warden/doctor/Regrade/adapter evidence. Create a focused Linear issue first unless Matt chooses a non-issue branch. |
+
+## Recommended Direction
+
+For `TRL-772`, bias toward rejecting schema features the marker projector cannot
+canonically represent with confidence for v1. This is a contract line, not a
+convenience API. A clear unsupported diagnostic is better than two different
+runtime contracts sharing the same marker.
+
+For the capstone checkpoint, keep the first slice narrow:
+
+- read-only;
+- existing evidence only;
+- no git or Graphite mutation;
+- no autofix;
+- no typecheck/build shell-out orchestration as part of the checkpoint itself;
+- verdict vocabulary distinct from rule severity: `pass`, `caution`, `block`,
+  and maybe `reroute`.
+
+The checkpoint can call or compose existing Trails/Warden/doctor surfaces if the
+repo shape supports that cleanly. It should not become a generic task runner.
+
+## Branch Slice Details
+
+### TRL-772: Marker Semantics
+
+Problem: version-marker content currently runs through JSON-schema projection
+and canonicalization. The issue audit says several Zod validation semantics are
+accepted but do not change marker content.
+
+Primary source anchors:
+
+- `packages/core/src/version-marker.ts`
+- `packages/core/src/__tests__/version-marker.test.ts`
+- `packages/topographer/src/versioning.ts`
+- `packages/topographer/src/__tests__/derive.test.ts`
+- `docs/adr/0048-trail-versioning-v3.md`
+
+Completion contract:
+
+- Decide per construct whether it is supported marker content or unsupported
+  bounded-Zod input for v1.
+- Cover string checks, number checks, array checks, object
+  strict/passthrough/catchall policy, `refine`, and `superRefine`.
+- If supported, marker hashes must change when semantics change.
+- If unsupported, marker derivation must fail loudly with pathful diagnostics.
+- Update ADR/docs if the bounded marker subset changes.
+
+### TRL-773: Warden Early Diagnostics
+
+Problem: Warden currently flags only `any`, `custom`, `preprocess`,
+`transform`, and `unknown` in versioned schemas. Runtime marker derivation also
+rejects additional constructs such as `lazy`, `intersection`, and `record`.
+
+Primary source anchors:
+
+- `packages/warden/src/rules/trail-versioning-source.ts`
+- `packages/warden/src/__tests__/trail-versioning-rules.test.ts`
+- `packages/warden/src/rules/ast.ts`
+
+Completion contract:
+
+- Expand `marker-schema-unsupported` to match the bounded marker subset from
+  `TRL-772`.
+- Preserve the callback-scope guard. A helper named `transform` or a method
+  call inside a callback must not become a false positive.
+- Keep the rule scoped to versioned trail `input`/`output` schemas and
+  historical version entries.
+
+### TRL-770, TRL-769, TRL-771: Doctor and Release Gate
+
+Problem: `deriveDoctorSummary()` counts `entry.forces`, but graph-level
+`graph.forces` records removed-entity force events. Current doctor output is
+aggregate-only and not actionable enough for a release reviewer.
+
+Primary source anchors:
+
+- `apps/trails/src/trails/doctor.ts`
+- `apps/trails/src/trails/version-lifecycle-support.ts`
+- `apps/trails/src/__tests__/version-lifecycle.test.ts`
+- `apps/trails/src/__tests__/survey.test.ts`
+- `packages/topographer/src/forces.ts`
+- `packages/topographer/src/types.ts`
+- `docs/releases/stable-cutover.md`
+
+Completion contract:
+
+- Doctor counts both entry-attached and graph-level force events.
+- Doctor reports enough structured detail to identify forced
+  trail/resource/signal/contour, change type, detail, severity, and source.
+- Release docs name pending force events as a stable cutover gate after the
+  doctor output can support that review.
+- Accepted-exception semantics are implemented only if necessary for the
+  checkpoint verdict or stable cutover gate. Do not invent a broad policy model
+  prematurely.
+
+### TRL-878: Regrade Scan-Target Parity
+
+Problem: Regrade invokes Warden-backed term-rewrite logic on collected
+`.ts`/`.tsx` files, but Warden's CLI excludes `.d.ts`, `__tests__/`,
+`*.test.ts`, and `*.spec.ts` before most rule dispatch. Regrade must not route
+files to review that Warden itself would skip.
+
+Primary source anchors:
+
+- `packages/warden/src/cli.ts`
+- `packages/warden/src/rules/scan.ts`
+- `packages/warden/src/trails/run.ts`
+- `packages/regrade/src/downstream/collect.ts`
+- `packages/regrade/src/downstream/report.ts`
+- `packages/regrade/src/downstream/__tests__/report.test.ts`
+- `packages/warden/src/rules/no-legacy-layer-imports.ts`
+
+Completion contract:
+
+- Regrade applies the same Warden target filtering before Warden-backed rule
+  checks, or routes through a shared Warden dispatcher/helper.
+- `.tsx` source support remains intact.
+- Regression covers test fixtures, declaration files, and normal source files.
+
+### TRL-877 and TRL-872: Adapter Catalog Trust
+
+Problem: catalog derivation drops wildcard export keys because
+`exportSpecifierFromKey()` ignores keys containing `*`. That makes valid package
+exports like `"./*": "./src/*.ts"` fail owner-import validation.
+
+Primary source anchors:
+
+- `packages/adapter-kit/src/catalog.ts`
+- `packages/adapter-kit/src/__tests__/catalog.test.ts`
+- `packages/adapter-kit/src/__tests__/check.test.ts`
+- `apps/trails/src/__tests__/adapter-check.test.ts`
+- `packages/warden/src/__tests__/adapter-check.test.ts`
+- `docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md`
+
+Completion contract:
+
+- Resolve declared owner imports against wildcard export keys before reporting
+  `invalid-import`.
+- Add focused regression coverage for pattern export keys and existing explicit
+  exports.
+- Migrate remaining first-party adapters only after owner target/conformance
+  decisions are explicit. Do not infer targets from package names.
+
+### Capstone: Read-Only Checkpoint Verdict
+
+This slice needs a tracker decision before implementation. Either create a new
+Linear issue or use an explicit non-issue branch if Matt chooses that path.
+
+Completion contract:
+
+- Produces a read-only verdict over the evidence now made reliable:
+  marker/Warden state, doctor pending-force state, Regrade scan-target parity,
+  adapter-check state, and possibly open PR/review state if done outside the
+  package API.
+- Machine-readable output includes verdict, blockers, cautions, reroutes, and
+  source evidence references.
+- Does not mutate git, Graphite, GitHub, Linear, source files, lockfiles, or
+  generated artifacts.
+- Does not shell out to broad build/typecheck/test gates in the first slice.
+
+## Source-Control Plan
+
+Planning phase:
+
+- Do not create branches.
+- Do not edit the primary worktree.
+- Do not commit this home-level packet.
+
+Execution phase:
+
+1. Run the Graphite first-pass state check before any source-control write:
+
+   ```bash
+   git status --short
+   git diff --stat
+   git worktree list --porcelain
+   gt log --no-interactive
+   gh pr list --repo outfitter-dev/trails --state open --limit 100 --json number,title,headRefName,isDraft,url
+   ```
+
+2. Create or choose a dedicated execution worktree. The worktree must have a
+   real Graphite-tracked branch checked out. Do not execute this stack from a
+   detached Codex worktree. If Codex creates the delegated worktree, treat
+   `pwd -P` inside that delegated thread as the authoritative worktree path.
+3. Prefer the first-real-branch worktree pattern for this stack. Either the
+   coordinator creates the branch before launching the delegated worktree, or
+   the delegated thread is launched directly from this already-created branch:
+
+   ```bash
+   # from the primary clean worktree
+   gt checkout main --no-interactive
+   gt create trl-772-make-version-markers-account-for-or-reject-zod-validation --no-interactive
+   gt checkout main --no-interactive
+
+   # from the execution worktree
+   pwd -P
+   ./scripts/bootstrap.sh codex
+   ```
+
+   Do not run `gt sync` as setup unless the current turn explicitly authorizes
+   it after inspecting live state. In active multi-worktree repos, `gt sync` is
+   not harmless cleanup.
+4. Copy this packet into that worktree at
+   `.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/`.
+5. Commit the packet on the lowest branch where it becomes load-bearing by
+   staging the specific packet files:
+
+   ```bash
+   git add .agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/PLAN.md \
+     .agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/GOAL.md \
+     .agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md \
+     .agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/REFS.md
+   gt modify -c -m "chore(agent-trust): add execution packet" --no-interactive
+   ```
+
+6. Continue building the stack from the execution worktree with Graphite using
+   exact Linear branch names. The first branch is already `TRL-772`; create
+   each child branch with `gt create <branch> --no-interactive` from the current
+   stack tip.
+7. Keep the primary worktree free for coordination.
+
+Use Graphite for source-control writes. Do not use `gt absorb`. Do not submit
+empty branches. Do not merge, queue, or publish without Matt explicitly asking.
+Subagents may inspect, edit files, run checks, and write reports only when
+briefed; they must not run git/gt write commands or mutate PRs/Linear.
+
+If a worker worktree farm is needed instead of this single stack-owner worktree,
+use the Graphite-tracked base-lane pattern from the Graphite skill: create a
+real zero-diff base branch under `main`, track it with Graphite, and let worker
+lanes edit/test/report from child branches. Workers still must not submit,
+sync, delete, untrack, merge, broadly restack, or perform source-control writes
+unless Matt explicitly changes the repo rule for that delegation.
+
+## Review Loop
+
+Run local review from the stack tip before submission and repeat until the
+latest pass is clean or P3-only.
+
+Minimum local review lanes:
+
+- marker semantics and ADR fit;
+- Warden source-rule correctness and false-positive risk;
+- doctor/release-gate product shape;
+- Regrade/Warden parity;
+- adapter catalog export-pattern correctness;
+- checkpoint first-slice boundary.
+
+Review output must use:
+
+```markdown
+Overall score: n/5
+
+Summary:
+<one short prose judgment>
+
+Findings:
+- P0/P1/P2/P3 - <file:line> - <finding>
+  Prompt To Fix With AI:
+  <concise fix prompt>
+
+No-findings statement:
+<what was inspected and what residual risk remains>
+```
+
+Fix all P0/P1/P2. P3 findings may be fixed if cheap or recorded in `RETRO.md`
+with a reason.
+
+## Validation Ladder
+
+Use narrow checks per branch, then broaden at the stack tip.
+
+Focused checks likely needed:
+
+- `bun test packages/core/src/__tests__/version-marker.test.ts`
+- `bun test packages/topographer/src/__tests__/derive.test.ts`
+- `bun test packages/warden/src/__tests__/trail-versioning-rules.test.ts`
+- `bun test apps/trails/src/__tests__/version-lifecycle.test.ts`
+- `bun test apps/trails/src/__tests__/survey.test.ts`
+- `bun test packages/regrade/src/downstream/__tests__/report.test.ts`
+- `bun test packages/adapter-kit/src/__tests__/catalog.test.ts`
+- `bun test packages/adapter-kit/src/__tests__/check.test.ts`
+- `bun test packages/warden/src/__tests__/adapter-check.test.ts`
+- `bun test apps/trails/src/__tests__/adapter-check.test.ts`
+
+Broader checks before submission:
+
+- `bun run lint`
+- `bun run lint:ast-grep`
+- `bun run format:check`
+- `bun run typecheck`
+- `bun run test`
+- `bun run build`
+- `bun run check`
+- `bun run publish:check`
+- `git diff --check`
+
+Before submission:
+
+```bash
+gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
+gt submit --stack --draft --restack --no-edit --no-interactive
+```
+
+After submit, inspect each PR title/body and rewrite stale or placeholder
+bodies with `gh pr edit --body-file` using real temp files. Keep PRs draft until
+CI and local review are clean. Do not mark ready or merge unless the current
+turn authorizes it.
+
+When ADRs, generated guides, or agent-facing Warden docs change:
+
+- `bun scripts/adr.ts map`
+- `bun scripts/adr.ts check`
+- `bun run warden:agents:sync`
+- `bun run warden:skills:sync`
+- `bun run warden:agents:check`
+- `bun run warden:skills:check`
+
+## Stop Rules
+
+Stop and report before continuing if:
+
+- `main`, Linear, or open PR state has drifted enough to invalidate the stack
+  order.
+- `TRL-772` requires supporting broad Zod semantics instead of rejecting
+  unsupported constructs.
+- The checkpoint capstone wants to mutate git, Graphite, GitHub, Linear, source
+  files, or generated artifacts.
+- `TRL-771` grows into a broad exception-governance system instead of the
+  minimum shape needed for stable cutover.
+- Review feedback finds P0/P1/P2 issues after four post-ready turns.
+- Any command requires secrets, production access, publishing, merge, or merge
+  queue actions.
+
+## Handoff Requirements
+
+The executor must update `RETRO.md` before every meaningful handoff:
+
+- local completion;
+- draft PR submission;
+- ready-for-review request;
+- remote review closeout;
+- explicit user handoff;
+- merge-readiness report;
+- archive.
+
+The final transcript must summarize branch/PR state, verification results,
+review status, skipped checks, remaining risks, and confirmation that forbidden
+actions did not occur.

--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/REFS.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/REFS.md
@@ -1,0 +1,168 @@
+---
+created: "2026-06-01T17:30:00-04:00"
+updated: "2026-06-01T17:47:00-04:00"
+status: staged-outside-worktree
+---
+
+# References
+
+## Packet Locations
+
+- Staged packet:
+  `/Users/mg/.agents/plans/trails/2026-06-01-agent-trust-stable-cutover-integrity`
+- Eventual in-repo destination:
+  `.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/`
+
+## Repo Guidance
+
+- `AGENTS.md`
+- `.agents/plans/PLANNING.md`
+- `docs/tenets.md`
+- `docs/lexicon.md`
+- `docs/architecture.md`
+- `docs/adr/0048-trail-versioning-v3.md`
+- `docs/releases/stable-cutover.md`
+
+## Linear Issues
+
+- `TRL-772`: Make version markers account for or reject Zod validation checks.
+- `TRL-773`: Align marker-schema-unsupported Warden coverage with runtime
+  marker failures.
+- `TRL-770`: Make trails doctor pending-force output complete and actionable.
+- `TRL-769`: Document pending-force stable cutover gate.
+- `TRL-771`: Define accepted-exception semantics for pending force events.
+- `TRL-878`: Apply Warden scan-target filtering to Regrade.
+- `TRL-877`: Resolve wildcard export keys in catalog derivation.
+- `TRL-872`: Migrate remaining first-party adapters into adapter.check model.
+
+## Marker and Versioning
+
+- `packages/core/src/version-marker.ts`
+- `packages/core/src/__tests__/version-marker.test.ts`
+- `packages/core/src/version-resolution.ts`
+- `packages/core/src/__tests__/version-execution.test.ts`
+- `packages/topographer/src/versioning.ts`
+- `packages/topographer/src/derive.ts`
+- `packages/topographer/src/__tests__/derive.test.ts`
+- `packages/topographer/src/__tests__/diff.test.ts`
+- `docs/adr/0048-trail-versioning-v3.md`
+
+Notable evidence:
+
+- ADR-0048 says marker canonicalization is intentionally bounded to the
+  supported Zod subset and unsupported schema features must fail loudly.
+- `deriveTrailVersionMarker()` hashes canonicalized marker content from the
+  projected contract.
+- Current Warden source rule coverage is narrower than runtime marker failures.
+
+## Warden Marker Diagnostics
+
+- `packages/warden/src/rules/trail-versioning-source.ts`
+- `packages/warden/src/__tests__/trail-versioning-rules.test.ts`
+- `packages/warden/src/rules/ast.ts`
+- `packages/warden/src/rules/metadata.ts`
+
+Notable evidence:
+
+- `unsupportedSchemaCalls` currently includes `any`, `custom`, `preprocess`,
+  `transform`, and `unknown`.
+- `markerSchemaUnsupported` already scopes analysis to versioned trail
+  `input`/`output` and historical version entries.
+- The existing test suite pins a callback-scope guard.
+
+## Doctor and Pending Force Events
+
+- `apps/trails/src/trails/doctor.ts`
+- `apps/trails/src/trails/version-lifecycle-support.ts`
+- `apps/trails/src/__tests__/version-lifecycle.test.ts`
+- `apps/trails/src/__tests__/survey.test.ts`
+- `packages/topographer/src/forces.ts`
+- `packages/topographer/src/types.ts`
+- `packages/topographer/src/__tests__/forces.test.ts`
+
+Notable evidence:
+
+- `deriveDoctorSummary()` currently increments `forceEvents` from
+  `entry.forces?.length`.
+- Graph-level removed-entity force events are stored on `graph.forces`.
+- `survey.test.ts` already covers graph-level removed-trail force events.
+
+## Regrade and Warden Scan Targets
+
+- `packages/warden/src/cli.ts`
+- `packages/warden/src/rules/scan.ts`
+- `packages/warden/src/trails/run.ts`
+- `packages/warden/src/rules/no-legacy-layer-imports.ts`
+- `packages/regrade/src/downstream/collect.ts`
+- `packages/regrade/src/downstream/report.ts`
+- `packages/regrade/src/downstream/__tests__/report.test.ts`
+- `packages/regrade/src/downstream/__tests__/radio-fixture.test.ts`
+
+Notable evidence:
+
+- Warden CLI excludes `.d.ts`, `__tests__/`, `__test__/`, `*.test.ts`, and
+  `*.spec.ts` from most committed-source diagnostics.
+- Regrade collects `.ts` and `.tsx` sources and projects Warden
+  `term-rewrite` metadata into Regrade classes.
+- `no-legacy-layer-imports` comments rely on test files being filtered before
+  that rule is applied.
+
+## Adapter Catalog and Checks
+
+- `packages/adapter-kit/src/catalog.ts`
+- `packages/adapter-kit/src/check.ts`
+- `packages/adapter-kit/src/__tests__/catalog.test.ts`
+- `packages/adapter-kit/src/__tests__/check.test.ts`
+- `packages/adapter-kit/src/__tests__/dogfood.test.ts`
+- `packages/warden/src/__tests__/adapter-check.test.ts`
+- `apps/trails/src/__tests__/adapter-check.test.ts`
+- `docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md`
+- `.agents/plans/2026-05-30-v1-convergence-loop/PLAN.md`
+- `.agents/plans/2026-05-30-v1-convergence-loop/RETRO.md`
+
+Notable evidence:
+
+- `exportSpecifierFromKey()` currently returns `undefined` for export keys that
+  contain `*`.
+- `TRL-877` was filed from review feedback showing valid pattern exports can
+  make declared owner imports look invalid.
+- `TRL-872` is intentionally conditional until remaining first-party adapter
+  owner targets/conformance surfaces are explicit.
+
+## Review and Planning References
+
+- `/Users/mg/.agents/skills/goal-planning/references/code-review.md`
+- `/Users/mg/.agents/skills/goal-planning/references/source-control.md`
+- `/Users/mg/.agents/skills/goal-planning/references/trackers.md`
+- `/Users/mg/.agents/skills/goal-planning/references/goal-runtimes.md`
+- `/Users/mg/.agents/skills/graphite/SKILL.md`
+- `/Users/mg/.agents/skills/graphite/references/STACK_SURGERY.md`
+
+Graphite worktree notes:
+
+- A Codex execution worktree must have a real branch checked out; detached
+  worktrees cannot create Graphite child branches.
+- Prefer creating the first real Linear branch with Graphite, returning the
+  primary worktree to `main`, then launching or adding the dedicated worktree
+  on that branch.
+- If the Codex thread tool owns the worktree location, use `pwd -P` inside the
+  delegated thread as the authoritative path.
+- Use zero-diff Graphite-tracked base lanes only for worker-farm setups where a
+  worker needs a real branch under `main`; do not submit those base lanes as PRs.
+- `gt sync` is not part of default worktree setup for this packet.
+
+## Current Live Commands
+
+Useful refresh commands before execution:
+
+```bash
+pwd
+git status --short --branch
+git diff --stat
+git worktree list --porcelain
+gt log --no-interactive
+gh pr list --repo outfitter-dev/trails --state open --limit 20 --json number,title,headRefName,isDraft,url,mergeStateStatus,statusCheckRollup
+```
+
+If `gt` resolves through `/Users/mg/.codex/rtk-shims/gt`, use
+`RTK_SHIM_BYPASS=1` for Graphite commands until the environment is clean.

--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md
@@ -1,0 +1,191 @@
+---
+created: "2026-06-01T17:30:00-04:00"
+updated: "2026-06-01T17:47:00-04:00"
+status: seeded
+packet_location: "/Users/mg/.agents/plans/trails/2026-06-01-agent-trust-stable-cutover-integrity"
+eventual_repo_packet: ".agents/plans/2026-06-01-agent-trust-stable-cutover-integrity"
+---
+
+# Retro
+
+## Execution Summary
+
+Seeded outside the Trails worktree by Lewis on 2026-06-01.
+
+This packet has not been copied into the repo, committed, submitted, or tied to
+an execution worktree yet.
+
+## Branch / PR / Issue Ledger
+
+| Kind | Identifier | State | Notes |
+| --- | --- | --- | --- |
+| Branch | none | not started | No branch created during planning. |
+| PR | none | not started | No PR created during planning. |
+| Issues | TRL-772, TRL-773, TRL-770, TRL-769, TRL-771, TRL-878, TRL-877, TRL-872 | live | Existing Linear issues compose the planned stack. |
+
+## Planning Log
+
+### 2026-06-01 17:21 EDT - Context primed
+
+- Ran goal-planning context prime from
+  `/Users/mg/Developer/outfitter/trails`.
+- Verified primary worktree is clean on `main`.
+- Verified Graphite shows only `main`.
+- Verified open PR list is empty.
+- Read `.agents/plans/PLANNING.md`.
+- Read goal-planning code-review and source-control references.
+
+### 2026-06-01 17:24 EDT - Tracker shape verified
+
+- Fetched current Linear issue details for:
+  - TRL-772
+  - TRL-773
+  - TRL-770
+  - TRL-878
+  - TRL-877
+  - TRL-872
+- No Linear mutation was performed during planning.
+- No new checkpoint capstone issue was created yet.
+
+### 2026-06-01 17:28 EDT - Source anchors checked
+
+- Inspected marker projection and Warden versioning source paths.
+- Inspected `trails doctor` implementation and force-event tests.
+- Inspected Regrade/Warden scan target seams.
+- Inspected adapter catalog wildcard export seam.
+
+### 2026-06-01 17:31 EDT - Graphite worktree mechanics folded in
+
+- Read `/Users/mg/.agents/skills/graphite/SKILL.md`.
+- Read `/Users/mg/.agents/skills/graphite/references/STACK_SURGERY.md`.
+- Updated `PLAN.md`, `GOAL.md`, and `REFS.md` so execution starts from a
+  dedicated worktree with a real Graphite-tracked branch checked out.
+- Chose the first-real-branch pattern for the canonical stack owner:
+  create `trl-772-make-version-markers-account-for-or-reject-zod-validation`
+  with `gt create`, return the primary worktree to `main`, then add the
+  execution worktree on that branch.
+- Kept zero-diff base lanes as a worker-farm fallback only.
+- Explicitly excluded default `gt sync` during setup unless current-turn
+  authorization is given after live-state inspection.
+
+### 2026-06-01 17:47 EDT - Packet made Codex-worktree agnostic
+
+- The Codex thread tool accepts saved project roots, not arbitrary manually
+  created worktree paths.
+- Removed the hardcoded execution worktree path from the staged goal prompt.
+- The delegated thread must use `pwd -P` inside its managed worktree as the
+  authoritative cwd.
+
+## Tracker Mutations
+
+None during planning. This is intentional: the existing issue shards are live,
+and the only missing tracker object is the capstone checkpoint verdict branch.
+Executor should create or choose that issue before implementing the capstone.
+
+## Execution Log
+
+### 2026-06-01 17:48 EDT - Delegated worktree attached and packet copied
+
+- Started delegated execution lane `waymark` in
+  `/Users/mg/.config/codex/worktrees/533d/trails`.
+- Initial preflight found the Codex worktree detached at `HEAD`; stopped before
+  copying the packet or mutating files and sent the required
+  blocked-with-evidence callback to Lewis.
+- Lewis authorized
+  `gt checkout trl-772-make-version-markers-account-for-or-reject-zod-validation --no-interactive`
+  in this delegated worktree.
+- Checkout succeeded and full preflight was clean:
+  - `pwd -P` resolved to `/Users/mg/.config/codex/worktrees/533d/trails`.
+  - `git status --short --branch` showed
+    `trl-772-make-version-markers-account-for-or-reject-zod-validation`.
+  - `git diff --stat` was empty before packet copy.
+  - `git worktree list --porcelain` showed this worktree on the intended
+    branch and no other worktree owning it.
+  - `gt log --no-interactive` showed current branch `trl-772...` under `main`.
+  - `gh pr list --repo outfitter-dev/trails --state open --limit 100 --json ...`
+    returned `[]`.
+- Copied the staged packet into
+  `.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/`.
+
+### 2026-06-01 17:56 EDT - TRL-772 bounded marker rejection implemented
+
+- Implemented runtime marker-schema subset enforcement in
+  `packages/core/src/version-marker.ts`.
+- Chose bounded rejection for v1 marker-unsafe Zod semantics rather than
+  attempting broad canonical support:
+  - string, number, and array validation `checks`;
+  - `refine` and `superRefine`;
+  - object catchall and unknown-key policies such as `strict`,
+    `passthrough`, and `catchall`;
+  - unsupported Zod schema types outside the marker subset.
+- Added pathful focused coverage in
+  `packages/core/src/__tests__/version-marker.test.ts` and
+  `packages/topographer/src/__tests__/derive.test.ts`.
+- Updated ADR-0048 to state the excluded v1 marker subset explicitly.
+- Added `.changeset/marker-schema-bounds.md` for `@ontrails/core`.
+- Ran red checks before implementation:
+  - `bun test packages/core/src/__tests__/version-marker.test.ts` failed on
+    the new unsupported-schema assertions as expected.
+  - `bun test packages/topographer/src/__tests__/derive.test.ts` failed on
+    the new marker-validation-check derivation assertion as expected.
+- Verification after implementation:
+  - `bun test packages/core/src/__tests__/version-marker.test.ts` passed.
+  - `bun test packages/topographer/src/__tests__/derive.test.ts` passed.
+  - `bun scripts/adr.ts map` updated generated ADR maps.
+  - `bun scripts/adr.ts check` passed.
+  - `bun run oxlint-plugin:build` passed.
+  - `bun run typecheck` from `packages/core` passed.
+  - `bun run lint` from `packages/core` passed after renaming the test catch
+    binding.
+  - `bun run typecheck` from `packages/topographer` passed.
+  - `bun run lint` from `packages/topographer` passed.
+  - `bun run format:check` passed.
+  - `git diff --check` passed.
+
+## Verification Log
+
+Planning verification only:
+
+| Command | Scope | Result | Notes |
+| --- | --- | --- | --- |
+| `/Users/mg/.agents/skills/goal-planning/scripts/context-prime.sh` | Planning context | pass | Clean `main`, Graphite `main` only, no open PRs. |
+| `gh pr list --repo outfitter-dev/trails --state open --limit 20 --json ...` | PR state | pass | Returned `[]`. |
+| `gt log --no-interactive` | Graphite state | pass | Only `main` visible. |
+| Linear fetches for TRL-772/773/770/878/877/872 | Tracker state | pass | Issues are current and uncompleted. |
+| `git status --short && git diff --stat && git worktree list --porcelain && gt log --no-interactive && gh pr list ...` | Graphite first-pass refresh | pass | Clean primary worktree, only primary and Clark worktrees, Graphite `main`, no open PRs. |
+
+## Local Review Log
+
+No local or remote code review has run. Executor must run local review from the
+stack tip before submission and record P0-P3 findings here.
+
+## Remote Review / CI Log
+
+Not started. No PRs exist for this packet yet.
+
+## Forbidden Actions Audit
+
+Planning phase:
+
+- No branch created.
+- No source files edited in the Trails worktree.
+- No git add/commit/push.
+- No `gt create`, `gt modify`, `gt submit`, `gt sync`, `gt restack`, or merge.
+- No PR mutation.
+- No Linear mutation.
+- No publish or registry mutation.
+
+## Final State
+
+Not complete. This packet is ready to copy into a dedicated execution worktree
+when Matt chooses to start the goal.
+
+## Remaining Risks
+
+- The capstone checkpoint slice needs a tracker decision before implementation.
+- `TRL-772` may force a doctrinal decision about whether to support or reject
+  certain Zod validation checks in v1 marker content. The recommended default
+  is reject unsupported constructs loudly unless canonical support is clearly
+  bounded.
+- `TRL-771` should stay conditional; accepted-exception semantics can sprawl if
+  it is started before doctor output proves the minimum shape needed.

--- a/.changeset/marker-schema-bounds.md
+++ b/.changeset/marker-schema-bounds.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/core": patch
+---
+
+Reject versioned trail marker schemas that use Zod validation checks or object
+catchall policies outside the bounded marker subset.

--- a/docs/adr/0048-trail-versioning-v3.md
+++ b/docs/adr/0048-trail-versioning-v3.md
@@ -138,7 +138,7 @@ Marker inputs are contract content, not implementation source:
 - `status` and `examples` are mutable and do not participate in the frozen
   marker hash.
 
-Marker canonicalization in v1 is intentionally bounded to the supported Zod subset the implementation can serialize deterministically. Unsupported schema features must fail loudly with a clear diagnostic instead of producing unstable markers. If implementation evidence shows the needed Zod semantics cannot be bounded safely in M2, the stack must stop and defer that part to the later bounded-Zod rule work.
+Marker canonicalization in v1 is intentionally bounded to the supported Zod subset the implementation can serialize deterministically. Unsupported schema features must fail loudly with a clear diagnostic instead of producing unstable markers. The v1 marker subset excludes Zod validation checks (`min`, `email`, `int`, array length checks, `refine`, `superRefine`, and similar `checks`) plus object unknown-key and catchall policy changes (`strict`, `passthrough`, and `catchall`) until those semantics can be represented canonically. If implementation evidence shows additional Zod semantics cannot be bounded safely in M2, the stack must stop and defer that part to the later bounded-Zod rule work.
 
 `@N` references resolve by integer version. `@<marker-prefix>` references resolve by unambiguous marker prefix.
 

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -708,7 +708,7 @@
           "fromPath": "docs/adr/0038-typed-signal-emission.md"
         },
         {
-          "context": "before runtime, and [ADR-0007](../0007-governance-as-trails.md) made that",
+          "context": "Warden is the governance arm of Trails. It is where drift becomes visible before runtime, and [ADR-0007](../0007-governance-as-trails.md) made that governance trail-shaped instead of a parallel lint s",
           "from": "20260530",
           "fromPath": "docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md"
         },
@@ -2228,7 +2228,7 @@
           "fromPath": "docs/adr/0037-owner-first-authority.md"
         },
         {
-          "context": "[ADR-0036](../0036-warden-rules-ship-only-as-trails.md) tightened the public",
+          "context": "Warden is the governance arm of Trails. It is where drift becomes visible before runtime, and [ADR-0007](../0007-governance-as-trails.md) made that governance trail-shaped instead of a parallel lint s",
           "from": "20260530",
           "fromPath": "docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md"
         },

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -237,7 +237,7 @@
       "status": "draft",
       "superseded_by": null,
       "title": "Adapter authoring as a paved path",
-      "updated": "2026-05-28"
+      "updated": "2026-05-30"
     },
     {
       "created": "2026-05-30",

--- a/packages/core/src/__tests__/version-marker.test.ts
+++ b/packages/core/src/__tests__/version-marker.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 
 import { z } from 'zod';
 
+import { blobRefSchema } from '../blob-ref.js';
 import { AmbiguousError, ValidationError } from '../errors.js';
 import {
   TRAIL_VERSION_MARKER_LENGTH,
@@ -12,6 +13,32 @@ import {
   deriveTrailVersionMarker,
   resolveTrailVersionMarkerPrefix,
 } from '../version-marker.js';
+
+const markerInput = (input: z.ZodType) =>
+  ({
+    composes: [],
+    detours: [],
+    input,
+    output: z.object({ ok: z.boolean() }),
+    resources: [],
+  }) as never;
+
+const expectUnsupportedMarkerSchema = (
+  input: z.ZodType,
+  expectedPath: string,
+  expectedDetail: string
+): void => {
+  let error: unknown;
+  try {
+    deriveCurrentTrailVersionMarker(markerInput(input));
+  } catch (caughtError) {
+    error = caughtError;
+  }
+
+  expect(error).toBeInstanceOf(ValidationError);
+  expect((error as Error).message).toContain(expectedPath);
+  expect((error as Error).message).toContain(expectedDetail);
+};
 
 describe('trail version markers', () => {
   test('hashes canonicalized content into a 16-character marker', () => {
@@ -55,6 +82,268 @@ describe('trail version markers', () => {
     });
     expect(deriveCurrentTrailVersionMarker(base as never)).not.toBe(
       deriveCurrentTrailVersionMarker(current as never)
+    );
+  });
+
+  test('rejects Zod validation checks that are not part of marker content', () => {
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.string().min(3) }),
+      'input.value',
+      'min_length'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.string().email() }),
+      'input.value',
+      'string_format'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.number().int() }),
+      'input.value',
+      'number_format'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.email() }),
+      'input.value',
+      'string_format'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.uuid() }),
+      'input.value',
+      'string_format'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.int() }),
+      'input.value',
+      'number_format'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.array(z.string()).min(1) }),
+      'input.value',
+      'min_length'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.string().refine((value) => value.length > 0) }),
+      'input.value',
+      'custom'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({
+        value: z.string().superRefine((value, ctx) => {
+          if (value.length === 0) {
+            ctx.addIssue({ code: 'custom', message: 'value is required' });
+          }
+        }),
+      }),
+      'input.value',
+      'custom'
+    );
+  });
+
+  test('rejects coerced Zod primitives so markers cannot collide with plain ones', () => {
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.coerce.number() }),
+      'input.value',
+      'coercion'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.coerce.string() }),
+      'input.value',
+      'coercion'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.coerce.boolean() }),
+      'input.value',
+      'coercion'
+    );
+
+    // A coerced primitive must not hash identically to its plain counterpart.
+    expect(() =>
+      deriveCurrentTrailVersionMarker(
+        markerInput(z.object({ value: z.coerce.number() }))
+      )
+    ).toThrow(ValidationError);
+  });
+
+  test('rejects defaults because factories are opaque after Zod normalization', () => {
+    expectUnsupportedMarkerSchema(
+      z.object({
+        value: z.string().default(() => Math.random().toString()),
+      }),
+      'input.value',
+      'schema type "default"'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({
+        value: z.number().default(() => Date.now()),
+      }),
+      'input.value',
+      'schema type "default"'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({
+        value: z.number().default(() => Math.floor(Date.now() / 1000)),
+      }),
+      'input.value',
+      'schema type "default"'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.string().default('stable') }),
+      'input.value',
+      'schema type "default"'
+    );
+  });
+
+  test('rejects JSON-lossy enum values before marker hashing', () => {
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.enum({ A: Number.NaN } as never) }),
+      'input.value',
+      'non-finite JSON value'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.enum({ A: Number.POSITIVE_INFINITY } as never) }),
+      'input.value',
+      'non-finite JSON value'
+    );
+
+    expect(() =>
+      deriveCurrentTrailVersionMarker(
+        markerInput(z.object({ value: z.enum(['a', 'b']) }))
+      )
+    ).not.toThrow();
+    expect(() =>
+      deriveCurrentTrailVersionMarker(
+        markerInput(z.object({ value: z.enum({ A: null } as never) }))
+      )
+    ).not.toThrow();
+  });
+
+  test('rejects reference-valued literal and enum values before marker hashing', () => {
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.literal({ key: 'value' } as never) }),
+      'input.value',
+      'reference-valued literal or enum value'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.literal([['value']] as never) }),
+      'input.value',
+      'reference-valued literal or enum value'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.enum({ A: { key: 'value' } } as never) }),
+      'input.value.A',
+      'reference-valued literal or enum value'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.enum({ A: ['value'] } as never) }),
+      'input.value.A',
+      'reference-valued literal or enum value'
+    );
+  });
+
+  test('accepts optional schemas without marker defaults', () => {
+    expect(() =>
+      deriveCurrentTrailVersionMarker(
+        markerInput(z.object({ value: z.string().optional() }))
+      )
+    ).not.toThrow();
+  });
+
+  test('rejects hidden optional wrappers before marker hashing', () => {
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.string().optional().nullable() }),
+      'input.value',
+      'hidden optional wrapper'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.string().optional().readonly() }),
+      'input.value',
+      'hidden optional wrapper'
+    );
+
+    expect(() =>
+      deriveCurrentTrailVersionMarker(
+        markerInput(z.object({ value: z.string().nullable().optional() }))
+      )
+    ).not.toThrow();
+    expect(() =>
+      deriveCurrentTrailVersionMarker(
+        markerInput(z.object({ value: z.string().readonly().optional() }))
+      )
+    ).not.toThrow();
+  });
+
+  test('accepts schemas with a deterministic JSON-schema override (blobRefSchema)', () => {
+    // blobRefSchema is z.custom(...).meta({...}) — the preflight must not reject
+    // it, because zodToJsonSchema projects it to a canonical descriptor.
+    const marker = deriveCurrentTrailVersionMarker(
+      markerInput(z.object({ file: blobRefSchema }))
+    );
+    expect(marker).toHaveLength(TRAIL_VERSION_MARKER_LENGTH);
+  });
+
+  test('rejects validation checks on schemas with JSON-schema overrides', () => {
+    expectUnsupportedMarkerSchema(
+      z.object({ file: blobRefSchema.refine((blob) => blob.size < 1024) }),
+      'input.file',
+      'custom'
+    );
+  });
+
+  test('rejects multi-value literals that the projection cannot represent', () => {
+    // The projection emits only the first literal value, so a multi-value
+    // literal must fail loudly instead of colliding with a single-value one.
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.literal(['a', 'b']) }),
+      'input.value',
+      'multi-value literal'
+    );
+    // Single-value literals remain supported.
+    expect(() =>
+      deriveCurrentTrailVersionMarker(
+        markerInput(z.object({ value: z.literal('a') }))
+      )
+    ).not.toThrow();
+  });
+
+  test('rejects non-finite literals that JSON serialization cannot preserve', () => {
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.literal(Number.NaN) }),
+      'input.value',
+      'non-finite literal'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ value: z.literal(Number.POSITIVE_INFINITY) }),
+      'input.value',
+      'non-finite literal'
+    );
+    // Finite and null literals remain supported and distinct.
+    expect(() =>
+      deriveCurrentTrailVersionMarker(
+        markerInput(z.object({ value: z.literal(1) }))
+      )
+    ).not.toThrow();
+    expect(() =>
+      deriveCurrentTrailVersionMarker(
+        markerInput(z.object({ value: z.literal(null) }))
+      )
+    ).not.toThrow();
+  });
+
+  test('rejects object unknown-key and catchall policies for markers', () => {
+    expectUnsupportedMarkerSchema(
+      z.object({ id: z.string() }).strict(),
+      'input',
+      'catchall'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ id: z.string() }).passthrough(),
+      'input',
+      'catchall'
+    );
+    expectUnsupportedMarkerSchema(
+      z.object({ id: z.string() }).catchall(z.string()),
+      'input',
+      'catchall'
     );
   });
 

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -83,6 +83,15 @@ const getSchemaJsonSchemaOverride = (
   return undefined;
 };
 
+/**
+ * Whether a schema has a deterministic JSON-schema override projection (for
+ * example `blobRefSchema`, a `z.custom(...)` carrying the descriptor metadata).
+ * Such schemas project to a canonical descriptor regardless of their underlying
+ * Zod internals, so marker derivation can treat them as supported.
+ */
+export const schemaHasJsonSchemaOverride = (schema: z.ZodType): boolean =>
+  getSchemaJsonSchemaOverride(schema) !== undefined;
+
 // ---------------------------------------------------------------------------
 // Issue formatting
 // ---------------------------------------------------------------------------
@@ -152,22 +161,74 @@ export const validateOutput = <T>(
 const DYNAMIC_DEFAULT = Symbol('DYNAMIC_DEFAULT');
 const defaultValueCache = new WeakMap<object, unknown>();
 
-/** Read a Zod v4 default getter twice and decide if it's stable.
- *  Uses Object.is for primitives and JSON.stringify for objects/arrays. */
+const defaultsMatch = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  try {
+    return JSON.stringify(left) === JSON.stringify(right);
+  } catch {
+    return false;
+  }
+};
+
+const waitForClockAdvance = (): void => {
+  const wallStart = Date.now();
+  const monotonicStart = performance.now();
+  while (Date.now() === wallStart && performance.now() - monotonicStart < 4) {
+    // Zod hides default factories behind a getter. A bounded sync wait lets
+    // Date.now()-style factories reveal themselves without making the API async.
+  }
+};
+
+const readDefaultWithDateNowOffset = (
+  def: Record<string, unknown>
+): unknown => {
+  const originalDateNow = Date.now;
+  try {
+    Date.now = () => originalDateNow() + 86_400_000;
+    return def['defaultValue'];
+  } finally {
+    Date.now = originalDateNow;
+  }
+};
+
+/**
+ * Read a Zod v4 default getter and decide if it is stable.
+ *
+ * Uses Object.is for primitives and JSON.stringify for objects/arrays. A delayed
+ * third read catches default factories such as `() => Date.now()` that can return
+ * equal values for immediate back-to-back reads. A Date.now() probe catches
+ * coarser clock factories without requiring marker derivation to wait for the
+ * next second/day boundary.
+ */
 const resolveDefault = (def: Record<string, unknown>): unknown => {
   try {
     const a = def['defaultValue'];
     const b = def['defaultValue'];
-    if (Object.is(a, b)) {
-      return a;
+    if (!defaultsMatch(a, b)) {
+      return DYNAMIC_DEFAULT;
     }
-    // Object/array defaults produce new references each call but may
-    // still be structurally identical (e.g. `() => ({ key: 'val' })`).
-    return JSON.stringify(a) === JSON.stringify(b) ? a : DYNAMIC_DEFAULT;
+    waitForClockAdvance();
+    const c = def['defaultValue'];
+    if (!defaultsMatch(a, c)) {
+      return DYNAMIC_DEFAULT;
+    }
+    const d = readDefaultWithDateNowOffset(def);
+    return defaultsMatch(a, d) ? a : DYNAMIC_DEFAULT;
   } catch {
     // BigInt, circular refs, or other non-serializable defaults
     return DYNAMIC_DEFAULT;
   }
+};
+
+export const zodDefaultValueIsDynamic = (
+  def: Record<string, unknown>
+): boolean => {
+  if (!defaultValueCache.has(def)) {
+    defaultValueCache.set(def, resolveDefault(def));
+  }
+  return defaultValueCache.get(def) === DYNAMIC_DEFAULT;
 };
 
 /**
@@ -223,9 +284,7 @@ export const zodToJsonSchema: JsonSchemaConverter = (
     default: (value) => {
       const inner = value._zod.def['innerType'] as unknown as z.ZodType;
       const innerSchema = zodToJsonSchema(inner);
-      if (!defaultValueCache.has(value._zod.def)) {
-        defaultValueCache.set(value._zod.def, resolveDefault(value._zod.def));
-      }
+      zodDefaultValueIsDynamic(value._zod.def);
       const cached = defaultValueCache.get(value._zod.def);
       if (cached !== DYNAMIC_DEFAULT) {
         innerSchema['default'] = cached;

--- a/packages/core/src/version-marker.ts
+++ b/packages/core/src/version-marker.ts
@@ -6,7 +6,7 @@ import {
   isArchivedTrailVersionEntry,
 } from './trail.js';
 import type { AnyTrail, TrailVersionEntry } from './trail.js';
-import { zodToJsonSchema } from './validation.js';
+import { schemaHasJsonSchemaOverride, zodToJsonSchema } from './validation.js';
 
 export const TRAIL_VERSION_MARKER_LENGTH = 16;
 export const TRAIL_VERSION_MARKER_MIN_PREFIX_LENGTH = 4;
@@ -31,6 +31,300 @@ const markerPrefixPattern = /^[0-9a-f]+$/;
 
 const markerValuePath = (path: readonly string[]): string =>
   path.length === 0 ? '<root>' : path.join('.');
+
+const markerSchemaPath = (path: readonly string[]): string => {
+  if (path.length === 0) {
+    return '<schema>';
+  }
+  let formatted = '';
+  for (const segment of path) {
+    if (segment === '[]') {
+      formatted = `${formatted}[]`;
+      continue;
+    }
+    formatted = formatted.length === 0 ? segment : `${formatted}.${segment}`;
+  }
+  return formatted;
+};
+
+const supportedMarkerSchemaTypes = new Set([
+  'array',
+  'boolean',
+  'enum',
+  'literal',
+  'nullable',
+  'number',
+  'object',
+  'optional',
+  'readonly',
+  'string',
+  'union',
+]);
+
+const zodDef = (
+  schema: unknown,
+  path: readonly string[]
+): Readonly<Record<string, unknown>> => {
+  if (typeof schema !== 'object' || schema === null) {
+    throw new ValidationError(
+      `Trail version marker schema at ${markerSchemaPath(path)} is not a Zod schema`
+    );
+  }
+
+  const def = (schema as { readonly _zod?: { readonly def?: unknown } })._zod
+    ?.def;
+  if (!isPlainObject(def)) {
+    throw new ValidationError(
+      `Trail version marker schema at ${markerSchemaPath(path)} is not a supported Zod schema`
+    );
+  }
+  return def;
+};
+
+const zodType = (def: Readonly<Record<string, unknown>>): string =>
+  typeof def['type'] === 'string' ? def['type'] : '<unknown>';
+
+const zodChecks = (
+  def: Readonly<Record<string, unknown>>
+): readonly unknown[] => {
+  const { checks } = def;
+  return Array.isArray(checks) ? checks : [];
+};
+
+const zodDirectCheckName = (
+  def: Readonly<Record<string, unknown>>
+): string | undefined =>
+  typeof def['check'] === 'string' ? def['check'] : undefined;
+
+const zodCheckName = (check: unknown): string => {
+  if (typeof check !== 'object' || check === null) {
+    return '<unknown>';
+  }
+
+  const def = (
+    check as {
+      readonly _zod?: { readonly def?: Readonly<Record<string, unknown>> };
+    }
+  )._zod?.def;
+  if (!isPlainObject(def)) {
+    return '<unknown>';
+  }
+
+  const name = def['check'] ?? def['type'];
+  return typeof name === 'string' ? name : '<unknown>';
+};
+
+const nestedZodSchema = (value: unknown, path: readonly string[]): unknown => {
+  if (value === undefined) {
+    throw new ValidationError(
+      `Trail version marker schema at ${markerSchemaPath(path)} is missing an expected nested schema`
+    );
+  }
+  return value;
+};
+
+// Wrapper schema types that delegate to a single inner schema.
+const wrappedMarkerSchemaTypes = new Set([
+  'default',
+  'nullable',
+  'optional',
+  'readonly',
+]);
+
+// Schemas with a deterministic JSON-schema override (e.g. blobRefSchema) project
+// to a canonical descriptor, so the preflight accepts them without inspecting
+// the underlying custom Zod internals once runtime-only checks have been ruled
+// out.
+const hasMarkerSchemaOverride = (schema: unknown): boolean =>
+  typeof schema === 'object' &&
+  schema !== null &&
+  schemaHasJsonSchemaOverride(schema as never);
+
+const assertMarkerJsonSafe = (
+  value: unknown,
+  path: readonly string[]
+): void => {
+  if (
+    value === null ||
+    typeof value === 'boolean' ||
+    typeof value === 'string'
+  ) {
+    return;
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      throw new ValidationError(
+        `Trail version marker schema at ${markerSchemaPath(path)} uses an unsupported non-finite JSON value`
+      );
+    }
+    return;
+  }
+
+  if (!isPlainObject(value) && !Array.isArray(value)) {
+    throw new ValidationError(
+      `Trail version marker schema at ${markerSchemaPath(path)} uses an unsupported JSON-lossy value`
+    );
+  }
+
+  throw new ValidationError(
+    `Trail version marker schema at ${markerSchemaPath(path)} uses an unsupported reference-valued literal or enum value`
+  );
+};
+
+const assertMarkerLiteralSupported = (
+  def: Readonly<Record<string, unknown>>,
+  path: readonly string[]
+): void => {
+  // The JSON-schema projection only emits the first literal value, so a
+  // multi-value literal (z.literal(['a', 'b'])) would hash identically to a
+  // single-value literal and silently collide.
+  const { values } = def;
+  if (Array.isArray(values) && values.length > 1) {
+    throw new ValidationError(
+      `Trail version marker schema at ${markerSchemaPath(path)} uses an unsupported multi-value literal`
+    );
+  }
+  const [value] = Array.isArray(values) ? values : [];
+  if (typeof value === 'number' && !Number.isFinite(value)) {
+    throw new ValidationError(
+      `Trail version marker schema at ${markerSchemaPath(path)} uses an unsupported non-finite literal`
+    );
+  }
+  assertMarkerJsonSafe(value, path);
+};
+
+const assertMarkerEnumSupported = (
+  def: Readonly<Record<string, unknown>>,
+  path: readonly string[]
+): void => {
+  const { entries } = def;
+  if (!isPlainObject(entries)) {
+    throw new ValidationError(
+      `Trail version marker schema at ${markerSchemaPath(path)} has unsupported enum entries`
+    );
+  }
+  for (const [key, value] of Object.entries(entries)) {
+    assertMarkerJsonSafe(value, [...path, key]);
+  }
+};
+
+const nestedMarkerWrappedSchema = (
+  type: string,
+  def: Readonly<Record<string, unknown>>,
+  path: readonly string[],
+  options: { readonly optionalWrapperAllowed?: boolean }
+): unknown => {
+  if (type === 'optional' && options.optionalWrapperAllowed !== true) {
+    throw new ValidationError(
+      `Trail version marker schema at ${markerSchemaPath(path)} uses an unsupported hidden optional wrapper`
+    );
+  }
+  return nestedZodSchema(def['innerType'], path);
+};
+
+const assertMarkerSchemaSupported = (
+  schema: unknown,
+  path: readonly string[],
+  options: { readonly optionalWrapperAllowed?: boolean } = {}
+): void => {
+  const def = zodDef(schema, path);
+  if (def['coerce'] === true) {
+    throw new ValidationError(
+      `Trail version marker schema at ${markerSchemaPath(path)} uses unsupported Zod coercion`
+    );
+  }
+
+  const [firstCheck] = zodChecks(def);
+  if (firstCheck !== undefined) {
+    throw new ValidationError(
+      `Trail version marker schema at ${markerSchemaPath(path)} uses unsupported Zod validation check "${zodCheckName(firstCheck)}"`
+    );
+  }
+
+  if (hasMarkerSchemaOverride(schema)) {
+    return;
+  }
+
+  const directCheckName = zodDirectCheckName(def);
+  if (directCheckName !== undefined) {
+    throw new ValidationError(
+      `Trail version marker schema at ${markerSchemaPath(path)} uses unsupported Zod validation check "${directCheckName}"`
+    );
+  }
+
+  const type = zodType(def);
+  if (!supportedMarkerSchemaTypes.has(type)) {
+    throw new ValidationError(
+      `Trail version marker schema at ${markerSchemaPath(path)} uses unsupported Zod schema type "${type}"`
+    );
+  }
+
+  if (type === 'literal') {
+    assertMarkerLiteralSupported(def, path);
+    return;
+  }
+
+  if (type === 'enum') {
+    assertMarkerEnumSupported(def, path);
+    return;
+  }
+
+  if (type === 'array') {
+    assertMarkerSchemaSupported(
+      nestedZodSchema(def['element'], [...path, '[]']),
+      [...path, '[]']
+    );
+    return;
+  }
+
+  if (type === 'object') {
+    if (def['catchall'] !== undefined) {
+      throw new ValidationError(
+        `Trail version marker schema at ${markerSchemaPath(path)} uses unsupported object catchall or unknown-key policy`
+      );
+    }
+
+    const { shape } = def;
+    if (shape === undefined) {
+      return;
+    }
+    if (!isPlainObject(shape)) {
+      throw new ValidationError(
+        `Trail version marker schema at ${markerSchemaPath(path)} has an unsupported object shape`
+      );
+    }
+
+    for (const [key, value] of Object.entries(shape).toSorted(
+      ([left], [right]) => left.localeCompare(right)
+    )) {
+      assertMarkerSchemaSupported(value, [...path, key], {
+        optionalWrapperAllowed: true,
+      });
+    }
+    return;
+  }
+
+  if (wrappedMarkerSchemaTypes.has(type)) {
+    assertMarkerSchemaSupported(
+      nestedMarkerWrappedSchema(type, def, path, options),
+      path
+    );
+    return;
+  }
+
+  if (type === 'union') {
+    const unionOptions = def['options'];
+    if (!Array.isArray(unionOptions)) {
+      throw new ValidationError(
+        `Trail version marker schema at ${markerSchemaPath(path)} has unsupported union options`
+      );
+    }
+    for (const [index, option] of unionOptions.entries()) {
+      assertMarkerSchemaSupported(option, [...path, `option${index}`]);
+    }
+  }
+};
 
 const assertMarkerContentSupported = (
   value: unknown,
@@ -134,8 +428,12 @@ export const deriveTrailVersionMarker = (content: unknown): string => {
   return hasher.digest('hex').slice(0, TRAIL_VERSION_MARKER_LENGTH);
 };
 
-const projectSchema = (schema: unknown): unknown =>
-  canonicalizeTrailVersionMarkerContent(zodToJsonSchema(schema as never));
+const projectSchema = (schema: unknown, path: readonly string[]): unknown => {
+  assertMarkerSchemaSupported(schema, path);
+  return canonicalizeTrailVersionMarkerContent(
+    zodToJsonSchema(schema as never)
+  );
+};
 
 const projectVersionDetours = (
   entry: unknown
@@ -196,11 +494,11 @@ export const deriveCurrentTrailVersionMarkerContent = (
   >
 ): Readonly<Record<string, unknown>> => {
   const content: Record<string, unknown> = {
-    input: projectSchema(trail.input),
+    input: projectSchema(trail.input, ['input']),
     kind: 'current',
     ...(trail.output === undefined
       ? {}
-      : { output: projectSchema(trail.output) }),
+      : { output: projectSchema(trail.output, ['output']) }),
   };
 
   const composes = projectVersionRuntimeRefs(trail, 'composes');
@@ -224,9 +522,9 @@ export const deriveTrailVersionEntryMarkerContent = (
 ): Readonly<Record<string, unknown>> => {
   const kind = getTrailVersionEntryKind(entry);
   const content: Record<string, unknown> = {
-    input: projectSchema(entry.input),
+    input: projectSchema(entry.input, ['input']),
     kind,
-    output: projectSchema(entry.output),
+    output: projectSchema(entry.output, ['output']),
   };
 
   if (kind === 'revision' && entry.transpose !== undefined) {

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -518,6 +518,29 @@ describe('deriveTopoGraph', () => {
       );
     });
 
+    test('rejects unsupported marker validation checks with schema paths', () => {
+      const versioned = trail('marker.validation-check', {
+        blaze: (input) => Result.ok({ value: input.value }),
+        input: z.object({ value: z.string().min(3) }),
+        output: z.object({ value: z.string() }),
+        version: 2,
+        versions: {
+          1: {
+            input: z.object({ value: z.string() }),
+            output: z.object({ value: z.string() }),
+            transpose: {
+              input: ({ input }) => input,
+              output: ({ output }) => output,
+            },
+          },
+        },
+      });
+
+      expect(() => deriveTopoGraph(topoFrom({ versioned }))).toThrow(
+        'input.value'
+      );
+    });
+
     test('trail entries include composes array when non-empty', () => {
       const base = trail('user.get', {
         blaze: noop,


### PR DESCRIPTION
## Summary

- Reject marker-unsafe Zod schema constructs before version marker derivation so canonical marker hashes do not silently collide.
- Add pathful coverage for unsupported string, number, array, refine/superRefine, object policy, and unsupported schema-type cases.
- Document the bounded marker subset in ADR-0048 and include the execution packet for the stack.

## Verification

- `bun test packages/core/src/__tests__/version-marker.test.ts`
- `bun test packages/topographer/src/__tests__/derive.test.ts`
- `bun scripts/adr.ts check`
- `bun run oxlint-plugin:build`
- `bun run typecheck` from `packages/core`
- `bun run lint` from `packages/core`
- `bun run typecheck` from `packages/topographer`
- `bun run lint` from `packages/topographer`
- `bun run format:check`
- `git diff --check`

## Notes

- Linear: TRL-772
- This PR intentionally rejects unsupported v1 marker schema semantics instead of trying to widen canonical support in the same slice.
