### PR TITLE
chore(agent-trust): add checkpoint verdict

### DIFF
--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/CHECKPOINT-TRL-879.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/CHECKPOINT-TRL-879.md
@@ -1,0 +1,112 @@
+# TRL-879 Checkpoint Verdict
+
+Date: 2026-06-01
+
+Issue: TRL-879 - Checkpoint Agent Trust stable cutover stack verdict
+
+Branch: `trl-879-checkpoint-agent-trust-stable-cutover-stack-verdict`
+
+## Verdict
+
+`caution`
+
+Submission status: `draft-submit-ready`.
+
+The Agent Trust / Stable Cutover Integrity stack is ready for draft Graphite
+submission, with caution because TRL-771 and TRL-872 were intentionally skipped
+for the reasons below. The first checkpoint slice stayed read-only and
+evidence-based: it did not mutate source behavior, generated lockfiles, Linear,
+registry state, or publish state.
+
+## Stack Scope
+
+- TRL-772: copied and committed the execution packet, then bounded v1 marker
+  projection by rejecting unsupported Zod semantics at runtime.
+- TRL-773: aligned Warden `marker-schema-unsupported` coverage with the runtime
+  marker subset.
+- TRL-770: made `trails doctor` report structured force audit details from
+  committed topo evidence.
+- TRL-769: documented pending force events as a stable cutover draft gate.
+- TRL-771: skipped; see conditional rationale below.
+- TRL-878: preserved Warden scan-target filtering before Regrade invokes
+  Warden-backed term-rewrite rules.
+- TRL-877: resolved adapter owner imports through wildcard package export keys.
+- TRL-872: skipped; see conditional rationale below.
+- TRL-879: this read-only checkpoint verdict.
+
+## Changed Files
+
+- `.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/GOAL.md`
+- `.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/PLAN.md`
+- `.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/REFS.md`
+- `.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md`
+- `.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/CHECKPOINT-TRL-879.md`
+- `.changeset/adapter-kit-wildcard-exports.md`
+- `.changeset/marker-schema-bounds.md`
+- `.changeset/trails-doctor-force-details.md`
+- `.changeset/warden-marker-schema-bounds.md`
+- `.changeset/warden-scan-target-helper.md`
+- `apps/trails/src/__tests__/version-lifecycle.test.ts`
+- `apps/trails/src/trails/doctor.ts`
+- `apps/trails/src/trails/version-lifecycle-support.ts`
+- `docs/adr/0048-trail-versioning-v3.md`
+- `docs/adr/decision-map.json`
+- `docs/adr/drafts/decision-map.json`
+- `docs/releases/stable-cutover.md`
+- `packages/adapter-kit/src/__tests__/catalog.test.ts`
+- `packages/adapter-kit/src/__tests__/check.test.ts`
+- `packages/adapter-kit/src/catalog.ts`
+- `packages/core/src/__tests__/version-marker.test.ts`
+- `packages/core/src/validation.ts`
+- `packages/core/src/version-marker.ts`
+- `packages/regrade/src/downstream/__tests__/report.test.ts`
+- `packages/regrade/src/downstream/report.ts`
+- `packages/topographer/src/__tests__/derive.test.ts`
+- `packages/warden/src/__tests__/scan.test.ts`
+- `packages/warden/src/__tests__/trail-versioning-rules.test.ts`
+- `packages/warden/src/cli.ts`
+- `packages/warden/src/index.ts`
+- `packages/warden/src/rules/scan.ts`
+- `packages/warden/src/rules/trail-versioning-source.ts`
+
+## Verification
+
+Focused red/green checks were recorded branch-by-branch in `RETRO.md`.
+
+Stack-tip validation:
+
+- `bun scripts/adr.ts check` - pass, 0 errors, 0 warnings.
+- `bun run check` - pass. This included lint, ast-grep, vocabulary audit,
+  format check, typecheck, docs checks, error-taxonomy check, scaffold-version
+  check, Warden guide checks, skillset check, `trails warden`, and dead-code.
+  `trails warden` reported PASS with 0 errors and 3 existing
+  `signal-graph-coaching` warnings in the demo topo.
+- `bun run test` - pass, 40 Turbo tasks successful.
+- `bun run build` - pass, 24 Turbo tasks successful.
+- `bun run publish:check` - pass. This was dry pack validation only; no publish
+  command ran.
+
+## Conditional Rationale
+
+TRL-771 was skipped because `trails doctor` now reports structured force
+evidence and the stable cutover gate only needs PR-body exception evidence. A
+separate accepted-exception governance model would be broader than the packet's
+minimum shape.
+
+TRL-872 was skipped because the live Linear issue still says Commander, Vite,
+and Drizzle need owner target/conformance decisions before they participate in
+the hard adapter-check predicate. Current adapter-check evidence reports two
+owner targets (`@ontrails/http:http`, `@ontrails/store:store`) and one adapter
+subject (`@ontrails/hono`) with no diagnostics.
+
+## Post-Submit Status
+
+Graphite submission already happened: PRs #652-#658 exist for this stack and the
+checkpoint review-log update was recorded after CI was green. This checkpoint is
+evidence-only, so no further source-control action is required from it.
+
+Only post-submit monitoring remains:
+
+1. Watch CI and reviewer status on PRs #652-#658.
+2. Do not resubmit or otherwise mutate the Graphite stack from this checkpoint.
+3. Do not merge, queue, publish, or mutate registry state.

