### PR TITLE
fix(types): derive trail input from authored schemas

### DIFF
--- a/.changeset/schema-owned-trail-input.md
+++ b/.changeset/schema-owned-trail-input.md
@@ -1,0 +1,8 @@
+---
+'@ontrails/core': patch
+'@ontrails/store': patch
+'@ontrails/trails': patch
+'@ontrails/warden': patch
+---
+
+Derive trail caller and blaze input types from the authored input schema while keeping one public input contract.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
+      - name: Trail input type-cost guard
+        run: bun run type-cost:trail-input
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/apps/trails/src/trails/compile.ts
+++ b/apps/trails/src/trails/compile.ts
@@ -16,8 +16,19 @@ export const compileCurrentTopo = async (
   options?: { readonly force?: boolean | undefined; readonly rootDir?: string }
 ): Promise<Result<TopoExportReport, Error>> => exportCurrentTopo(app, options);
 
+const compileTrailInputSchema = z.object({
+  force: z
+    .boolean()
+    .optional()
+    .describe('Record graph-only force events for breaking changes'),
+  module: z.string().optional().describe('Path to the app module'),
+  rootDir: z.string().optional().describe('Workspace root directory'),
+});
+
+type CompileTrailInput = z.output<typeof compileTrailInputSchema>;
+
 export const compileTrail = trail('compile', {
-  blaze: async (input, ctx) => {
+  blaze: async (input: CompileTrailInput, ctx) => {
     const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
     if (rootDirResult.isErr()) {
       return rootDirResult;
@@ -44,14 +55,7 @@ export const compileTrail = trail('compile', {
       name: 'Compile the current topo artifacts',
     },
   ],
-  input: z.object({
-    force: z
-      .boolean()
-      .optional()
-      .describe('Record graph-only force events for breaking changes'),
-    module: z.string().optional().describe('Path to the app module'),
-    rootDir: z.string().optional().describe('Workspace root directory'),
-  }),
+  input: compileTrailInputSchema,
   intent: 'write',
   output: z.object({
     hash: z.string(),

--- a/apps/trails/src/trails/guide.ts
+++ b/apps/trails/src/trails/guide.ts
@@ -28,12 +28,20 @@ interface GuideEntry {
   readonly kind: 'trail';
 }
 
+const guideTrailInputSchema = z.object({
+  module: z.string().optional().describe('Path to the app module'),
+  rootDir: z.string().optional().describe('Workspace root directory'),
+  trailId: z.string().optional().describe('Trail ID for detailed guidance'),
+});
+
+type GuideTrailInput = z.output<typeof guideTrailInputSchema>;
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 export const guideTrail = trail('guide', {
-  blaze: async (input, ctx) => {
+  blaze: async (input: GuideTrailInput, ctx) => {
     const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
     if (rootDirResult.isErr()) {
       return rootDirResult;
@@ -80,11 +88,7 @@ export const guideTrail = trail('guide', {
       name: 'List trail guidance',
     },
   ],
-  input: z.object({
-    module: z.string().optional().describe('Path to the app module'),
-    rootDir: z.string().optional().describe('Workspace root directory'),
-    trailId: z.string().optional().describe('Trail ID for detailed guidance'),
-  }),
+  input: guideTrailInputSchema,
   intent: 'read',
   output: z.discriminatedUnion('mode', [
     z.object({

--- a/apps/trails/src/trails/run-example.ts
+++ b/apps/trails/src/trails/run-example.ts
@@ -423,9 +423,24 @@ const buildComparisonEnvelope = async (
   });
 };
 
+const runExampleTrailInputSchema = z.object({
+  app: z
+    .string()
+    .optional()
+    .describe(
+      'Workspace app to resolve the trail ID against; required when the ID is exposed by more than one app'
+    ),
+  exampleName: z.string().describe('Name of the example to run'),
+  id: z.string().describe('Trail ID whose example should run'),
+  module: z.string().optional().describe('Path to the app module'),
+  rootDir: z.string().optional().describe('Workspace root directory'),
+});
+
+type RunExampleTrailInput = z.output<typeof runExampleTrailInputSchema>;
+
 export const runExampleTrail = trail('run.example', {
   args: ['id', 'exampleName'],
-  blaze: async (input, ctx) => {
+  blaze: async (input: RunExampleTrailInput, ctx) => {
     const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
     if (rootDirResult.isErr()) {
       return rootDirResult;
@@ -469,18 +484,7 @@ export const runExampleTrail = trail('run.example', {
       name: 'Run named example',
     },
   ],
-  input: z.object({
-    app: z
-      .string()
-      .optional()
-      .describe(
-        'Workspace app to resolve the trail ID against; required when the ID is exposed by more than one app'
-      ),
-    exampleName: z.string().describe('Name of the example to run'),
-    id: z.string().describe('Trail ID whose example should run'),
-    module: z.string().optional().describe('Path to the app module'),
-    rootDir: z.string().optional().describe('Workspace root directory'),
-  }),
+  input: runExampleTrailInputSchema,
   intent: 'write',
   output: runExampleComparisonSchema,
   permit: { scopes: ['trails:run'] },

--- a/apps/trails/src/trails/run-examples.ts
+++ b/apps/trails/src/trails/run-examples.ts
@@ -84,9 +84,23 @@ const buildExamplesListing = (
   });
 };
 
+const runExamplesTrailInputSchema = z.object({
+  app: z
+    .string()
+    .optional()
+    .describe(
+      'Workspace app to resolve the trail ID against; required when the ID is exposed by more than one app'
+    ),
+  id: z.string().describe('Trail ID whose examples should be listed'),
+  module: z.string().optional().describe('Path to the app module'),
+  rootDir: z.string().optional().describe('Workspace root directory'),
+});
+
+type RunExamplesTrailInput = z.output<typeof runExamplesTrailInputSchema>;
+
 export const runExamplesTrail = trail('run.examples', {
   args: ['id'],
-  blaze: async (input, ctx) => {
+  blaze: async (input: RunExamplesTrailInput, ctx) => {
     const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
     if (rootDirResult.isErr()) {
       return rootDirResult;
@@ -125,17 +139,7 @@ export const runExamplesTrail = trail('run.examples', {
       name: 'List trail examples',
     },
   ],
-  input: z.object({
-    app: z
-      .string()
-      .optional()
-      .describe(
-        'Workspace app to resolve the trail ID against; required when the ID is exposed by more than one app'
-      ),
-    id: z.string().describe('Trail ID whose examples should be listed'),
-    module: z.string().optional().describe('Path to the app module'),
-    rootDir: z.string().optional().describe('Workspace root directory'),
-  }),
+  input: runExamplesTrailInputSchema,
   intent: 'read',
   output: runExamplesListingSchema,
 });

--- a/apps/trails/src/trails/run.ts
+++ b/apps/trails/src/trails/run.ts
@@ -313,13 +313,33 @@ const buildAmbiguousExampleInput = (): {
   return { id: 'shared.id', rootDir: root };
 };
 
+const runTrailInputSchema = z.object({
+  app: z
+    .string()
+    .optional()
+    .describe(
+      'Workspace app to resolve the trail ID against; required when the ID is exposed by more than one app'
+    ),
+  id: z.string().describe('Trail ID to invoke'),
+  input: z
+    .unknown()
+    .optional()
+    .describe(
+      'Parsed input for the resolved trail; the CLI surface JSON.parses the inline argument before passing it through'
+    ),
+  module: z.string().optional().describe('Path to the app module'),
+  rootDir: z.string().optional().describe('Workspace root directory'),
+});
+
+type RunTrailInput = z.output<typeof runTrailInputSchema>;
+
 // ---------------------------------------------------------------------------
 // Trail definition
 // ---------------------------------------------------------------------------
 
 export const runTrail = trail('run', {
   args: ['id'],
-  blaze: async (input, ctx) => {
+  blaze: async (input: RunTrailInput, ctx) => {
     const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
     if (rootDirResult.isErr()) {
       return rootDirResult;
@@ -383,23 +403,7 @@ export const runTrail = trail('run', {
       name: 'Reject ambiguous trail ID without --app',
     },
   ],
-  input: z.object({
-    app: z
-      .string()
-      .optional()
-      .describe(
-        'Workspace app to resolve the trail ID against; required when the ID is exposed by more than one app'
-      ),
-    id: z.string().describe('Trail ID to invoke'),
-    input: z
-      .unknown()
-      .optional()
-      .describe(
-        'Parsed input for the resolved trail; the CLI surface JSON.parses the inline argument before passing it through'
-      ),
-    module: z.string().optional().describe('Path to the app module'),
-    rootDir: z.string().optional().describe('Workspace root directory'),
-  }),
+  input: runTrailInputSchema,
   intent: 'write',
   output: innerTrailResultSchema,
   permit: { scopes: ['trails:run'] },

--- a/apps/trails/src/trails/topo-history.ts
+++ b/apps/trails/src/trails/topo-history.ts
@@ -9,8 +9,18 @@ import {
 } from './topo-support.js';
 import { resolveTrailRootDir } from './root-dir.js';
 
+const topoHistoryTrailInputSchema = z.object({
+  limit: z
+    .number()
+    .default(DEFAULT_TOPO_HISTORY_LIMIT)
+    .describe('Maximum number of snapshots to return'),
+  rootDir: z.string().optional().describe('Workspace root directory'),
+});
+
+type TopoHistoryTrailInput = z.output<typeof topoHistoryTrailInputSchema>;
+
 export const topoHistoryTrail = trail('topo.history', {
-  blaze: (input, ctx) => {
+  blaze: (input: TopoHistoryTrailInput, ctx) => {
     const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
     if (rootDirResult.isErr()) {
       return rootDirResult;
@@ -25,13 +35,7 @@ export const topoHistoryTrail = trail('topo.history', {
       name: 'Show topo history',
     },
   ],
-  input: z.object({
-    limit: z
-      .number()
-      .default(DEFAULT_TOPO_HISTORY_LIMIT)
-      .describe('Maximum number of snapshots to return'),
-    rootDir: z.string().optional().describe('Workspace root directory'),
-  }),
+  input: topoHistoryTrailInputSchema,
   intent: 'read',
   output: z.object({
     dbPath: z.string(),

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "format:guard": "if git grep -nE \"(\\\\./)?node_modules/\\\\.bin/ultra[c]ite\" -- ':!bun.lock'; then echo 'Direct node_modules/.bin formatter invocation found'; exit 1; fi",
     "mdlint:fix": "./node_modules/.bin/markdownlint-cli2 --fix",
     "typecheck": "turbo run typecheck",
-    "check": "bun run lint && bun run lint:ast-grep && bun run vocab:audit && bun run format:check && bun run typecheck && bun run docs:links && bun run docs:snippets && bun run docs:api-examples && bun run docs:wrap-check && bun run error-taxonomy:check && bun run scaffold-versions:check && bun run warden:agents:check && bun run warden:skills:check && bun run skillset:check && bun run trails:check && bun run dead-code",
+    "check": "bun run lint && bun run lint:ast-grep && bun run vocab:audit && bun run format:check && bun run typecheck && bun run type-cost:trail-input && bun run docs:links && bun run docs:snippets && bun run docs:api-examples && bun run docs:wrap-check && bun run error-taxonomy:check && bun run scaffold-versions:check && bun run warden:agents:check && bun run warden:skills:check && bun run skillset:check && bun run trails:check && bun run dead-code",
     "clean": "turbo run clean --no-cache && rm -rf node_modules",
     "oxlint-plugin:build": "bun run --cwd packages/oxlint-plugin build:oxlint",
     "publish:check": "bun scripts/publish.ts --check",

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -86,6 +86,102 @@ export type BlazeInput<I, CI> = [CI] extends [never] ? I : I & CI;
 
 type TrailRef = string | { readonly id: string };
 
+type ComposeSchemaOutput<TSchema extends z.ZodType | undefined> =
+  TSchema extends z.ZodType ? z.output<TSchema> : never;
+
+type SchemaOwnedTrailSpec<
+  TInputSchema extends z.ZodType,
+  O,
+  TComposeInputSchema extends z.ZodType | undefined = undefined,
+  C extends readonly TrailRef[] | undefined = undefined,
+> = Omit<
+  TrailSpec<
+    z.output<TInputSchema>,
+    O,
+    ComposeSchemaOutput<TComposeInputSchema>,
+    C
+  >,
+  'blaze' | 'composeInput' | 'detours' | 'examples' | 'input' | 'versions'
+> & {
+  /** Zod schema for validating caller input and materializing blaze input. */
+  readonly input: TInputSchema;
+  /** The pure function receives schema-materialized input after validation/defaults. */
+  readonly blaze: Implementation<
+    BlazeInput<
+      z.output<TInputSchema>,
+      ComposeSchemaOutput<TComposeInputSchema>
+    >,
+    O,
+    ComposeContextFor<C>
+  >;
+  /** Named examples use caller-side input; schema defaults may be omitted. */
+  readonly examples?:
+    | readonly TrailExample<z.input<TInputSchema>, O>[]
+    | undefined;
+  /** Recovery paths see the same materialized input as the blaze. */
+  readonly detours?:
+    | readonly Detour<z.output<TInputSchema>, O, TrailsError>[]
+    | undefined;
+  /** Composition-only schema, merged internally for ctx.compose() calls. */
+  readonly composeInput?: TComposeInputSchema | undefined;
+  /** Explicit historical trail versions. Current stays top-level. */
+  readonly versions?: TrailVersions<z.output<TInputSchema>, O> | undefined;
+};
+
+type SchemaOwnedOutputTrailSpec<
+  TInputSchema extends z.ZodType,
+  TOutputSchema extends z.ZodType,
+  TComposeInputSchema extends z.ZodType | undefined = undefined,
+  C extends readonly TrailRef[] | undefined = undefined,
+> = Omit<
+  SchemaOwnedTrailSpec<
+    TInputSchema,
+    z.output<TOutputSchema>,
+    TComposeInputSchema,
+    C
+  >,
+  'output'
+> & {
+  readonly output: TOutputSchema;
+};
+
+type SchemaOwnedTrail<
+  TInputSchema extends z.ZodType,
+  O,
+  TComposeInputSchema extends z.ZodType | undefined,
+> = Trail<
+  z.output<TInputSchema>,
+  O,
+  ComposeSchemaOutput<TComposeInputSchema>
+> & {
+  readonly input: TInputSchema;
+  readonly composeInput?: TComposeInputSchema | undefined;
+};
+
+type LegacyOutputTrailSpec<
+  I,
+  O,
+  CI,
+  C extends readonly TrailRef[] | undefined,
+> = Omit<TrailSpec<I, O, CI, C>, 'blaze' | 'output'> & {
+  readonly blaze: Implementation<
+    BlazeInput<I, CI>,
+    NoInfer<O>,
+    ComposeContextFor<C>
+  >;
+  readonly output: z.ZodType<O>;
+};
+
+type LegacyOutputlessTrailSpec<
+  I,
+  O,
+  CI,
+  C extends readonly TrailRef[] | undefined,
+> = Omit<TrailSpec<I, O, CI, C>, 'blaze' | 'output'> & {
+  readonly blaze: Implementation<BlazeInput<I, CI>, O, ComposeContextFor<C>>;
+  readonly output?: undefined;
+};
+
 // ---------------------------------------------------------------------------
 // Trail versioning
 // ---------------------------------------------------------------------------
@@ -1016,17 +1112,74 @@ const normalizeCollections = <
  * ```
  */
 export function trail<
-  I,
-  O,
-  CI = never,
+  const TInputSchema extends z.ZodType,
+  const TOutputSchema extends z.ZodType,
+  const TComposeInputSchema extends z.ZodType | undefined = undefined,
   const C extends readonly TrailRef[] | undefined = undefined,
->(id: string, spec: TrailSpec<I, O, CI, C>): Trail<I, O, CI>;
+>(
+  id: string,
+  spec: SchemaOwnedOutputTrailSpec<
+    TInputSchema,
+    TOutputSchema,
+    TComposeInputSchema,
+    C
+  >
+): SchemaOwnedTrail<TInputSchema, z.output<TOutputSchema>, TComposeInputSchema>;
+export function trail<
+  const TInputSchema extends z.ZodType,
+  const TOutputSchema extends z.ZodType,
+  const TComposeInputSchema extends z.ZodType | undefined = undefined,
+  const C extends readonly TrailRef[] | undefined = undefined,
+>(
+  spec: SchemaOwnedOutputTrailSpec<
+    TInputSchema,
+    TOutputSchema,
+    TComposeInputSchema,
+    C
+  > & {
+    readonly id: string;
+  }
+): SchemaOwnedTrail<TInputSchema, z.output<TOutputSchema>, TComposeInputSchema>;
+export function trail<
+  const TInputSchema extends z.ZodType,
+  O,
+  const TComposeInputSchema extends z.ZodType | undefined = undefined,
+  const C extends readonly TrailRef[] | undefined = undefined,
+>(
+  id: string,
+  spec: SchemaOwnedTrailSpec<TInputSchema, O, TComposeInputSchema, C>
+): SchemaOwnedTrail<TInputSchema, O, TComposeInputSchema>;
+export function trail<
+  const TInputSchema extends z.ZodType,
+  O,
+  const TComposeInputSchema extends z.ZodType | undefined = undefined,
+  const C extends readonly TrailRef[] | undefined = undefined,
+>(
+  spec: SchemaOwnedTrailSpec<TInputSchema, O, TComposeInputSchema, C> & {
+    readonly id: string;
+  }
+): SchemaOwnedTrail<TInputSchema, O, TComposeInputSchema>;
 export function trail<
   I,
   O,
   CI = never,
   const C extends readonly TrailRef[] | undefined = undefined,
->(spec: TrailSpec<I, O, CI, C> & { readonly id: string }): Trail<I, O, CI>;
+>(
+  id: string,
+  spec:
+    | LegacyOutputTrailSpec<I, O, CI, C>
+    | LegacyOutputlessTrailSpec<I, O, CI, C>
+): Trail<I, O, CI>;
+export function trail<
+  I,
+  O,
+  CI = never,
+  const C extends readonly TrailRef[] | undefined = undefined,
+>(
+  spec:
+    | (LegacyOutputTrailSpec<I, O, CI, C> & { readonly id: string })
+    | (LegacyOutputlessTrailSpec<I, O, CI, C> & { readonly id: string })
+): Trail<I, O, CI>;
 export function trail<
   I,
   O,

--- a/packages/core/src/trails/ingest.ts
+++ b/packages/core/src/trails/ingest.ts
@@ -114,16 +114,17 @@ export const ingest = <
     id,
     transform
   );
-  const baseTrail = trail(id, {
+  const baseSpec = {
     ...trailSpec,
-    blaze: baseBlaze,
+    blaze: baseBlaze as TrailSpec<unknown, unknown>['blaze'],
     examples: deriveExamples(schema as ExampleBearingSchema<TSchema>, signalId),
     fires: [signal],
-    input: schema as z.ZodType<SchemaValue<TSchema>>,
+    input: schema as z.ZodType<unknown>,
     intent: 'write',
     output: z.void(),
     pattern: 'ingest',
-  }) as Trail<SchemaValue<TSchema>, void>;
+  } as TrailSpec<unknown, unknown>;
+  const baseTrail = trail(id, baseSpec) as Trail<SchemaValue<TSchema>, void>;
 
   if (verify === undefined) {
     return baseTrail;

--- a/packages/core/src/type-checks.test-d.ts
+++ b/packages/core/src/type-checks.test-d.ts
@@ -11,6 +11,7 @@
  */
 
 import type { Signal, SignalSpec } from './signal.js';
+import { trail } from './trail.js';
 import type { Trail, TrailSpec, TrailVersionRevisionEntry } from './trail.js';
 import type { ExecuteTrailOptions } from './execute.js';
 import { resource } from './resource.js';
@@ -19,10 +20,10 @@ import type { ContourOptions } from './contour.js';
 import type { ScheduleSpec } from './schedule.js';
 import type { WebhookSpec } from './webhook.js';
 import type { BasePermit } from './permits.js';
-import type { Result } from './result.js';
+import { Result } from './result.js';
 import type { ComposeFn, FireFn } from './types.js';
 import type { ComposeInput, TrailInput, TrailOutput } from './type-utils.js';
-import type { z } from 'zod';
+import { z } from 'zod';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -35,6 +36,85 @@ type IsExact<A, B> =
       ? true
       : false
     : false;
+
+declare const compose: ComposeFn;
+
+const defaultedTrail = trail('typecheck.defaulted-input', {
+  blaze: (input) => {
+    const { limit }: { limit: number } = input;
+    return Result.ok({ limit });
+  },
+  examples: [
+    {
+      expected: { limit: 20 },
+      input: { name: 'Ada' },
+      name: 'Caller omits defaulted limit',
+    },
+  ],
+  input: z.object({
+    limit: z.number().int().positive().default(20),
+    name: z.string(),
+  }),
+  output: z.object({ limit: z.number() }),
+});
+
+type DefaultedCallerInput = TrailInput<typeof defaultedTrail>;
+type DefaultedComposeInput = ComposeInput<typeof defaultedTrail>;
+type DefaultedBlazeInput = Parameters<typeof defaultedTrail.blaze>[0];
+
+export type DefaultedCallerInputIsCallerSide = Assert<
+  IsExact<DefaultedCallerInput, { name: string; limit?: number | undefined }>
+>;
+export type DefaultedComposeInputIsCallerSide = Assert<
+  IsExact<DefaultedComposeInput, DefaultedCallerInput>
+>;
+export type DefaultedBlazeInputIsMaterialized = Assert<
+  IsExact<DefaultedBlazeInput, { name: string; limit: number }>
+>;
+
+trail('typecheck.output-schema-mismatch', {
+  // @ts-expect-error blaze output must match the authored output schema.
+  blaze: () => Result.ok({ id: 123 }),
+  input: z.object({}),
+  output: z.object({ id: z.string() }),
+});
+
+export const defaultedTrailObjectComposeOk: Promise<
+  Result<{ limit: number }, Error>
+> = compose(defaultedTrail, { name: 'Ada' });
+// @ts-expect-error caller-side input still requires non-defaulted fields.
+compose(defaultedTrail, { limit: 10 });
+
+const composeDefaultSchema = z.object({
+  forkedFrom: z.string().default('root'),
+});
+const composedDefaultedTrail = trail('typecheck.defaulted-compose-input', {
+  blaze: (input) => Result.ok({ forkedFrom: input.forkedFrom }),
+  composeInput: composeDefaultSchema,
+  input: z.object({ name: z.string() }),
+  output: z.object({ forkedFrom: z.string() }),
+});
+
+type DefaultedComposeOnlyInput = ComposeInput<typeof composedDefaultedTrail>;
+type DefaultedComposeOnlyBlazeInput = Parameters<
+  typeof composedDefaultedTrail.blaze
+>[0];
+
+export type DefaultedComposeOnlyInputIsCallerSide = Assert<
+  IsExact<
+    DefaultedComposeOnlyInput,
+    { name: string } & { forkedFrom?: string | undefined }
+  >
+>;
+export type DefaultedComposeOnlyBlazeInputIsMaterialized = Assert<
+  IsExact<
+    DefaultedComposeOnlyBlazeInput,
+    { name: string } & { forkedFrom: string }
+  >
+>;
+export const defaultedComposeInputTrailObjectComposeOk: Promise<
+  Result<{ forkedFrom: string }, Error>
+> = compose(composedDefaultedTrail, { name: 'Ada' });
 
 /** A trail with composeInput declared. */
 type ComposeTrail = Trail<
@@ -109,7 +189,6 @@ export type TypedTrailObjectComposeOutput = [
 export type TypedTrailObjectComposeNotNeverAssert =
   Assert<AssertTypedComposeNotNever>;
 
-declare const compose: ComposeFn;
 declare const composeTrail: ComposeTrail;
 
 export const plainTrailObjectComposeOk: Promise<Result<{ id: string }, Error>> =

--- a/packages/core/src/type-utils.ts
+++ b/packages/core/src/type-utils.ts
@@ -3,7 +3,7 @@
  */
 
 import type { Result } from './result.js';
-import type { AnyTrail } from './trail.js';
+import type { AnyTrail, Trail } from './trail.js';
 import type { Implementation } from './types.js';
 import type { z } from 'zod';
 
@@ -13,11 +13,31 @@ import type { z } from 'zod';
 
 /* oxlint-disable no-explicit-any -- `any` required for conditional type inference; `unknown` breaks inference */
 
+type SchemaInputOrFallback<TSchema extends z.ZodType, TFallback> =
+  unknown extends z.input<TSchema> ? TFallback : z.input<TSchema>;
+
+type ComposeSchemaOf<T extends AnyTrail> = T extends {
+  readonly composeInput?: (infer TComposeSchema) | undefined;
+}
+  ? NonNullable<TComposeSchema>
+  : never;
+
+type ComposeInputPart<T extends AnyTrail> =
+  ComposeSchemaOf<T> extends z.ZodType
+    ? T extends Trail<any, any, infer CI>
+      ? SchemaInputOrFallback<ComposeSchemaOf<T>, CI>
+      : z.input<ComposeSchemaOf<T>>
+    : T extends Trail<any, any, infer CI>
+      ? CI
+      : never;
+
 /** Extract the input type from a Trail. */
 export type TrailInput<T extends AnyTrail> = T extends {
-  readonly input: z.ZodType<infer I>;
+  readonly input: infer TInputSchema extends z.ZodType;
 }
-  ? I
+  ? T extends Trail<infer I, any, any>
+    ? SchemaInputOrFallback<TInputSchema, I>
+    : z.input<TInputSchema>
   : never;
 
 /** Extract the output type from a Trail. */
@@ -35,12 +55,11 @@ export type TrailOutput<T extends AnyTrail> = T extends {
  * merges both schemas so the compiler enforces the full shape at the call
  * site. Falls back to plain `TrailInput<T>` when no `composeInput` exists.
  */
-export type ComposeInput<T extends AnyTrail> =
-  NonNullable<T['composeInput']> extends z.ZodType<infer CI>
-    ? [CI] extends [never]
-      ? TrailInput<T>
-      : TrailInput<T> & CI
-    : TrailInput<T>;
+export type ComposeInput<T extends AnyTrail> = [ComposeInputPart<T>] extends [
+  never,
+]
+  ? TrailInput<T>
+  : TrailInput<T> & ComposeInputPart<T>;
 
 /**
  * Extracts the full `Result<Output, Error>` type from a trail definition.

--- a/packages/regrade/src/literal-transform.ts
+++ b/packages/regrade/src/literal-transform.ts
@@ -89,7 +89,8 @@ export const literalRegradeTrail = trail('regrade.literal.run', {
         )
       );
     }
-    return await ctx.compose(normalizeExportConstTrail, input.child);
+    const blazeInput = input as RegradeTransformBlazeInput;
+    return await ctx.compose(normalizeExportConstTrail, blazeInput.child);
   },
   composes: [normalizeExportConstTrail],
   examples: [

--- a/packages/store/src/trails/reconcile.ts
+++ b/packages/store/src/trails/reconcile.ts
@@ -263,7 +263,7 @@ export const reconcile = <
   const entityContour = createTableContour(options.table);
   const strategy = options.strategy ?? 'last-write-wins';
 
-  return trail<UpsertOf<TTable>, EntityOf<TTable>>(id, {
+  return trail(id, {
     blaze: createReconcileBlaze(options, id),
     contours: [entityContour],
     description:

--- a/packages/store/src/trails/sync.ts
+++ b/packages/store/src/trails/sync.ts
@@ -178,7 +178,7 @@ export const sync = <
   const sourceContour = createTableContour(options.from.table);
   const targetContour = createTableContour(options.to.table);
 
-  return trail<IdentityInputOf<TSourceTable>, EntityOf<TTargetTable>>(id, {
+  return trail(id, {
     // oxlint-disable-next-line max-statements -- sync blaze reads more clearly as one try/catch with schema validation, transform, and accessor call inline
     blaze: async (input, ctx) => {
       try {

--- a/packages/warden/src/trails/version-gap.trail.ts
+++ b/packages/warden/src/trails/version-gap.trail.ts
@@ -14,7 +14,7 @@ const versionedTrail = trail('version.gap.clean', {
       input: z.object({}),
       output: z.object({ ok: z.boolean() }),
       transpose: {
-        input: ({ input }) => input,
+        input: () => ({}),
         output: ({ output }) => output,
       },
     },

--- a/packages/warden/src/trails/version-without-examples.trail.ts
+++ b/packages/warden/src/trails/version-without-examples.trail.ts
@@ -15,7 +15,7 @@ const archivedWithoutExamples = trail('version.examples.archived', {
       output: z.object({ ok: z.boolean() }),
       status: { state: 'archived' },
       transpose: {
-        input: ({ input }) => input,
+        input: () => ({}),
         output: ({ output }) => output,
       },
     },


### PR DESCRIPTION
## Context

This is the top branch for TRL-881 / TRL-884. It makes the `trail()` type surface schema-owned so one authored Zod input schema can support both caller-side and blaze-side TypeScript projections internally.

The intent is to fix the Almanac type-cost cliff without introducing a public two-input API or erasing schema precision.

## What Changed

- Refactored core trail typing and supporting type utilities so input is derived from the authored schema.
- Updated core type tests for the entry-point matrix.
- Adjusted app trail schemas and compatibility sites in store, warden, and regrade that depended on the old value-projection typing.
- Added a changeset for the user-visible typing improvement.

Changed areas include:

- `packages/core/src/trail.ts`
- `packages/core/src/type-utils.ts`
- `packages/core/src/type-checks.test-d.ts`
- app trail schema call sites under `apps/trails/src/trails/`
- store factory return typing in `packages/store/src/trails/`
- compatibility call sites in `packages/warden` and `packages/regrade`

## Contract Preserved

- No public `callInput` / `blazeInput` authoring fields.
- No public `accepted` / `materialized` projection ontology.
- Examples remain caller-side input.
- Blazes receive materialized input after validation/defaults.
- Defaults remain the sanctioned caller/blaze divergence.
- Type-changing transform/coerce/codec behavior remains deferred to the future adapter/codec story.

## Evidence

- TRL-882 guard before the typing fix: `1,308,164,096` bytes RSS.
- No-Commander comparison: `1,284,866,048` bytes RSS, ruling out Commander as the causal variable.
- After this branch: `bun run type-cost:trail-input` passed at `834,306,048` bytes RSS under the `900,000,000` byte ceiling.

## Validation

Worker-local validation before submit:

- `bun run type-cost:trail-input`
- `packages/core` typecheck/test: passed
- `packages/cli` typecheck: passed
- `packages/http` typecheck: passed
- `packages/mcp` typecheck: passed
- `bun run check`: passed
- `bun run test`: passed
- `bun run build`: passed
- `git diff --check`: passed
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`: passed
- real submit pre-push hook: dead-code, format, lint, lint-ast-grep, test, typecheck, warden: passed with Warden PASS 0 errors / 0 warnings

## Local Review

The delegate ran a local P0-P2 review loop before submit. The review was clean after fixing branch ownership, changeset, and documentation wrapping issues. No unresolved local P0-P2 findings were submitted.

## Notes

This PR intentionally does not mark the doctrine ADR accepted. It proves the implementation side needed before that draft doctrine can be ratified.