### PR TITLE
fix(warden): follow hidden optional aliases

### DIFF
--- a/.changeset/warden-hidden-optional-aliases.md
+++ b/.changeset/warden-hidden-optional-aliases.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/warden": patch
+---
+
+Follow schema aliases when detecting hidden optional wrappers in version marker
+schemas.

--- a/packages/warden/src/__tests__/trail-versioning-rules.test.ts
+++ b/packages/warden/src/__tests__/trail-versioning-rules.test.ts
@@ -460,6 +460,36 @@ trail('versioned.hidden-optional', {
     ).toBe(true);
   });
 
+  test('marker-schema-unsupported follows aliases for hidden optional wrappers', () => {
+    const diagnostics = markerSchemaUnsupported.check(
+      `
+const base = z.string().optional();
+const nested = base.nullable();
+
+trail('versioned.hidden-optional-alias', {
+  version: 2,
+  input: z.object({
+    visible: base,
+    directHidden: base.nullable(),
+    nestedHidden: nested,
+  }),
+  output: z.object({ ok: z.boolean() }),
+  blaze: async () => Result.ok({ ok: true }),
+});
+`,
+      sourceFile
+    );
+
+    expect(diagnostics).toHaveLength(2);
+    expect(
+      diagnostics.every(
+        (entry) =>
+          entry.rule === 'marker-schema-unsupported' &&
+          entry.severity === 'error'
+      )
+    ).toBe(true);
+  });
+
   test('marker-schema-unsupported rejects optional wrappers outside object properties', () => {
     const diagnostics = markerSchemaUnsupported.check(
       `

--- a/packages/warden/src/rules/trail-versioning-source.ts
+++ b/packages/warden/src/rules/trail-versioning-source.ts
@@ -520,25 +520,37 @@ const callChainHasOptionalWrapper = (
   node: AstNode | undefined,
   schemaBindings: SchemaBindings
 ): boolean => {
-  let current = node;
-  while (current !== undefined) {
-    if (current.type === 'CallExpression') {
-      const callee = callCallee(current);
+  const seen = new Set<number>();
+  const visit = (current: AstNode | undefined): boolean => {
+    const expression = unwrapExpression(current);
+    if (expression === undefined || seen.has(expression.start)) {
+      return false;
+    }
+    seen.add(expression.start);
+
+    const name = identifierName(expression);
+    if (name !== undefined) {
+      return visit(
+        schemaBindingInitializer(schemaBindings, name, expression.start)
+      );
+    }
+
+    if (expression.type === 'CallExpression') {
+      const callee = callCallee(expression);
       if (
         memberPropertyName(callee) === 'optional' &&
         isZodSchemaCallee(callee, schemaBindings)
       ) {
         return true;
       }
-      current = memberObject(callee);
-      continue;
+      return visit(memberObject(callee));
     }
-    if (!isMemberAccessNonComputed(current)) {
+    if (!isMemberAccessNonComputed(expression)) {
       return false;
     }
-    current = memberObject(current);
-  }
-  return false;
+    return visit(memberObject(expression));
+  };
+  return visit(node);
 };
 
 const isHiddenOptionalWrapperCall = (


### PR DESCRIPTION
## Context

Follow-up for the late Codex P2 on #653: Warden detected hidden optional wrappers in direct chains, but missed wrapper calls on aliases such as `base.nullable()` where `base` was `z.string().optional()`.

## Changes

- Resolve schema aliases while walking hidden optional wrapper receiver chains.
- Add regression coverage for direct alias and alias-to-alias hidden optional wrapper cases.
- Add a Warden patch changeset.

## Verification

- `bun test packages/warden/src/__tests__/trail-versioning-rules.test.ts`
- `bun run format:check`
- `bun run check`
- `gt submit --stack --no-edit --no-interactive --dry-run`
- pre-push hook during `gt submit --stack --no-edit --no-interactive`
