### PR TITLE
feat(mcp): add surface facet projection

### DIFF
--- a/.changeset/trl-892-mcp-surface-facets.md
+++ b/.changeset/trl-892-mcp-surface-facets.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/mcp': minor
+---
+
+Add MCP surface facets, MCP resource projection for cold context, and deferred-loading metadata hints.

--- a/packages/mcp/src/__tests__/build.test.ts
+++ b/packages/mcp/src/__tests__/build.test.ts
@@ -16,8 +16,10 @@ import type { Layer, TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
 import {
+  MCP_TOOL_DEFERRED_META_KEY,
   MCP_TOOL_ERROR_META_KEY,
   MCP_TOOL_EXAMPLES_META_KEY,
+  MCP_TOOL_FACET_META_KEY,
   deriveMcpTools,
 } from '../build.js';
 import type { McpExtra, McpToolDefinition } from '../build.js';
@@ -638,6 +640,132 @@ describe('deriveMcpTools', () => {
       });
 
       expect(tools.map((tool) => tool.trailId)).toEqual(['item.delete']);
+    });
+  });
+
+  describe('facets', () => {
+    const readTopoTrail = trail('topo.read', {
+      blaze: (input) => Result.ok({ id: input.id, title: 'Topo' }),
+      description: 'Read topo.',
+      input: z.object({ id: z.string() }),
+      intent: 'read',
+      output: z.object({ id: z.string(), title: z.string() }),
+    });
+    const describeTopoTrail = trail('topo.describe', {
+      blaze: () => Result.ok({ summary: 'Topo summary' }),
+      description: 'Describe topo.',
+      input: z.object({}),
+      intent: 'read',
+      output: z.object({ summary: z.string() }),
+    });
+
+    test('collapses selected member trails into one faceted tool', () => {
+      const app = topo('myapp', {
+        describeTopoTrail,
+        echoTrail,
+        readTopoTrail,
+      });
+      const tools = buildTools(app, {
+        facets: {
+          topo: {
+            description: 'Read topo state.',
+            mcp: { loading: 'deferred' },
+            trails: 'topo.*',
+          },
+        },
+      });
+
+      expect(tools.map((tool) => tool.name).toSorted()).toEqual([
+        'myapp_echo',
+        'myapp_topo',
+      ]);
+
+      const facetTool = requireTool(tools, 'myapp_topo');
+      expect(facetTool.trailId).toBeUndefined();
+      expect(facetTool.facetId).toBe('topo');
+      expect(facetTool.memberTrailIds).toEqual(['topo.describe', 'topo.read']);
+      expect(facetTool._meta?.[MCP_TOOL_DEFERRED_META_KEY]).toBe(true);
+      expect(facetTool._meta?.[MCP_TOOL_FACET_META_KEY]).toEqual({
+        id: 'topo',
+        memberTrailIds: ['topo.describe', 'topo.read'],
+      });
+      expect(facetTool.inputSchema).toMatchObject({
+        properties: {
+          trail: { enum: ['topo.describe', 'topo.read'], type: 'string' },
+        },
+        required: ['trail', 'input'],
+        type: 'object',
+      });
+    });
+
+    test('dispatches to the selected trail and correlates output', async () => {
+      const app = topo('myapp', { describeTopoTrail, readTopoTrail });
+      const tool = requireOnlyTool(
+        buildTools(app, {
+          facets: {
+            topo: {
+              description: 'Read topo state.',
+              trails: 'topo.*',
+            },
+          },
+        })
+      );
+
+      const result = await tool.handler(
+        { input: { id: 'topo-1' }, trail: 'topo.read' },
+        noExtra
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(result.structuredContent).toEqual({
+        output: { id: 'topo-1', title: 'Topo' },
+        trail: 'topo.read',
+      });
+      expect(parseJsonContent(result.content[0])).toEqual({
+        output: { id: 'topo-1', title: 'Topo' },
+        trail: 'topo.read',
+      });
+    });
+
+    test('returns a validation error for unknown facet trail selectors', async () => {
+      const app = topo('myapp', { readTopoTrail });
+      const tool = requireOnlyTool(
+        buildTools(app, {
+          facets: {
+            topo: {
+              description: 'Read topo state.',
+              trails: 'topo.*',
+            },
+          },
+        })
+      );
+
+      const result = await tool.handler(
+        { input: {}, trail: 'topo.missing' },
+        noExtra
+      );
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0]?.text).toContain('unknown trail selector');
+    });
+
+    test('rejects facet selectors that overlap without narrowing', () => {
+      const app = topo('myapp', { describeTopoTrail, readTopoTrail });
+      const result = deriveMcpTools(app, {
+        facets: {
+          one: {
+            description: 'One.',
+            trails: 'topo.*',
+          },
+          two: {
+            description: 'Two.',
+            trails: ['topo.read'],
+          },
+        },
+      });
+
+      expect(result.isErr()).toBe(true);
+      expect(result.error?.message).toMatch(/facet overlap/i);
     });
   });
 

