### PR TITLE
docs: define distribution-ready done doctrine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,21 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 
 Shared TSDoc and code-shape guidance for packages and apps lives in [Code Standards](docs/contributing/code-standards.md). `apps/AGENTS.md` and `packages/AGENTS.md` should remain thin pointers there plus any small local overrides. `.claude/rules/coding-conventions.md` is a compatibility pointer for Claude rule loaders and older prompts.
 
+## Distribution-Ready Done
+
+Feature work is not complete until the surrounding developer experience is complete or explicitly marked not applicable. Treat this as part of the implementation, not a separate cleanup wish.
+
+Before calling an issue done or moving a PR out of draft, check the affected distribution surfaces:
+
+- **Docs and examples:** update the nearest fieldguide, API docs, examples, ADRs, or runbooks that teach the behavior.
+- **Agent guidance:** update `AGENTS.md`, repo skills, plugin metadata, or tool-specific guidance when agents need new rules or vocabulary.
+- **Governance:** add or update Warden rules, generated Warden guide output, and drift checks when the behavior creates governable contract boundaries.
+- **Release path:** add a branch-local changeset for publishable package changes, or apply `release:none` only when the package-touching change is truly not user-visible.
+- **Migration path:** document commands, compatibility windows, bridge steps, or intentional non-support when existing apps may have committed artifacts or source that need to move.
+- **Publication readiness:** run `bun run publish:check` for package-impacting work and record any first-time package, dist-tag, registry, or auth considerations before release.
+
+Small internal refactors do not need ceremonial docs. They do need an explicit "not applicable" callout when a reviewer or future agent could reasonably expect docs, skills, changesets, or migration notes. Done means the framework change is usable, teachable, and releasable, not merely implemented.
+
 ## Workflow
 
 Use Graphite for source control operations.

--- a/docs/tenets.md
+++ b/docs/tenets.md
@@ -66,6 +66,14 @@ Good additions reduce ceremony, lower drift potential, impose an acceptable foot
 
 This does not preclude experimentation. Trails itself was formed through iteration, refinement, and repeated shaping over time. The key is that experimentation should feed the core story, not bypass it. Broadening the built-in surface is worth doing when it is a net win across the system. It is not worth doing to chase a trend or accumulate surface area.
 
+### Ship the whole developer experience
+
+Framework work is not done when the code compiles. A shipped capability must be usable, teachable, governable, and releasable by the next developer or agent that meets it.
+
+That means feature work carries its surrounding distribution story with it: contract docs, examples, agent guidance, Warden guidance when behavior becomes governable, changesets or release notes when packages move, and migration guidance when existing apps have to adapt. Internal-only work can mark those surfaces not applicable, but the decision should be visible. Silent omission creates drift.
+
+This is not process for its own sake. Trails promises one authored contract can feed many readers. If we ship a new behavior without updating the readers that explain, inspect, review, package, or migrate it, we have not upheld the contract-first model. We have only moved the burden onto the developer.
+
 ### The information architecture
 
 Six categories describe how information flows through the system. Understanding these categories is essential for evaluating any proposed feature or API change.


### PR DESCRIPTION
## Summary
- Defines distribution-ready done doctrine in AGENTS.md and docs/tenets.md.
- Makes docs, skills, changesets, release planning, and migration guidance part of shipping, not optional cleanup.
- Sets the quality bar that feature work is not done until downstream developer experience is updated.

## Verification
- bun run check
- bun run test
- bun run build
- bun run publish:check
- git diff --check
- gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
- real submit pre-push hook passed