### PR TITLE
fix(warden): align marker schema unsupported checks

### DIFF
--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md
@@ -142,6 +142,34 @@ Executor should create or choose that issue before implementing the capstone.
   - `bun run format:check` passed.
   - `git diff --check` passed.
 
+### 2026-06-01 18:02 EDT - TRL-773 Warden marker diagnostics aligned
+
+- Created child branch
+  `trl-773-align-marker-schema-unsupported-warden-coverage-with-runtime`.
+- Expanded `marker-schema-unsupported` in
+  `packages/warden/src/rules/trail-versioning-source.ts` to flag source-level
+  schema calls that the runtime marker subset rejects, including
+  `lazy`, `intersection`, `record`, validation-check methods, and object
+  catchall/unknown-key policy methods.
+- Added Warden source-rule regressions for:
+  - `lazy`, `intersection`, and `record`;
+  - string, number, and array validation checks;
+  - `refine` and `superRefine`;
+  - `strict`, `passthrough`, and `catchall`;
+  - unversioned trail scoping;
+  - callback-scope guard behavior.
+- Added `.changeset/warden-marker-schema-bounds.md` for `@ontrails/warden`.
+- Ran red check before implementation:
+  - `bun test packages/warden/src/__tests__/trail-versioning-rules.test.ts`
+    failed on the new Warden diagnostics as expected.
+- Verification after implementation:
+  - `bun test packages/warden/src/__tests__/trail-versioning-rules.test.ts`
+    passed.
+  - `bun run typecheck` from `packages/warden` passed.
+  - `bun run lint` from `packages/warden` passed.
+  - `bun run format:check` passed after formatting the touched Warden test.
+  - `git diff --check` passed.
+
 ## Verification Log
 
 Planning verification only:

--- a/.changeset/warden-marker-schema-bounds.md
+++ b/.changeset/warden-marker-schema-bounds.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/warden": patch
+---
+
+Expand marker-schema-unsupported diagnostics to catch Zod schema constructs that
+runtime marker derivation rejects.

--- a/packages/warden/src/__tests__/trail-versioning-rules.test.ts
+++ b/packages/warden/src/__tests__/trail-versioning-rules.test.ts
@@ -128,7 +128,533 @@ trail('versioned.schema', {
     ]);
   });
 
