### PR TITLE
fix(regrade): derive cross compose migration class

### DIFF
--- a/.agents/skills/clark/references/warden-guide.md
+++ b/.agents/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 60
+- Rule count: 61
 
 ## Agent Instructions
 
@@ -26,6 +26,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `missing-visibility` (warn, project/project-static, external): Composition-only trails declare internal visibility.
 - `no-destructured-compose` (warn, source/source-static, external): Trail blazes compose through ctx.compose() directly instead of destructuring compose from the context.
 - `no-direct-implementation-call` (warn, source/source-static, external): Application code composes trails through ctx.compose().
+- `no-retired-cross-vocabulary` (error, source/source-static, external): Retired cross composition vocabulary does not remain in downstream source after the beta.19 compose cutover.
 - `resolved-import-boundary` (error, project/project-static, external): Cross-package imports resolve through public export maps.
 - `version-pinned-compose` (warn, source/source-static, external): Version-pinned ctx.compose() calls stay visible migration debt.
 - `webhook-route-collision` (error, topo/topo-aware, external): Webhook routes do not collide with each other or direct HTTP trail routes.

--- a/.changeset/warden-cross-compose-rewrite.md
+++ b/.changeset/warden-cross-compose-rewrite.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Add a Warden rule and safe-fix metadata for rewriting retired cross vocabulary to compose vocabulary.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 60
+- Rule count: 61
 
 ## Agent Instructions
 
@@ -26,6 +26,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `missing-visibility` (warn, project/project-static, external): Composition-only trails declare internal visibility.
 - `no-destructured-compose` (warn, source/source-static, external): Trail blazes compose through ctx.compose() directly instead of destructuring compose from the context.
 - `no-direct-implementation-call` (warn, source/source-static, external): Application code composes trails through ctx.compose().
+- `no-retired-cross-vocabulary` (error, source/source-static, external): Retired cross composition vocabulary does not remain in downstream source after the beta.19 compose cutover.
 - `resolved-import-boundary` (error, project/project-static, external): Cross-package imports resolve through public export maps.
 - `version-pinned-compose` (warn, source/source-static, external): Version-pinned ctx.compose() calls stay visible migration debt.
 - `webhook-route-collision` (error, topo/topo-aware, external): Webhook routes do not collide with each other or direct HTTP trail routes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Use the project language consistently:
 This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
-- Rule count: 60
+- Rule count: 61
 
 ### Rule Index
 
@@ -99,6 +99,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `missing-visibility` (warn, project/project-static, external): Composition-only trails declare internal visibility.
 - `no-destructured-compose` (warn, source/source-static, external): Trail blazes compose through ctx.compose() directly instead of destructuring compose from the context.
 - `no-direct-implementation-call` (warn, source/source-static, external): Application code composes trails through ctx.compose().
+- `no-retired-cross-vocabulary` (error, source/source-static, external): Retired cross composition vocabulary does not remain in downstream source after the beta.19 compose cutover.
 - `resolved-import-boundary` (error, project/project-static, external): Cross-package imports resolve through public export maps.
 - `version-pinned-compose` (warn, source/source-static, external): Version-pinned ctx.compose() calls stay visible migration debt.
 - `webhook-route-collision` (error, topo/topo-aware, external): Webhook routes do not collide with each other or direct HTTP trail routes.

--- a/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/src/signals/track.ts.txt
+++ b/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/src/signals/track.ts.txt
@@ -1,8 +1,13 @@
-// Radio-shaped fixture: a notification-source module. The whole-word binding
-// below is the rewrite target; `defineSignal` is a partial match and must stay
-// untouched.
-import { defineSignal } from '@radio/runtime';
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
 
