### PR TITLE
fix(adapter-kit): resolve wildcard owner exports

### DIFF
--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md
@@ -244,6 +244,52 @@ Executor should create or choose that issue before implementing the capstone.
   - `bun run lint` from `packages/regrade` passed.
   - `bun run lint` from `packages/warden` passed.
 
+### 2026-06-01 18:18 EDT - TRL-877 wildcard export resolution implemented
+
+- Created child branch
+  `trl-877-resolve-wildcard-export-keys-in-catalog-derivation`.
+- Updated adapter target catalog export resolution so exact package export
+  keys still win, then declared owner imports can resolve through wildcard
+  package export keys such as `"./*": "./src/*.ts"`.
+- Added catalog regression coverage for support/testing owner imports resolved
+  through wildcard export keys while existing explicit export coverage remains
+  intact.
+- Added adapter-check regression coverage proving wildcard-exported owner
+  `testingImport` metadata unblocks extracted adapter conformance checking.
+- Added `.changeset/adapter-kit-wildcard-exports.md` for
+  `@ontrails/adapter-kit`.
+- Ran red checks before implementation:
+  - `bun test packages/adapter-kit/src/__tests__/catalog.test.ts` failed on
+    the new wildcard export assertion as expected.
+  - `bun test packages/adapter-kit/src/__tests__/check.test.ts` failed on
+    the new wildcard adapter-check assertion as expected.
+- Verification after implementation:
+  - `bun test packages/adapter-kit/src/__tests__/catalog.test.ts` passed.
+  - `bun test packages/adapter-kit/src/__tests__/check.test.ts` passed.
+  - `bun run typecheck` from `packages/adapter-kit` passed.
+  - `bun run lint` from `packages/adapter-kit` passed.
+  - `bun test apps/trails/src/__tests__/adapter-check.test.ts packages/warden/src/__tests__/adapter-check.test.ts`
+    passed.
+
+### 2026-06-01 18:20 EDT - TRL-872 skipped pending owner decisions
+
+- Evaluated conditional `TRL-872`; skipped it because the live Linear issue
+  still says Commander, Vite, and Drizzle need owner target/conformance
+  decisions before they participate in the hard adapter-check predicate.
+- Verified current repo adapter metadata:
+  - `packages/http/package.json` and `packages/store/package.json` declare
+    owner targets.
+  - `adapters/hono/package.json` declares an extracted `http` adapter.
+  - `adapters/commander/package.json`, `adapters/vite/package.json`, and
+    `adapters/drizzle/package.json` do not yet declare `trails.adapter`
+    metadata.
+- Ran `bun apps/trails/bin/trails.ts adapter check --root-dir . --json`; it
+  passed with two owner targets (`@ontrails/http:http`,
+  `@ontrails/store:store`) and one adapter subject (`@ontrails/hono`).
+- Checkpoint capstone remains blocked on a tracker decision: create/choose the
+  Linear issue for the read-only verdict branch, or confirm an explicit
+  non-issue branch with Matt.
+
 ## Verification Log
 
 Planning verification only:

--- a/.changeset/adapter-kit-wildcard-exports.md
+++ b/.changeset/adapter-kit-wildcard-exports.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/adapter-kit": patch
+---
+
+Resolve declared adapter owner imports through wildcard package export keys
+before reporting missing owner subpath exports.

--- a/packages/adapter-kit/src/__tests__/catalog.test.ts
+++ b/packages/adapter-kit/src/__tests__/catalog.test.ts
@@ -88,6 +88,533 @@ describe('deriveAdapterTargetCatalog', () => {
     );
   });
 
