### PR TITLE
feat(regrade): add apply mode for downstream migrations

### DIFF
--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, test } from 'bun:test';
 import { executeTrail } from '@ontrails/core';
 import type { WardenRule } from '@ontrails/warden';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -14,6 +20,7 @@ import {
   selectRegradeClasses,
   wardenTermRewriteClasses,
 } from '../report.js';
+import type { RegradeClass } from '../report.js';
 
 const signalToPing = createTermRewriteClass({ from: 'signal', to: 'ping' });
 
@@ -320,6 +327,29 @@ describe('buildRegradeReport', () => {
     expect(skipEntry?.outcome).toBe('skip');
     expect(skipEntry?.reason).toBe('warden-scan-target-filtered');
   });
+
+  test('routes rewrite outcomes without concrete nextSource to review', () => {
+    const brokenRewrite = {
+      apply: () => ({
+        kind: 'rewrite',
+        notes: ['missing source'],
+      }),
+      describe: 'Broken rewrite for test coverage.',
+      id: 'broken-rewrite',
+    } satisfies RegradeClass;
+
+    const report = buildRegradeReport({
+      classes: [brokenRewrite],
+      files: [{ path: 'src/a.ts', source: 'const x = 1;' }],
+      root: '/repo',
+      skipped: [],
+    });
+
+    expect(report.rewritten).toBe(0);
+    expect(report.review).toBe(1);
+    expect(report.entries[0]?.outcome).toBe('needs-review');
+    expect(report.entries[0]?.reason).toBe('regrade-rewrite-missing-source');
+  });
 });
 
 const writeReportFixture = (): string => {
@@ -335,6 +365,17 @@ const writeReportFixture = (): string => {
   );
   writeFileSync(join(root, 'src', 'b.ts'), 'export const signalHandler = 2;\n');
   writeFileSync(join(root, 'dist', 'out.ts'), 'export const signal = 9;\n');
+  return root;
+};
+
+const writeApplyFixture = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'regrade-apply-'));
+  mkdirSync(join(root, 'src'), { recursive: true });
+  mkdirSync(join(root, 'dist'), { recursive: true });
+  writeFileSync(join(root, 'src', 'a.ts'), 'export const signal = 1;\n');
+  writeFileSync(join(root, 'src', 'b.ts'), 'export const signalHandler = 2;\n');
+  writeFileSync(join(root, 'src', 'c.ts'), 'export const x = 3;\n');
+  writeFileSync(join(root, 'dist', 'out.ts'), 'export const signal = 4;\n');
   return root;
 };
 
@@ -364,6 +405,83 @@ describe('runRegrade + regradeReportTrail', () => {
         root: join(import.meta.dir, 'does-not-exist-xyz'),
       })
     ).toBeNull();