-export const signal = defineSignal('track.changed', {
-  trackId: 'string',
+const loadTrack = trail('track.load', {
+  blaze: () => Result.ok({ title: 'Lost Coast' }),
+  output: z.object({ title: z.string() }),
+});
+
+export const playTrack = trail('play.track', {
+  crosses: [loadTrack],
+  input: crossInput,
+  blaze: (input, ctx) => ctx.cross(loadTrack, input),
 });

--- a/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/src/trails/play.ts.txt
+++ b/packages/regrade/src/downstream/__tests__/fixtures/radio-shaped/src/trails/play.ts.txt
@@ -1,5 +1,7 @@
-// Radio-shaped fixture: a trail module where the term appears only inside the
-// larger identifier `signalHandler`. The term-rewrite class must route this to
-// review rather than rewrite a partial match.
-export const signalHandler = (trackId: string): string =>
-  `playing ${trackId}`;
+type CrossTrailInput = {
+  readonly trackId: string;
+};
+
+export const crossOrigin = 'studio';
+export const crossfade = (input: CrossTrailInput): string =>
+  `${crossOrigin}:${input.trackId}`;

--- a/packages/regrade/src/downstream/__tests__/radio-fixture.test.ts
+++ b/packages/regrade/src/downstream/__tests__/radio-fixture.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { collectDownstreamSources } from '../collect.js';
-import { createTermRewriteClass, runRegrade } from '../report.js';
+import { runRegrade, wardenTermRewriteClasses } from '../report.js';
 
 /**
  * Radio-shaped downstream regrade regression fixture (TRL-846).
@@ -59,6 +59,8 @@ const materializeFixture = (): string => {
 };
 
 describe('Radio-shaped downstream fixture (TRL-846)', () => {
+  const crossToComposeClassId = 'term-rewrite:no-retired-cross-vocabulary';
+
   test('collects only in-scope source files and records skips', () => {
     const root = materializeFixture();
     try {
@@ -90,14 +92,15 @@ describe('Radio-shaped downstream fixture (TRL-846)', () => {
     const root = materializeFixture();
     try {
       const report = runRegrade({
-        classes: [createTermRewriteClass({ from: 'signal', to: 'ping' })],
+        classes: wardenTermRewriteClasses,
         root,
+        selection: { classIds: [crossToComposeClassId] },
       });
       expect(report).not.toBeNull();
       const r = report as NonNullable<typeof report>;
 
-      // track.ts -> rewrite (whole-word signal), play.ts -> review
-      // (signalHandler partial), now-playing.tsx -> no-op.
+      expect(r.selectedClassIds).toEqual([crossToComposeClassId]);
+      expect(r.unknownClassIds).toEqual([]);
       expect(r.scanned).toBe(3);
       expect(r.rewritten).toBe(1);
       expect(r.review).toBe(1);
@@ -106,6 +109,9 @@ describe('Radio-shaped downstream fixture (TRL-846)', () => {
       const byPath = new Map(r.entries.map((entry) => [entry.path, entry]));
       expect(byPath.get('src/signals/track.ts')?.outcome).toBe('rewrite');
       expect(byPath.get('src/trails/play.ts')?.outcome).toBe('needs-review');
+      expect(byPath.get('src/trails/play.ts')?.reason).toBe(
+        'warden-review-required'
+      );
       expect(byPath.get('src/components/now-playing.tsx')?.outcome).toBe(
         'no-op'
       );

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -57,6 +57,29 @@ describe('wardenTermRewriteClasses', () => {
     expect(wardenTermRewriteClasses.map((cls) => cls.id)).toContain(
       'term-rewrite:no-legacy-layer-imports'
     );
+    expect(wardenTermRewriteClasses.map((cls) => cls.id)).toContain(
+      'term-rewrite:no-retired-cross-vocabulary'
+    );
+  });
+
+  test('rewrites safe Warden term-rewrite diagnostics', () => {
+    const crossClass = wardenTermRewriteClasses.find(
+      (cls) => cls.id === 'term-rewrite:no-retired-cross-vocabulary'
+    );
+    expect(crossClass).toBeDefined();
+
+    const result = crossClass?.apply(
+      'export const play = trail("play", { crosses: [] });\n',
+      { absolutePath: '/repo/src/play.ts', path: 'src/play.ts' }
+    );
+
+    expect(result?.kind).toBe('rewrite');
+    expect(result?.nextSource).toBe(
+      'export const play = trail("play", { composes: [] });\n'
+    );
+    expect(result?.notes.join('\n')).toContain(
+      'Retired composition vocabulary'
+    );
   });
 
   test('routes review-required Warden term rewrites to review', () => {
@@ -88,6 +111,7 @@ describe('wardenTermRewriteClasses', () => {
 
     expect(report.selectedClassIds).toEqual([
       'term-rewrite:no-legacy-layer-imports',
+      'term-rewrite:no-retired-cross-vocabulary',
     ]);
     expect(report.matched).toBe(0);
     expect(report.entries[0]?.outcome).toBe('no-op');
@@ -361,6 +385,7 @@ describe('runRegrade + regradeReportTrail', () => {
         expect(value.rewritten).toBe(0);
         expect(value.selectedClassIds).toEqual([
           'term-rewrite:no-legacy-layer-imports',
+          'term-rewrite:no-retired-cross-vocabulary',
         ]);
       }
     } finally {

--- a/packages/warden/src/__tests__/no-retired-cross-vocabulary.test.ts
+++ b/packages/warden/src/__tests__/no-retired-cross-vocabulary.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test';
+
+import { noRetiredCrossVocabulary } from '../rules/no-retired-cross-vocabulary.js';
+
+const RULE_NAME = 'no-retired-cross-vocabulary';
+
+const check = (sourceCode: string) =>
+  noRetiredCrossVocabulary.check(
+    sourceCode,
+    '/repo/apps/radio/src/trails/play.ts'
+  );
+
+describe('no-retired-cross-vocabulary', () => {
+  test('carries safe term-rewrite metadata for exact beta.19 replacements', () => {
+    const source = [
+      'export const play = trail("play", {',
+      '  crosses: [loadTrack],',
+      '  input: crossInput,',
+      '  blaze: (input, ctx) => ctx.cross(loadTrack, input),',
+      '});',
+    ].join('\n');
+
+    const diagnostics = check(source);
+
+    expect(diagnostics).toHaveLength(3);
+    expect(diagnostics.map((diagnostic) => diagnostic.line)).toEqual([2, 3, 4]);
+    expect(diagnostics.map((diagnostic) => diagnostic.rule)).toEqual([
+      RULE_NAME,
+      RULE_NAME,
+      RULE_NAME,
+    ]);
+    expect(diagnostics.map((diagnostic) => diagnostic.fix?.safety)).toEqual([
+      'safe',
+      'safe',
+      'safe',
+    ]);
+    expect(diagnostics.map((diagnostic) => diagnostic.fix?.edits?.[0])).toEqual(
+      [
+        {
+          end: source.indexOf('crosses') + 'crosses'.length,
+          replacement: 'composes',
+          start: source.indexOf('crosses'),
+        },
+        {
+          end: source.indexOf('crossInput') + 'crossInput'.length,
+          replacement: 'composeInput',
+          start: source.indexOf('crossInput'),
+        },
+        {
+          end: source.indexOf('ctx.cross') + 'ctx.cross'.length,
+          replacement: 'ctx.compose',
+          start: source.indexOf('ctx.cross'),
+        },
+      ]
+    );
+  });
+
+  test('routes Cross type prefixes and partial identifiers to review', () => {
+    const diagnostics = check(
+      [
+        'type CrossTrailInput = { id: string };',
+        'const crossOrigin = "*";',
+        'const crossfade = true;',
+      ].join('\n')
+    );
+
+    expect(diagnostics).toHaveLength(3);
+    expect(diagnostics.map((diagnostic) => diagnostic.line)).toEqual([1, 2, 3]);
+    expect(diagnostics.map((diagnostic) => diagnostic.fix?.safety)).toEqual([
+      'review',
+      'review',
+      'review',
+    ]);
+    expect(
+      diagnostics.every((diagnostic) => diagnostic.fix?.edits === undefined)
+    ).toBe(true);
+  });
+
+  test('does not flag unrelated prose or non-identifier substrings', () => {
+    const diagnostics = check(
+      [
+        'const message = "searches across packages";',
+        'const note = "cross-package imports";',
+        'const url = "cross-to-compose";',
+        'const crossesPackageBoundary = true;',
+      ].join('\n')
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not produce safe edits when a file also needs review', () => {
+    const diagnostics = check(
+      ['const crossOrigin = "*";', 'ctx.cross(loadTrack, input);'].join('\n')
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.line).toBe(1);
+    expect(diagnostics[0]?.fix?.safety).toBe('review');
+    expect(diagnostics[0]?.fix?.edits).toBeUndefined();
+  });
+
+  test('clean compose vocabulary produces no diagnostics', () => {
+    const diagnostics = check(
+      [
+        'export const play = trail("play", {',
+        '  composes: [loadTrack],',
+        '  input: composeInput,',
+        '  blaze: (input, ctx) => ctx.compose(loadTrack, input),',
+        '});',
+      ].join('\n')
+    );
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  test('does not fire on migration documentation and rule-owned files', () => {
+    for (const filePath of [
+      '/repo/docs/migration/cross-to-compose.md',
+      '/repo/docs/releases/beta15-to-beta19.md',
+      '/repo/docs/adr/0049-composition-is-compose-not-cross.md',
+      '/repo/packages/warden/src/rules/no-retired-cross-vocabulary.ts',
+      '/repo/packages/warden/src/rules/metadata.ts',
+      '/repo/packages/warden/src/trails/no-retired-cross-vocabulary.trail.ts',
+    ]) {
+      const diagnostics = noRetiredCrossVocabulary.check(
+        'cross crosses ctx.cross crossInput CrossTrail crossOrigin crossfade',
+        filePath
+      );
+      expect(diagnostics).toHaveLength(0);
+    }
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -9,8 +9,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 60 rule trails', () => {
-    expect(wardenTopo.count).toBe(60);
+  test('contains all 61 rule trails', () => {
+    expect(wardenTopo.count).toBe(61);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {
@@ -53,12 +53,13 @@ describe('wardenTopo', () => {
         filePath: 'src/trail.ts',
         fix: {
           class: 'term-rewrite',
+          edits: [{ end: 7, replacement: 'composes', start: 0 }],
           reason: 'Retired term needs a reviewed migration.',
-          safety: 'review',
+          safety: 'safe',
         },
         line: 1,
         message: 'Retired term used.',
-        rule: 'no-legacy-layer-imports',
+        rule: 'no-retired-cross-vocabulary',
         severity: 'error',
       }).success
     ).toBe(true);
@@ -83,18 +84,20 @@ describe('wardenTopo', () => {
   test('rule trail execution preserves diagnostic fix metadata', async () => {
     const diagnostics = await runWardenTrails(
       '/repo/apps/example/src/cli.ts',
-      "import { authLayer } from '@ontrails/permits';\n"
+      'export const play = trail("play", { crosses: [] });\n'
     );
 
     const diagnostic = diagnostics.find(
-      (entry) => entry.rule === 'no-legacy-layer-imports'
+      (entry) => entry.rule === 'no-retired-cross-vocabulary'
     );
 
     expect(diagnostic?.fix).toMatchObject({
       class: 'term-rewrite',
-      safety: 'review',
+      safety: 'safe',
     });
-    expect(diagnostic?.fix?.reason).toContain('authLayer');
-    expect(diagnostic?.fix?.edits).toBeUndefined();
+    expect(diagnostic?.fix?.reason).toContain('crosses');
+    expect(diagnostic?.fix?.edits).toEqual([
+      { end: 43, replacement: 'composes', start: 36 },
+    ]);
   });
 });

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -188,6 +188,7 @@ export {
   noLegacyLayerImportsTrail,
   noNativeErrorResultTrail,
   noRedundantResultErrorWrapTrail,
+  noRetiredCrossVocabularyTrail,
   noSyncResultAssumptionTrail,
   noThrowInDetourRecoverTrail,
   noThrowInImplementationTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -22,6 +22,7 @@ import { noLegacyLayerImports } from './no-legacy-layer-imports.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noNativeErrorResult } from './no-native-error-result.js';
 import { noRedundantResultErrorWrap } from './no-redundant-result-error-wrap.js';
+import { noRetiredCrossVocabulary } from './no-retired-cross-vocabulary.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
 import { noThrowInDetourRecover } from './no-throw-in-detour-recover.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
@@ -124,6 +125,7 @@ export { noLegacyLayerImports } from './no-legacy-layer-imports.js';
 export { noDirectImplementationCall } from './no-direct-implementation-call.js';
 export { noNativeErrorResult } from './no-native-error-result.js';
 export { noRedundantResultErrorWrap } from './no-redundant-result-error-wrap.js';
+export { noRetiredCrossVocabulary } from './no-retired-cross-vocabulary.js';
 export { noSyncResultAssumption } from './no-sync-result-assumption.js';
 export { implementationReturnsResult } from './implementation-returns-result.js';
 export { noThrowInDetourRecover } from './no-throw-in-detour-recover.js';
@@ -203,6 +205,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [noLegacyLayerImports.name, noLegacyLayerImports],
   [noNativeErrorResult.name, noNativeErrorResult],
   [noRedundantResultErrorWrap.name, noRedundantResultErrorWrap],
+  [noRetiredCrossVocabulary.name, noRetiredCrossVocabulary],
   [noSyncResultAssumption.name, noSyncResultAssumption],
   [implementationReturnsResult.name, implementationReturnsResult],
   [noThrowInDetourRecover.name, noThrowInDetourRecover],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -87,6 +87,7 @@ const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
   'no-direct-implementation-call': 'composition',
   'no-native-error-result': 'results',
   'no-redundant-result-error-wrap': 'results',
+  'no-retired-cross-vocabulary': 'composition',
   'no-sync-result-assumption': 'results',
   'no-throw-in-detour-recover': 'results',
   'no-throw-in-implementation': 'results',
@@ -293,6 +294,18 @@ const builtinWardenRuleMetadataInput = {
     ...durableExternal,
     invariant:
       'Result error pass-throughs preserve the original Result boundary.',
+    tier: 'source-static',
+  },
+  'no-retired-cross-vocabulary': {
+    fix: { class: 'term-rewrite', safety: 'safe' },
+    invariant:
+      'Retired cross composition vocabulary does not remain in downstream source after the beta.19 compose cutover.',
+    lifecycle: {
+      retireWhen:
+        'Downstream beta.19 cross-to-compose migration window closes and supported apps have adopted compose vocabulary.',
+      state: 'temporary',
+    },
+    scope: 'external',
     tier: 'source-static',
   },
   'no-sync-result-assumption': {

--- a/packages/warden/src/rules/no-retired-cross-vocabulary.ts
+++ b/packages/warden/src/rules/no-retired-cross-vocabulary.ts
@@ -1,0 +1,194 @@
+/**
+ * Flags retired `cross` composition vocabulary after the beta.19 compose cutover.
+ *
+ * Exact authored terms that have a mechanical successor carry safe
+ * `term-rewrite` edits. Larger identifiers and type prefixes remain
+ * review-required because the text-only rule cannot prove the intended symbol
+ * boundary.
+ */
+import { resolve, sep } from 'node:path';
+
+import type { WardenDiagnostic, WardenFix, WardenRule } from './types.js';
+
+const RULE_NAME = 'no-retired-cross-vocabulary';
+
+const SAFE_REWRITES = [
+  { from: 'ctx.cross', to: 'ctx.compose' },
+  { from: 'crossInput', to: 'composeInput' },
+  { from: 'crosses', to: 'composes' },
+] as const;
+
+const REVIEW_TERMS = ['Cross', 'cross'] as const;
+
+const IDENTIFIER_CHAR = /[$0-9A-Z_a-z]/u;
+
+const ALLOWED_PATH_SUFFIXES: readonly string[] = [
+  '/docs/migration/cross-to-compose.md',
+  '/docs/releases/beta15-to-beta19.md',
+  '/docs/adr/0049-composition-is-compose-not-cross.md',
+  '/packages/warden/src/rules/no-retired-cross-vocabulary.ts',
+  '/packages/warden/src/rules/metadata.ts',
+  '/packages/warden/src/trails/no-retired-cross-vocabulary.trail.ts',
+  '/scripts/vocab-cutover-rewrite.ts',
+];
+
+interface SafeRewriteMatch {
+  readonly from: string;
+  readonly index: number;
+  readonly to: string;
+}
+
+interface ReviewMatch {
+  readonly index: number;
+  readonly term: (typeof REVIEW_TERMS)[number];
+}
+
+const normalizePath = (filePath: string): string =>
+  resolve(filePath).split(sep).join('/');
+
+const isAllowedFile = (filePath: string): boolean => {
+  const normalized = normalizePath(filePath);
+  return ALLOWED_PATH_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+};
+
+const isIdentifierChar = (value: string): boolean =>
+  value !== '' && IDENTIFIER_CHAR.test(value);
+
+const isReviewPrefix = (
+  sourceCode: string,
+  index: number,
+  term: string
+): boolean => !(term === 'cross' && sourceCode.startsWith('crosses', index));
+
+const isStandaloneSpan = (
+  sourceCode: string,
+  start: number,
+  end: number
+): boolean => {
+  const before = start === 0 ? '' : (sourceCode[start - 1] ?? '');
+  const after = sourceCode[end] ?? '';
+  return !(isIdentifierChar(before) || isIdentifierChar(after));
+};
+
+const findSafeRewriteMatches = (
+  sourceCode: string
+): readonly SafeRewriteMatch[] => {
+  const matches: SafeRewriteMatch[] = [];
+  for (const rewrite of SAFE_REWRITES) {
+    let fromIndex = 0;
+    while (fromIndex < sourceCode.length) {
+      const index = sourceCode.indexOf(rewrite.from, fromIndex);
+      if (index === -1) {
+        break;
+      }
+      const end = index + rewrite.from.length;
+      if (isStandaloneSpan(sourceCode, index, end)) {
+        matches.push({ ...rewrite, index });
+      }
+      fromIndex = end;
+    }
+  }
+  return matches.toSorted((a, b) => a.index - b.index);
+};
+
+const findReviewMatches = (sourceCode: string): readonly ReviewMatch[] => {
+  const safeSpans = findSafeRewriteMatches(sourceCode).map((match) => ({
+    end: match.index + match.from.length,
+    start: match.index,
+  }));
+  const isInsideSafeSpan = (index: number): boolean =>
+    safeSpans.some((span) => index >= span.start && index < span.end);
+
+  const matches: ReviewMatch[] = [];
+  for (const term of REVIEW_TERMS) {
+    let fromIndex = 0;
+    while (fromIndex < sourceCode.length) {
+      const index = sourceCode.indexOf(term, fromIndex);
+      if (index === -1) {
+        break;
+      }
+      const end = index + term.length;
+      if (!isInsideSafeSpan(index)) {
+        const before = index === 0 ? '' : (sourceCode[index - 1] ?? '');
+        const after = sourceCode[end] ?? '';
+        if (
+          !isIdentifierChar(before) &&
+          isIdentifierChar(after) &&
+          isReviewPrefix(sourceCode, index, term)
+        ) {
+          matches.push({ index, term });
+        }
+      }
+      fromIndex = end;
+    }
+  }
+  return matches.toSorted((a, b) => a.index - b.index);
+};
+
+const lineForOffset = (sourceCode: string, offset: number): number => {
+  let line = 1;
+  for (let i = 0; i < offset; i += 1) {
+    if (sourceCode.codePointAt(i) === 10) {
+      line += 1;
+    }
+  }
+  return line;
+};
+
+const safeFix = (match: SafeRewriteMatch): WardenFix => ({
+  class: 'term-rewrite',
+  edits: [
+    {
+      end: match.index + match.from.length,
+      replacement: match.to,
+      start: match.index,
+    },
+  ],
+  reason: `Retired composition vocabulary '${match.from}' has a mechanical beta.19 replacement '${match.to}'.`,
+  safety: 'safe',
+});
+
+const reviewFix = (term: string): WardenFix => ({
+  class: 'term-rewrite',
+  reason: `Retired composition vocabulary '${term}' appears in a larger or ambiguous form. Review before migrating to compose vocabulary.`,
+  safety: 'review',
+});
+
+const safeMessage = (match: SafeRewriteMatch): string =>
+  `Retired composition vocabulary '${match.from}' should be '${match.to}' after the beta.19 compose cutover.`;
+
+const reviewMessage = (term: string): string =>
+  `Retired composition vocabulary '${term}' needs review before migrating to compose vocabulary.`;
+
+export const noRetiredCrossVocabulary: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isAllowedFile(filePath)) {
+      return [];
+    }
+
+    const reviewMatches = findReviewMatches(sourceCode);
+    if (reviewMatches.length > 0) {
+      return reviewMatches.map((match) => ({
+        filePath,
+        fix: reviewFix(match.term),
+        line: lineForOffset(sourceCode, match.index),
+        message: reviewMessage(match.term),
+        rule: RULE_NAME,
+        severity: 'error',
+      }));
+    }
+
+    return findSafeRewriteMatches(sourceCode).map((match) => ({
+      filePath,
+      fix: safeFix(match),
+      line: lineForOffset(sourceCode, match.index),
+      message: safeMessage(match),
+      rule: RULE_NAME,
+      severity: 'error',
+    }));
+  },
+  description:
+    'Disallow retired cross composition vocabulary after the beta.19 compose cutover.',
+  name: RULE_NAME,
+  severity: 'error',
+};

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -30,6 +30,7 @@ import { noLegacyLayerImports } from './no-legacy-layer-imports.js';
 import { noDirectImplementationCall } from './no-direct-implementation-call.js';
 import { noNativeErrorResult } from './no-native-error-result.js';
 import { noRedundantResultErrorWrap } from './no-redundant-result-error-wrap.js';
