### PR TITLE
feat(trails): shape operator mcp surface

### DIFF
--- a/.changeset/trl-888-trails-operator-mcp-facets.md
+++ b/.changeset/trl-888-trails-operator-mcp-facets.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': minor
+---
+
+Add the Trails operator MCP entrypoint with deferred surface facets and cold-context resources.

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  MCP_EXAMPLES_RESOURCE_PREFIX,
+  MCP_SURFACE_MAP_RESOURCE_URI,
+  MCP_TOOL_DEFERRED_META_KEY,
+  buildMcpResources,
+  deriveMcpTools,
+} from '@ontrails/mcp';
+
+import { app } from '../app.js';
+import { trailsMcpFacets, trailsMcpSurfaceOptions } from '../mcp-options.js';
+
+const unwrapTools = (...args: Parameters<typeof deriveMcpTools>) => {
+  const result = deriveMcpTools(...args);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+const parseJson = (text: string | undefined): unknown => {
+  expect(text).toBeDefined();
+  return JSON.parse(text ?? 'null');
+};
+
+describe('Trails MCP surface shaping', () => {
+  test('projects the Trails operator app as deferred facet tools', () => {
+    const tools = unwrapTools(app, trailsMcpSurfaceOptions);
+
+    expect(tools.map((tool) => tool.name).toSorted()).toEqual([
+      'trails_artifacts',
+      'trails_authoring',
+      'trails_execution',
+      'trails_governance',
+      'trails_inspect',
+      'trails_shell',
+      'trails_workspace',
+    ]);
+
+    for (const tool of tools) {
+      expect(tool.trailId).toBeUndefined();
+      expect(tool.facetId).toBeDefined();
+      expect(tool.memberTrailIds?.length).toBeGreaterThan(0);
+      expect(tool._meta?.[MCP_TOOL_DEFERRED_META_KEY]).toBe(true);
+      expect(tool.inputSchema).toMatchObject({
+        required: ['trail', 'input'],
+        type: 'object',
+      });
+    }
+  });
+
+  test('accounts for every public operator trail without widening internal trails', () => {
+    const rawTools = unwrapTools(app);
+    const shapedTools = unwrapTools(app, trailsMcpSurfaceOptions);
+    const rawTrailIds = rawTools
+      .map((tool) => tool.trailId)
+      .filter((trailId) => trailId !== undefined)
+      .toSorted();
+    const shapedTrailIds = shapedTools
+      .flatMap((tool) => tool.memberTrailIds ?? [])
+      .toSorted();
+
+    expect(shapedTrailIds).toEqual(rawTrailIds);
+    expect(shapedTrailIds).not.toContain('add.verify');
+    expect(shapedTrailIds).not.toContain('create.scaffold');
+  });
+
+  test('keeps app-authored facet selectors explicit enough for review', () => {
+    expect(trailsMcpFacets.inspect.trails).toContain('survey');
+    expect(trailsMcpFacets.inspect.trails).not.toContain('survey.*');
+    expect(trailsMcpFacets.authoring.trails).toContain('draft.promote');
+    expect(trailsMcpFacets.workspace.trails).toEqual([
+      'dev.stats',
+      'dev.clean',
+      'dev.reset',
+    ]);
+  });
+
+  test('exposes cold context resources for the shaped surface', () => {
+    const tools = unwrapTools(app, trailsMcpSurfaceOptions);
+    const resources = buildMcpResources(
+      app,
+      tools,
+      trailsMcpSurfaceOptions.mcpResources
+    );
+    const surfaceMap = resources.read(MCP_SURFACE_MAP_RESOURCE_URI);
+    const runExampleUri = `${MCP_EXAMPLES_RESOURCE_PREFIX}${encodeURIComponent('run.example')}`;
+
+    expect(resources.list.map((resource) => resource.uri)).toContain(
+      MCP_SURFACE_MAP_RESOURCE_URI
+    );
+    expect(resources.list.map((resource) => resource.uri)).toContain(
+      runExampleUri
+    );
+    const projectedMap = parseJson(surfaceMap?.text) as {
+      readonly tools?: readonly {
+        readonly deferred?: boolean | undefined;
+        readonly facetId?: string | undefined;
+        readonly name?: string | undefined;
+      }[];
+    };
+    expect(
+      projectedMap.tools?.find((tool) => tool.facetId === 'artifacts')
+    ).toEqual(
+      expect.objectContaining({
+        deferred: true,
+        facetId: 'artifacts',
+        name: 'trails_artifacts',
+      })
+    );
+  });
+});

--- a/apps/trails/src/mcp-options.ts
+++ b/apps/trails/src/mcp-options.ts
@@ -1,0 +1,72 @@
+import type { CreateServerOptions, McpSurfaceFacetMap } from '@ontrails/mcp';
+
+export const trailsMcpFacets = {
+  artifacts: {
+    description:
+      'Compile, validate, and manage local topo artifacts for a Trails workspace.',
+    mcp: { loading: 'deferred' },
+    trails: ['compile', 'validate', 'topo.history', 'topo.pin', 'topo.unpin'],
+  },
+  authoring: {
+    description:
+      'Create and evolve Trails projects, surfaces, trails, and version entries.',
+    mcp: { loading: 'deferred' },
+    trails: [
+      'create',
+      'create.adapter',
+      'add.surface',
+      'add.trail',
+      'revise',
+      'deprecate',
+      'draft.promote',
+    ],
+  },
+  execution: {
+    description:
+      'Run trails and examples from a Trails workspace with traceable outcomes.',
+    mcp: { loading: 'deferred' },
+    trails: ['run', 'run.examples', 'run.example'],
+  },
+  governance: {
+    description:
+      'Run project diagnostics, adapter readiness checks, and Warden guidance.',
+    mcp: { loading: 'deferred' },
+    trails: ['doctor', 'adapter.check', 'warden', 'warden.guide'],
+  },
+  inspect: {
+    description:
+      'Inspect topo structure, contracts, resources, signals, surfaces, and diffs.',
+    mcp: { loading: 'deferred' },
+    trails: [
+      'survey',
+      'diff',
+      'topo',
+      'guide',
+      'survey.brief',
+      'survey.diff',
+      'survey.resource',
+      'survey.signal',
+      'survey.surfaces',
+      'survey.trail',
+    ],
+  },
+  shell: {
+    description: 'Render and complete Trails shell completions.',
+    mcp: { loading: 'deferred' },
+    trails: ['completions', 'completions.__complete'],
+  },
+  workspace: {
+    description:
+      'Inspect and maintain local Trails developer state such as snapshots and traces.',
+    mcp: { loading: 'deferred' },
+    trails: ['dev.stats', 'dev.clean', 'dev.reset'],
+  },
+} satisfies McpSurfaceFacetMap;
+
+export const trailsMcpSurfaceOptions = {
+  description:
+    'Trails framework operator surface. Use MCP resources for cold context, then call a facet tool with a trail ID and input payload.',
+  facets: trailsMcpFacets,
+  mcpResources: { examples: true, surfaceMap: true },
+  name: 'trails',
+} satisfies CreateServerOptions;

--- a/apps/trails/src/mcp.ts
+++ b/apps/trails/src/mcp.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env bun
+/* oxlint-disable eslint-plugin-jest/require-hook -- MCP stdio entrypoints execute at module scope */
+import { surface } from '@ontrails/mcp';
+
+import { app } from './app.js';
+import { trailsMcpSurfaceOptions } from './mcp-options.js';
+
+await surface(app, trailsMcpSurfaceOptions);


### PR DESCRIPTION
## Summary
- Shapes the Trails operator MCP surface into explicit deferred facets.
- Keeps all public operator trails accounted for without widening internal trails.
- Adds MCP surface tests for facet projection and cold-context resource exposure plus changeset coverage.

## Verification
- bun run check
- bun run test
- bun run build
- bun run publish:check
- git diff --check
- gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
- real submit pre-push hook passed