--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/GOAL.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/GOAL.md
@@ -1,14 +1,19 @@
 ---
 created: "2026-06-01T17:30:00-04:00"
-updated: "2026-06-01T17:47:00-04:00"
-status: staged-outside-worktree
+updated: "2026-06-02T16:04:19-04:00"
+status: historical-execution-prompt
 eventual_repo_packet: ".agents/plans/2026-06-01-agent-trust-stable-cutover-integrity"
 ---
 
 # Goal Prompt
 
-Paste this into the executor once the packet has been copied into the dedicated
-execution worktree.
+Historical executor prompt. The packet has already been copied into the stack
+and PRs #652-#658 have been submitted through Graphite. Future operators should
+use `RETRO.md` for post-submit monitoring, review response, and merge evidence
+instead of pasting this prompt to start a new execution lane.
+
+This was pasted into the executor after the packet was copied into the
+dedicated execution worktree.
 
 ````text
 /goal
@@ -34,9 +39,11 @@ Validation: use narrow tests per branch, then broaden at the tip. Expected focus
 Stop and ask if main/Linear/PR state invalidates the order, TRL-772 requires broad Zod support rather than bounded rejection, checkpoint pressure wants mutation/autofix/shell-runner behavior, TRL-771 sprawls into broad exception governance, P0/P1/P2 review debt remains after four post-ready turns, or secrets/production/publish/merge actions are needed.
 ````
 
-## Copy-In Step
+## Historical Copy-In Step
 
-Before using the prompt, copy the staged packet into the execution worktree:
+The copy-in step below was completed during the initial delegated execution.
+Do not rerun it as a current action unless Matt explicitly reopens the packet
+setup flow.
 
 ```bash
 pwd -P
@@ -44,4 +51,4 @@ mkdir -p .agents/plans/2026-06-01-agent-trust-stable-cutover-integrity
 cp -R /Users/mg/.agents/plans/trails/2026-06-01-agent-trust-stable-cutover-integrity/. .agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/
 ```
 
-After that copy, the in-worktree packet becomes the active source of truth.
+After that copy, the in-worktree packet became the active source of truth.

--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/PLAN.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/PLAN.md
@@ -1,7 +1,7 @@
 ---
 created: "2026-06-01T17:30:00-04:00"
-updated: "2026-06-01T17:47:00-04:00"
-status: staged-outside-worktree
+updated: "2026-06-02T17:39:23-04:00"
+status: post-submit-monitoring
 owner: Lewis
 eventual_repo_packet: ".agents/plans/2026-06-01-agent-trust-stable-cutover-integrity"
 linear:
@@ -13,24 +13,27 @@ linear:
   - TRL-878
   - TRL-877
   - TRL-872
+  - TRL-879
 ---
 
 # Agent Trust / Stable Cutover Integrity
 
 ## Packet Status
 
-This packet is intentionally staged outside the Trails worktree at:
+This in-repo packet has been copied, committed, and submitted as part of the
+Graphite stack for PRs #652-#658. Current operators should use `RETRO.md` for
+post-submit review response, CI state, and merge evidence.
+
+The original home-level packet remains as provenance at:
 
 `/Users/mg/.agents/plans/trails/2026-06-01-agent-trust-stable-cutover-integrity`
 
-The eventual in-repo packet destination is:
+The active in-repo packet destination is:
 
 `.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/`
 
-Do not treat this home-level packet as source already committed to Trails. When
-execution starts in a dedicated worktree, copy the packet wholesale into the
-execution worktree, then commit it on the lowest branch in the implementation
-stack or on the first branch that makes the packet load-bearing.
+Do not recopy the home-level packet or recommit the initial packet setup unless
+Matt explicitly reopens the execution-bootstrap flow.
 
 ## Objective
 