+  test('derives owner imports from wildcard package export keys', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': './src/*.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            supportImport: '@ontrails/http/adapter-support',
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/adapter-support.ts', 'export {};\n');
+    writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets).toHaveLength(1);
+    expect(catalog.targets[0]).toMatchObject({
+      supportImport: '@ontrails/http/adapter-support',
+      testingImport: '@ontrails/http/testing',
+    });
+    expect(catalog.targets[0]?.supportExportTarget).toEndWith(
+      'packages/http/src/adapter-support.ts'
+    );
+    expect(catalog.targets[0]?.testingExportTarget).toEndWith(
+      'packages/http/src/testing.ts'
+    );
+  });
+
+  test('rejects wildcard imports excluded by a more specific null export', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': './src/*.ts',
+        './private/*': null,
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/private/testing',
+          },
+        },
+      },
+    });
+    // The file exists, but the package explicitly blocks ./private/* so the
+    // import must not fall through to the broader ./* wildcard.
+    writeFile(root, 'packages/http/src/private/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(1);
+    expect(catalog.diagnostics[0]).toMatchObject({
+      code: 'invalid-import',
+      message: expect.stringContaining('does not export that subpath'),
+      target: 'http',
+    });
+  });
+
+  test('resolves wildcard imports when default precedes conditional null export', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': './src/*.ts',
+        './private/*': {
+          default: './src/private/*.ts',
+          import: null,
+        },
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/private/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/private/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets).toHaveLength(1);
+    expect(catalog.targets[0]?.testingExportTarget).toEndWith(
+      'packages/http/src/private/testing.ts'
+    );
+  });
+
+  test('resolves wildcard imports through Node import-compatible conditions', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './module-sync/*': {
+          'module-sync': './src/module-sync/*.ts',
+        },
+        './node-addons/*': {
+          'node-addons': './src/node-addons/*.ts',
+        },
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            supportImport: '@ontrails/http/module-sync/support',
+            testingImport: '@ontrails/http/node-addons/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/module-sync/support.ts', 'export {};\n');
+    writeFile(root, 'packages/http/src/node-addons/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets).toHaveLength(1);
+    expect(catalog.targets[0]?.supportExportTarget).toEndWith(
+      'packages/http/src/module-sync/support.ts'
+    );
+    expect(catalog.targets[0]?.testingExportTarget).toEndWith(
+      'packages/http/src/node-addons/testing.ts'
+    );
+  });
+
+  test('rejects wildcard imports when conditional null precedes default export', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': './src/*.ts',
+        './private/*': Object.fromEntries([
+          ['import', null],
+          ['default', './src/private/*.ts'],
+        ]),
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/private/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/private/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(1);
+    expect(catalog.diagnostics[0]).toMatchObject({
+      code: 'invalid-import',
+      message: expect.stringContaining('does not export that subpath'),
+      target: 'http',
+    });
+  });
+
+  test('rejects wildcard imports when conditional arrays exhaust before default export', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': './src/*.ts',
+        './private/*': Object.fromEntries([
+          ['import', [null]],
+          ['default', './src/private/*.ts'],
+        ]),
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/private/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/private/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(1);
+    expect(catalog.diagnostics[0]).toMatchObject({
+      code: 'invalid-import',
+      message: expect.stringContaining('does not export that subpath'),
+      target: 'http',
+    });
+  });
+
+  test('rejects wildcard imports with only require conditions', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './private/*': {
+          require: './src/private/*.cjs',
+        },
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/private/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/private/testing.cjs',
+      'module.exports = {};\n'
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(1);
+    expect(catalog.diagnostics[0]).toMatchObject({
+      code: 'invalid-import',
+      message: expect.stringContaining('does not export that subpath'),
+      target: 'http',
+    });
+  });
+
+  test('resolves wildcard imports exposed through node conditions', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './private/*': {
+          node: './src/private/*.ts',
+        },
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/private/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/private/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets).toHaveLength(1);
+    expect(catalog.targets[0]?.testingExportTarget).toEndWith(
+      'packages/http/src/private/testing.ts'
+    );
+  });
+
+  test('resolves wildcard imports exposed through export target arrays', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': ['./src/*.ts'],
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets).toHaveLength(1);
+    expect(catalog.targets[0]?.testingExportTarget).toEndWith(
+      'packages/http/src/testing.ts'
+    );
+  });
+
+  test('continues wildcard export arrays past invalid targets', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': ['../outside/*.ts', './src/*.ts'],
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets).toHaveLength(1);
+    expect(catalog.targets[0]?.testingExportTarget).toEndWith(
+      'packages/http/src/testing.ts'
+    );
+  });
+
+  test('rejects wildcard imports with path-traversal captures', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': './src/*.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/foo/../testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(1);
+    expect(catalog.diagnostics[0]).toMatchObject({
+      code: 'invalid-import',
+      message: expect.stringContaining('does not export that subpath'),
+      target: 'http',
+    });
+  });
+
+  test('rejects wildcard imports with encoded invalid captures', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': './src/*.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          encoded: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/%2e%2e/testing',
+          },
+          reserved: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/node_modules/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/%2e%2e/testing.ts', 'export {};\n');
+    writeFile(
+      root,
+      'packages/http/src/node_modules/testing.ts',
+      'export {};\n'
+    );
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(2);
+    expect(catalog.diagnostics.map((diagnostic) => diagnostic.target)).toEqual([
+      'encoded',
+      'reserved',
+    ]);
+    expect(
+      catalog.diagnostics.every(
+        (diagnostic) => diagnostic.code === 'invalid-import'
+      )
+    ).toBe(true);
+  });
+
+  test('rejects wildcard imports with invalid export targets', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': '../outside/*.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/outside/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(1);
+    expect(catalog.diagnostics[0]).toMatchObject({
+      code: 'invalid-import',
+      message: expect.stringContaining('does not export that subpath'),
+      target: 'http',
+    });
+  });
+
+  test('rejects wildcard imports shadowed by a more specific types-only entry', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': './src/*.ts',
+        // A conditions object with no runtime target (types-only): Node treats
+        // the matched subpath as not exported, so it must block, not fall back.
+        './private/*': { types: './src/private/*.d.ts' },
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/private/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/private/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.targets).toEqual([]);
+    expect(catalog.diagnostics).toHaveLength(1);
+    expect(catalog.diagnostics[0]).toMatchObject({
+      code: 'invalid-import',
+      message: expect.stringContaining('does not export that subpath'),
+      target: 'http',
+    });
+  });
+
+  test('resolves sibling wildcard imports when a null exclusion targets another subpath', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': './src/*.ts',
+        './private/*': null,
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets).toHaveLength(1);
+    expect(catalog.targets[0]?.testingExportTarget).toEndWith(
+      'packages/http/src/testing.ts'
+    );
+  });
+
+  test('resolves overlapping wildcards by Node prefix precedence, not key length', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        // Equal total key length; Node prefers the longer prefix before the
+        // wildcard, so `@ontrails/http/bar/foo` must resolve through `./bar/*`.
+        './*/foo': './src/generic/*.ts',
+        './bar/*': './src/bar/*.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/bar/foo',
+          },
+        },
+      },
+    });
+    // Only the Node-correct target exists; the leading-wildcard target does not.
+    writeFile(root, 'packages/http/src/bar/foo.ts', 'export {};\n');
+
+    const catalog = deriveAdapterTargetCatalog(root);
+
+    expect(catalog.diagnostics).toEqual([]);
+    expect(catalog.targets).toHaveLength(1);
+    expect(catalog.targets[0]?.testingExportTarget).toEndWith(
+      'packages/http/src/bar/foo.ts'
+    );
+  });
+
   test('derives optional owner conformance helper metadata', () => {
     const root = makeRoot();
     writePackage(root, 'packages/http', {

--- a/packages/adapter-kit/src/__tests__/check.test.ts
+++ b/packages/adapter-kit/src/__tests__/check.test.ts
@@ -158,6 +158,53 @@ describe('checkAdapters', () => {
     });
   });
 
+  test('accepts owner testing imports exported through wildcard keys', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './*': './src/*.ts',
+        './package.json': './package.json',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['extracted'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = () => undefined;',
+        '',
+      ].join('\n')
+    );
+    writeHonoAdapter(root);
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects).toHaveLength(1);
+    expect(report.subjects[0]).toMatchObject({
+      ownerPackage: '@ontrails/http',
+      target: 'http',
+      testingImport: '@ontrails/http/testing',
+    });
+  });
+
   test('ignores extracted adapter packages until they declare target metadata', () => {
     const root = makeRoot();
     writeHttpOwner(root);

--- a/packages/adapter-kit/src/catalog.ts
+++ b/packages/adapter-kit/src/catalog.ts
@@ -77,6 +77,7 @@ export interface AdapterTargetPackageManifest {
 }
 
 export interface AdapterTargetParseContext {
+  readonly blockedExportSpecifiers: readonly string[];
   readonly exportTargets: Readonly<Record<string, string>>;
   readonly packageJsonPath: string;
   readonly packageName: string;
@@ -451,19 +452,77 @@ const workspaceDirsForPattern = (
     .toSorted();
 };
 
+const exportConditions = new Set([
+  'bun',
+  'node',
+  'node-addons',
+  'module-sync',
+  'import',
+  'default',
+]);
+
+type ResolvedExportTarget =
+  | { readonly kind: 'target'; readonly target: string }
+  | { readonly kind: 'blocked' };
+
+const packageExportSegmentIsSafe = (segment: string): boolean => {
+  if (segment.length === 0) {
+    return false;
+  }
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    return false;
+  }
+  return (
+    decoded !== '.' &&
+    decoded !== '..' &&
+    decoded.toLowerCase() !== 'node_modules' &&
+    !decoded.includes('/') &&
+    !decoded.includes('\\')
+  );
+};
+
+const exportTargetIsSafe = (target: string): boolean =>
+  target.startsWith('./') &&
+  !target.includes('\\') &&
+  target.slice(2).split('/').every(packageExportSegmentIsSafe);
+
 const resolveExportTarget = (
   target: unknown,
   depth = 0
-): string | undefined => {
+): ResolvedExportTarget | undefined => {
   if (typeof target === 'string') {
-    return target;
+    return { kind: 'target', target };
+  }
+  if (target === null) {
+    return { kind: 'blocked' };
+  }
+  if (Array.isArray(target)) {
+    if (depth > 8) {
+      return undefined;
+    }
+    for (const targetEntry of target) {
+      const resolvedTarget = resolveExportTarget(targetEntry, depth + 1);
+      if (
+        resolvedTarget?.kind === 'target' &&
+        exportTargetIsSafe(resolvedTarget.target)
+      ) {
+        return resolvedTarget;
+      }
+    }
+    return { kind: 'blocked' };
   }
   if (!isRecord(target) || depth > 8) {
     return undefined;
   }
 
-  for (const condition of ['bun', 'import', 'default', 'require'] as const) {
-    const resolvedTarget = resolveExportTarget(target[condition], depth + 1);
+  for (const [condition, conditionTarget] of Object.entries(target)) {
+    if (!exportConditions.has(condition)) {
+      continue;
+    }
+    const resolvedTarget = resolveExportTarget(conditionTarget, depth + 1);
     if (resolvedTarget) {
       return resolvedTarget;
     }
@@ -478,31 +537,152 @@ const exportSpecifierFromKey = (
   if (key === '.') {
     return packageName;
   }
-  if (!key.startsWith('./') || key.includes('*')) {
+  if (!key.startsWith('./')) {
     return undefined;
   }
   return `${packageName}/${key.slice(2)}`;
 };
 
+const wildcardCaptureIsSafe = (capture: string): boolean =>
+  !capture.includes('\\') &&
+  capture.split('/').every(packageExportSegmentIsSafe);
+
+const wildcardCapture = (
+  pattern: string,
+  value: string
+): string | undefined => {
+  const star = pattern.indexOf('*');
+  if (star === -1) {
+    return undefined;
+  }
+
+  const prefix = pattern.slice(0, star);
+  const suffix = pattern.slice(star + 1);
+  if (!value.startsWith(prefix) || !value.endsWith(suffix)) {
+    return undefined;
+  }
+
+  const capture = value.slice(prefix.length, value.length - suffix.length);
+  return capture.length > 0 && wildcardCaptureIsSafe(capture)
+    ? capture
+    : undefined;
+};
+
+const applyWildcardCapture = (targetPattern: string, capture: string): string =>
+  targetPattern.replaceAll('*', capture);
+
+type WildcardExportCandidate =
+  | {
+      readonly kind: 'target';
+      readonly pattern: string;
+      readonly target: string;
+    }
+  | { readonly kind: 'blocked'; readonly pattern: string };
+
+/**
+ * Order two wildcard export keys by Node's package-exports precedence: the
+ * longer prefix before the wildcard wins first, then the longer total key. This
+ * mirrors Node's `patternKeyCompare`, so equal-total-length patterns (for
+ * example a leading-wildcard key versus a trailing-wildcard key) resolve the
+ * way the runtime loader would.
+ */
+const patternKeyCompare = (left: string, right: string): number => {
+  const leftBase = left.indexOf('*') + 1;
+  const rightBase = right.indexOf('*') + 1;
+  if (leftBase !== rightBase) {
+    return rightBase - leftBase;
+  }
+  return right.length - left.length;
+};
+
+const resolveExportTargetForImport = (
+  context: AdapterTargetParseContext,
+  importSpecifier: string
+): string | undefined => {
+  // Exact `null` exclusions block the subpath before any wildcard fallback.
+  if (context.blockedExportSpecifiers.includes(importSpecifier)) {
+    return undefined;
+  }
+
+  const exactTarget = context.exportTargets[importSpecifier];
+  if (exactTarget) {
+    return exactTarget;
+  }
+
+  // Match the most specific wildcard key using Node's exports precedence
+  // (longer prefix before the wildcard first, then longer total key). A blocked
+  // pattern that is more specific than a broader target pattern must reject the
+  // import instead of resolving it.
+  const candidates: WildcardExportCandidate[] = [
+    ...Object.entries(context.exportTargets)
+      .filter(([specifier]) => specifier.includes('*'))
+      .map(
+        ([pattern, target]): WildcardExportCandidate => ({
+          kind: 'target',
+          pattern,
+          target,
+        })
+      ),
+    ...context.blockedExportSpecifiers
+      .filter((specifier) => specifier.includes('*'))
+      .map(
+        (pattern): WildcardExportCandidate => ({ kind: 'blocked', pattern })
+      ),
+  ].toSorted((left, right) => patternKeyCompare(left.pattern, right.pattern));
+
+  for (const candidate of candidates) {
+    const capture = wildcardCapture(candidate.pattern, importSpecifier);
+    if (capture === undefined) {
+      continue;
+    }
+    return candidate.kind === 'blocked'
+      ? undefined
+      : applyWildcardCapture(candidate.target, capture);
+  }
+
+  return undefined;
+};
+
+interface NormalizedExportTargets {
+  readonly blocked: readonly string[];
+  readonly targets: Readonly<Record<string, string>>;
+}
+
 const normalizeExportTargets = (
   packageRoot: string,
   packageName: string,
   exportsValue: unknown
-): Readonly<Record<string, string>> => {
+): NormalizedExportTargets => {
   if (!isRecord(exportsValue)) {
-    return {};
+    return { blocked: [], targets: {} };
   }
 
   const targets: Record<string, string> = {};
+  const blocked: string[] = [];
   for (const [key, value] of Object.entries(exportsValue)) {
     const specifier = exportSpecifierFromKey(packageName, key);
-    const target = resolveExportTarget(value);
-    if (!specifier || !target) {
+    if (!specifier) {
       continue;
     }
-    targets[specifier] = normalizeRealPath(join(packageRoot, target));
+    const resolvedTarget = resolveExportTarget(value);
+    if (resolvedTarget?.kind === 'target') {
+      if (!exportTargetIsSafe(resolvedTarget.target)) {
+        blocked.push(specifier);
+        continue;
+      }
+      targets[specifier] = normalizeRealPath(
+        join(packageRoot, resolvedTarget.target)
+      );
+      continue;
+    }
+    // A declared export key that does not resolve to a runtime target (an
+    // explicit `null` exclusion, or a conditions object with no runtime
+    // condition such as a `types`-only entry) blocks the subpath. Node selects
+    // the most specific matching key and reports the subpath as not exported, so
+    // it must not fall through to a broader wildcard.
+    blocked.push(specifier);
   }
-  return targets;
+  return { blocked, targets };
 };
 
 const diagnostic = (
@@ -1088,12 +1268,12 @@ const parseCatalogTarget = (
   ];
   const supportImportSpecifier = supportImport.importSpecifier;
   const supportExportTarget = supportImportSpecifier
-    ? context.exportTargets[supportImportSpecifier]
+    ? resolveExportTargetForImport(context, supportImportSpecifier)
     : undefined;
   const testingImportSpecifier = testingImport.importSpecifier;
   const conformanceManifest = conformance.conformance;
   const testingExportTarget = testingImportSpecifier
-    ? context.exportTargets[testingImportSpecifier]
+    ? resolveExportTargetForImport(context, testingImportSpecifier)
     : undefined;
 
   if (supportImportSpecifier) {
@@ -1240,12 +1420,14 @@ export const deriveAdapterTargetCatalog = (
       }
 
       const packageRoot = normalizeRealPath(dirname(packageJsonPath));
+      const normalizedExports = normalizeExportTargets(
+        packageRoot,
+        manifest.name,
+        manifest.exports
+      );
       const parsed = parseAdapterTargetsFromManifest(manifest, {
-        exportTargets: normalizeExportTargets(
-          packageRoot,
-          manifest.name,
-          manifest.exports
-        ),
+        blockedExportSpecifiers: normalizedExports.blocked,
+        exportTargets: normalizedExports.targets,
         packageJsonPath: normalizeRealPath(packageJsonPath),
         packageName: manifest.name,
         packageRoot,


### PR DESCRIPTION
## Summary

- Resolve declared adapter owner imports through wildcard package export keys after exact export keys are checked.
- Add catalog coverage for support/testing owner imports resolved through wildcard exports.
- Add adapter-check coverage proving wildcard-exported owner testing metadata unblocks extracted adapter conformance checking.
- Record that TRL-872 stays skipped until Commander, Vite, and Drizzle have explicit owner target/conformance decisions.

## Verification

- `bun test packages/adapter-kit/src/__tests__/catalog.test.ts`
- `bun test packages/adapter-kit/src/__tests__/check.test.ts`
- `bun run typecheck` from `packages/adapter-kit`
- `bun run lint` from `packages/adapter-kit`
- `bun test apps/trails/src/__tests__/adapter-check.test.ts packages/warden/src/__tests__/adapter-check.test.ts`
- `bun run format:check`
- `git diff --check`

## Notes

- Linear: TRL-877
- Conditional skip recorded: TRL-872