+import { noRetiredCrossVocabulary } from './no-retired-cross-vocabulary.js';
 import { noSyncResultAssumption } from './no-sync-result-assumption.js';
 import { noThrowInDetourRecover } from './no-throw-in-detour-recover.js';
 import { noThrowInImplementation } from './no-throw-in-implementation.js';
@@ -104,6 +105,7 @@ export const registeredRuleNames: readonly string[] = [
   noDirectImplementationCall.name,
   noNativeErrorResult.name,
   noRedundantResultErrorWrap.name,
+  noRetiredCrossVocabulary.name,
   noSyncResultAssumption.name,
   noThrowInDetourRecover.name,
   noThrowInImplementation.name,

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -26,6 +26,7 @@ export { noLegacyLayerImportsTrail } from './no-legacy-layer-imports.trail.js';
 export { noDirectImplementationCallTrail } from './no-direct-implementation-call.trail.js';
 export { noNativeErrorResultTrail } from './no-native-error-result.trail.js';
 export { noRedundantResultErrorWrapTrail } from './no-redundant-result-error-wrap.trail.js';
+export { noRetiredCrossVocabularyTrail } from './no-retired-cross-vocabulary.trail.js';
 export { noSyncResultAssumptionTrail } from './no-sync-result-assumption.trail.js';
 export { noThrowInDetourRecoverTrail } from './no-throw-in-detour-recover.trail.js';
 export { noThrowInImplementationTrail } from './no-throw-in-implementation.trail.js';

--- a/packages/warden/src/trails/no-retired-cross-vocabulary.trail.ts
+++ b/packages/warden/src/trails/no-retired-cross-vocabulary.trail.ts
@@ -1,0 +1,42 @@
+import { noRetiredCrossVocabulary } from '../rules/no-retired-cross-vocabulary.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const noRetiredCrossVocabularyTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'apps/example/src/trails/play.ts',
+        sourceCode: 'export const play = trail("play", { composes: [] });\n',
+      },
+      name: 'Source files using compose vocabulary are clean',
+    },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: 'apps/example/src/trails/play.ts',
+            fix: {
+              class: 'term-rewrite',
+              edits: [{ end: 43, replacement: 'composes', start: 36 }],
+              reason:
+                "Retired composition vocabulary 'crosses' has a mechanical beta.19 replacement 'composes'.",
+              safety: 'safe',
+            },
+            line: 1,
+            message:
+              "Retired composition vocabulary 'crosses' should be 'composes' after the beta.19 compose cutover.",
+            rule: 'no-retired-cross-vocabulary',
+            severity: 'error',
+          },
+        ],
+      },
+      input: {
+        filePath: 'apps/example/src/trails/play.ts',
+        sourceCode: 'export const play = trail("play", { crosses: [] });\n',
+      },
+      name: 'Retired crosses declarations produce safe migration diagnostics',
+    },
+  ],
+  rule: noRetiredCrossVocabulary,
+});

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 60
+- Rule count: 61
 
 ## Agent Instructions
 