--- a/packages/mcp/src/__tests__/resources.test.ts
+++ b/packages/mcp/src/__tests__/resources.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { MCP_TOOL_DEFERRED_META_KEY, deriveMcpTools } from '../build.js';
+import {
+  MCP_EXAMPLES_RESOURCE_PREFIX,
+  MCP_SURFACE_MAP_RESOURCE_URI,
+  buildMcpResources,
+} from '../resources.js';
+
+const unwrapTools = (...args: Parameters<typeof deriveMcpTools>) => {
+  const result = deriveMcpTools(...args);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+const parseJson = (text: string | undefined): unknown => {
+  expect(text).toBeDefined();
+  return JSON.parse(text ?? 'null');
+};
+
+describe('buildMcpResources', () => {
+  test('projects a surface map resource with faceted tool metadata', () => {
+    const readTopo = trail('topo.read', {
+      blaze: () => Result.ok({ ok: true }),
+      description: 'Read topo.',
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+    });
+    const app = topo('myapp', { readTopo });
+    const tools = unwrapTools(app, {
+      facets: {
+        topo: {
+          description: 'Read topo state.',
+          mcp: { loading: 'deferred' },
+          trails: 'topo.*',
+        },
+      },
+    });
+
+    const resources = buildMcpResources(app, tools);
+    const surfaceMap = resources.read(MCP_SURFACE_MAP_RESOURCE_URI);
+
+    expect(resources.list.map((resource) => resource.uri)).toContain(
+      MCP_SURFACE_MAP_RESOURCE_URI
+    );
+    expect(parseJson(surfaceMap?.text)).toMatchObject({
+      surface: 'mcp',
+      tools: [
+        {
+          deferred: true,
+          facetId: 'topo',
+          memberTrailIds: ['topo.read'],
+          name: 'myapp_topo',
+        },
+      ],
+    });
+    expect(tools[0]?._meta?.[MCP_TOOL_DEFERRED_META_KEY]).toBe(true);
+  });
+
+  test('projects examples for trails exposed through a facet', () => {
+    const readTopo = trail('topo.read', {
+      blaze: (input) => Result.ok({ id: input.id }),
+      examples: [
+        {
+          expected: { id: 'topo-1' },
+          input: { id: 'topo-1' },
+          name: 'basic',
+        },
+      ],
+      input: z.object({ id: z.string() }),
+      output: z.object({ id: z.string() }),
+    });
+    const app = topo('myapp', { readTopo });
+    const tools = unwrapTools(app, {
+      facets: {
+        topo: {
+          description: 'Read topo state.',
+          trails: 'topo.*',
+        },
+      },
+    });
+    const resources = buildMcpResources(app, tools);
+    const uri = `${MCP_EXAMPLES_RESOURCE_PREFIX}${encodeURIComponent('topo.read')}`;
+    const content = resources.read(uri);
+
+    expect(resources.list.map((resource) => resource.uri)).toContain(uri);
+    expect(parseJson(content?.text)).toMatchObject({
+      examples: [
+        {
+          expected: { id: 'topo-1' },
+          input: { id: 'topo-1' },
+          kind: 'success',
+          name: 'basic',
+        },
+      ],
+      trailId: 'topo.read',
+    });
+  });
+
+  test('can disable surface map and example resources', () => {
+    const readTopo = trail('topo.read', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+    });
+    const app = topo('myapp', { readTopo });
+    const resources = buildMcpResources(app, unwrapTools(app), {
+      examples: false,
+      surfaceMap: false,
+    });
+
+    expect(resources.list).toEqual([]);
+    expect(resources.read(MCP_SURFACE_MAP_RESOURCE_URI)).toBeUndefined();
+  });
+});

