### PR TITLE
docs(adr): record one-schema input doctrine

### DIFF
--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -180,6 +180,11 @@
           "fromPath": "docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md"
         },
         {
+          "context": "- docs/adr/0000-core-premise.md",
+          "from": "20260603",
+          "fromPath": "docs/adr/drafts/20260603-one-schema-trail-input.md"
+        },
+        {
           "context": "- **[ADR-0000: Core Premise](./adr/0000-core-premise.md)** — Why contracts, why Result, why derive",
           "from": "index",
           "fromPath": "docs/index.md"
@@ -642,6 +647,11 @@
           "context": "- docs/adr/0006-shared-execution-pipeline.md",
           "from": "20260401",
           "fromPath": "docs/adr/drafts/20260401-compiled-pack-trailhead.md"
+        },
+        {
+          "context": "- docs/adr/0006-shared-execution-pipeline.md",
+          "from": "20260603",
+          "fromPath": "docs/adr/drafts/20260603-one-schema-trail-input.md"
         },
         {
           "context": "- **[ADR-0006: Shared Execution Pipeline](./adr/0006-shared-execution-pipeline.md)** — One `executeTrail`, Result-returning builders",
@@ -1520,6 +1530,11 @@
           "fromPath": "docs/adr/0008-deterministic-trailhead-derivation.md"
         },
         {
+          "context": "- docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md",
+          "from": "20260603",
+          "fromPath": "docs/adr/drafts/20260603-one-schema-trail-input.md"
+        },
+        {
           "context": "- **[ADR-0020: Structured CLI Input](./adr/0020-flags-for-fields-structured-input-on-the-cli.md)** — Flags for fields, JSON/file/stdin channels",
           "from": "index",
           "fromPath": "docs/index.md"
@@ -1744,6 +1759,11 @@
           "context": "- [ADR-0024: Typed Trail Composition](0024-typed-trail-composition.md) — the composition contract this renames in place (`crossInput` → `composeInput`).",
           "from": "0049",
           "fromPath": "docs/adr/0049-composition-is-compose-not-cross.md"
+        },
+        {
+          "context": "- docs/adr/0024-typed-trail-composition.md",
+          "from": "20260603",
+          "fromPath": "docs/adr/drafts/20260603-one-schema-trail-input.md"
         },
         {
           "context": "`composeInput` fields are merged with `input` for the blaze. When invoked via a surface, `composeInput` fields are absent. When invoked via `ctx.compose()`, the caller can pass both. See [ADR-0024](ad",
@@ -2671,6 +2691,11 @@
           "context": "- docs/adr/0048-trail-versioning-v3.md",
           "from": "20260524",
           "fromPath": "docs/adr/drafts/20260524-scaffold-forward-compatibility.md"
+        },
+        {
+          "context": "- docs/adr/0048-trail-versioning-v3.md",
+          "from": "20260603",
+          "fromPath": "docs/adr/drafts/20260603-one-schema-trail-input.md"
         }
       ],
       "number": "0048",