@@ -26,6 +26,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `missing-visibility` (warn, project/project-static, external): Composition-only trails declare internal visibility.
 - `no-destructured-compose` (warn, source/source-static, external): Trail blazes compose through ctx.compose() directly instead of destructuring compose from the context.
 - `no-direct-implementation-call` (warn, source/source-static, external): Application code composes trails through ctx.compose().
+- `no-retired-cross-vocabulary` (error, source/source-static, external): Retired cross composition vocabulary does not remain in downstream source after the beta.19 compose cutover.
 - `resolved-import-boundary` (error, project/project-static, external): Cross-package imports resolve through public export maps.
 - `version-pinned-compose` (warn, source/source-static, external): Version-pinned ctx.compose() calls stay visible migration debt.
 - `webhook-route-collision` (error, topo/topo-aware, external): Webhook routes do not collide with each other or direct HTTP trail routes.


### PR DESCRIPTION
## Context

Part of TRL-880. This lower branch gives Warden and Regrade a concrete, bounded migration class for retiring the old cross vocabulary in favor of compose vocabulary.

## What Changed

- Added a temporary Warden `no-retired-cross-vocabulary` rule.
- Added safe `term-rewrite` fix metadata for exact rewrites such as `crosses` to `composes`, `ctx.cross` to `ctx.compose`, and `crossInput` to `composeInput`.
- Routed partial or ambiguous matches to review instead of applying unsafe edits.
- Updated the Warden guide references so agents see the new rule.
- Updated the radio-shaped Regrade fixture and tests to prove the downstream migration class.
- Added a patch changeset for `@ontrails/warden`.

## Verification

- `bun run check` passed.
- `bun run test` passed: 40 Turbo tasks successful.
- `bun run build` passed: 24 Turbo tasks successful.
- `bun run publish:check` passed.
- `git diff --check` passed.
- `gt submit --stack --restack --no-edit --no-interactive --dry-run` passed after reparenting the real stack directly onto `main`.
- Pre-push hook passed during submit: dead-code, format, lint, ast-grep, test, typecheck, and Warden.

## Risk

The new rule is intentionally narrow and temporary. Safe fixes are limited to exact known vocabulary rewrites; uncertain cases are surfaced for review rather than rewritten.