@@ -78,7 +81,7 @@ Verified on 2026-06-01:
 | 6 | TRL-878 | `trl-878-apply-warden-scan-target-filtering-to-regrade` | Keep Regrade's Warden-backed route aligned with Warden's own scan-target exclusions. |
 | 7 | TRL-877 | `trl-877-resolve-wildcard-export-keys-in-catalog-derivation` | Fix adapter catalog export-pattern support before more adapter subjects opt in. |
 | 8 | TRL-872 | `trl-872-migrate-remaining-first-party-adapters-into-adaptercheck` | Conditional: migrate Commander/Vite/Drizzle only after catalog truth is solid and owner targets are explicit. |
-| 9 | New or explicit non-Linear branch | TBD | Read-only checkpoint verdict over existing Warden/doctor/Regrade/adapter evidence. Create a focused Linear issue first unless Matt chooses a non-issue branch. |
+| 9 | TRL-879 | `trl-879-checkpoint-agent-trust-stable-cutover-stack-verdict` | Read-only checkpoint verdict over existing Warden/doctor/Regrade/adapter evidence. Submitted as PR #658; verdict is `caution`, with submission status `draft-submit-ready`. |
 
 ## Recommended Direction
 
@@ -224,8 +227,10 @@ Completion contract:
 
 ### Capstone: Read-Only Checkpoint Verdict
 
-This slice needs a tracker decision before implementation. Either create a new
-Linear issue or use an explicit non-issue branch if Matt chooses that path.
+This slice was implemented as `TRL-879` on
+`trl-879-checkpoint-agent-trust-stable-cutover-stack-verdict` and submitted as
+PR #658. Current operators should treat this section as provenance for the
+checkpoint boundary, not as a prompt to create a new tracker issue or branch.
 
 Completion contract:
 
@@ -247,7 +252,11 @@ Planning phase:
 - Do not edit the primary worktree.
 - Do not commit this home-level packet.
 
-Execution phase:
+Historical execution phase:
+
+The bootstrap steps below were completed during the delegated stack execution.
+They remain as provenance for how the stack was created; they are not current
+instructions for post-submit operators.
 
 1. Run the Graphite first-pass state check before any source-control write:
 
@@ -363,7 +372,7 @@ Focused checks likely needed:
 - `bun test packages/warden/src/__tests__/adapter-check.test.ts`
 - `bun test apps/trails/src/__tests__/adapter-check.test.ts`
 
-Broader checks before submission:
+Broader checks for submit or review-response validation:
 
 - `bun run lint`
 - `bun run lint:ast-grep`
@@ -375,12 +384,14 @@ Broader checks before submission:
 - `bun run publish:check`
 - `git diff --check`
 
-Before submission:
+Historical submit gate:
 
-```bash
-gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
-gt submit --stack --draft --restack --no-edit --no-interactive
-```
+The original execution used a Graphite stack dry-run followed by real stack
+submission from the stack tip. That step has already happened for PRs #652-#658
+and is retained here as provenance only. Post-submit operators should not rerun
+`gt submit` from this packet; current work is review-thread response, CI
+monitoring, ready/merge evidence, and source-control actions explicitly
+authorized in the coordinating turn.
 
 After submit, inspect each PR title/body and rewrite stale or placeholder
 bodies with `gh pr edit --body-file` using real temp files. Keep PRs draft until

--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/REFS.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/REFS.md
@@ -1,16 +1,16 @@
 ---
 created: "2026-06-01T17:30:00-04:00"
-updated: "2026-06-01T17:47:00-04:00"
-status: staged-outside-worktree
+updated: "2026-06-02T17:30:57-04:00"
+status: post-submit-monitoring
 ---
 
 # References
 
 ## Packet Locations
 
-- Staged packet:
+- Original staged packet:
   `/Users/mg/.agents/plans/trails/2026-06-01-agent-trust-stable-cutover-integrity`
-- Eventual in-repo destination:
+- Submitted in-repo packet:
   `.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/`
 
 ## Repo Guidance
@@ -34,6 +34,7 @@ status: staged-outside-worktree
 - `TRL-878`: Apply Warden scan-target filtering to Regrade.
 - `TRL-877`: Resolve wildcard export keys in catalog derivation.
 - `TRL-872`: Migrate remaining first-party adapters into adapter.check model.
+- `TRL-879`: Checkpoint Agent Trust stable cutover stack verdict.
 
 ## Marker and Versioning
 

--- a/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md
+++ b/.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/RETRO.md
@@ -1,7 +1,7 @@
 ---
 created: "2026-06-01T17:30:00-04:00"
