### PR TITLE
fix(regrade): preserve warden scan target filtering

### DIFF
--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md
@@ -216,6 +216,34 @@ Executor should create or choose that issue before implementing the capstone.
   - `bun run format:check` passed.
   - `git diff --check` passed.
 
+### 2026-06-01 18:14 EDT - TRL-771 skipped and TRL-878 scan filtering implemented
+
+- Evaluated conditional `TRL-771`; skipped it because `trails doctor` now
+  reports structured force evidence and the stable cutover gate only needs
+  PR-body exception evidence, not a broad accepted-exception governance model.
+- Created child branch
+  `trl-878-apply-warden-scan-target-filtering-to-regrade`.
+- Moved Warden's source scan-target predicate into
+  `packages/warden/src/rules/scan.ts`, kept the CLI on that helper, and
+  exported it through `@ontrails/warden`.
+- Updated Regrade's Warden-backed term-rewrite class to check the shared
+  Warden scan target helper before invoking `rule.check()`.
+- Added regression coverage proving `.d.ts`, `*.test.ts`, and `__tests__/`
+  files are skipped while normal `.tsx` source remains eligible for Warden
+  review routing.
+- Added `.changeset/warden-scan-target-helper.md` for `@ontrails/warden`.
+- Ran red check before implementation:
+  - `bun test packages/regrade/src/downstream/__tests__/report.test.ts`
+    failed on the new scan-target filtering assertion as expected.
+- Verification after implementation:
+  - `bun test packages/regrade/src/downstream/__tests__/report.test.ts`
+    passed.
+  - `bun test packages/warden/src/__tests__/cli.test.ts` passed.
+  - `bun run typecheck` from `packages/regrade` passed.
+  - `bun run typecheck` from `packages/warden` passed.
+  - `bun run lint` from `packages/regrade` passed.
+  - `bun run lint` from `packages/warden` passed.
+
 ## Verification Log
 
 Planning verification only:

--- a/.changeset/warden-scan-target-helper.md
+++ b/.changeset/warden-scan-target-helper.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/warden": patch
+---
+
+Expose shared Warden source scan-target predicates so downstream consumers can
+preserve the CLI runner's test and declaration-file filtering before invoking
+Warden-owned rules directly.

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -141,6 +141,60 @@ describe('wardenTermRewriteClasses', () => {
       'Safe fix metadata was missing concrete edits.'
     );
   });
+
+  test('preserves Warden scan-target filtering for Warden-backed classes', () => {
+    const checkedPaths: string[] = [];
+    const rule = {
+      check: (_source, filePath) => {
+        checkedPaths.push(filePath);
+        return [
+          {
+            filePath,
+            fix: {
+              class: 'term-rewrite',
+              reason: 'Test Warden term-rewrite diagnostic.',
+              safety: 'review',
+            },
+            line: 1,
+            message: 'Test Warden term-rewrite diagnostic.',
+            rule: 'no-legacy-layer-imports',
+            severity: 'error',
+          },
+        ];
+      },
+      description: 'Test Warden-backed term rewrites.',
+      name: 'no-legacy-layer-imports',
+      severity: 'error',
+    } satisfies WardenRule;
+    const cls = createWardenTermRewriteClass(rule);
+
+    for (const context of [
+      {
+        absolutePath: '/repo/src/types.d.ts',
+        path: 'src/types.d.ts',
+      },
+      {
+        absolutePath: '/repo/src/auth.test.ts',
+        path: 'src/auth.test.ts',
+      },
+      {
+        absolutePath: '/repo/src/__tests__/auth.ts',
+        path: 'src/__tests__/auth.ts',
+      },
+    ]) {
+      const result = cls?.apply('authLayer();\n', context);
+      // Scan-filtered files report `skipped`, not a scanned/clean `no-op`.
+      expect(result?.kind).toBe('skipped');
+    }
+    expect(checkedPaths).toEqual([]);
+
+    const result = cls?.apply('authLayer();\n', {
+      absolutePath: '/repo/src/auth.tsx',
+      path: 'src/auth.tsx',
+    });
+    expect(result?.kind).toBe('needs-review');
+    expect(checkedPaths).toEqual(['/repo/src/auth.tsx']);
+  });
 });
 
 describe('selectRegradeClasses', () => {
@@ -212,6 +266,35 @@ describe('buildRegradeReport', () => {
     expect(report.selectedClassIds).toEqual(['cls.foo']);
     expect(report.entries[0]?.classId).toBe('cls.foo');
     expect(report.entries[0]?.outcome).toBe('rewrite');
+  });
+
+  test('counts scan-filtered files as skipped, not scanned', () => {
+    const rule = {
+      check: () => [],
+      description: 'Test Warden-backed term rewrites.',
+      name: 'no-legacy-layer-imports',
+      severity: 'error',
+    } satisfies WardenRule;
+    const cls = createWardenTermRewriteClass(rule);
+    expect(cls).not.toBeNull();
+
+    const report = buildRegradeReport({
+      classes: cls ? [cls] : [],
+      files: [
+        // Scan-filtered (infrastructure) — must be skipped, not scanned/clean.
+        { path: 'src/types.d.ts', source: 'export {};\n' },
+        // Real source file with no diagnostics — a genuine no-op scan.
+        { path: 'src/auth.ts', source: 'export const x = 1;\n' },
+      ],
+      root: '/repo',
+      skipped: [],
+    });
+
+    expect(report.scanned).toBe(1);
+    expect(report.skipped).toBe(1);
+    const skipEntry = report.entries.find((e) => e.path === 'src/types.d.ts');
+    expect(skipEntry?.outcome).toBe('skip');
+    expect(skipEntry?.reason).toBe('warden-scan-target-filtered');
   });
 });
 

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -5,7 +5,11 @@ import type {
   WardenFixEdit,
   WardenRule,
 } from '@ontrails/warden';
