### PR TITLE
feat(topographer): serialize surface facet metadata

### DIFF
--- a/.changeset/trl-889-surface-facet-metadata.md
+++ b/.changeset/trl-889-surface-facet-metadata.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/topographer': minor
+'@ontrails/adapter-kit': patch
+---
+
+Serialize resolved surface facet metadata in TopoGraph artifacts and expose adapter type evidence for downstream projection checks.

--- a/packages/adapter-kit/src/__tests__/check.test.ts
+++ b/packages/adapter-kit/src/__tests__/check.test.ts
@@ -143,6 +143,7 @@ describe('checkAdapters', () => {
     expect(report.diagnostics).toEqual([]);
     expect(report.subjects).toHaveLength(1);
     expect(report.subjects[0]).toMatchObject({
+      adapterType: 'HttpAdapterConformanceAdapter',
       conformanceTestPaths: [
         expect.stringContaining(
           'adapters/hono/src/__tests__/conformance.test.ts'
@@ -199,10 +200,22 @@ describe('checkAdapters', () => {
     expect(report.diagnostics).toEqual([]);
     expect(report.subjects).toHaveLength(1);
     expect(report.subjects[0]).toMatchObject({
+      adapterType: 'HttpAdapterConformanceAdapter',
       ownerPackage: '@ontrails/http',
       target: 'http',
       testingImport: '@ontrails/http/testing',
     });
+  });
+
+  test('leaves adapterType absent when target conformance has no adapter type', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeHttpConformanceTest(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.adapterType).toBeUndefined();
   });
 
   test('ignores extracted adapter packages until they declare target metadata', () => {

--- a/packages/adapter-kit/src/check.ts
+++ b/packages/adapter-kit/src/check.ts
@@ -46,6 +46,7 @@ export interface AdapterCheckDiagnostic {
 }
 
 export interface AdapterCheckSubject {
+  readonly adapterType?: string | undefined;
   readonly conformanceTestPaths: readonly string[];
   readonly key: string;
   readonly ownerPackage: string;
@@ -2033,6 +2034,9 @@ const checkAdapterPackage = (
       placement,
       target: targetEntry.target,
       targetKey: targetEntry.key,
+      ...(conformance?.adapterType
+        ? { adapterType: conformance.adapterType }
+        : {}),
       ...(testingImport ? { testingImport } : {}),
     },
   };

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -1017,6 +1017,72 @@ describe('deriveTopoGraph', () => {
     });
   });
 
+  describe('facets', () => {
+    test('derives sorted resolved facet metadata from selectors', () => {
+      const describeTopo = trail('topo.describe', {
+        blaze: noop,
+        input: z.object({ root: z.string() }),
+      });
+      const listTopo = trail('topo.list', {
+        blaze: noop,
+        input: z.object({ root: z.string() }),
+      });
+      const resetDev = trail('dev.reset', {
+        blaze: noop,
+        input: z.object({}),
+      });
+
+      const map = deriveTopoGraph(
+        topoFrom({ describeTopo, listTopo, resetDev }),
+        {
+          facets: [
+            {
+              description: 'Read and inspect topo state.',
+              id: 'topo',
+              surfaces: ['mcp'],
+              trails: 'topo.*',
+            },
+          ],
+        }
+      );
+
+      expect(map.facets).toEqual([
+        expect.objectContaining({
+          description: 'Read and inspect topo state.',
+          id: 'topo',
+          memberIds: ['topo.describe', 'topo.list'],
+          memberSetHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+          surfaces: ['mcp'],
+        }),
+      ]);
+    });
+
+    test('sorts facet members and surfaces for deterministic output', () => {
+      const read = trail('topo.read', {
+        blaze: noop,
+        input: z.object({}),
+      });
+      const write = trail('topo.write', {
+        blaze: noop,
+        input: z.object({}),
+      });
+
+      const map = deriveTopoGraph(topoFrom({ read, write }), {
+        facets: [
+          {
+            description: 'Topo operations.',
+            id: 'topo',
+            surfaces: ['mcp', 'cli'],
+            trails: ['topo.write', 'topo.read'],
+          },
+        ],
+      });
+
+      expect(map.facets?.[0]?.memberIds).toEqual(['topo.read', 'topo.write']);
+      expect(map.facets?.[0]?.surfaces).toEqual(['cli', 'mcp']);
+    });
+  });
+
   describe('stability', () => {
     test('determinism: same topo produces identical output', () => {
       const t = trail('stable', {

--- a/packages/topographer/src/__tests__/diff.test.ts
+++ b/packages/topographer/src/__tests__/diff.test.ts
@@ -637,6 +637,110 @@ describe('deriveTopoGraphDiff', () => {
     });
   });
 
+  describe('facets', () => {
+    test('reports added facets as informational', () => {
+      const prev = topoGraph([]);
+      const curr = {
+        ...topoGraph([]),
+        facets: [
+          {
+            description: 'Read topo.',
+            id: 'topo',
+            memberIds: ['topo.read'],
+            memberSetHash: 'a'.repeat(64),
+            surfaces: ['mcp'],
+          },
+        ],
+      };
+
+      const result = deriveTopoGraphDiff(prev, curr);
+
+      expect(result.info[0]).toMatchObject({
+        change: 'added',
+        id: 'topo',
+        kind: 'facet',
+      });
+      expect(result.info[0]?.details).toContain('Facet "topo" added');
+    });
+
+    test('reports facet membership changes as warnings', () => {
+      const prev = {
+        ...topoGraph([]),
+        facets: [
+          {
+            description: 'Read topo.',
+            id: 'topo',
+            memberIds: ['topo.read'],
+            memberSetHash: 'a'.repeat(64),
+            surfaces: ['mcp'],
+          },
+        ],
+      };
+      const curr = {
+        ...topoGraph([]),
+        facets: [
+          {
+            description: 'Read topo.',
+            id: 'topo',
+            memberIds: ['topo.read', 'topo.describe'],
+            memberSetHash: 'b'.repeat(64),
+            surfaces: ['mcp'],
+          },
+        ],
+      };
+
+      const result = deriveTopoGraphDiff(prev, curr);
+
+      expect(result.warnings[0]).toMatchObject({
+        change: 'modified',
+        id: 'topo',
+        kind: 'facet',
+      });
+      expect(result.warnings[0]?.details).toContain(
+        'Facet member added: "topo.describe"'
+      );
+      expect(result.warnings[0]?.details).toContain(
+        'Facet member-set hash changed'
+      );
+    });
+
+    test('reports facet description changes as informational', () => {
+      const prev = {
+        ...topoGraph([]),
+        facets: [
+          {
+            description: 'Old topo.',
+            id: 'topo',
+            memberIds: ['topo.read'],
+            memberSetHash: 'a'.repeat(64),
+            surfaces: ['mcp'],
+          },
+        ],
+      };
+      const curr = {
+        ...topoGraph([]),
+        facets: [
+          {
+            description: 'New topo.',
+            id: 'topo',
+            memberIds: ['topo.read'],
+            memberSetHash: 'a'.repeat(64),
+            surfaces: ['mcp'],
+          },
+        ],
+      };
+
+      const result = deriveTopoGraphDiff(prev, curr);
+
+      expect(result.info[0]).toMatchObject({
+        change: 'modified',
+        id: 'topo',
+        kind: 'facet',
+      });
+      expect(result.info[0]?.details).toContain('Description updated');
+    });
+  });
+
   describe('severity partitioning', () => {
     test('DiffResult partitions correctly into breaking, warnings, info', () => {
       const prev = topoGraph([

--- a/packages/topographer/src/__tests__/hash.test.ts
+++ b/packages/topographer/src/__tests__/hash.test.ts
@@ -121,4 +121,21 @@ describe('deriveTopoGraphHash', () => {
 
     expect(deriveTopoGraphHash(map1)).toBe(deriveTopoGraphHash(map2));
   });
+
+  test('facet metadata participates in the hash', () => {
+    const map1 = makeTopoGraph();
+    const map2 = makeTopoGraph({
+      facets: [
+        {
+          description: 'Read topo.',
+          id: 'topo',
+          memberIds: ['topo.read'],
+          memberSetHash: 'a'.repeat(64),
+          surfaces: ['mcp'],
+        },
+      ],
+    });
+
+    expect(deriveTopoGraphHash(map1)).not.toBe(deriveTopoGraphHash(map2));
+  });
 });

--- a/packages/topographer/src/__tests__/io.test.ts
+++ b/packages/topographer/src/__tests__/io.test.ts
@@ -107,6 +107,26 @@ describe('writeTopoGraph / readTopoGraph', () => {
     expect(result).toEqual(map);
   });
 
+  test('round-trips topo facet metadata', async () => {
+    const map: TopoGraph = {
+      ...makeTopoGraph(),
+      facets: [
+        {
+          description: 'Read topo.',
+          id: 'topo',
+          memberIds: ['topo.read'],
+          memberSetHash: 'a'.repeat(64),
+          surfaces: ['mcp'],
+        },
+      ],
+    };
+
+    await writeTopoGraph(map, { dir: tempDir });
+    const result = await readTopoGraph({ dir: tempDir });
+
+    expect(result?.facets).toEqual(map.facets);
+  });
+
   test('returns null for missing file', async () => {
     const result = await readTopoGraph({
       dir: join(tempDir, 'nonexistent'),

--- a/packages/topographer/src/derive.ts
+++ b/packages/topographer/src/derive.ts
@@ -11,6 +11,7 @@ import {
   getContourReferences,
   projectActivationSourceDeclaration,
   validateEstablishedTopo,
+  matchesTrailPattern,
   signalDiagnosticDefinitions,
   zodToJsonSchema,
 } from '@ontrails/core';
@@ -27,15 +28,19 @@ import type {
 } from '@ontrails/core';
 
 import { addPermitRequirement } from './permit.js';
+import { deriveStableHash } from './hash.js';
 import { TOPO_GRAPH_SCHEMA_VERSION } from './types.js';
 import { projectTrailVersions } from './versioning.js';
 import type {
+  DeriveTopoGraphOptions,
   JsonSchema,
   TopoGraph,
   TopoGraphActivationEdge,
   TopoGraphActivationGraph,
   TopoGraphActivationSource,
   TopoGraphEntry,
+  TopoGraphFacetDeclaration,
+  TopoGraphFacetEntry,
   TopoGraphFieldOverride,
   TopoGraphFieldOverrideKey,
 } from './types.js';
@@ -629,6 +634,62 @@ const collectEntries = (topo: Topo): TopoGraphEntry[] => {
   ];
 };
 
+const selectorPatterns = (
+  selector: TopoGraphFacetDeclaration['trails']
+): readonly string[] => (typeof selector === 'string' ? [selector] : selector);
+
+const resolveFacetMemberIds = (
+  topo: Topo,
+  facet: TopoGraphFacetDeclaration
+): readonly string[] => {
+  const patterns = selectorPatterns(facet.trails);
+  return [...topo.trails.values()]
+    .filter((trail) =>
+      patterns.some((pattern) => matchesTrailPattern(trail.id, pattern))
+    )
+    .map((trail) => trail.id)
+    .toSorted();
+};
+
+const facetToEntry = (
+  topo: Topo,
+  facet: TopoGraphFacetDeclaration
+): TopoGraphFacetEntry => {
+  const memberIds = resolveFacetMemberIds(topo, facet);
+  const entry: Record<string, unknown> = {
+    description: facet.description,
+    id: facet.id,
+    memberIds,
+    memberSetHash: deriveStableHash(memberIds),
+    surfaces: (facet.surfaces ?? []).toSorted(),
+  };
+
+  if (facet.descriptionStableThrough !== undefined) {
+    entry['descriptionStableThrough'] = facet.descriptionStableThrough;
+  }
+  if (facet.visibility !== undefined) {
+    entry['visibility'] = facet.visibility;
+  }
+  if (facet.visibilityWideningAccepted === true) {
+    entry['visibilityWideningAccepted'] = true;
+  }
+
+  return sortKeys(entry) as unknown as TopoGraphFacetEntry;
+};
+
+const collectFacets = (
+  topo: Topo,
+  options: DeriveTopoGraphOptions | undefined
+): readonly TopoGraphFacetEntry[] | undefined => {
+  const facets = options?.facets;
+  if (facets === undefined || facets.length === 0) {
+    return undefined;
+  }
+  return facets
+    .map((facet) => facetToEntry(topo, facet))
+    .toSorted((a, b) => a.id.localeCompare(b.id));
+};
+
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -639,13 +700,17 @@ const collectEntries = (topo: Topo): TopoGraphEntry[] => {
  * Entries are sorted alphabetically by id. Object keys within each entry
  * are sorted lexicographically for stable serialization.
  */
-export const deriveTopoGraph = (topo: Topo): TopoGraph => {
+export const deriveTopoGraph = (
+  topo: Topo,
+  options?: DeriveTopoGraphOptions
+): TopoGraph => {
   assertEstablishedTopo(topo);
   const sorted = collectEntries(topo).toSorted((a, b) =>
     a.id.localeCompare(b.id)
   );
   const activationSources = collectActivationSourceCatalog(topo);
   const activationEdges = collectActivationGraphEdges(topo);
+  const facets = collectFacets(topo, options);
 
   return {
     activationGraph: buildActivationGraph(activationEdges, activationSources),
@@ -653,6 +718,7 @@ export const deriveTopoGraph = (topo: Topo): TopoGraph => {
       activationSources.map((source) => [source.key, source])
     ),
     entries: sorted,
+    ...(facets === undefined ? {} : { facets }),
     generatedAt: new Date().toISOString(),
     topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
   };

--- a/packages/topographer/src/diff.ts
+++ b/packages/topographer/src/diff.ts
@@ -8,6 +8,7 @@ import type {
   JsonSchema,
   TopoGraph,
   TopoGraphEntry,
+  TopoGraphFacetEntry,
   TopoGraphForceEntry,
   TopoGraphVersionEntry,
 } from './types.js';
@@ -46,7 +47,10 @@ const addDetail = (
 const capitalize = (s: string): string =>
   `${s.charAt(0).toUpperCase()}${s.slice(1)}`;
 
-const labelForKind = (kind: TopoGraphEntry['kind']): string => {
+const labelForKind = (kind: DiffEntry['kind']): string => {
+  if (kind === 'facet') {
+    return 'Facet';
+  }
   if (kind === 'contour') {
     return 'Contour';
   }
@@ -721,6 +725,141 @@ const diffGraphForces = (prev: TopoGraph, curr: TopoGraph): DiffEntry[] => {
   return entries;
 };
 
+const setDelta = (
+  prevValues: readonly string[] | undefined,
+  currValues: readonly string[] | undefined
+): {
+  readonly added: readonly string[];
+  readonly removed: readonly string[];
+} => {
+  const prevSet = new Set(prevValues);
+  const currSet = new Set(currValues);
+  return {
+    added: [...currSet].filter((value) => !prevSet.has(value)).toSorted(),
+    removed: [...prevSet].filter((value) => !currSet.has(value)).toSorted(),
+  };
+};
+
+const addSetChangeDetail = (
+  acc: DetailAccumulator,
+  label: string,
+  previous: readonly string[] | undefined,
+  current: readonly string[] | undefined,
+  removedSeverity: Severity
+): void => {
+  const { added, removed } = setDelta(previous, current);
+  if (added.length > 0) {
+    addDetail(acc, 'info', `${label} added: "${added.join('", "')}"`);
+  }
+  if (removed.length > 0) {
+    addDetail(
+      acc,
+      removedSeverity,
+      `${label} removed: "${removed.join('", "')}"`
+    );
+  }
+};
+
+const diffFacet = (
+  prev: TopoGraphFacetEntry,
+  curr: TopoGraphFacetEntry
+): DiffEntry | undefined => {
+  const acc: DetailAccumulator = { details: [], severity: 'info' };
+
+  addSetChangeDetail(
+    acc,
+    'Facet member',
+    prev.memberIds,
+    curr.memberIds,
+    'warning'
+  );
+  addSetChangeDetail(
+    acc,
+    'Facet surface',
+    prev.surfaces,
+    curr.surfaces,
+    'warning'
+  );
+
+  if (prev.memberSetHash !== curr.memberSetHash) {
+    addDetail(acc, 'warning', 'Facet member-set hash changed');
+  }
+  if (prev.description !== curr.description) {
+    addDetail(acc, 'info', 'Description updated');
+  }
+  if (prev.visibility !== curr.visibility) {
+    addDetail(
+      acc,
+      'warning',
+      `visibility changed: ${String(prev.visibility ?? 'public')} -> ${String(curr.visibility ?? 'public')}`
+    );
+  }
+  if (prev.descriptionStableThrough !== curr.descriptionStableThrough) {
+    addDetail(acc, 'info', 'descriptionStableThrough updated');
+  }
+  if (prev.visibilityWideningAccepted !== curr.visibilityWideningAccepted) {
+    addDetail(acc, 'info', 'visibilityWideningAccepted updated');
+  }
+
+  if (acc.details.length === 0) {
+    return undefined;
+  }
+
+  return {
+    change: 'modified',
+    details: acc.details,
+    id: curr.id,
+    kind: 'facet',
+    severity: acc.severity,
+  };
+};
+
+const diffFacets = (prev: TopoGraph, curr: TopoGraph): DiffEntry[] => {
+  const prevById = new Map(
+    (prev.facets ?? []).map((facet) => [facet.id, facet])
+  );
+  const currById = new Map(
+    (curr.facets ?? []).map((facet) => [facet.id, facet])
+  );
+  const entries: DiffEntry[] = [];
+
+  for (const [id, facet] of [...currById.entries()].toSorted(([a], [b]) =>
+    a.localeCompare(b)
+  )) {
+    const previous = prevById.get(id);
+    if (previous === undefined) {
+      entries.push({
+        change: 'added',
+        details: [`Facet "${id}" added`],
+        id,
+        kind: 'facet',
+        severity: 'info',
+      });
+      continue;
+    }
+    const diff = diffFacet(previous, facet);
+    if (diff !== undefined) {
+      entries.push(diff);
+    }
+  }
+
+  for (const [id] of [...prevById.entries()].toSorted(([a], [b]) =>
+    a.localeCompare(b)
+  )) {
+    if (!currById.has(id)) {
+      entries.push({
+        change: 'removed',
+        details: [`Facet "${id}" removed`],
+        id,
+        kind: 'facet',
+        severity: 'warning',
+      });
+    }
+  }
+
+  return entries;
+};
+
 /** Diff declared contour arrays on trail entries. */
 const diffContours = (
   acc: DetailAccumulator,
@@ -922,6 +1061,7 @@ const collectDiffEntries = (
   ...findRemoved(prevById, currById),
   ...findModified(prevById, currById),
   ...diffGraphForces(prev, curr),
+  ...diffFacets(prev, curr),
 ];
 
 export const deriveTopoGraphDiff = (

--- a/packages/topographer/src/forces.ts
+++ b/packages/topographer/src/forces.ts
@@ -10,8 +10,15 @@ export interface TopoGraphForceOptions {
   readonly reason?: string | undefined;
 }
 
+type ForceableDiffEntry = DiffEntry & {
+  readonly kind: TopoGraphForceEntry['kind'];
+};
+
+const isForceableDiffEntry = (diff: DiffEntry): diff is ForceableDiffEntry =>
+  diff.kind !== 'facet';
+
 const toForceEntry = (
-  diff: DiffEntry,
+  diff: ForceableDiffEntry,
   detail: string,
   acceptedAt: string,
   reason?: string | undefined
@@ -30,7 +37,7 @@ export const deriveTopoGraphForceEntries = (
   diff: DiffEntry,
   options?: TopoGraphForceOptions
 ): readonly TopoGraphForceEntry[] => {
-  if (diff.severity !== 'breaking') {
+  if (diff.severity !== 'breaking' || !isForceableDiffEntry(diff)) {
     return [];
   }
 

--- a/packages/topographer/src/hash.ts
+++ b/packages/topographer/src/hash.ts
@@ -38,14 +38,18 @@ const canonicalize = (value: unknown): unknown => {
  * The `generatedAt` field is excluded so that identical topos always
  * produce the same hash regardless of when they were generated.
  */
-export const deriveTopoGraphHash = (topoGraph: TopoGraph): string => {
-  // Strip generatedAt before hashing
-  const { generatedAt: _unused, ...rest } = topoGraph;
-
-  const canonical = canonicalize(rest);
+export const deriveStableHash = (value: unknown): string => {
+  const canonical = canonicalize(value);
   const json = JSON.stringify(canonical);
 
   const hasher = new Bun.CryptoHasher('sha256');
   hasher.update(json);
   return hasher.digest('hex');
+};
+
+export const deriveTopoGraphHash = (topoGraph: TopoGraph): string => {
+  // Strip generatedAt before hashing
+  const { generatedAt: _unused, ...rest } = topoGraph;
+
+  return deriveStableHash(rest);
 };

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -40,6 +40,7 @@ export {
   lockManifestSchema,
   lockManifestSummarySchema,
   TOPO_GRAPH_SCHEMA_VERSION,
+  topoGraphFacetEntrySchema,
   workspaceTopoMetadataSchema,
   workspaceTrailCollisionSchema,
   workspaceTrailEntrySchema,
@@ -67,6 +68,9 @@ export type {
 export type {
   TopoGraph,
   TopoGraphEntry,
+  TopoGraphFacetDeclaration,
+  TopoGraphFacetEntry,
+  TopoGraphFacetTrailSelector,
   TopoGraphForceEntry,
   TopoGraphFieldOverride,
   TopoGraphFieldOverrideKey,

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -124,6 +124,29 @@ export interface TopoGraphForceEntry {
   readonly source: 'trails compile --force';
 }
 
+export type TopoGraphFacetTrailSelector = string | readonly string[];
+
+export interface TopoGraphFacetDeclaration {
+  readonly id: string;
+  readonly trails: TopoGraphFacetTrailSelector;
+  readonly description: string;
+  readonly surfaces?: readonly string[] | undefined;
+  readonly visibility?: 'public' | 'internal' | undefined;
+  readonly descriptionStableThrough?: string | undefined;
+  readonly visibilityWideningAccepted?: true | undefined;
+}
+
+export interface TopoGraphFacetEntry {
+  readonly id: string;
+  readonly description: string;
+  readonly memberIds: readonly string[];
+  readonly memberSetHash: string;
+  readonly surfaces: readonly string[];
+  readonly visibility?: 'public' | 'internal' | undefined;
+  readonly descriptionStableThrough?: string | undefined;
+  readonly visibilityWideningAccepted?: true | undefined;
+}
+
 // ---------------------------------------------------------------------------
 // TopoGraph
 // ---------------------------------------------------------------------------
@@ -188,8 +211,13 @@ export interface TopoGraph {
   >;
   readonly generatedAt: string;
   readonly entries: readonly TopoGraphEntry[];
+  readonly facets?: readonly TopoGraphFacetEntry[] | undefined;
   readonly forces?: readonly TopoGraphForceEntry[] | undefined;
   readonly workspace?: WorkspaceTopoMetadata | undefined;
+}
+
+export interface DeriveTopoGraphOptions {
+  readonly facets?: readonly TopoGraphFacetDeclaration[] | undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -259,6 +287,19 @@ const topoGraphForceEntrySchema = z
   })
   .strict();
 
+export const topoGraphFacetEntrySchema = z
+  .object({
+    description: z.string(),
+    descriptionStableThrough: z.string().optional(),
+    id: z.string(),
+    memberIds: z.array(z.string()),
+    memberSetHash: z.string().regex(/^[0-9a-f]{64}$/),
+    surfaces: z.array(z.string()),
+    visibility: z.enum(['public', 'internal']).optional(),
+    visibilityWideningAccepted: z.literal(true).optional(),
+  })
+  .strict();
+
 export const topoGraphSchema = z
   .object({
     activationGraph: z
@@ -281,6 +322,7 @@ export const topoGraphSchema = z
         })
         .passthrough()
     ),
+    facets: z.array(topoGraphFacetEntrySchema).optional(),
     forces: z.array(topoGraphForceEntrySchema).optional(),
     generatedAt: z.string(),
     topoGraphSchemaVersion: z.literal(TOPO_GRAPH_SCHEMA_VERSION),
@@ -327,7 +369,7 @@ export type LockManifest = z.infer<typeof lockManifestSchema>;
 
 export interface DiffEntry {
   readonly id: string;
-  readonly kind: 'contour' | 'trail' | 'signal' | 'resource';
+  readonly kind: 'contour' | 'trail' | 'signal' | 'resource' | 'facet';
   readonly change: 'added' | 'removed' | 'modified';
   readonly severity: 'info' | 'warning' | 'breaking';
   readonly details: readonly string[];


### PR DESCRIPTION
## Summary
- Serializes surface facet metadata into TopoGraph artifacts so facet projection can be inspected and diffed.
- Extends hash/diff/io coverage for facet entries without making facets forceable breaking-change entries.
- Adds adapter metadata evidence and changeset coverage for the publishable topographer update.

## Verification
- bun run check
- bun run test
- bun run build
- bun run publish:check
- git diff --check
- gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
- real submit pre-push hook passed