-updated: "2026-06-01T17:47:00-04:00"
-status: seeded
+updated: "2026-06-02T15:42:06-04:00"
+status: post-submit-monitoring
 packet_location: "/Users/mg/.agents/plans/trails/2026-06-01-agent-trust-stable-cutover-integrity"
 eventual_repo_packet: ".agents/plans/2026-06-01-agent-trust-stable-cutover-integrity"
 ---
@@ -10,18 +10,25 @@ eventual_repo_packet: ".agents/plans/2026-06-01-agent-trust-stable-cutover-integ
 
 ## Execution Summary
 
-Seeded outside the Trails worktree by Lewis on 2026-06-01.
+Seeded outside the Trails worktree by Lewis on 2026-06-01, then copied into
+the Trails stack as the checkpoint record.
 
-This packet has not been copied into the repo, committed, submitted, or tied to
-an execution worktree yet.
+PRs #652-#658 have been submitted through Graphite, including the TRL-879
+checkpoint branch. The stack is not merged; current work is post-submit CI,
+remote-review monitoring, and owning-branch review response.
 
 ## Branch / PR / Issue Ledger
 
 | Kind | Identifier | State | Notes |
 | --- | --- | --- | --- |
-| Branch | none | not started | No branch created during planning. |
-| PR | none | not started | No PR created during planning. |
-| Issues | TRL-772, TRL-773, TRL-770, TRL-769, TRL-771, TRL-878, TRL-877, TRL-872 | live | Existing Linear issues compose the planned stack. |
+| Branch | `trl-772-make-version-markers-account-for-or-reject-zod-validation` | submitted | PR #652; marker-schema runtime guard slice. |
+| Branch | `trl-773-align-marker-schema-unsupported-warden-coverage-with-runtime` | submitted | PR #653; Warden source-rule parity slice. |
+| Branch | `trl-770-make-trails-doctor-pending-force-output-complete-and` | submitted | PR #654; doctor pending-force output slice. |
+| Branch | `trl-769-document-pending-force-stable-cutover-gate` | submitted | PR #655; stable cutover gate docs slice. |
+| Branch | `trl-878-apply-warden-scan-target-filtering-to-regrade` | submitted | PR #656; Regrade scan-target filtering slice. |
+| Branch | `trl-877-resolve-wildcard-export-keys-in-catalog-derivation` | submitted | PR #657; adapter catalog export resolution slice. |
+| Branch | `trl-879-checkpoint-agent-trust-stable-cutover-stack-verdict` | submitted | PR #658; checkpoint evidence slice. |
+| Issues | TRL-772, TRL-773, TRL-770, TRL-769, TRL-771, TRL-878, TRL-877, TRL-872, TRL-879 | live | Existing Linear issues compose the submitted stack. |
 
 ## Planning Log
 
@@ -78,9 +85,11 @@ an execution worktree yet.
 
 ## Tracker Mutations
 
-None during planning. This is intentional: the existing issue shards are live,
-and the only missing tracker object is the capstone checkpoint verdict branch.
-Executor should create or choose that issue before implementing the capstone.
+None during planning. The existing issue shards remained live, and the
+checkpoint issue was chosen later as TRL-879 before the capstone branch was
+created. No additional tracker creation is needed for this submitted checkpoint;
+future operators should limit this packet to post-submit review, CI, and merge
+evidence unless Matt explicitly reopens tracker scope.
 
 ## Execution Log
 
@@ -286,9 +295,36 @@ Executor should create or choose that issue before implementing the capstone.
 - Ran `bun apps/trails/bin/trails.ts adapter check --root-dir . --json`; it
   passed with two owner targets (`@ontrails/http:http`,
   `@ontrails/store:store`) and one adapter subject (`@ontrails/hono`).