--- a/docs/adr/drafts/20260603-one-schema-trail-input.md
+++ b/docs/adr/drafts/20260603-one-schema-trail-input.md
@@ -1,0 +1,118 @@
+---
+slug: one-schema-trail-input
+title: One-Schema Trail Input
+status: draft
+created: 2026-06-03
+updated: 2026-06-03
+owners: ['[galligan](https://github.com/galligan)']
+depends_on: [0, 6, 20, 24, 48]
+description: "Records proposed doctrine for deriving caller-side and blaze-side TypeScript input projections from one authored trail input schema without adding public callInput/blazeInput fields."
+references:
+  - docs/adr/0000-core-premise.md
+  - docs/adr/0006-shared-execution-pipeline.md
+  - docs/adr/0020-flags-for-fields-structured-input-on-the-cli.md
+  - docs/adr/0024-typed-trail-composition.md
+  - docs/adr/0048-trail-versioning-v3.md
+linear:
+  - TRL-881
+  - TRL-883
+  - TRL-884
+impl_status: proposed
+---
+
+# ADR: One-Schema Trail Input
+
+## Status
+
+This doctrine is proposed, not accepted. It records the Lewis/Clark input-shape convergence from TRL-881 so implementation can stay oriented, but ratification depends on TRL-884 proving the schema-owned typing model affordable under the TRL-882 consumer type-cost guard.
+
+## Context
+
+Trails already promises one input schema per trail. That schema feeds validation, surface derivation, examples, composition, guide output, survey output, and the resolved graph. Almanac adoption exposed a TypeScript pressure point inside that promise: a schema with defaults naturally has two TypeScript views.
+
+Callers may omit defaulted fields. The blaze receives the parsed value after validation/defaulting and can rely on those fields being present. Splitting the public authoring API into `callInput` and `blazeInput` would make that difference explicit, but it would also create a second authored contract and a new place for drift.
+
+The framework should absorb that distinction internally. The author writes one schema. Trails reads it as caller-side input at public boundaries and as materialized input at the blaze boundary.
+
+## Decision
+
+### One authored input schema, two internal reads
+
+> A trail has one authored input schema. The framework reads it two ways — what a caller may send, and what the blaze receives — but only the first is ever public. We do not author the split; we derive it. Contract schemas validate and default; they never transform.
+
+Internally, the framework may use `z.input<S>` and `z.output<S>` to derive the caller-side and blaze-side TypeScript projections from the authored schema. Those are implementation projections, not public ontology. Guide, survey, and resolved graph output continue to expose one input contract.
+
+### Validation matrix
+
+| Schema feature | Proposed treatment |
+| --- | --- |
+| Optionality and defaults | Allowed. Defaults are the sanctioned source of visible caller/blaze divergence: callers may omit defaulted fields; blazes receive materialized values. |
+| Standard type-preserving refinements | Allowed and queryable where Zod and Trails projection support them. Examples include common string, number, array, and enum constraints. |
+| Type-preserving custom `.refine()` | Allowed but opaque. Prefer standard refinements when the contract should be queryable. |
+| Type-changing `.transform()` | Deferred to a future adapter/codec ADR. Contract schemas validate/default only in v1. |
+| `.pipe()` to a new type | Deferred to the same adapter/codec story as transforms. |
+| `.coerce()` | Deferred. Coercion belongs to surfaces and materialization, not trail contract schemas. |
+| Codecs | Deferred to an explicit future adapter/codec story. |
+| `.catch()` | Discouraged because it converts boundary failure into silent fallback. |
+
+Coercion is a surface/materialization concern. For example, a CLI surface may parse argv strings into booleans or numbers before validation. The trail schema then validates and defaults that materialized boundary input; it does not own transport-specific coercion.
+
+### Public contract shape
+
+Public surfaces expose caller-side input:
+
+- CLI flags and args derive from the authored input schema.
+- HTTP request bodies and query parameters derive from the authored input schema.
+- MCP `inputSchema` derives from the authored input schema.
+- `ctx.compose()` accepts caller-side input for the target trail, plus any explicitly declared composition-only fields.
+- `examples[].input` is caller-side input and must not be forced into post-default or materialized shape.
+
+Blazes receive materialized input after validation/defaults. That is a type system guarantee and an execution-pipeline guarantee, not a second public contract.
+
+Historical version transpose stays materialized-to-materialized: a historical revision validates the historical caller input, materializes it through that historical schema, transposes into the current materialized input shape, runs the current blazed trail, then transposes current materialized output into the historical output shape.
+
+### Resolved graph and guidance
+
+Guide, survey, and resolved graph output continue to expose one input contract with field metadata such as `type`, `optional`, `default`, and `describe`. They must not expose separate public `accepted` or `materialized` contracts.
+
+If tooling needs to explain defaults, it should say that fields with defaults may be omitted by callers and are present when the blaze runs. It should not ask authors or consumers to learn a second input-contract vocabulary.
+
+### Non-goals
+
+- Do not introduce public `callInput`, `blazeInput`, `accepted`, or `materialized` authoring fields.
+- Do not create the future adapter/codec API here.
+- Do not ban defaults.
+- Do not make examples post-default/materialized input.
+- Do not expose internal projection names as published graph vocabulary.
+
+### Ratification bar
+
+This draft becomes acceptable only if TRL-884 proves that schema-owned typing can make the TRL-882 guard pass under default heap and the current allowed Zod range while preserving schema precision. If the guard shows the causal variable is not the current free-generic input inversion, this doctrine should be revisited before implementation is ratified.
+
+## Consequences
+
+### Positive
+
+- Trail authors keep one public input schema and do not author a `callInput`/`blazeInput` split.
+- Defaults become an explicit, sanctioned way for caller-side and blaze-side TypeScript shapes to differ without creating contract drift.
+- Examples stay caller-facing and continue to serve documentation, testing, and agent guidance.
+- Surface and graph projections stay aligned with the Tenets: one input contract, many reads.
+
+### Tradeoffs
+
+- Trails must reject or defer schema features that change the TypeScript type between input and output until an adapter/codec model exists.
+- Some Zod custom refinements remain opaque to guide/survey output even when they are type-preserving.
+- The type system carries more responsibility: it must preserve schema precision while avoiding the consumer type-cost cliff that motivated this draft.
+
+### Open until TRL-884
+
+The doctrine is not ratified until the implementation proves affordable under the guard from TRL-882. If preserving precision requires a public two-input API or a topo-wide string-id input map, this draft should stay unaccepted.
+
+## References
+
+- [ADR-0000: Core Premise](../0000-core-premise.md)
+- [ADR-0006: Shared Execution Pipeline](../0006-shared-execution-pipeline.md)
+- [ADR-0020: Flags for Fields, Structured Input on the CLI](../0020-flags-for-fields-structured-input-on-the-cli.md)
+- [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md)
+- [ADR-0048: Trail Versioning v3](../0048-trail-versioning-v3.md)
+- [TRL-881: Stabilize the one-schema trail input model for Almanac adoption](https://linear.app/outfitter/issue/TRL-881/stabilize-the-one-schema-trail-input-model-for-almanac-adoption)

--- a/docs/adr/drafts/README.md
+++ b/docs/adr/drafts/README.md
@@ -41,3 +41,8 @@ Draft map: `docs/adr/drafts/decision-map.json`; numbered map: `docs/adr/decision
   - depends on [ADR-0029: Adapter Extraction and Composition Around Core Contracts](../0029-connector-extraction-and-the-with-packaging-model.md)
 - [Fixes are Warden diagnostic metadata](20260530-fixes-are-warden-diagnostic-metadata.md)
   - depends on [ADR-0000: Core Premise — Contract-First, Surface-Agnostic Design](../0000-core-premise.md), [ADR-0007: Governance as Trails with AST-Based Analysis](../0007-governance-as-trails.md), [ADR-0036: Warden rules ship only as trails](../0036-warden-rules-ship-only-as-trails.md), [ADR-0037: Owner-First Authority](../0037-owner-first-authority.md), [ADR-0043: Layer Evolution](../0043-layer-evolution.md)
+
+## 2026-06
+
+- [One-Schema Trail Input](20260603-one-schema-trail-input.md)
+  - depends on [ADR-0000: Core Premise — Contract-First, Surface-Agnostic Design](../0000-core-premise.md), [ADR-0006: Shared Execution Pipeline with Result-Returning Builders](../0006-shared-execution-pipeline.md), [ADR-0020: Flags for Fields, Structured Input on the CLI](../0020-flags-for-fields-structured-input-on-the-cli.md), [ADR-0024: Typed Trail Composition](../0024-typed-trail-composition.md), [ADR-0048: Trail Versioning v3](../0048-trail-versioning-v3.md)

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -251,6 +251,19 @@
       "superseded_by": null,
       "title": "Fixes are Warden diagnostic metadata",
       "updated": "2026-05-30"
+    },
+    {
+      "created": "2026-06-03",
+      "depends_on": ["0", "6", "20", "24", "48"],
+      "inbound": [],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/drafts/20260603-one-schema-trail-input.md",
+      "slug": "one-schema-trail-input",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "One-Schema Trail Input",
+      "updated": "2026-06-03"
     }
   ],
   "version": 1


### PR DESCRIPTION
## Context

This is the middle branch for TRL-881 / TRL-883. It records the Lewis/Clark input-shape convergence as proposed doctrine while keeping ratification gated on the implementation proof.

The doctrine is meant to prevent a public `callInput` / `blazeInput` split while still acknowledging that the framework can derive caller-side and blaze-side TypeScript projections internally.

## What Changed

- Added draft ADR `docs/adr/drafts/20260603-one-schema-trail-input.md`.
- Updated generated ADR draft maps/readmes.
- Captured the proposed doctrine sentence:

> A trail has one authored input schema. The framework reads it two ways — what a caller may send, and what the blaze receives — but only the first is ever public. We do not author the split; we derive it. Contract schemas validate and default; they never transform.

## Doctrine Shape

- One authored input schema; one public input contract.
- Defaults are in-bounds and are the sanctioned source of caller/blaze shape divergence.
- Standard type-preserving refinements are queryable.
- Custom type-preserving `.refine()` remains allowed but opaque.
- Type-changing `.transform()`, `.pipe()` to a new type, `.coerce()`, and codecs are deferred to the future adapter/codec story.
- Coercion belongs to surfaces/materialization, not trail contract schemas.
- Examples remain caller-side.
- Resolved graph/guide/survey should not expose a public accepted/materialized projection ontology.

## Validation

Worker-local validation before submit:

- `bun run type-cost:trail-input`
- targeted `packages/core` typecheck/test
- `packages/cli`, `packages/http`, and `packages/mcp` typecheck
- `bun run check`
- `bun run test`
- `bun run build`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`
- real submit pre-push hook: dead-code, format, lint, lint-ast-grep, test, typecheck, warden

## Notes

This branch keeps the ADR in draft/proposed state. It should not be cited as accepted law until the top branch proves the schema-owned typing model is affordable under the type-cost guard.