-  test('marker-schema-unsupported ignores unsupported call names inside schema callbacks', () => {
+  test('marker-schema-unsupported rejects runtime-unsupported schema types', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+trail('versioned.schema-types', {
+  version: 2,
+  input: z.object({
+    deferred: z.lazy(() => z.string()),
+    merged: z.intersection(z.object({ a: z.string() }), z.object({ b: z.string() })),
+    keyed: z.record(z.string(), z.string()),
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(3);
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: 'marker-schema-unsupported',
+          severity: 'error',
+        }),
+      ])
+    );
+  });
+
+  test('marker-schema-unsupported rejects validation checks and object policies', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+const constrained = z.string().min(3);
+
+trail('versioned.validation-checks', {
+  version: 2,
+  input: z.object({
+    name: z.string().min(3),
+    email: z.string().email(),
+    count: z.number().int(),
+    tags: z.array(z.string()).min(1),
+    refined: z.string().refine((value) => value.length > 0),
+    superRefined: z.string().superRefine((value, ctx) => {
+      if (value.length === 0) {
+        ctx.addIssue({ code: 'custom', message: 'required' });
+      }
+    }),
+    strictObject: z.object({ id: z.string() }).strict(),
+    openObject: z.object({ id: z.string() }).passthrough(),
+    catchallObject: z.object({ id: z.string() }).catchall(z.string()),
+    fromBinding: constrained,
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(10);
+    expect(diagnostics.every((entry) => entry.severity === 'error')).toBe(true);
+  });
+
+  test('marker-schema-unsupported covers string and number checks the runtime guard rejects', () => {
+    // The runtime marker guard rejects any non-empty Zod def.checks, so these
+    // previously omitted Zod v4 checks must surface as Warden diagnostics too.
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+trail('versioned.omitted-checks', {
+  version: 2,
+  input: z.object({
+    trimmed: z.string().trim(),
+    emoji: z.string().emoji(),
+    base64: z.string().base64(),
+    base64url: z.string().base64url(),
+    cuid: z.string().cuid(),
+    cuid2: z.string().cuid2(),
+    ksuid: z.string().ksuid(),
+    stepped: z.number().step(2),
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(8);
+    expect(diagnostics.every((entry) => entry.severity === 'error')).toBe(true);
+    expect(
+      diagnostics.every((entry) => entry.rule === 'marker-schema-unsupported')
+    ).toBe(true);
+  });
+
+  test('marker-schema-unsupported flags coerced primitives the runtime guard rejects', () => {
+    // z.coerce.number()/string()/boolean() end in a supported primitive name,
+    // so the deny-list never matches; the coercion lives on the intermediate
+    // .coerce member, which the runtime marker guard rejects.
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+trail('versioned.coerced', {
+  version: 2,
+  input: z.object({
+    n: z.coerce.number(),
+    s: z.coerce.string(),
+    b: z.coerce.boolean(),
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(3);
+    expect(
+      diagnostics.every(
+        (entry) =>
+          entry.rule === 'marker-schema-unsupported' &&
+          entry.severity === 'error'
+      )
+    ).toBe(true);
+  });
+
+  test('marker-schema-unsupported covers runtime-rejected constructors and modifiers', () => {
+    // Evidence-verified against the runtime marker guard: each of these forms is
+    // rejected at marker derivation, so the source rule must flag them too.
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+trail('versioned.runtime-rejected', {
+  version: 2,
+  input: z.object({
+    big: z.bigint(),
+    tup: z.tuple([z.string()]),
+    strictObj: z.strictObject({ a: z.string() }),
+    looseObj: z.looseObject({ a: z.string() }),
+    intersected: z.string().and(z.string()),
+    caught: z.string().catch('x'),
+    piped: z.string().pipe(z.string()),
+    mapped: z.map(z.string(), z.string()),
+    setted: z.set(z.string()),
+    promised: z.promise(z.string()),
+    sym: z.symbol(),
+    notANumber: z.nan(),
+    nul: z.null(),
+    undef: z.undefined(),
+    voided: z.void(),
+    nevered: z.never(),
+    fileField: z.file(),
+    fn: z.function(),
+    coded: z.codec(z.string(), z.string(), {
+      decode: (value) => value,
+      encode: (value) => value,
+    }),
+    stringBoolean: z.stringbool(),
+    hashed: z.hash('sha256'),
+    looseRec: z.looseRecord(z.string(), z.string()),
+    instance: z.instanceof(Date),
+    template: z.templateLiteral([z.string()]),
+    partial: z.partialRecord(z.string(), z.string()),
+    jsonField: z.json(),
+    requiredAgain: z.string().nonoptional(),
+    prefaulted: z.string().prefault('x'),
+	    overwritten: z.string().overwrite((value) => value.trim()),
+	    manualCheck: z.string().check((ctx) => {}),
+	    requiredObject: z.object({ a: z.string().optional() }).required(),
+	    defaulted: z.string().default('x'),
+	    multiLiteral: z.literal(['a', 'b']),
+	    constMultiLiteral: z.literal(['a', 'b'] as const),
+	  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(34);
+    expect(
+      diagnostics.every(
+        (entry) =>
+          entry.rule === 'marker-schema-unsupported' &&
+          entry.severity === 'error'
+      )
+    ).toBe(true);
+  });
+
+  test('marker-schema-unsupported rejects reference-valued literal and enum values', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+trail('versioned.reference-values', {
+  version: 2,
+  input: z.object({
+    objectLiteral: z.literal({ key: 'value' } as const),
+    arrayLiteral: z.literal([['value']] as const),
+    objectEnum: z.enum({ A: { key: 'value' } } as never),
+    arrayEnum: z.enum({ A: ['value'] } as never),
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(4);
+    expect(
+      diagnostics.every(
+        (entry) =>
+          entry.rule === 'marker-schema-unsupported' &&
+          entry.severity === 'error'
+      )
+    ).toBe(true);
+  });
+
+  test('marker-schema-unsupported keeps supported wrappers and unions clean', () => {
+    // Guard against deny-list false positives on runtime-accepted forms.
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+const statuses = ['a', 'b'] as const;
+
+trail('versioned.supported', {
+  version: 2,
+  input: z.object({
+    opt: z.string().optional(),
+    nullable: z.string().nullable(),
+    nullish: z.string().nullish(),
+    readonlyField: z.string().readonly(),
+    described: z.string().describe('d'),
+    union: z.string().or(z.number()),
+    branded: z.string().brand('X'),
+    choice: z.enum(['a', 'b']),
+    computedChoice: z.enum(statuses.map((status) => status)),
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('marker-schema-unsupported rejects defaults in versioned marker schemas', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+trail('versioned.defaults', {
+  version: 2,
+  input: z.object({
+    stable: z.string().default('draft'),
+    random: z.string().default(() => Math.random().toString()),
+    clock: z.number().default(() => Date.now()),
+    lossy: z.number().default(Number.NaN),
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(4);
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rule: 'marker-schema-unsupported',
+          severity: 'error',
+        }),
+      ])
+    );
+  });
+
+  test('marker-schema-unsupported rejects JSON-lossy literal and enum values', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+trail('versioned.json-lossy-values', {
+  version: 2,
+  input: z.object({
+    nanLiteral: z.literal(Number.NaN),
+	    infiniteLiteral: z.literal(Number.POSITIVE_INFINITY),
+	    undefinedLiteral: z.literal(undefined),
+	    bigintLiteral: z.literal(1n),
+	    regexLiteral: z.literal(/x/),
+	    arrayLiteral: z.literal([Number.NaN] as const),
+	    nanEnum: z.enum({ A: Number.NaN } as never),
+	    infiniteEnum: z.enum([Number.POSITIVE_INFINITY] as never),
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(8);
+    expect(
+      diagnostics.every(
+        (entry) =>
+          entry.rule === 'marker-schema-unsupported' &&
+          entry.severity === 'error'
+      )
+    ).toBe(true);
+  });
+
+  test('marker-schema-unsupported rejects hidden optional wrappers', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+trail('versioned.hidden-optional', {
+  version: 2,
+  input: z.object({
+    hiddenInNullable: z.string().optional().nullable(),
+    hiddenInReadonly: z.string().optional().readonly(),
+    visibleNullable: z.string().nullable().optional(),
+    visibleReadonly: z.string().readonly().optional(),
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(2);
+    expect(
+      diagnostics.every(
+        (entry) =>
+          entry.rule === 'marker-schema-unsupported' &&
+          entry.severity === 'error'
+      )
+    ).toBe(true);
+  });
+
+  test('marker-schema-unsupported rejects optional wrappers outside object properties', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+const visible = z.string().optional();
+const hidden = z.string().optional();
+const nested = z.string().optional();
+
+trail('versioned.optional-context', {
+  version: 2,
+  input: hidden,
+  output: z.object({
+    visible,
+    nestedHidden: z.array(nested),
+    directNestedHidden: z.array(z.string().optional()),
+  }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(3);
+    expect(
+      diagnostics.every(
+        (entry) =>
+          entry.rule === 'marker-schema-unsupported' &&
+          entry.severity === 'error'
+      )
+    ).toBe(true);
+  });
+
+  test('marker-schema-unsupported covers named Zod schema bindings', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+const base = z.string();
+
+trail('versioned.schema-binding', {
+  version: 2,
+  input: z.object({
+    name: base.min(3),
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toEqual(
+      expect.objectContaining({
+        rule: 'marker-schema-unsupported',
+        severity: 'error',
+      })
+    );
+  });
+
+  test('marker-schema-unsupported does not follow shadowed schema binding names', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+		function buildHelper() {
+	  const status = z.string().min(3);
+	  return status;
+	}
+
+	const status = 'active';
+
+	trail('versioned.shadowed-binding', {
+	  version: 2,
+	  input: z.object({
+	    status: z.literal(status),
+	  }),
+	  output: z.object({ ok: z.boolean() }),
+	  blaze: async () => Result.ok({ ok: true }),
+	});
+	`,
+      sourceFile
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('marker-schema-unsupported treats function parameters as binding shadows', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+const status = z.string().min(3);
+
+function makeTrail(status: 'active') {
+  return trail('versioned.parameter-shadow', {
+    version: 2,
+    input: z.object({
+      status: z.literal(status),
+    }),
+    output: z.object({ ok: z.boolean() }),
+    blaze: async () => Result.ok({ ok: true }),
+  });
+}
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('marker-schema-unsupported respects block scope for schema bindings', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+const status = 'active';
+
+{
+  const status = z.string().min(3);
+}
+
+trail('versioned.block-shadowed-binding', {
+  version: 2,
+  input: z.object({
+    status: z.literal(status),
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('marker-schema-unsupported follows schema aliases', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+const constrained = z.string().min(3);
+const field = constrained;
+
+trail('versioned.schema-alias', {
+  version: 2,
+  input: z.object({
+    name: field,
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toEqual(
+      expect.objectContaining({
+        rule: 'marker-schema-unsupported',
+        severity: 'error',
+      })
+    );
+  });
+
+  test('marker-schema-unsupported ignores helper factories named like checks', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+const email = () => z.string();
+const map = () => z.string();
+const min = () => z.number();
+
+trail('versioned.helper-factories', {
+  version: 2,
+  input: z.object({
+    address: email(),
+    label: map(),
+    count: min(),
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('marker-schema-unsupported ignores unversioned trail schemas', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+trail('unversioned.schema', {
+  input: z.object({ payload: z.record(z.string(), z.string()) }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('marker-schema-unsupported skips unsupported call names inside schema callbacks', () => {
     const diagnostics = markerSchemaUnsupported.check(
       `
 const parser = {
@@ -147,7 +673,12 @@ trail('versioned.schema-callback', {
       sourceFile
     );
 
-    expect(diagnostics).toEqual([]);
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        rule: 'marker-schema-unsupported',
+        severity: 'error',
+      }),
+    ]);
   });
 });
 

--- a/packages/warden/src/rules/trail-versioning-source.ts
+++ b/packages/warden/src/rules/trail-versioning-source.ts
@@ -15,12 +15,120 @@ const VERSION_PINNED_COMPOSE = 'version-pinned-compose';
 const FORK_WITHOUT_PRESERVED_BLAZE = 'fork-without-preserved-blaze';
 const MARKER_SCHEMA_UNSUPPORTED = 'marker-schema-unsupported';
 
+interface SchemaBindingRecord {
+  readonly initializer: AstNode | undefined;
+  readonly scopeEnd: number;
+  readonly scopeStart: number;
+  readonly start: number;
+}
+
+type SchemaBindings = ReadonlyMap<string, readonly SchemaBindingRecord[]>;
+
+// Zod schema constructors and modifiers outside the marker subset that the
+// runtime guard in packages/core/src/version-marker.ts rejects. This deny-list
+// is best-effort source-static coverage; the runtime allow-list remains the
+// authoritative gate. Entries are evidence-verified against the runtime guard.
 const unsupportedSchemaCalls = new Set([
+  'and',
   'any',
+  'base64',
+  'base64url',
+  'bigint',
+  'catch',
+  'catchall',
+  'check',
+  'cidrv4',
+  'cidrv6',
+  'codec',
+  'cuid',
+  'cuid2',
   'custom',
+  'date',
+  'datetime',
+  'default',
+  'duration',
+  'e164',
+  'email',
+  'emoji',
+  'endsWith',
+  'file',
+  'finite',
+  'function',
+  'gt',
+  'gte',
+  'guid',
+  'hash',
+  'includes',
+  'instanceof',
+  'int',
+  'intersection',
+  'ipv4',
+  'ipv6',
+  'json',
+  'jwt',
+  'ksuid',
+  'lazy',
+  'length',
+  'loose',
+  'looseObject',
+  'looseRecord',
+  'lowercase',
+  'lt',
+  'lte',
+  'map',
+  'max',
+  'min',
+  'multipleOf',
+  'nan',
+  'nanoid',
+  'negative',
+  'never',
+  'nonempty',
+  'nonnegative',
+  'nonoptional',
+  'nonpositive',
+  'normalize',
+  'null',
+  'overwrite',
+  'partialRecord',
+  'passthrough',
+  'pipe',
+  'positive',
+  'prefault',
   'preprocess',
+  'promise',
+  'record',
+  'refine',
+  'regex',
+  'required',
+  'safe',
+  'set',
+  'slugify',
+  'startsWith',
+  'step',
+  'strict',
+  'strictObject',
+  'stringbool',
+  'superRefine',
+  'symbol',
+  'templateLiteral',
+  'time',
+  'toLowerCase',
+  'toUpperCase',
   'transform',
+  'trim',
+  'tuple',
+  'ulid',
+  'undefined',
   'unknown',
+  'uppercase',
+  'url',
+  'uuid',
+  'uuidv4',
+  'uuidv6',
+  'uuidv7',
+  'void',
+  'xid',
 ]);
 
 const diagnostic = (
@@ -85,28 +193,678 @@ const versionEntries = (config: AstNode): readonly AstNode[] => {
     .filter((entry): entry is AstNode => entry?.type === 'ObjectExpression');
 };
 
+const identifierName = (node: AstNode | undefined): string | undefined =>
+  node?.type === 'Identifier'
+    ? (node as unknown as { name?: string }).name
+    : undefined;
+
+const schemaBindingInitializer = (
+  schemaBindings: SchemaBindings,
+  name: string,
+  referenceStart: number
+): AstNode | undefined => {
+  let resolved: SchemaBindingRecord | undefined;
+  for (const record of schemaBindings.get(name) ?? []) {
+    if (record.start >= referenceStart) {
+      break;
+    }
+    if (
+      record.scopeStart > referenceStart ||
+      record.scopeEnd < referenceStart
+    ) {
+      continue;
+    }
+    resolved = record;
+  }
+  return resolved?.initializer;
+};
+
+const memberObject = (node: AstNode | undefined): AstNode | undefined =>
+  node !== undefined && isMemberAccessNonComputed(node)
+    ? (node as unknown as { object?: AstNode }).object
+    : undefined;
+
+const memberPropertyName = (node: AstNode | undefined): string | undefined =>
+  node !== undefined && isMemberAccessNonComputed(node)
+    ? identifierName((node as unknown as { property?: AstNode }).property)
+    : undefined;
+
+const callCallee = (node: AstNode): AstNode | undefined =>
+  node.type === 'CallExpression'
+    ? (node as unknown as { callee?: AstNode }).callee
+    : undefined;
+
+const isZodSchemaReceiver = (
+  node: AstNode | undefined,
+  schemaBindings: SchemaBindings = new Map(),
+  referenceStart = node?.start ?? Number.POSITIVE_INFINITY
+): boolean => {
+  if (!node) {
+    return false;
+  }
+  const name = identifierName(node);
+  if (
+    name === 'z' ||
+    (name !== undefined &&
+      schemaBindingInitializer(schemaBindings, name, referenceStart) !==
+        undefined)
+  ) {
+    return true;
+  }
+  if (node.type === 'CallExpression') {
+    return isZodSchemaReceiver(
+      memberObject(callCallee(node)),
+      schemaBindings,
+      referenceStart
+    );
+  }
+  return isZodSchemaReceiver(
+    memberObject(node),
+    schemaBindings,
+    referenceStart
+  );
+};
+
+const isZodSchemaCallee = (
+  node: AstNode | undefined,
+  schemaBindings: SchemaBindings = new Map()
+): boolean =>
+  node !== undefined && isZodSchemaReceiver(memberObject(node), schemaBindings);
+
+const callArguments = (node: AstNode): readonly AstNode[] =>
+  node.type === 'CallExpression'
+    ? ((node as unknown as { arguments?: readonly AstNode[] }).arguments ?? [])
+    : [];
+
+const unwrapExpression = (node: AstNode | undefined): AstNode | undefined => {
+  let current = node;
+  while (
+    current?.type === 'TSAsExpression' ||
+    current?.type === 'TSSatisfiesExpression' ||
+    current?.type === 'TSNonNullExpression'
+  ) {
+    current = (current as unknown as { expression?: AstNode }).expression;
+  }
+  return current;
+};
+
+const arrayExpressionLength = (node: AstNode | undefined): number => {
+  const expression = unwrapExpression(node);
+  return expression?.type === 'ArrayExpression'
+    ? (
+        (expression as unknown as { elements?: readonly unknown[] }).elements ??
+        []
+      ).length
+    : 0;
+};
+
+const isNumberProperty = (
+  node: AstNode | undefined,
+  names: ReadonlySet<string>
+): boolean =>
+  node !== undefined &&
+  isMemberAccessNonComputed(node) &&
+  identifierName(memberObject(node)) === 'Number' &&
+  names.has(memberPropertyName(node) ?? '');
+
+const nonFiniteNumberProperties = new Set([
+  'NaN',
+  'NEGATIVE_INFINITY',
+  'POSITIVE_INFINITY',
+]);
+
+const literalExpressionIsJsonLossy = (expression: AstNode): boolean => {
+  if (
+    expression.type === 'BigIntLiteral' ||
+    expression.type === 'RegExpLiteral'
+  ) {
+    return true;
+  }
+  const literal = expression as unknown as {
+    readonly bigint?: unknown;
+    readonly regex?: unknown;
+    readonly value?: unknown;
+  };
+  if (literal.bigint !== undefined || literal.regex !== undefined) {
+    return true;
+  }
+  if (literal.value instanceof RegExp) {
+    return true;
+  }
+  return typeof literal.value === 'number' && !Number.isFinite(literal.value);
+};
+
+const expressionIsJsonLossy = (node: AstNode | undefined): boolean => {
+  const expression = unwrapExpression(node);
+  if (!expression) {
+    return true;
+  }
+
+  const name = identifierName(expression);
+  if (name === 'NaN' || name === 'Infinity' || name === 'undefined') {
+    return true;
+  }
+
+  if (isNumberProperty(expression, nonFiniteNumberProperties)) {
+    return true;
+  }
+
+  if (expression.type === 'UnaryExpression') {
+    return expressionIsJsonLossy(
+      (expression as unknown as { argument?: AstNode }).argument
+    );
+  }
+
+  if (expression.type === 'Literal' || expression.type === 'NumericLiteral') {
+    return literalExpressionIsJsonLossy(expression);
+  }
+
+  if (expression.type === 'ArrayExpression') {
+    const elements =
+      (expression as unknown as { elements?: readonly (AstNode | null)[] })
+        .elements ?? [];
+    return elements.some((element) =>
+      expressionIsJsonLossy(element ?? undefined)
+    );
+  }
+
+  if (expression.type === 'ObjectExpression') {
+    return objectProperties(expression).some((property) => {
+      if (property.type !== 'Property') {
+        return false;
+      }
+      return expressionIsJsonLossy(propertyValue(property));
+    });
+  }
+
+  return false;
+};
+
+const expressionIsReferenceValued = (node: AstNode | undefined): boolean => {
+  const expression = unwrapExpression(node);
+  return (
+    expression?.type === 'ArrayExpression' ||
+    expression?.type === 'ObjectExpression'
+  );
+};
+
+const isMultiValueLiteralCall = (
+  node: AstNode,
+  schemaBindings: SchemaBindings
+): boolean => {
+  const callee = callCallee(node);
+  return (
+    node.type === 'CallExpression' &&
+    memberPropertyName(callee) === 'literal' &&
+    isZodSchemaCallee(callee, schemaBindings) &&
+    arrayExpressionLength(callArguments(node)[0]) > 1
+  );
+};
+
+const isJsonLossyLiteralCall = (
+  node: AstNode,
+  schemaBindings: SchemaBindings
+): boolean => {
+  const callee = callCallee(node);
+  return (
+    node.type === 'CallExpression' &&
+    memberPropertyName(callee) === 'literal' &&
+    isZodSchemaCallee(callee, schemaBindings) &&
+    expressionIsJsonLossy(callArguments(node)[0])
+  );
+};
+
+const isReferenceValuedLiteralCall = (
+  node: AstNode,
+  schemaBindings: SchemaBindings
+): boolean => {
+  const callee = callCallee(node);
+  if (
+    node.type !== 'CallExpression' ||
+    memberPropertyName(callee) !== 'literal' ||
+    !isZodSchemaCallee(callee, schemaBindings)
+  ) {
+    return false;
+  }
+
+  const [rawValue] = callArguments(node);
+  const value = unwrapExpression(rawValue);
+  if (value?.type === 'ObjectExpression') {
+    return true;
+  }
+  if (value?.type !== 'ArrayExpression') {
+    return false;
+  }
+  return (
+    (value as unknown as { elements?: readonly (AstNode | null)[] }).elements ??
+    []
+  ).some((element) => expressionIsReferenceValued(element ?? undefined));
+};
+
+const isJsonLossyEnumCall = (
+  node: AstNode,
+  schemaBindings: SchemaBindings
+): boolean => {
+  const callee = callCallee(node);
+  if (
+    node.type !== 'CallExpression' ||
+    memberPropertyName(callee) !== 'enum' ||
+    !isZodSchemaCallee(callee, schemaBindings)
+  ) {
+    return false;
+  }
+
+  const [rawOptions] = callArguments(node);
+  const options = unwrapExpression(rawOptions);
+  if (options?.type === 'ArrayExpression') {
+    return expressionIsJsonLossy(options);
+  }
+  if (options?.type !== 'ObjectExpression') {
+    return false;
+  }
+  return objectProperties(options).some((property) => {
+    if (property.type !== 'Property') {
+      return false;
+    }
+    return expressionIsJsonLossy(propertyValue(property));
+  });
+};
+
+const isReferenceValuedEnumCall = (
+  node: AstNode,
+  schemaBindings: SchemaBindings
+): boolean => {
+  const callee = callCallee(node);
+  if (
+    node.type !== 'CallExpression' ||
+    memberPropertyName(callee) !== 'enum' ||
+    !isZodSchemaCallee(callee, schemaBindings)
+  ) {
+    return false;
+  }
+
+  const [rawOptions] = callArguments(node);
+  const options = unwrapExpression(rawOptions);
+  if (options?.type === 'ArrayExpression') {
+    return (
+      (options as unknown as { elements?: readonly (AstNode | null)[] })
+        .elements ?? []
+    ).some((element) => expressionIsReferenceValued(element ?? undefined));
+  }
+  if (options?.type !== 'ObjectExpression') {
+    return false;
+  }
+  return objectProperties(options).some((property) => {
+    if (property.type !== 'Property') {
+      return false;
+    }
+    return expressionIsReferenceValued(propertyValue(property));
+  });
+};
+
+const markerWrapperCanHideOptional = new Set(['nullable', 'readonly']);
+
+const isOptionalWrapperCall = (
+  node: AstNode,
+  schemaBindings: SchemaBindings
+): boolean => {
+  const callee = callCallee(node);
+  return (
+    node.type === 'CallExpression' &&
+    memberPropertyName(callee) === 'optional' &&
+    isZodSchemaCallee(callee, schemaBindings)
+  );
+};
+
+const callChainHasOptionalWrapper = (
+  node: AstNode | undefined,
+  schemaBindings: SchemaBindings
+): boolean => {
+  let current = node;
+  while (current !== undefined) {
+    if (current.type === 'CallExpression') {
+      const callee = callCallee(current);
+      if (
+        memberPropertyName(callee) === 'optional' &&
+        isZodSchemaCallee(callee, schemaBindings)
+      ) {
+        return true;
+      }
+      current = memberObject(callee);
+      continue;
+    }
+    if (!isMemberAccessNonComputed(current)) {
+      return false;
+    }
+    current = memberObject(current);
+  }
+  return false;
+};
+
+const isHiddenOptionalWrapperCall = (
+  node: AstNode,
+  schemaBindings: SchemaBindings
+): boolean => {
+  const callee = callCallee(node);
+  return (
+    node.type === 'CallExpression' &&
+    markerWrapperCanHideOptional.has(memberPropertyName(callee) ?? '') &&
+    isZodSchemaCallee(callee, schemaBindings) &&
+    callChainHasOptionalWrapper(memberObject(callee), schemaBindings)
+  );
+};
+
+const nestedSchemaArguments = (node: AstNode): readonly AstNode[] => {
+  if (node.type !== 'CallExpression') {
+    return [];
+  }
+  const name = memberPropertyName(callCallee(node));
+  if (name === 'array') {
+    return callArguments(node).slice(0, 1);
+  }
+  if (name === 'or') {
+    return callArguments(node).slice(0, 1);
+  }
+  if (name !== 'union') {
+    return [];
+  }
+  const [rawOptions] = callArguments(node);
+  const options = unwrapExpression(rawOptions);
+  return options?.type === 'ArrayExpression'
+    ? (
+        (options as unknown as { elements?: readonly (AstNode | null)[] })
+          .elements ?? []
+      ).filter((element): element is AstNode => element !== null)
+    : [];
+};
+
+const collectUnsupportedOptionalWrapperStarts = (
+  node: AstNode,
+  schemaBindings: SchemaBindings,
+  unsupported: Set<number>,
+  options: { readonly optionalWrapperAllowed?: boolean } = {}
+): void => {
+  const expression = unwrapExpression(node);
+  if (expression === undefined) {
+    return;
+  }
+  const name = identifierName(expression);
+  if (name !== undefined) {
+    const initializer = schemaBindingInitializer(
+      schemaBindings,
+      name,
+      expression.start
+    );
+    if (initializer !== undefined) {
+      collectUnsupportedOptionalWrapperStarts(
+        initializer,
+        schemaBindings,
+        unsupported,
+        options
+      );
+    }
+    return;
+  }
+  if (isOptionalWrapperCall(expression, schemaBindings)) {
+    if (options.optionalWrapperAllowed !== true) {
+      unsupported.add(expression.start);
+    }
+    const inner = memberObject(callCallee(expression));
+    if (inner) {
+      collectUnsupportedOptionalWrapperStarts(
+        inner,
+        schemaBindings,
+        unsupported
+      );
+    }
+    return;
+  }
+  if (expression.type === 'ObjectExpression') {
+    for (const property of objectProperties(expression)) {
+      collectUnsupportedOptionalWrapperStarts(
+        propertyValue(property) ?? property,
+        schemaBindings,
+        unsupported,
+        { optionalWrapperAllowed: true }
+      );
+    }
+    return;
+  }
+  if (
+    expression.type === 'CallExpression' &&
+    memberPropertyName(callCallee(expression)) === 'object'
+  ) {
+    const [rawShape] = callArguments(expression);
+    const shape = unwrapExpression(rawShape);
+    if (shape?.type === 'ObjectExpression') {
+      for (const property of objectProperties(shape)) {
+        collectUnsupportedOptionalWrapperStarts(
+          propertyValue(property) ?? property,
+          schemaBindings,
+          unsupported,
+          { optionalWrapperAllowed: true }
+        );
+      }
+    }
+    return;
+  }
+  for (const argument of nestedSchemaArguments(expression)) {
+    collectUnsupportedOptionalWrapperStarts(
+      argument,
+      schemaBindings,
+      unsupported
+    );
+  }
+};
+
 const isMemberCallNamed = (
   node: AstNode,
-  names: ReadonlySet<string>
+  names: ReadonlySet<string>,
+  schemaBindings: SchemaBindings
 ): boolean => {
   if (node.type !== 'CallExpression') {
     return false;
   }
-  const { callee } = node as unknown as { callee?: AstNode };
+  const callee = callCallee(node);
   if (!callee) {
     return false;
   }
-  if (callee.type === 'Identifier') {
-    const { name } = callee as unknown as { name?: string };
-    return name !== undefined && names.has(name);
-  }
-  if (!isMemberAccessNonComputed(callee)) {
+  if (!isZodSchemaCallee(callee, schemaBindings)) {
     return false;
   }
-  const { property } = callee as unknown as { property?: AstNode };
+  return names.has(memberPropertyName(callee) ?? '');
+};
+
+const bindingName = (node: AstNode): string | undefined =>
+  node.type === 'VariableDeclarator'
+    ? identifierName((node as unknown as { id?: AstNode }).id)
+    : undefined;
+
+const lexicalScopeTypes = new Set([
+  'ArrowFunctionExpression',
+  'BlockStatement',
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'Program',
+  'StaticBlock',
+]);
+
+const addPatternBindingNames = (
+  node: AstNode | undefined,
+  into: Set<string>
+) => {
+  if (!node) {
+    return;
+  }
+  if (node.type === 'Identifier') {
+    const name = identifierName(node);
+    if (name !== undefined) {
+      into.add(name);
+    }
+    return;
+  }
+  if (node.type === 'AssignmentPattern') {
+    addPatternBindingNames((node as unknown as { left?: AstNode }).left, into);
+    return;
+  }
+  if (node.type === 'RestElement') {
+    addPatternBindingNames(
+      (node as unknown as { argument?: AstNode }).argument,
+      into
+    );
+    return;
+  }
+  if (node.type === 'ArrayPattern') {
+    const elements =
+      (node as unknown as { elements?: readonly (AstNode | null)[] })
+        .elements ?? [];
+    for (const element of elements) {
+      addPatternBindingNames(element ?? undefined, into);
+    }
+    return;
+  }
+  if (node.type !== 'ObjectPattern') {
+    return;
+  }
+  const properties =
+    (node as unknown as { properties?: readonly AstNode[] }).properties ?? [];
+  for (const property of properties) {
+    if (property.type === 'RestElement') {
+      addPatternBindingNames(property, into);
+      continue;
+    }
+    addPatternBindingNames(
+      (property as unknown as { value?: AstNode }).value,
+      into
+    );
+  }
+};
+
+const parameterBindingNames = (node: AstNode): readonly string[] => {
+  if (!lexicalScopeTypes.has(node.type) || node.type === 'BlockStatement') {
+    return [];
+  }
+  const names = new Set<string>();
+  const params =
+    (node as unknown as { params?: readonly AstNode[] }).params ?? [];
+  for (const param of params) {
+    addPatternBindingNames(param, names);
+  }
+  return [...names];
+};
+
+const variableInitializer = (node: AstNode): AstNode | undefined =>
+  node.type === 'VariableDeclarator'
+    ? ((node as unknown as { init?: AstNode }).init ?? undefined)
+    : undefined;
+
+const isZodSchemaExpression = (
+  node: AstNode | undefined,
+  schemaBindings: SchemaBindings
+): boolean =>
+  node?.type === 'CallExpression' &&
+  isZodSchemaCallee(callCallee(node), schemaBindings);
+
+const schemaBindingExpressionInitializer = (
+  node: AstNode | undefined,
+  schemaBindings: SchemaBindings
+): AstNode | undefined => {
+  if (isZodSchemaExpression(node, schemaBindings)) {
+    return node;
+  }
+  const name = identifierName(node);
+  return name === undefined || node === undefined
+    ? undefined
+    : schemaBindingInitializer(schemaBindings, name, node.start);
+};
+
+const astChildNodes = (node: AstNode): readonly AstNode[] => {
+  const children: AstNode[] = [];
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      children.push(
+        ...value.filter(
+          (entry): entry is AstNode =>
+            typeof entry === 'object' &&
+            entry !== null &&
+            typeof (entry as AstNode).type === 'string'
+        )
+      );
+      continue;
+    }
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as AstNode).type === 'string'
+    ) {
+      children.push(value as AstNode);
+    }
+  }
+  return children;
+};
+
+const collectZodSchemaBindings = (ast: AstNode): SchemaBindings => {
+  const bindings = new Map<string, SchemaBindingRecord[]>();
+
+  const visit = (
+    node: AstNode,
+    scope: { readonly end: number; readonly start: number }
+  ): void => {
+    const nextScope = lexicalScopeTypes.has(node.type)
+      ? { end: node.end, start: node.start }
+      : scope;
+    const name = bindingName(node);
+    const initializer = variableInitializer(node);
+    for (const parameterName of parameterBindingNames(node)) {
+      const records = bindings.get(parameterName) ?? [];
+      records.push({
+        initializer: undefined,
+        scopeEnd: nextScope.end,
+        scopeStart: nextScope.start,
+        start: node.start,
+      });
+      bindings.set(parameterName, records);
+    }
+    if (name !== undefined) {
+      const records = bindings.get(name) ?? [];
+      records.push({
+        initializer: schemaBindingExpressionInitializer(initializer, bindings),
+        scopeEnd: nextScope.end,
+        scopeStart: nextScope.start,
+        start: node.start,
+      });
+      bindings.set(name, records);
+    }
+
+    for (const child of astChildNodes(node)) {
+      visit(child, nextScope);
+    }
+  };
+
+  visit(ast, { end: ast.end, start: ast.start });
+  return bindings;
+};
+
+/**
+ * Detect coerced primitive schema calls such as `z.coerce.number()`. The final
+ * callee property is a supported primitive name, so the deny-list never matches;
+ * the coercion lives on the intermediate `.coerce` member. The runtime marker
+ * guard rejects `def.coerce === true`, so Warden must flag the same shape.
+ */
+const isCoerceMarkerCall = (node: AstNode): boolean => {
+  if (node.type !== 'CallExpression') {
+    return false;
+  }
+  const callee = callCallee(node);
+  if (!callee || !isMemberAccessNonComputed(callee)) {
+    return false;
+  }
+  const object = memberObject(callee);
   return (
-    property?.type === 'Identifier' &&
-    names.has((property as unknown as { name?: string }).name ?? '')
+    object !== undefined &&
+    isMemberAccessNonComputed(object) &&
+    memberPropertyName(object) === 'coerce' &&
+    isZodSchemaReceiver(memberObject(object))
   );
 };
 
@@ -206,7 +964,7 @@ export const forkWithoutPreservedBlaze: WardenRule = {
   severity: 'error',
 };
 
-const schemaNodesForTrail = (config: AstNode): readonly AstNode[] => {
+const directSchemaNodesForTrail = (config: AstNode): readonly AstNode[] => {
   const nodes: AstNode[] = [];
   for (const key of ['input', 'output']) {
     const value = propertyValue(findConfigProperty(config, key));
@@ -225,6 +983,39 @@ const schemaNodesForTrail = (config: AstNode): readonly AstNode[] => {
   return nodes;
 };
 
+const schemaNodesForTrail = (
+  config: AstNode,
+  schemaBindings: SchemaBindings
+): readonly AstNode[] => {
+  const nodes: AstNode[] = [...directSchemaNodesForTrail(config)];
+  const seenBindings = new Set<string>();
+  let index = 0;
+  while (index < nodes.length) {
+    const node = nodes[index];
+    index += 1;
+    if (node === undefined) {
+      continue;
+    }
+    walkScope(node, (candidate) => {
+      const name = identifierName(candidate);
+      if (name === undefined || seenBindings.has(name)) {
+        return;
+      }
+      const initializer = schemaBindingInitializer(
+        schemaBindings,
+        name,
+        candidate.start
+      );
+      if (initializer === undefined) {
+        return;
+      }
+      seenBindings.add(name);
+      nodes.push(initializer);
+    });
+  }
+  return nodes;
+};
+
 export const markerSchemaUnsupported: WardenRule = {
   check(sourceCode, filePath) {
     const ast = parse(filePath, sourceCode);
@@ -233,15 +1024,42 @@ export const markerSchemaUnsupported: WardenRule = {
     }
 
     const diagnostics: WardenDiagnostic[] = [];
+    const schemaBindings = collectZodSchemaBindings(ast);
     for (const definition of findTrailDefinitions(ast)) {
       if (definition.kind !== 'trail' || !trailIsVersioned(definition.config)) {
         continue;
       }
-      for (const schema of schemaNodesForTrail(definition.config)) {
+      const seenDiagnostics = new Set<number>();
+      const unsupportedOptionalWrapperStarts = new Set<number>();
+      for (const schema of directSchemaNodesForTrail(definition.config)) {
+        collectUnsupportedOptionalWrapperStarts(
+          schema,
+          schemaBindings,
+          unsupportedOptionalWrapperStarts
+        );
+      }
+      for (const schema of schemaNodesForTrail(
+        definition.config,
+        schemaBindings
+      )) {
         walkScope(schema, (node) => {
-          if (!isMemberCallNamed(node, unsupportedSchemaCalls)) {
+          if (
+            !unsupportedOptionalWrapperStarts.has(node.start) &&
+            !isMemberCallNamed(node, unsupportedSchemaCalls, schemaBindings) &&
+            !isCoerceMarkerCall(node) &&
+            !isMultiValueLiteralCall(node, schemaBindings) &&
+            !isJsonLossyLiteralCall(node, schemaBindings) &&
+            !isJsonLossyEnumCall(node, schemaBindings) &&
+            !isReferenceValuedLiteralCall(node, schemaBindings) &&
+            !isReferenceValuedEnumCall(node, schemaBindings) &&
+            !isHiddenOptionalWrapperCall(node, schemaBindings)
+          ) {
             return;
           }
+          if (seenDiagnostics.has(node.start)) {
+            return;
+          }
+          seenDiagnostics.add(node.start);
           diagnostics.push(
             diagnostic(
               MARKER_SCHEMA_UNSUPPORTED,


### PR DESCRIPTION
## Summary

- Align Warden's `marker-schema-unsupported` diagnostics with the runtime marker subset from TRL-772.
- Flag runtime-unsupported `lazy`, `intersection`, `record`, validation-check, refine/superRefine, and object policy schema calls in versioned schemas.
- Preserve the callback-scope guard so helper calls inside callbacks do not create noisy nested diagnostics.

## Verification

- `bun test packages/warden/src/__tests__/trail-versioning-rules.test.ts`
- `bun run typecheck` from `packages/warden`
- `bun run lint` from `packages/warden`
- `bun run format:check`
- `git diff --check`

## Notes

- Linear: TRL-773