+  });
+
+  test('dry-run is the default and does not write rewrite outcomes', () => {
+    const root = writeApplyFixture();
+    try {
+      const target = join(root, 'src', 'a.ts');
+      const report = runRegrade({ classes: [signalToPing], root });
+
+      expect(report?.rewritten).toBe(1);
+      expect(report?.apply).toBeUndefined();
+      expect(readFileSync(target, 'utf8')).toBe('export const signal = 1;\n');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('apply mode writes only safe rewrite outcomes with nextSource', () => {
+    const root = writeApplyFixture();
+    try {
+      const report = runRegrade({
+        apply: true,
+        classes: [signalToPing],
+        root,
+      });
+
+      expect(report?.apply).toEqual({
+        applied: 1,
+        filesChanged: 1,
+        review: 1,
+        skipped: 1,
+        unknown: 0,
+      });
+      expect(readFileSync(join(root, 'src', 'a.ts'), 'utf8')).toBe(
+        'export const ping = 1;\n'
+      );
+      expect(readFileSync(join(root, 'src', 'b.ts'), 'utf8')).toBe(
+        'export const signalHandler = 2;\n'
+      );
+      expect(readFileSync(join(root, 'src', 'c.ts'), 'utf8')).toBe(
+        'export const x = 3;\n'
+      );
+      expect(readFileSync(join(root, 'dist', 'out.ts'), 'utf8')).toBe(
+        'export const signal = 4;\n'
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('apply mode writes nothing when selected classes include an unknown id', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-apply-unknown-'));
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writeFileSync(join(root, 'src', 'a.ts'), 'export const signal = 1;\n');
+    try {
+      const report = runRegrade({
+        apply: true,
+        classes: [signalToPing],
+        root,
+        selection: {
+          classIds: ['term-rewrite:signal->ping', 'missing-class'],
+        },
+      });
+
+      expect(report?.unknownClassIds).toEqual(['missing-class']);
+      expect(report?.apply).toEqual({
+        applied: 0,
+        filesChanged: 0,
+        review: 0,
+        skipped: 1,
+        unknown: 1,
+      });
+      expect(readFileSync(join(root, 'src', 'a.ts'), 'utf8')).toBe(
+        'export const signal = 1;\n'
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
   });
 
   test('trail returns Ok with a report for a readable root', async () => {
@@ -400,6 +518,33 @@ describe('runRegrade + regradeReportTrail', () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.constructor.name).toBe('NotFoundError');
+    }
+  });
+
+  test('trail apply input writes through explicit apply mode', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-trail-apply-'));
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writeFileSync(
+      join(root, 'src', 'play.ts'),
+      'export const play = trail("play", { crosses: [] });\n'
+    );
+    try {
+      const result = await executeTrail(regradeReportTrail, {
+        apply: true,
+        classIds: ['term-rewrite:no-retired-cross-vocabulary'],
+        root,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(readFileSync(join(root, 'src', 'play.ts'), 'utf8')).toBe(
+        'export const play = trail("play", { composes: [] });\n'
+      );
+      if (result.isOk()) {
+        const value = result.value as { apply?: { applied: number } };
+        expect(value.apply?.applied).toBe(1);
+      }
+    } finally {
+      rmSync(root, { force: true, recursive: true });
     }
   });
 });

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -10,7 +10,7 @@ import {
   isWardenSourceScanTarget,
   wardenRules,
 } from '@ontrails/warden';
-import { readFileSync } from 'node:fs';
+import { readFileSync, writeFileSync } from 'node:fs';
 import { z } from 'zod';
 
 import { collectDownstreamSources } from './collect.js';
@@ -78,6 +78,20 @@ export interface RegradeClass {
 export interface RegradeSelection {
   /** Class ids to run. Omit to run every provided class. */
   readonly classIds?: readonly string[];
+}
+
+/** Optional write summary for an apply-mode regrade run. */
+export interface RegradeApplySummary {
+  /** Safe rewrite outcomes written to disk. */
+  readonly applied: number;
+  /** Distinct files changed on disk. */
+  readonly filesChanged: number;
+  /** Rewrite candidates intentionally not written. */
+  readonly skipped: number;
+  /** Files still requiring review. */
+  readonly review: number;
+  /** Unknown selected class ids; apply mode writes nothing when non-zero. */
+  readonly unknown: number;
 }
 
 const escapeRegExp = (value: string): string =>
@@ -328,6 +342,20 @@ export interface RegradeReport {
   readonly skipped: number;
   /** Per-entry detail, sorted by path. */
   readonly entries: readonly RegradeReportEntry[];
+  /** Apply-mode summary; absent for dry-run report-only calls. */
+  readonly apply?: RegradeApplySummary;
+}
+
+interface RegradeRewriteCandidate {
+  readonly absolutePath: string;
+  readonly classId: string;
+  readonly nextSource: string;
+  readonly path: string;
+}
+
+interface RegradeClassifiedFile {
+  readonly entry: RegradeReportEntry;
+  readonly rewrite?: RegradeRewriteCandidate;
 }
 
 const classifyFile = (
@@ -335,7 +363,7 @@ const classifyFile = (
   source: string,
   context: RegradeClassContext,
   selected: readonly RegradeClass[]
-): RegradeReportEntry => {
+): RegradeClassifiedFile => {
   // First selected class that matches (rewrite or review) wins, mirroring the
   // "run one class" emphasis. A scan-target skip is remembered so the file is
   // accounted as skipped rather than a scanned/clean no-op. No-ops fall through.
@@ -345,15 +373,46 @@ const classifyFile = (
   for (const cls of selected) {
     const result = cls.apply(source, context);
     if (result.kind === 'rewrite') {
-      return { classId: cls.id, notes: result.notes, outcome: 'rewrite', path };
+      if (typeof result.nextSource !== 'string') {
+        return {
+          entry: {
+            classId: cls.id,
+            notes: result.notes,
+            outcome: 'needs-review',
+            path,
+            reason: 'regrade-rewrite-missing-source',
+          },
+        };
+      }
+      const entry = {
+        classId: cls.id,
+        notes: result.notes,
+        outcome: 'rewrite',
+        path,
+      } satisfies RegradeReportEntry;
+      return {
+        entry,
+        ...(context.absolutePath === undefined
+          ? {}
+          : {
+              rewrite: {
+                absolutePath: context.absolutePath,
+                classId: cls.id,
+                nextSource: result.nextSource,
+                path,
+              },
+            }),
+      };
     }
     if (result.kind === 'needs-review') {
       return {
-        classId: cls.id,
-        notes: result.notes,
-        outcome: 'needs-review',
-        path,
-        reason: result.reason ?? 'needs-review',
+        entry: {
+          classId: cls.id,
+          notes: result.notes,
+          outcome: 'needs-review',
+          path,
+          reason: result.reason ?? 'needs-review',
+        },
       };
     }
     if (result.kind === 'skipped' && skipped === undefined) {
@@ -362,21 +421,28 @@ const classifyFile = (
   }
   if (skipped !== undefined) {
     return {
-      classId: skipped.classId,
-      notes: skipped.result.notes,
-      outcome: 'skip',
-      path,
-      reason: skipped.result.reason ?? 'skipped',
+      entry: {
+        classId: skipped.classId,
+        notes: skipped.result.notes,
+        outcome: 'skip',
+        path,
+        reason: skipped.result.reason ?? 'skipped',
+      },
     };
   }
-  return { outcome: 'no-op', path };
+  return { entry: { outcome: 'no-op', path } };
 };
+
+interface RegradeEvaluation {
+  readonly report: RegradeReport;
+  readonly rewrites: readonly RegradeRewriteCandidate[];
+}
 
 /**
  * Build a coverage report from already-read source files. Pure: no filesystem
  * access, so coverage semantics are testable directly.
  */
-export const buildRegradeReport = (params: {
+const buildRegradeEvaluation = (params: {
   readonly root: string;
   readonly files: readonly {
     readonly path: string;
@@ -386,13 +452,13 @@ export const buildRegradeReport = (params: {
   readonly skipped: readonly SkippedSource[];
   readonly classes: readonly RegradeClass[];
   readonly selection?: RegradeSelection;
-}): RegradeReport => {
+}): RegradeEvaluation => {
   const { selected, unknownClassIds } = selectRegradeClasses(
     params.classes,
     params.selection
   );
 
-  const fileEntries = params.files.map((file) =>
+  const classifiedFiles = params.files.map((file) =>
     classifyFile(
       file.path,
       file.source,
@@ -404,6 +470,10 @@ export const buildRegradeReport = (params: {
       },
       selected
     )
+  );
+  const fileEntries = classifiedFiles.map((file) => file.entry);
+  const rewrites = classifiedFiles.flatMap((file) =>
+    file.rewrite === undefined ? [] : [file.rewrite]
   );
   const skipEntries: RegradeReportEntry[] = params.skipped.map((entry) => ({
     outcome: 'skip',
@@ -427,31 +497,75 @@ export const buildRegradeReport = (params: {
   ).length;
 
   return {
-    entries,
-    matched: rewritten + review,
-    review,
-    rewritten,
-    root: params.root,
-    scanned: scannedEntries.length,
-    selectedClassIds: selected.map((cls) => cls.id),
-    skipped: skipEntries.length + fileSkipCount,
-    unknownClassIds,
+    report: {
+      entries,
+      matched: rewritten + review,
+      review,
+      rewritten,
+      root: params.root,
+      scanned: scannedEntries.length,
+      selectedClassIds: selected.map((cls) => cls.id),
+      skipped: skipEntries.length + fileSkipCount,
+      unknownClassIds,
+    },
+    rewrites,
   };
 };
 
-/**
- * Run a regrade over an explicit downstream root, producing a coverage report.
- *
- * Never throws: an unreadable root yields `null` (the trail maps it to a
- * `NotFoundError`); files that cannot be read are recorded as skips. This does
- * not write to disk — it reports the rewrites a run would make.
- */
-export const runRegrade = (params: {
+export const buildRegradeReport = (params: {
+  readonly root: string;
+  readonly files: readonly {
+    readonly path: string;
+    readonly source: string;
+    readonly absolutePath?: string;
+  }[];
+  readonly skipped: readonly SkippedSource[];
+  readonly classes: readonly RegradeClass[];
+  readonly selection?: RegradeSelection;
+}): RegradeReport => buildRegradeEvaluation(params).report;
+
+const applyRegradeEvaluation = (
+  evaluation: RegradeEvaluation
+): RegradeApplySummary => {
+  if (evaluation.report.unknownClassIds.length > 0) {
+    return {
+      applied: 0,
+      filesChanged: 0,
+      review: evaluation.report.review,
+      skipped: evaluation.report.skipped + evaluation.rewrites.length,
+      unknown: evaluation.report.unknownClassIds.length,
+    };
+  }
+
+  const changedFiles = new Set<string>();
+  for (const rewrite of evaluation.rewrites) {
+    writeFileSync(rewrite.absolutePath, rewrite.nextSource, 'utf8');
+    changedFiles.add(rewrite.path);
+  }
+
+  return {
+    applied: evaluation.rewrites.length,
+    filesChanged: changedFiles.size,
+    review: evaluation.report.review,
+    skipped: evaluation.report.skipped,
+    unknown: 0,
+  };
+};
+
+const withApplySummary = (
+  report: RegradeReport,
+  apply: RegradeApplySummary
+): RegradeReport => ({
+  ...report,
+  apply,
+});
+
+const runRegradeEvaluation = (params: {
   readonly root: string;
   readonly classes: readonly RegradeClass[];
   readonly selection?: RegradeSelection;
   readonly collection?: DownstreamCollectionOptions;
-}): RegradeReport | null => {
+}): RegradeEvaluation | null => {
   const collected = collectDownstreamSources(
     params.root,
     params.collection ?? {}
@@ -474,13 +588,42 @@ export const runRegrade = (params: {
     }
   }
 
-  return buildRegradeReport({
+  return buildRegradeEvaluation({
     classes: params.classes,
     files,
     root: params.root,
     skipped,
     ...(params.selection === undefined ? {} : { selection: params.selection }),
   });
+};
+
+/**
+ * Run a regrade over an explicit downstream root.
+ *
+ * Dry-run is the default and only reports candidate rewrites. Explicit apply
+ * mode writes safe rewrite outcomes with concrete `nextSource` payloads and
+ * summarizes what was written or intentionally skipped.
+ */
+export const runRegrade = (params: {
+  readonly root: string;
+  readonly classes: readonly RegradeClass[];
+  readonly selection?: RegradeSelection;
+  readonly collection?: DownstreamCollectionOptions;
+  readonly apply?: boolean;
+}): RegradeReport | null => {
+  const evaluation = runRegradeEvaluation(params);
+  if (evaluation === null) {
+    return null;
+  }
+
+  if (params.apply !== true) {
+    return evaluation.report;
+  }
+
+  return withApplySummary(
+    evaluation.report,
+    applyRegradeEvaluation(evaluation)
+  );
 };
 
 const regradeReportEntrySchema = z.object({
@@ -494,6 +637,10 @@ const regradeReportEntrySchema = z.object({
 });
 
 export const regradeReportInput = z.object({
+  apply: z
+    .boolean()
+    .default(false)
+    .describe('Write safe rewrites to disk; dry-run report only by default'),
   classIds: z
     .array(z.string())
     .optional()
@@ -503,7 +650,18 @@ export const regradeReportInput = z.object({
     .describe('Absolute path to the downstream repo root to scan'),
 });
 
+const regradeApplySummarySchema = z.object({
+  applied: z.number().describe('Safe rewrite outcomes written to disk'),
+  filesChanged: z.number().describe('Distinct files changed on disk'),
+  review: z.number().describe('Files still requiring review'),
+  skipped: z.number().describe('Rewrite candidates intentionally not written'),
+  unknown: z.number().describe('Unknown selected class ids'),
+});
+
 export const regradeReportOutput = z.object({
+  apply: regradeApplySummarySchema
+    .optional()
+    .describe('Apply-mode summary; absent for dry-run report-only calls'),
   entries: z
     .array(regradeReportEntrySchema)
     .describe('Per-entry detail, sorted by path'),
@@ -548,6 +706,7 @@ export const wardenTermRewriteClasses: readonly RegradeClass[] = Object.freeze(
 export const regradeReportTrail = trail('regrade.downstream.report', {
   blaze: (input) => {
     const report = runRegrade({
+      apply: input.apply,
       classes: wardenTermRewriteClasses,
       root: input.root,
       ...(input.classIds === undefined


### PR DESCRIPTION
## Context

Part of TRL-880 and stacked on #661. This branch adds private Regrade apply support for downstream migration classes after Warden can report safe rewrite metadata.

## What Changed

- Added private `@ontrails/regrade` apply-mode support for downstream migration reports.
- Kept dry-run as the default behavior.
- Applied only safe rewrite outcomes with concrete `nextSource` values.
- Added applied, files changed, skipped, review, and unknown counts to the report.
- Expanded report tests for dry-run, apply, review, skipped, and unknown outcomes.
- Deferred the public `trails regrade` CLI surface while `@ontrails/regrade` remains private.

## Verification

- `bun run check` passed.
- `bun run test` passed: 40 Turbo tasks successful.
- `bun run build` passed: 24 Turbo tasks successful.
- `bun run publish:check` passed.
- `git diff --check` passed.
- `gt submit --stack --restack --no-edit --no-interactive --dry-run` passed after the stack topology repair.
- Pre-push hook passed during submit: dead-code, format, lint, ast-grep, test, typecheck, and Warden.

## Risk

The write path stays inside private `@ontrails/regrade`; it is explicit apply-mode work and still defaults to dry-run. The public CLI/package boundary remains intentionally deferred.
