### PR TITLE
feat(trails): report doctor force details

### DIFF
--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md
@@ -170,6 +170,33 @@ Executor should create or choose that issue before implementing the capstone.
   - `bun run format:check` passed after formatting the touched Warden test.
   - `git diff --check` passed.
 
+### 2026-06-01 18:10 EDT - TRL-770 doctor force evidence implemented
+
+- Created child branch
+  `trl-770-make-trails-doctor-pending-force-output-complete-and`.
+- Updated `trails doctor` to read committed `.trails/topo.lock` force audit
+  details when available and keep lifecycle counts derived from the current app.
+- Extended doctor output with `forceDetails`, including force `id`, `kind`,
+  `change`, `detail`, `severity`, `source`, optional `reason`, and scope
+  (`entry` or `graph`).
+- Updated `deriveDoctorSummary()` to count both entry-attached and graph-level
+  force events from the force evidence graph.
+- Added focused regressions in
+  `apps/trails/src/__tests__/version-lifecycle.test.ts` for summary-level force
+  details and the doctor trail reading committed force audit events.
+- Added `.changeset/trails-doctor-force-details.md` for `@ontrails/trails`.
+- Ran red check before implementation:
+  - `bun test apps/trails/src/__tests__/version-lifecycle.test.ts` failed on
+    the new force-detail summary assertion as expected.
+- Verification after implementation:
+  - `bun test apps/trails/src/__tests__/version-lifecycle.test.ts` passed.
+  - `bun test apps/trails/src/__tests__/survey.test.ts` passed.
+  - `bun run typecheck` from `apps/trails` passed.
+  - `bun run lint` from `apps/trails` passed after simplifying the doctor
+    error wrapper.
+  - `bun run format:check` passed after formatting the touched app files.
+  - `git diff --check` passed.
+
 ## Verification Log
 
 Planning verification only:

--- a/.changeset/trails-doctor-force-details.md
+++ b/.changeset/trails-doctor-force-details.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Report structured entry and graph force audit details from `trails doctor`.