-import { getWardenRuleMetadata, wardenRules } from '@ontrails/warden';
+import {
+  getWardenRuleMetadata,
+  isWardenSourceScanTarget,
+  wardenRules,
+} from '@ontrails/warden';
 import { readFileSync } from 'node:fs';
 import { z } from 'zod';
 
@@ -27,8 +31,16 @@ import type { DownstreamCollectionOptions, SkippedSource } from './collect.js';
  * collection substrate (TRL-844).
  */
 
-/** Outcome a regrade class produces for a single source file. */
-export type RegradeOutcomeKind = 'needs-review' | 'no-op' | 'rewrite';
+/**
+ * Outcome a regrade class produces for a single source file. `skipped` means
+ * the class declined to inspect the file (for example, a scan-target filter
+ * excluded it) and it must not count as a scanned/clean no-op.
+ */
+export type RegradeOutcomeKind =
+  | 'needs-review'
+  | 'no-op'
+  | 'rewrite'
+  | 'skipped';
 
 /** Result of applying one regrade class to one source string. */
 export interface RegradeClassResult {
@@ -137,6 +149,9 @@ const diagnosticNote = (diagnostic: WardenDiagnostic): string => {
 const wardenFilePath = (context: RegradeClassContext | undefined): string =>
   context?.absolutePath ?? context?.path ?? '<regrade-source>';
 
+const wardenScanPath = (context: RegradeClassContext | undefined): string =>
+  context?.path ?? context?.absolutePath ?? '<regrade-source>';
+
 const applyWardenEdits = (
   source: string,
   edits: readonly WardenFixEdit[]
@@ -182,6 +197,14 @@ export const createWardenTermRewriteClass = (
       source: string,
       context?: RegradeClassContext
     ): RegradeClassResult => {
+      if (!isWardenSourceScanTarget(wardenScanPath(context))) {
+        return {
+          kind: 'skipped',
+          notes: ['Skipped by Warden source scan-target filtering.'],
+          reason: 'warden-scan-target-filtered',
+        };
+      }
+
       const diagnostics = rule
         .check(source, wardenFilePath(context))
         .filter(
@@ -314,7 +337,11 @@ const classifyFile = (
   selected: readonly RegradeClass[]
 ): RegradeReportEntry => {
   // First selected class that matches (rewrite or review) wins, mirroring the
-  // "run one class" emphasis. No-ops fall through to a no-op entry.
+  // "run one class" emphasis. A scan-target skip is remembered so the file is
+  // accounted as skipped rather than a scanned/clean no-op. No-ops fall through.
+  let skipped:
+    | { readonly classId: string; readonly result: RegradeClassResult }
+    | undefined;
   for (const cls of selected) {
     const result = cls.apply(source, context);
     if (result.kind === 'rewrite') {
@@ -329,6 +356,18 @@ const classifyFile = (
         reason: result.reason ?? 'needs-review',
       };
     }
+    if (result.kind === 'skipped' && skipped === undefined) {
+      skipped = { classId: cls.id, result };
+    }
+  }
+  if (skipped !== undefined) {
+    return {
+      classId: skipped.classId,
+      notes: skipped.result.notes,
+      outcome: 'skip',
+      path,
+      reason: skipped.result.reason ?? 'skipped',
+    };
   }
   return { outcome: 'no-op', path };
 };
@@ -376,8 +415,16 @@ export const buildRegradeReport = (params: {
     a.path.localeCompare(b.path)
   );
 
-  const rewritten = fileEntries.filter((e) => e.outcome === 'rewrite').length;
-  const review = fileEntries.filter((e) => e.outcome === 'needs-review').length;
+  // Class-level skips (e.g. scan-target filtering) are accounted as skipped, not
+  // as scanned/clean files.
+  const scannedEntries = fileEntries.filter((e) => e.outcome !== 'skip');
+  const fileSkipCount = fileEntries.length - scannedEntries.length;
+  const rewritten = scannedEntries.filter(
+    (e) => e.outcome === 'rewrite'
+  ).length;
+  const review = scannedEntries.filter(
+    (e) => e.outcome === 'needs-review'
+  ).length;
 
   return {
     entries,
@@ -385,9 +432,9 @@ export const buildRegradeReport = (params: {
     review,
     rewritten,
     root: params.root,
-    scanned: fileEntries.length,
+    scanned: scannedEntries.length,
     selectedClassIds: selected.map((cls) => cls.id),
-    skipped: skipEntries.length,
+    skipped: skipEntries.length + fileSkipCount,
     unknownClassIds,
   };
 };

--- a/packages/warden/src/__tests__/scan.test.ts
+++ b/packages/warden/src/__tests__/scan.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  isTestFile,
+  isWardenSourceScanTarget,
+  isWardenTestScanTarget,
+} from '../rules/scan.js';
+
+describe('warden scan target helpers', () => {
+  test('isTestFile only matches the plural __tests__ convention', () => {
+    expect(isTestFile('src/__tests__/foo.ts')).toBe(true);
+    expect(isTestFile('src/foo.test.ts')).toBe(true);
+    // The absolute-path rule predicate must not treat a singular __test__
+    // directory as a test convention.
+    expect(isTestFile('src/__test__/foo.ts')).toBe(false);
+  });
+
+  test('isTestFile ignores a __test__ ancestor in the absolute scan root', () => {
+    // runWarden may be pointed at a root whose absolute path contains __test__;
+    // rule predicates receive that absolute path and must not classify every
+    // source file under it as a test.
+    expect(isTestFile('/tmp/__test__/repo/src/foo.ts')).toBe(false);
+    expect(isWardenSourceScanTarget('src/foo.ts')).toBe(true);
+  });
+
+  test('root-relative scan helper keeps __test__ CLI compatibility', () => {
+    expect(isWardenTestScanTarget('src/__test__/foo.ts')).toBe(true);
+    expect(isWardenTestScanTarget('src/__tests__/foo.ts')).toBe(true);
+    expect(isWardenTestScanTarget('./src/__test__/foo.ts')).toBe(true);
+    expect(isWardenTestScanTarget('src/foo.ts')).toBe(false);
+  });
+});

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -48,6 +48,10 @@ import {
 import { collectFileCrudCoverage } from './rules/incomplete-crud.js';
 import { wardenRules, wardenTopoRules } from './rules/index.js';
 import { getWardenRuleMetadata } from './rules/metadata.js';
+import {
+  isWardenDevPermitTestScanTarget,
+  isWardenSourceScanTarget,
+} from './rules/scan.js';
 import type {
   ProjectAwareWardenRule,
   ProjectContext,
@@ -195,24 +199,6 @@ export interface WardenReport {
  * Collect Warden scan targets under a directory, excluding generated and test
  * surfaces that should not contribute most committed-source diagnostics.
  */
-const isInfrastructureScanTarget = (match: string): boolean =>
-  match.endsWith('.d.ts') ||
-  match.startsWith('node_modules/') ||
-  match.startsWith('dist/') ||
-  match.startsWith('.git/');
-
-const isTestScanTarget = (match: string): boolean =>
-  match.includes('__tests__/') ||
-  match.includes('__test__/') ||
-  match.endsWith('.test.ts') ||
-  match.endsWith('.spec.ts');
-
-const isAllowedScanTarget = (match: string): boolean =>
-  !isInfrastructureScanTarget(match) && !isTestScanTarget(match);
-
-const isDevPermitTestScanTarget = (match: string): boolean =>
-  !isInfrastructureScanTarget(match) && isTestScanTarget(match);
-
 const collectFilesMatching = (
   dir: string,
   pattern: string,
@@ -228,7 +214,7 @@ const collectFilesMatching = (
 
   const files: string[] = [];
   for (const match of matches) {
-    if (isAllowedScanTarget(match)) {
+    if (isWardenSourceScanTarget(match)) {
       files.push(`${dir}/${match}`);
     }
   }
@@ -273,7 +259,7 @@ const collectDevPermitTestFiles = (dir: string): readonly string[] => {
 
   const files: string[] = [];
   for (const match of matches) {
-    if (isDevPermitTestScanTarget(match)) {
+    if (isWardenDevPermitTestScanTarget(match)) {
       files.push(`${dir}/${match}`);
     }
   }
@@ -316,7 +302,7 @@ const collectDocumentationFiles = (dir: string): readonly string[] => {
 
   const files: string[] = [];
   for (const match of matches) {
-    if (isAllowedScanTarget(match) && isDocumentationScanTarget(match)) {
+    if (isWardenSourceScanTarget(match) && isDocumentationScanTarget(match)) {
       files.push(`${dir}/${match}`);
     }
   }

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -48,6 +48,12 @@ export {
 
 // Rule-scoped cache controls for long-lived consumers (watch mode, LSPs).
 export { clearImplementationReturnsResultCache } from './rules/implementation-returns-result.js';
+export {
+  isWardenDevPermitTestScanTarget,
+  isWardenInfrastructureScanTarget,
+  isWardenSourceScanTarget,
+  isWardenTestScanTarget,
+} from './rules/scan.js';
 
 // CLI runner
 export type {

--- a/packages/warden/src/rules/scan.ts
+++ b/packages/warden/src/rules/scan.ts
@@ -1,6 +1,13 @@
 const TEST_FILE_PATTERN =
   /(?:^|\/)__tests__(?:\/|$)|(?:\.test|\.spec)\.[cm]?[jt]sx?$/;
 
+// The CLI scan-target contract also recognizes a singular `__test__` directory.
+// That compatibility stays scoped to the root-relative scan helpers: it must not
+// reach the absolute-path `isTestFile` rule predicate, where an ancestor
+// directory named `__test__` would otherwise misclassify every source file.
+const SCAN_TARGET_TEST_FILE_PATTERN =
+  /(?:^|\/)__tests?__(?:\/|$)|(?:\.test|\.spec)\.[cm]?[jt]sx?$/;
+
 const FRAMEWORK_INTERNAL_SEGMENTS = [
   '/packages/testing/',
   '/packages/warden/',
@@ -9,8 +16,40 @@ const FRAMEWORK_INTERNAL_SEGMENTS = [
 const normalizeFilePath = (filePath: string): string =>
   filePath.replaceAll('\\', '/');
 
+const toRootRelativeScanPath = (filePath: string): string =>
+  normalizeFilePath(filePath).replace(/^\.\//, '');
+
 export const isTestFile = (filePath: string): boolean =>
   TEST_FILE_PATTERN.test(normalizeFilePath(filePath));
+
+export const isWardenTestScanTarget = (filePath: string): boolean =>
+  SCAN_TARGET_TEST_FILE_PATTERN.test(toRootRelativeScanPath(filePath));
+
+export const isWardenInfrastructureScanTarget = (filePath: string): boolean => {
+  const match = toRootRelativeScanPath(filePath);
+  return (
+    match.endsWith('.d.ts') ||
+    match.startsWith('node_modules/') ||
+    match.startsWith('dist/') ||
+    match.startsWith('.git/')
+  );
+};
+
+/**
+ * Whether a root-relative path should receive Warden committed-source checks.
+ *
+ * Warden's CLI glob runner passes root-relative matches here. Consumers that
+ * already have a root-relative source path should use the same helper before
+ * invoking Warden-owned rules directly so diagnostics do not drift from the
+ * CLI runner's scan target contract.
+ */
+export const isWardenSourceScanTarget = (filePath: string): boolean =>
+  !isWardenInfrastructureScanTarget(filePath) &&
+  !isWardenTestScanTarget(filePath);
+
+export const isWardenDevPermitTestScanTarget = (filePath: string): boolean =>
+  !isWardenInfrastructureScanTarget(filePath) &&
+  isWardenTestScanTarget(filePath);
 
 export const isFrameworkInternalFile = (filePath: string): boolean => {
   const normalized = normalizeFilePath(filePath);


### PR DESCRIPTION
## Summary

- Export Warden's source scan-target predicate from the shared Warden rule scan module.
- Keep Warden CLI and Regrade's Warden-backed term rewrite class on the same scan filtering behavior.
- Add Regrade coverage proving `.d.ts`, test files, and `__tests__/` paths are skipped while normal `.tsx` source remains eligible.

## Verification

- `bun test packages/regrade/src/downstream/__tests__/report.test.ts`
- `bun test packages/warden/src/__tests__/cli.test.ts`
- `bun run typecheck` from `packages/regrade`
- `bun run typecheck` from `packages/warden`
- `bun run lint` from `packages/regrade`
- `bun run lint` from `packages/warden`
- `bun run format:check`
- `git diff --check`

## Notes

- Linear: TRL-878