--- a/packages/mcp/src/__tests__/surface.test.ts
+++ b/packages/mcp/src/__tests__/surface.test.ts
@@ -95,12 +95,21 @@ describe('surface', () => {
   test('CreateServerOptions accepts flattened identity and resource fields', () => {
     const opts: Parameters<typeof surface>[1] = {
       description: 'Test MCP server',
+      facets: {
+        read: {
+          description: 'Read tools.',
+          trails: 'read.*',
+        },
+      },
+      mcpResources: { examples: true, surfaceMap: true },
       name: 'testapp',
       resources: {},
       validate: false,
       version: '1.2.3',
     };
     expect(opts.description).toBe('Test MCP server');
+    expect(opts.facets?.read?.trails).toBe('read.*');
+    expect(opts.mcpResources).toEqual({ examples: true, surfaceMap: true });
     expect(opts.name).toBe('testapp');
     expect(opts.resources).toEqual({});
     expect(opts.validate).toBe(false);

--- a/packages/mcp/src/build.ts
+++ b/packages/mcp/src/build.ts
@@ -18,6 +18,7 @@ import {
   isBlobRef,
   isTrailsError,
   LAYER_FIELD_RESERVED_NAMES,
+  matchesTrailPattern,
   projectLayerFieldName,
   projectPublicSurfaceError,
   toBlobRefDescriptor,
@@ -69,6 +70,31 @@ export const MCP_TOOL_EXAMPLES_META_KEY = 'ontrails/examples';
  */
 export const MCP_TOOL_ERROR_META_KEY = 'ontrails/error';
 
+/**
+ * Metadata key used to identify MCP tools derived from surface facets.
+ *
+ * @example
+ * ```ts
+ * import { MCP_TOOL_FACET_META_KEY } from '@ontrails/mcp';
+ *
+ * const facet = tool._meta?.[MCP_TOOL_FACET_META_KEY];
+ * ```
+ */
+export const MCP_TOOL_FACET_META_KEY = 'ontrails/facet';
+
+/**
+ * Metadata key used as a compatibility hint for clients that support
+ * deferred MCP tool loading.
+ *
+ * @example
+ * ```ts
+ * import { MCP_TOOL_DEFERRED_META_KEY } from '@ontrails/mcp';
+ *
+ * const isDeferred = tool._meta?.[MCP_TOOL_DEFERRED_META_KEY] === true;
+ * ```
+ */
+export const MCP_TOOL_DEFERRED_META_KEY = 'ontrails/deferred';
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -77,10 +103,30 @@ export interface DeriveMcpToolsOptions extends BaseSurfaceOptions {
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
+  readonly facets?: McpSurfaceFacetMap | undefined;
   readonly layers?: readonly Layer[] | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
   readonly resolvePermit?: ResolveMcpPermit | undefined;
 }
+
+export type McpSurfaceFacetTrailSelector = string | readonly string[];
+
+export interface McpSurfaceFacetDefinition {
+  readonly trails: McpSurfaceFacetTrailSelector;
+  readonly description: string;
+  readonly visibility?: 'public' | 'internal' | undefined;
+  readonly descriptionStableThrough?: string | undefined;
+  readonly visibilityWideningAccepted?: true | undefined;
+  readonly mcp?:
+    | {
+        readonly loading?: 'deferred' | undefined;
+      }
+    | undefined;
+}
+
+export type McpSurfaceFacetMap = Readonly<
+  Record<string, McpSurfaceFacetDefinition>
+>;
 
 export interface ResolveMcpPermitInput {
   readonly authorization?: string | undefined;
@@ -98,15 +144,17 @@ export interface McpToolDefinition {
   readonly _meta?: Record<string, unknown> | undefined;
   readonly annotations: McpAnnotations | undefined;
   readonly description: string | undefined;
+  readonly facetId?: string | undefined;
   readonly handler: (
     args: Record<string, unknown>,
     extra: McpExtra
   ) => Promise<McpToolResult>;
   readonly inputSchema: Record<string, unknown>;
+  readonly memberTrailIds?: readonly string[] | undefined;
   readonly name: string;
   readonly outputSchema?: Record<string, unknown> | undefined;
   /** The trail ID this tool was derived from. */
-  readonly trailId: string;
+  readonly trailId?: string | undefined;
   readonly versions?: readonly SurfaceTrailVersionProjection[] | undefined;
 }
 
@@ -923,6 +971,16 @@ const buildMeta = (
   return { [MCP_TOOL_EXAMPLES_META_KEY]: examples };
 };
 
+const mergeMeta = (
+  ...entries: readonly (Record<string, unknown> | undefined)[]
+): Record<string, unknown> | undefined => {
+  const merged = Object.assign(
+    {},
+    ...(entries.filter(Boolean) as Record<string, unknown>[])
+  );
+  return Object.keys(merged).length > 0 ? merged : undefined;
+};
+
 /** Build a single MCP tool definition from a trail. */
 const buildToolDefinition = (
   graph: Topo,
@@ -962,25 +1020,217 @@ const buildToolDefinition = (
   };
 };
 
+const facetSelectors = (
+  selector: McpSurfaceFacetTrailSelector
+): readonly string[] => (typeof selector === 'string' ? [selector] : selector);
+
+const matchesFacetSelector = (
+  trailId: string,
+  selector: McpSurfaceFacetTrailSelector
+): boolean =>
+  facetSelectors(selector).some((pattern) =>
+    matchesTrailPattern(trailId, pattern)
+  );
+
+interface FacetMemberTool {
+  readonly tool: McpToolDefinition;
+  readonly trail: Trail<unknown, unknown, unknown>;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+
+const buildFacetInputSchema = (
+  members: readonly FacetMemberTool[]
+): Record<string, unknown> => ({
+  anyOf: members.map(({ tool, trail }) => ({
+    properties: {
+      input: tool.inputSchema,
+      trail: { const: trail.id },
+    },
+    required: ['trail', 'input'],
+    type: 'object',
+  })),
+  properties: {
+    input: { type: 'object' },
+    trail: {
+      enum: members.map(({ trail }) => trail.id),
+      type: 'string',
+    },
+  },
+  required: ['trail', 'input'],
+  type: 'object',
+});
+
+const buildFacetOutputSchema = (
+  members: readonly FacetMemberTool[]
+): Record<string, unknown> => {
+  const outputSchemas = members.map(({ tool }) => tool.outputSchema ?? {});
+  return {
+    properties: {
+      output:
+        outputSchemas.length === 1
+          ? (outputSchemas[0] ?? {})
+          : { anyOf: outputSchemas },
+      trail: {
+        enum: members.map(({ trail }) => trail.id),
+        type: 'string',
+      },
+    },
+    required: ['trail', 'output'],
+    type: 'object',
+  };
+};
+
+const parseJsonTextContent = (
+  content: readonly McpContent[]
+): unknown | undefined => {
+  const text = content.find((item) => item.type === 'text')?.text;
+  if (text === undefined) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return undefined;
+  }
+};
+
+const wrapFacetResult = (
+  trailId: string,
+  result: McpToolResult
+): McpToolResult => {
+  if (result.isError === true) {
+    return result;
+  }
+  const output =
+    result.structuredContent ?? parseJsonTextContent(result.content) ?? null;
+  const envelope = { output, trail: trailId };
+  return {
+    ...(result._meta === undefined ? {} : { _meta: result._meta }),
+    content: [
+      { text: JSON.stringify(envelope), type: 'text' },
+      ...result.content.filter((item) => item.type !== 'text'),
+    ],
+    structuredContent: envelope,
+  };
+};
+
+const createFacetHandler = (
+  facetId: string,
+  members: readonly FacetMemberTool[]
+): McpToolDefinition['handler'] => {
+  const byTrailId = new Map(
+    members.map((member) => [member.trail.id, member.tool])
+  );
+
+  return async (args, extra): Promise<McpToolResult> => {
+    const trailId = typeof args['trail'] === 'string' ? args['trail'] : '';
+    const tool = byTrailId.get(trailId);
+    if (tool === undefined) {
+      return mcpError(
+        new ValidationError(
+          `MCP facet "${facetId}" received unknown trail selector "${trailId || '(missing)'}"`
+        )
+      );
+    }
+
+    const { input } = args;
+    if (!isRecord(input)) {
+      return mcpError(
+        new ValidationError(
+          `MCP facet "${facetId}" expects an object input for trail "${trailId}"`
+        )
+      );
+    }
+
+    return wrapFacetResult(trailId, await tool.handler(input, extra));
+  };
+};
+
+const deriveFacetIntent = (
+  members: readonly FacetMemberTool[]
+): Pick<Trail<unknown, unknown, unknown>, 'intent'>['intent'] => {
+  if (members.every(({ trail }) => trail.intent === 'read')) {
+    return 'read';
+  }
+  if (members.some(({ trail }) => trail.intent === 'destroy')) {
+    return 'destroy';
+  }
+  return 'write';
+};
+
+const deriveFacetAnnotations = (
+  definition: McpSurfaceFacetDefinition,
+  members: readonly FacetMemberTool[]
+): McpAnnotations | undefined => {
+  const annotations = deriveAnnotations({
+    description: definition.description,
+    idempotent: false,
+    intent: deriveFacetIntent(members),
+  } as Pick<
+    Trail<unknown, unknown, unknown>,
+    'description' | 'idempotent' | 'intent'
+  >);
+  return Object.keys(annotations).length > 0 ? annotations : undefined;
+};
+
+const buildFacetMeta = (
+  facetId: string,
+  definition: McpSurfaceFacetDefinition,
+  memberTrailIds: readonly string[]
+): Record<string, unknown> | undefined =>
+  mergeMeta(
+    {
+      [MCP_TOOL_FACET_META_KEY]: {
+        id: facetId,
+        memberTrailIds,
+      },
+    },
+    definition.mcp?.loading === 'deferred'
+      ? { [MCP_TOOL_DEFERRED_META_KEY]: true }
+      : undefined
+  );
+
+const buildFacetToolDefinition = (
+  graph: Topo,
+  facetId: string,
+  definition: McpSurfaceFacetDefinition,
+  members: readonly FacetMemberTool[]
+): McpToolDefinition => {
+  const memberTrailIds = members.map(({ trail }) => trail.id);
+  return {
+    _meta: buildFacetMeta(facetId, definition, memberTrailIds),
+    annotations: deriveFacetAnnotations(definition, members),
+    description: definition.description,
+    facetId,
+    handler: createFacetHandler(facetId, members),
+    inputSchema: buildFacetInputSchema(members),
+    memberTrailIds,
+    name: deriveToolName(graph.name, facetId),
+    outputSchema: buildFacetOutputSchema(members),
+  };
+};
+
 /** Register a trail as an MCP tool, checking for name collisions. */
 const registerTool = (
   graph: Topo,
   trailItem: Trail<unknown, unknown, unknown>,
   layers: readonly Layer[],
   options: DeriveMcpToolsOptions,
-  nameToTrailId: Map<string, string>,
+  nameToSourceId: Map<string, string>,
   tools: McpToolDefinition[]
 ): Result<void, Error> => {
   const toolName = deriveToolName(graph.name, trailItem.id);
-  const existingId = nameToTrailId.get(toolName);
+  const existingId = nameToSourceId.get(toolName);
   if (existingId !== undefined) {
     return Result.err(
       new ValidationError(
-        `MCP tool-name collision: trails "${existingId}" and "${trailItem.id}" both derive the tool name "${toolName}"`
+        `MCP tool-name collision: "${existingId}" and "trail:${trailItem.id}" both derive the tool name "${toolName}"`
       )
     );
   }
-  nameToTrailId.set(toolName, trailItem.id);
+  nameToSourceId.set(toolName, `trail:${trailItem.id}`);
   tools.push(buildToolDefinition(graph, trailItem, layers, options));
   return Result.ok();
 };
@@ -1001,21 +1251,137 @@ const validateToolBuild = (
   options: DeriveMcpToolsOptions
 ): Result<void, Error> => validateSurfaceTopo(graph, options);
 
+const collectFacetMembers = (
+  graph: Topo,
+  definition: McpSurfaceFacetDefinition,
+  availableTrails: readonly Trail<unknown, unknown, unknown>[],
+  layers: readonly Layer[],
+  options: DeriveMcpToolsOptions
+): readonly FacetMemberTool[] =>
+  availableTrails
+    .filter((trailItem) =>
+      matchesFacetSelector(trailItem.id, definition.trails)
+    )
+    .map((trailItem) => ({
+      tool: buildToolDefinition(graph, trailItem, layers, options),
+      trail: trailItem,
+    }));
+
+const registerFacet = (
+  graph: Topo,
+  facetId: string,
+  definition: McpSurfaceFacetDefinition,
+  members: readonly FacetMemberTool[],
+  nameToSourceId: Map<string, string>,
+  tools: McpToolDefinition[]
+): Result<void, Error> => {
+  if (members.length === 0) {
+    return Result.err(
+      new ValidationError(
+        `MCP facet "${facetId}" did not match any surface-eligible trails`
+      )
+    );
+  }
+
+  const toolName = deriveToolName(graph.name, facetId);
+  const existingId = nameToSourceId.get(toolName);
+  if (existingId !== undefined) {
+    return Result.err(
+      new ValidationError(
+        `MCP tool-name collision: "${existingId}" and "facet:${facetId}" both derive the tool name "${toolName}"`
+      )
+    );
+  }
+
+  nameToSourceId.set(toolName, `facet:${facetId}`);
+  tools.push(buildFacetToolDefinition(graph, facetId, definition, members));
+  return Result.ok();
+};
+
+const registerFacets = (
+  graph: Topo,
+  options: DeriveMcpToolsOptions,
+  layers: readonly Layer[],
+  availableTrails: readonly Trail<unknown, unknown, unknown>[],
+  nameToSourceId: Map<string, string>,
+  tools: McpToolDefinition[]
+): Result<ReadonlySet<string>, Error> => {
+  const { facets } = options;
+  const consumedTrailIds = new Set<string>();
+  const ownerByTrailId = new Map<string, string>();
+
+  if (facets === undefined || Object.keys(facets).length === 0) {
+    return Result.ok(consumedTrailIds);
+  }
+
+  for (const [facetId, definition] of Object.entries(facets).toSorted()) {
+    const members = collectFacetMembers(
+      graph,
+      definition,
+      availableTrails,
+      layers,
+      options
+    );
+    for (const { trail: memberTrail } of members) {
+      const previous = ownerByTrailId.get(memberTrail.id);
+      if (previous !== undefined) {
+        return Result.err(
+          new ValidationError(
+            `MCP facet overlap: trail "${memberTrail.id}" is selected by facets "${previous}" and "${facetId}"`
+          )
+        );
+      }
+      ownerByTrailId.set(memberTrail.id, facetId);
+      consumedTrailIds.add(memberTrail.id);
+    }
+
+    const registered = registerFacet(
+      graph,
+      facetId,
+      definition,
+      members,
+      nameToSourceId,
+      tools
+    );
+    if (registered.isErr()) {
+      return registered;
+    }
+  }
+
+  return Result.ok(consumedTrailIds);
+};
+
 const registerTools = (
   graph: Topo,
   options: DeriveMcpToolsOptions,
   layers: readonly Layer[]
 ): Result<McpToolDefinition[], Error> => {
   const tools: McpToolDefinition[] = [];
-  const nameToTrailId = new Map<string, string>();
+  const nameToSourceId = new Map<string, string>();
+  const availableTrails = eligibleTrails(graph, options);
+  const registeredFacets = registerFacets(
+    graph,
+    options,
+    layers,
+    availableTrails,
+    nameToSourceId,
+    tools
+  );
+  if (registeredFacets.isErr()) {
+    return registeredFacets;
+  }
+  const consumedTrailIds = registeredFacets.value;
 
-  for (const trailItem of eligibleTrails(graph, options)) {
+  for (const trailItem of availableTrails) {
+    if (consumedTrailIds.has(trailItem.id)) {
+      continue;
+    }
     const registered = registerTool(
       graph,
       trailItem,
       layers,
       options,
-      nameToTrailId,
+      nameToSourceId,
       tools
     );
     if (registered.isErr()) {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -2,8 +2,13 @@
 export {
   MCP_TOOL_ERROR_META_KEY,
   MCP_TOOL_EXAMPLES_META_KEY,
+  MCP_TOOL_DEFERRED_META_KEY,
+  MCP_TOOL_FACET_META_KEY,
   deriveMcpTools,
   type DeriveMcpToolsOptions,
+  type McpSurfaceFacetDefinition,
+  type McpSurfaceFacetMap,
+  type McpSurfaceFacetTrailSelector,
   type McpToolDefinition,
   type McpToolResult,
   type McpToolErrorMeta,
@@ -12,6 +17,18 @@ export {
   type ResolveMcpPermit,
   type ResolveMcpPermitInput,
 } from './build.js';
+
+// MCP resources
+export {
+  MCP_EXAMPLES_RESOURCE_PREFIX,
+  MCP_SURFACE_MAP_RESOURCE_URI,
+  buildMcpResources,
+  isMcpFacetTool,
+  type BuiltMcpResources,
+  type McpResourceContent,
+  type McpResourceDefinition,
+  type McpResourcesConfig,
+} from './resources.js';
 
 // Tool naming
 export { deriveToolName } from './tool-name.js';

--- a/packages/mcp/src/resources.ts
+++ b/packages/mcp/src/resources.ts
@@ -1,0 +1,228 @@
+/**
+ * MCP resource projection for cold Trails context.
+ */
+
+import { deriveStructuredTrailExamples } from '@ontrails/core';
+import type { Topo, Trail } from '@ontrails/core';
+
+import {
+  MCP_TOOL_DEFERRED_META_KEY,
+  MCP_TOOL_FACET_META_KEY,
+} from './build.js';
+import type { McpToolDefinition } from './build.js';
+
+/**
+ * Resource URI used for the resolved MCP surface map.
+ *
+ * @example
+ * ```ts
+ * import { MCP_SURFACE_MAP_RESOURCE_URI } from '@ontrails/mcp';
+ *
+ * const surfaceMap = resources.read(MCP_SURFACE_MAP_RESOURCE_URI);
+ * ```
+ */
+export const MCP_SURFACE_MAP_RESOURCE_URI = 'trails://surface-map';
+
+/**
+ * Prefix used for trail example resources exposed through MCP.
+ *
+ * @example
+ * ```ts
+ * import { MCP_EXAMPLES_RESOURCE_PREFIX } from '@ontrails/mcp';
+ *
+ * const uri = `${MCP_EXAMPLES_RESOURCE_PREFIX}${encodeURIComponent('tasks.create')}`;
+ * ```
+ */
+export const MCP_EXAMPLES_RESOURCE_PREFIX = 'trails://examples/';
+
+export interface McpResourceDefinition {
+  readonly uri: string;
+  readonly mimeType: string;
+  readonly name: string;
+  readonly description?: string | undefined;
+}
+
+export interface McpResourceContent {
+  readonly uri: string;
+  readonly mimeType: string;
+  readonly text: string;
+}
+
+export interface McpResourcesConfig {
+  readonly surfaceMap?: boolean | undefined;
+  readonly examples?: boolean | undefined;
+}
+
+export interface BuiltMcpResources {
+  readonly list: readonly McpResourceDefinition[];
+  readonly read: (uri: string) => McpResourceContent | undefined;
+}
+
+interface McpSurfaceMapTool {
+  readonly annotations: McpToolDefinition['annotations'];
+  readonly description: string | undefined;
+  readonly facetId?: string | undefined;
+  readonly inputSchema: Record<string, unknown>;
+  readonly memberTrailIds?: readonly string[] | undefined;
+  readonly name: string;
+  readonly outputSchema?: Record<string, unknown> | undefined;
+  readonly trailId?: string | undefined;
+  readonly versions?: McpToolDefinition['versions'];
+  readonly deferred?: true | undefined;
+}
+
+interface McpSurfaceMap {
+  readonly surface: 'mcp';
+  readonly tools: readonly McpSurfaceMapTool[];
+}
+
+const asJson = (value: unknown): string =>
+  `${JSON.stringify(value, null, 2)}\n`;
+
+const projectSurfaceMapTool = (tool: McpToolDefinition): McpSurfaceMapTool => ({
+  annotations: tool.annotations,
+  description: tool.description,
+  inputSchema: tool.inputSchema,
+  name: tool.name,
+  ...(tool.facetId === undefined ? {} : { facetId: tool.facetId }),
+  ...(tool.memberTrailIds === undefined
+    ? {}
+    : { memberTrailIds: tool.memberTrailIds }),
+  ...(tool.outputSchema === undefined
+    ? {}
+    : { outputSchema: tool.outputSchema }),
+  ...(tool.trailId === undefined ? {} : { trailId: tool.trailId }),
+  ...(tool.versions === undefined ? {} : { versions: tool.versions }),
+  ...(tool._meta?.[MCP_TOOL_DEFERRED_META_KEY] === true
+    ? { deferred: true }
+    : {}),
+});
+
+const buildSurfaceMap = (
+  tools: readonly McpToolDefinition[]
+): McpSurfaceMap => ({
+  surface: 'mcp',
+  tools: tools.map(projectSurfaceMapTool),
+});
+
+const exposedTrailIds = (
+  tools: readonly McpToolDefinition[]
+): ReadonlySet<string> =>
+  new Set(
+    tools.flatMap((tool) => [
+      ...(tool.trailId === undefined ? [] : [tool.trailId]),
+      ...(tool.memberTrailIds ?? []),
+    ])
+  );
+
+const examplesUriForTrail = (trailId: string): string =>
+  `${MCP_EXAMPLES_RESOURCE_PREFIX}${encodeURIComponent(trailId)}`;
+
+const buildExampleResource = (
+  trailItem: Trail<unknown, unknown, unknown>
+):
+  | {
+      readonly content: McpResourceContent;
+      readonly listing: McpResourceDefinition;
+    }
+  | undefined => {
+  const examples = deriveStructuredTrailExamples(trailItem.examples);
+  if (examples === undefined) {
+    return undefined;
+  }
+
+  const uri = examplesUriForTrail(trailItem.id);
+  return {
+    content: {
+      mimeType: 'application/json',
+      text: asJson({
+        examples,
+        trailId: trailItem.id,
+      }),
+      uri,
+    },
+    listing: {
+      description: `Structured examples for trail "${trailItem.id}".`,
+      mimeType: 'application/json',
+      name: `Trail examples: ${trailItem.id}`,
+      uri,
+    },
+  };
+};
+
+const buildExampleResources = (
+  graph: Topo,
+  tools: readonly McpToolDefinition[]
+): readonly {
+  readonly content: McpResourceContent;
+  readonly listing: McpResourceDefinition;
+}[] => {
+  const visibleTrailIds = exposedTrailIds(tools);
+  return graph
+    .list()
+    .filter((trailItem) => visibleTrailIds.has(trailItem.id))
+    .map((trailItem) =>
+      buildExampleResource(trailItem as Trail<unknown, unknown, unknown>)
+    )
+    .filter((resource) => resource !== undefined);
+};
+
+/**
+ * Build the cold-context MCP resources for a Trails graph and tool set.
+ *
+ * @example
+ * ```ts
+ * import { buildMcpResources, deriveMcpTools } from '@ontrails/mcp';
+ *
+ * const tools = deriveMcpTools(app).value;
+ * const resources = buildMcpResources(app, tools);
+ * ```
+ */
+export const buildMcpResources = (
+  graph: Topo,
+  tools: readonly McpToolDefinition[],
+  config: McpResourcesConfig = {}
+): BuiltMcpResources => {
+  const listings: McpResourceDefinition[] = [];
+  const contents = new Map<string, McpResourceContent>();
+
+  if (config.surfaceMap !== false) {
+    const surfaceMapListing = {
+      description: 'Resolved MCP surface projection for this Trails app.',
+      mimeType: 'application/json',
+      name: 'Trails MCP surface map',
+      uri: MCP_SURFACE_MAP_RESOURCE_URI,
+    };
+    listings.push(surfaceMapListing);
+    contents.set(MCP_SURFACE_MAP_RESOURCE_URI, {
+      mimeType: 'application/json',
+      text: asJson(buildSurfaceMap(tools)),
+      uri: MCP_SURFACE_MAP_RESOURCE_URI,
+    });
+  }
+
+  if (config.examples !== false) {
+    for (const resource of buildExampleResources(graph, tools)) {
+      listings.push(resource.listing);
+      contents.set(resource.content.uri, resource.content);
+    }
+  }
+
+  return {
+    list: listings,
+    read: (uri) => contents.get(uri),
+  };
+};
+
+/**
+ * Return whether an MCP tool was projected from a surface facet.
+ *
+ * @example
+ * ```ts
+ * import { isMcpFacetTool } from '@ontrails/mcp';
+ *
+ * const facetTools = tools.filter(isMcpFacetTool);
+ * ```
+ */
+export const isMcpFacetTool = (tool: McpToolDefinition): boolean =>
+  tool._meta?.[MCP_TOOL_FACET_META_KEY] !== undefined;

--- a/packages/mcp/src/surface.ts
+++ b/packages/mcp/src/surface.ts
@@ -5,7 +5,9 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   CallToolRequestSchema,
+  ListResourcesRequestSchema,
   ListToolsRequestSchema,
+  ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type {
   BaseSurfaceOptions,
@@ -15,8 +17,14 @@ import type {
   TrailContextInit,
 } from '@ontrails/core';
 
-import type { McpToolDefinition, ResolveMcpPermit } from './build.js';
+import type {
+  McpSurfaceFacetMap,
+  McpToolDefinition,
+  ResolveMcpPermit,
+} from './build.js';
 import { deriveMcpTools } from './build.js';
+import { buildMcpResources } from './resources.js';
+import type { BuiltMcpResources, McpResourcesConfig } from './resources.js';
 import { connectStdio } from './stdio.js';
 
 // ---------------------------------------------------------------------------
@@ -28,7 +36,9 @@ export interface CreateServerOptions extends BaseSurfaceOptions {
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
   readonly description?: string | undefined;
+  readonly facets?: McpSurfaceFacetMap | undefined;
   readonly layers?: readonly Layer[] | undefined;
+  readonly mcpResources?: McpResourcesConfig | false | undefined;
   readonly name?: string | undefined;
   readonly resources?: ResourceOverrideMap | undefined;
   readonly resolvePermit?: ResolveMcpPermit | undefined;
@@ -56,12 +66,16 @@ const createMcpServer = (
     readonly name: string;
     readonly version: string;
     readonly description?: string | undefined;
-  }
+  },
+  mcpResources?: BuiltMcpResources | undefined
 ): Server => {
   const server = new Server(
     { name: info.name, version: info.version },
     {
-      capabilities: { tools: {} },
+      capabilities: {
+        ...(mcpResources === undefined ? {} : { resources: {} }),
+        tools: {},
+      },
       ...(info.description === undefined
         ? {}
         : { instructions: info.description }),
@@ -149,6 +163,31 @@ const createMcpServer = (
     }
   );
 
+  if (mcpResources !== undefined) {
+    // oxlint-disable-next-line require-await -- MCP SDK requires async handler
+    server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+      resources: mcpResources.list.map((resource) => ({
+        description: resource.description,
+        mimeType: resource.mimeType,
+        name: resource.name,
+        uri: resource.uri,
+      })),
+    }));
+
+    server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+      const content = mcpResources.read(request.params.uri);
+      return {
+        contents: [
+          content ?? {
+            mimeType: 'text/plain',
+            text: `Unknown MCP resource: ${request.params.uri}`,
+            uri: request.params.uri,
+          },
+        ],
+      };
+    });
+  }
+
   return server;
 };
 
@@ -179,6 +218,7 @@ export const createServer = (
     configValues: options.configValues,
     createContext: options.createContext,
     exclude: options.exclude,
+    facets: options.facets,
     include: options.include,
     intent: options.intent,
     layers: options.layers,
@@ -191,11 +231,20 @@ export const createServer = (
     throw toolsResult.error;
   }
 
-  return createMcpServer(toolsResult.value, {
-    description: options.description ?? graph.description,
-    name: options.name ?? graph.name,
-    version: options.version ?? graph.version ?? '0.1.0',
-  });
+  const mcpResources =
+    options.mcpResources === false
+      ? undefined
+      : buildMcpResources(graph, toolsResult.value, options.mcpResources);
+
+  return createMcpServer(
+    toolsResult.value,
+    {
+      description: options.description ?? graph.description,
+      name: options.name ?? graph.name,
+      version: options.version ?? graph.version ?? '0.1.0',
+    },
+    mcpResources
+  );
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds the general MCP surface facet projection engine.
- Supports facet tools that dispatch to member trails while keeping member trails out of the direct tool list.
- Adds facet/deferred metadata, cold context resource helpers, public API examples, tests, and changeset coverage.

## Verification
- bun run check
- bun run test
- bun run build
- bun run publish:check
- git diff --check
- gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
- real submit pre-push hook passed