--- a/apps/trails/src/__tests__/version-lifecycle.test.ts
+++ b/apps/trails/src/__tests__/version-lifecycle.test.ts
@@ -9,6 +9,10 @@ import {
 import { join, resolve } from 'node:path';
 
 import { deriveCliCommands } from '@ontrails/cli';
+import { Result, topo, trail } from '@ontrails/core';
+import { TOPO_GRAPH_SCHEMA_VERSION } from '@ontrails/topographer';
+import type { TopoGraph } from '@ontrails/topographer';
+import { z } from 'zod';
 
 import { app } from '../app.js';
 import {
@@ -18,9 +22,54 @@ import {
 import { deprecateTrail } from '../trails/deprecate.js';
 import { doctorTrail } from '../trails/doctor.js';
 import { reviseTrail } from '../trails/revise.js';
+import { deriveDoctorSummary } from '../trails/version-lifecycle-support.js';
 
 const repoTempDir = (): string =>
   mkdtempSync(join(resolve('.'), '.trails-life-'));
+
+const createDoctorForceGraph = (): TopoGraph => ({
+  activationGraph: {
+    edgeCount: 0,
+    edges: [],
+    sourceCount: 0,
+    sourceKeys: [],
+    trailIds: [],
+  },
+  activationSources: {},
+  entries: [
+    {
+      exampleCount: 0,
+      forces: [
+        {
+          acceptedAt: '2026-06-01T00:00:00.000Z',
+          change: 'modified',
+          detail: 'Required input field "name" added',
+          id: 'force.current',
+          kind: 'trail',
+          severity: 'breaking',
+          source: 'trails compile --force',
+        },
+      ],
+      id: 'force.current',
+      kind: 'trail',
+      surfaces: [],
+    },
+  ],
+  forces: [
+    {
+      acceptedAt: '2026-06-01T00:00:00.000Z',
+      change: 'removed',
+      detail: 'Trail was removed',
+      id: 'force.removed',
+      kind: 'trail',
+      reason: 'No callers remain.',
+      severity: 'breaking',
+      source: 'trails compile --force',
+    },
+  ],
+  generatedAt: '2026-06-01T00:00:00.000Z',
+  topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
+});
 
 const writeLifecycleFixture = (
   dir: string,
@@ -536,5 +585,177 @@ import { topo, trail } from '@ontrails/core';`,
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }
+  });
+
+  test('doctor reports lifecycle counts when topo lock is unreadable', async () => {
+    const dir = repoTempDir();
+    try {
+      writeLifecycleFixture(dir);
+      await reviseTrail.blaze({ module: './src/app.ts', target: 'hello' }, {
+        cwd: dir,
+      } as never);
+      await deprecateTrail.blaze(
+        { archive: true, module: './src/app.ts', target: 'hello@1' },
+        { cwd: dir } as never
+      );
+      mkdirSync(join(dir, '.trails'), { recursive: true });
+      writeFileSync(join(dir, '.trails', 'topo.lock'), '{');
+
+      const doctor = await doctorTrail.blaze({ module: './src/app.ts' }, {
+        cwd: dir,
+      } as never);
+
+      if (doctor.isErr()) {
+        throw doctor.error;
+      }
+      expect(doctor.value).toMatchObject({
+        archived: 1,
+        forceDetails: [],
+        forceEvents: 0,
+        mode: 'doctor',
+        trails: 1,
+        versioned: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('doctor reads committed force audit details', async () => {
+    const dir = repoTempDir();
+    try {
+      writeLifecycleFixture(dir);
+      mkdirSync(join(dir, '.trails'), { recursive: true });
+      writeFileSync(
+        join(dir, '.trails', 'topo.lock'),
+        JSON.stringify(createDoctorForceGraph())
+      );
+
+      const doctor = await doctorTrail.blaze({ module: './src/app.ts' }, {
+        cwd: dir,
+      } as never);
+
+      if (doctor.isErr()) {
+        throw doctor.error;
+      }
+      expect(doctor.value.forceEvents).toBe(2);
+      expect(
+        doctor.value.forceDetails.map(({ id, scope }) => ({ id, scope }))
+      ).toEqual([
+        { id: 'force.current', scope: 'entry' },
+        { id: 'force.removed', scope: 'graph' },
+      ]);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('doctor summary reports entry and graph force details', () => {
+    const current = trail('force.current', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const summary = deriveDoctorSummary(topo('doctor-force', { current }), {
+      forceGraph: createDoctorForceGraph(),
+    });
+
+    expect(summary.forceEvents).toBe(2);
+    expect(summary.forceDetails).toEqual([
+      {
+        acceptedAt: '2026-06-01T00:00:00.000Z',
+        change: 'modified',
+        detail: 'Required input field "name" added',
+        id: 'force.current',
+        kind: 'trail',
+        scope: 'entry',
+        severity: 'breaking',
+        source: 'trails compile --force',
+      },
+      {
+        acceptedAt: '2026-06-01T00:00:00.000Z',
+        change: 'removed',
+        detail: 'Trail was removed',
+        id: 'force.removed',
+        kind: 'trail',
+        reason: 'No callers remain.',
+        scope: 'graph',
+        severity: 'breaking',
+        source: 'trails compile --force',
+      },
+    ]);
+  });
+
+  test('doctor summary deduplicates overlapping entry and graph force details', () => {
+    const current = trail('force.current', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+    });
+    const graph = createDoctorForceGraph();
+    const duplicate = graph.entries[0]?.forces?.[0];
+    if (duplicate === undefined) {
+      throw new Error('Expected force fixture to include an entry force');
+    }
+
+    const summary = deriveDoctorSummary(topo('doctor-force', { current }), {
+      forceGraph: {
+        ...graph,
+        forces: [duplicate, ...(graph.forces ?? [])],
+      },
+    });
+
+    expect(summary.forceEvents).toBe(2);
+    expect(
+      summary.forceDetails.map(({ id, scope }) => ({ id, scope }))
+    ).toEqual([
+      { id: 'force.current', scope: 'entry' },
+      { id: 'force.removed', scope: 'graph' },
+    ]);
+  });
+
+  test('doctor summary ignores malformed stale force payloads', () => {
+    const current = trail('force.current', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+    });
+    const graph = createDoctorForceGraph();
+    const [entry] = graph.entries;
+    const validEntryForce = entry?.forces?.[0];
+    if (entry === undefined || validEntryForce === undefined) {
+      throw new Error('Expected force fixture to include an entry force');
+    }
+
+    const summary = deriveDoctorSummary(topo('doctor-force', { current }), {
+      forceGraph: {
+        ...graph,
+        entries: [
+          {
+            ...entry,
+            forces: { stale: true } as never,
+          },
+          {
+            ...entry,
+            forces: [null, { ...validEntryForce, extra: 'ignored' }] as never,
+          },
+        ],
+        forces: [
+          undefined,
+          { ...(graph.forces?.[0] ?? validEntryForce), reason: 123 },
+          ...(graph.forces ?? []),
+        ] as never,
+      },
+    });
+
+    expect(summary.forceEvents).toBe(2);
+    expect(summary.forceDetails[0]).not.toHaveProperty('extra');
+    expect(
+      summary.forceDetails.map(({ id, scope }) => ({ id, scope }))
+    ).toEqual([
+      { id: 'force.current', scope: 'entry' },
+      { id: 'force.removed', scope: 'graph' },
+    ]);
   });
 });

--- a/apps/trails/src/trails/doctor.ts
+++ b/apps/trails/src/trails/doctor.ts
@@ -1,4 +1,5 @@
-import { Result, trail } from '@ontrails/core';
+import { deriveTrailsDir, Result, trail } from '@ontrails/core';
+import { readTopoGraph } from '@ontrails/topographer';
 import { z } from 'zod';
 
 import {
@@ -6,11 +7,23 @@ import {
   withLifecycleApp,
 } from './version-lifecycle-support.js';
 
+const readDoctorForceGraph = async (
+  rootDir: string
+): Promise<Awaited<ReturnType<typeof readTopoGraph>> | undefined> => {
+  try {
+    return await readTopoGraph({ dir: deriveTrailsDir({ rootDir }) });
+  } catch {
+    // Force audit details are supplemental; stale topo locks should not block doctor counts.
+    return undefined;
+  }
+};
+
 export const doctorTrail = trail('doctor', {
   blaze: async (input, ctx) =>
-    withLifecycleApp(input, ctx.cwd, async (app) =>
-      Result.ok(deriveDoctorSummary(app))
-    ),
+    withLifecycleApp(input, ctx.cwd, async (app, rootDir) => {
+      const forceGraph = await readDoctorForceGraph(rootDir);
+      return Result.ok(deriveDoctorSummary(app, { forceGraph }));
+    }),
   description: 'Diagnose trail versioning lifecycle state',
   input: z.object({
     module: z.string().optional().describe('Path to the app module'),
@@ -20,6 +33,21 @@ export const doctorTrail = trail('doctor', {
   output: z.object({
     archived: z.number(),
     deprecated: z.number(),
+    forceDetails: z.array(
+      z
+        .object({
+          acceptedAt: z.string(),
+          change: z.enum(['modified', 'removed']),
+          detail: z.string(),
+          id: z.string(),
+          kind: z.enum(['contour', 'trail', 'signal', 'resource']),
+          reason: z.string().optional(),
+          scope: z.enum(['entry', 'graph']),
+          severity: z.literal('breaking'),
+          source: z.literal('trails compile --force'),
+        })
+        .strict()
+    ),
     forceEvents: z.number(),
     mode: z.literal('doctor'),
     trails: z.number(),

--- a/apps/trails/src/trails/version-lifecycle-support.ts
+++ b/apps/trails/src/trails/version-lifecycle-support.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { Result, ValidationError } from '@ontrails/core';
 import type { AnyTrail, Topo } from '@ontrails/core';
 import { deriveTopoGraph } from '@ontrails/topographer';
+import type { TopoGraph, TopoGraphForceEntry } from '@ontrails/topographer';
 import { findTrailDefinitions, parse } from '@ontrails/warden/ast';
 
 import { tryLoadFreshAppLease } from './load-app.js';
@@ -823,20 +824,99 @@ export const findLifecycleTrail = (
     : Result.ok(found as AnyTrail);
 };
 
-export const deriveDoctorSummary = (
-  app: Topo
-): {
+export interface DoctorForceDetail extends TopoGraphForceEntry {
+  readonly scope: 'entry' | 'graph';
+}
+
+export interface DoctorSummary {
   readonly archived: number;
   readonly deprecated: number;
+  readonly forceDetails: readonly DoctorForceDetail[];
   readonly forceEvents: number;
   readonly mode: 'doctor';
   readonly trails: number;
   readonly versioned: number;
-} => {
+}
+
+const doctorForceKey = (force: TopoGraphForceEntry): string =>
+  JSON.stringify([
+    force.kind,
+    force.id,
+    force.change,
+    force.detail,
+    force.reason,
+    force.severity,
+    force.source,
+  ]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isDoctorForceEntry = (value: unknown): value is TopoGraphForceEntry =>
+  isRecord(value) &&
+  typeof value['acceptedAt'] === 'string' &&
+  (value['change'] === 'modified' || value['change'] === 'removed') &&
+  typeof value['detail'] === 'string' &&
+  typeof value['id'] === 'string' &&
+  (value['kind'] === 'contour' ||
+    value['kind'] === 'trail' ||
+    value['kind'] === 'signal' ||
+    value['kind'] === 'resource') &&
+  (value['reason'] === undefined || typeof value['reason'] === 'string') &&
+  value['severity'] === 'breaking' &&
+  value['source'] === 'trails compile --force';
+
+const doctorForceEntries = (value: unknown): readonly TopoGraphForceEntry[] =>
+  Array.isArray(value) ? value.filter(isDoctorForceEntry) : [];
+
+const pushDoctorForceDetail = (
+  details: DoctorForceDetail[],
+  seen: Set<string>,
+  force: TopoGraphForceEntry,
+  scope: DoctorForceDetail['scope']
+): void => {
+  const key = doctorForceKey(force);
+  if (seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+  details.push({
+    acceptedAt: force.acceptedAt,
+    change: force.change,
+    detail: force.detail,
+    id: force.id,
+    kind: force.kind,
+    ...(force.reason === undefined ? {} : { reason: force.reason }),
+    scope,
+    severity: force.severity,
+    source: force.source,
+  });
+};
+
+const collectDoctorForceDetails = (
+  graph: TopoGraph
+): readonly DoctorForceDetail[] => {
+  const details: DoctorForceDetail[] = [];
+  const seen = new Set<string>();
+  for (const entry of graph.entries) {
+    for (const force of doctorForceEntries(entry.forces)) {
+      pushDoctorForceDetail(details, seen, force, 'entry');
+    }
+  }
+  for (const force of doctorForceEntries(graph.forces)) {
+    pushDoctorForceDetail(details, seen, force, 'graph');
+  }
+  return details;
+};
+
+export const deriveDoctorSummary = (
+  app: Topo,
+  options?: { readonly forceGraph?: TopoGraph | null | undefined }
+): DoctorSummary => {
   const graph = deriveTopoGraph(app);
+  const forceDetails = collectDoctorForceDetails(options?.forceGraph ?? graph);
   let archived = 0;
   let deprecated = 0;
-  let forceEvents = 0;
   let versioned = 0;
   for (const entry of graph.entries) {
     if (entry.kind !== 'trail') {
@@ -845,7 +925,6 @@ export const deriveDoctorSummary = (
     if (entry.version !== undefined) {
       versioned += 1;
     }
-    forceEvents += entry.forces?.length ?? 0;
     for (const version of Object.values(entry.versions ?? {})) {
       if (version.status?.state === 'archived') {
         archived += 1;
@@ -857,7 +936,8 @@ export const deriveDoctorSummary = (
   return {
     archived,
     deprecated,
-    forceEvents,
+    forceDetails,
+    forceEvents: forceDetails.length,
     mode: 'doctor',
     trails: app.list().length,
     versioned,


### PR DESCRIPTION
## Summary

- Teach `trails doctor` to report structured pending-force evidence from committed `.trails/topo.lock` data when available.
- Add `forceDetails` with force id, kind, change, detail, severity, source, optional reason, and entry/graph scope.
- Count entry-attached and graph-level force events in doctor summaries.

## Verification

- `bun test apps/trails/src/__tests__/version-lifecycle.test.ts`
- `bun test apps/trails/src/__tests__/survey.test.ts`
- `bun run typecheck` from `apps/trails`
- `bun run lint` from `apps/trails`
- `bun run format:check`
- `git diff --check`

## Notes

- Linear: TRL-770