-- Checkpoint capstone remains blocked on a tracker decision: create/choose the
-  Linear issue for the read-only verdict branch, or confirm an explicit
-  non-issue branch with Matt.
+- Checkpoint capstone issue routing was resolved in the next step by using
+  TRL-879 for the read-only verdict branch; this line is historical context.
+
+### 2026-06-01 18:27 EDT - TRL-879 checkpoint verdict prepared
+
+- Coordinator provided checkpoint issue TRL-879 and branch
+  `trl-879-checkpoint-agent-trust-stable-cutover-stack-verdict`.
+- Created the checkpoint child from clean
+  `trl-877-resolve-wildcard-export-keys-in-catalog-derivation` tip.
+- Added
+  `.agents/plans/2026-06-01-agent-trust-stable-cutover-integrity/CHECKPOINT-TRL-879.md`
+  as the read-only checkpoint evidence surface.
+- Verdict: `caution`.
+- Submission status: `draft-submit-ready`.
+- The checkpoint slice made no source behavior edits, no generated or lockfile
+  edits, no Linear mutation, no registry or publish mutation, and no PR
+  readiness/merge/queue action.
+- Stack-tip validation before the checkpoint note:
+  - `bun scripts/adr.ts check` passed with 0 errors and 0 warnings.
+  - `bun run check` passed. `trails warden` reported PASS with 0 errors and
+    3 existing `signal-graph-coaching` warnings in the demo topo.
+  - `bun run test` passed with 40 successful Turbo tasks.
+  - `bun run build` passed with 24 successful Turbo tasks.
+  - `bun run publish:check` passed as dry pack validation only; no publish
+    command ran.
+- Post-submit status from the committed checkpoint tip: Graphite submission has
+  already happened (PRs #652-#658 exist and the checkpoint review-log update was
+  recorded after CI was green). This checkpoint is evidence-only, so only
+  post-submit monitoring remains — do not resubmit or otherwise mutate the
+  Graphite stack from it.
 
 ## Verification Log
 
@@ -304,12 +340,42 @@ Planning verification only:
 
 ## Local Review Log
 
-No local or remote code review has run. Executor must run local review from the
-stack tip before submission and record P0-P3 findings here.
+### 2026-06-01 22:54 EDT - Coordinator local review before ready
+
+Overall score: 4/5
+
+Summary:
+The stack passed local review well enough to mark ready after one P3
+documentation nit was corrected on the owning branch. No P0/P1/P2 findings
+remain.
+
+Findings:
+
+- P3 - `docs/releases/stable-cutover.md` - The inserted pending-force
+  precondition left the following "ADR and docs checks" item numbered as `1.`
+  instead of `11.`. Fixed on
+  `trl-769-document-pending-force-stable-cutover-gate` before ready.
+  Prompt To Fix With AI:
+  Update the stable cutover precondition list so numbering remains continuous
+  after the pending-force gate insertion.
+
+No-findings statement:
+Reviewed the stack-tip diff across marker semantics and ADR fit, Warden
+source-rule coverage and callback-scope false-positive risk, doctor force
+detail output and release-gate shape, Regrade/Warden scan-target parity,
+adapter wildcard export resolution, and the checkpoint first-slice boundary.
+Residual risk is limited to the intentionally bounded v1 marker-schema subset;
+unsupported Zod semantics now fail loudly rather than silently projecting
+unstable markers.
 
 ## Remote Review / CI Log
 
-Not started. No PRs exist for this packet yet.
+PRs #652-#658 have been submitted. Earlier coordinator inspection found no
+inline review threads and no actionable PR comments/reviews; only Linear
+linkbacks and Graphite stack comments were present. CI was green on all seven
+draft PRs before the P3 documentation numbering fix and checkpoint review-log
+update. New post-submit review or CI findings should be handled on the owning
+branch before any follow-up submit.
 
 ## Forbidden Actions Audit
 
@@ -325,12 +391,17 @@ Planning phase:
 
 ## Final State
 
-Not complete. This packet is ready to copy into a dedicated execution worktree
-when Matt chooses to start the goal.
+Submitted checkpoint state is recorded. TRL-879 provided the checkpoint issue
+and branch, PRs #652-#658 exist, and the checkpoint artifact records the
+pre-submit `draft-submit-ready` evidence-only verdict. No capstone tracker
+decision or initial-submit action remains in this packet. The stack is still
+open, so only post-submit monitoring and owning-branch review response work
+should mutate it until merge.
 
 ## Remaining Risks
 
-- The capstone checkpoint slice needs a tracker decision before implementation.
+- Remote review or CI can still produce follow-up work after submission; route
+  fixes to the owning branch and keep checkpoint-only evidence changes scoped.
 - `TRL-772` may force a doctrinal decision about whether to support or reject
   certain Zod validation checks in v1 marker content. The recommended default
   is reject unsupported constructs loudly unless canonical support is clearly


### PR DESCRIPTION
## Summary

- Add the read-only TRL-879 checkpoint verdict for the Agent Trust / Stable Cutover Integrity stack.
- Record the stack verdict as `draft-submit-ready`.
- Preserve the rationale for skipping conditional TRL-771 and TRL-872.

## Verification

- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`
- Graphite draft submit and pre-push hooks passed

## Notes

- Linear: TRL-879
- This checkpoint branch is evidence-only: packet note plus retro update.
