### PR TITLE
feat(warden): coach surface facet maps

### DIFF
--- a/.agents/skills/clark/references/warden-guide.md
+++ b/.agents/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 61
+- Rule count: 62
 
 ## Agent Instructions
 
@@ -63,6 +63,10 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `unmaterialized-activation-source` (warn, topo/topo-aware, external): Activation sources have an available runtime materializer before runtime delivery is assumed.
 - `version-gap` (error, topo/topo-aware, external): Trail version coverage remains contiguous through the current version.
 - `version-without-examples` (warn, topo/topo-aware, external): Live historical version entries include examples.
+
+### Meta
+
+- `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep surface facet maps reviewable before they reach MCP projection.
 
 ### Permits
 

--- a/.changeset/trl-893-surface-facet-warden.md
+++ b/.changeset/trl-893-surface-facet-warden.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/warden': minor
+---
+
+Add surface facet coherence diagnostics for selector overlap, visibility widening acknowledgements, dynamic selectors, and description hygiene.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 61
+- Rule count: 62
 
 ## Agent Instructions
 
@@ -63,6 +63,10 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `unmaterialized-activation-source` (warn, topo/topo-aware, external): Activation sources have an available runtime materializer before runtime delivery is assumed.
 - `version-gap` (error, topo/topo-aware, external): Trail version coverage remains contiguous through the current version.
 - `version-without-examples` (warn, topo/topo-aware, external): Live historical version entries include examples.
+
+### Meta
+
+- `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep surface facet maps reviewable before they reach MCP projection.
 
 ### Permits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ Use the project language consistently:
 This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
-- Rule count: 61
+- Rule count: 62
 
 ### Rule Index
 
@@ -137,6 +137,10 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `version-gap` (error, topo/topo-aware, external): Trail version coverage remains contiguous through the current version.
 - `version-without-examples` (warn, topo/topo-aware, external): Live historical version entries include examples.
 
+#### Meta
+
+- `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors.
+
 #### Permits
 
 - `no-dev-permit-in-source` (error, source/source-static, external): The `--dev-permit` CLI flag string never appears in committed source.
@@ -184,6 +188,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `resource-exists`: Make declared resources resolve to authored resource definitions.
 - `resource-mock-coverage`: Make each resource declare a test mock or an explicit unmockable reason.
 - `static-resource-accessor-preference`: Use statically scoped resource helpers when the resource definition is already available.
+- `surface-facet-coherence`: Keep surface facet maps reviewable before they reach MCP projection.
 
 <!-- warden-guide:end -->
 

--- a/packages/warden/src/__tests__/surface-facet-coherence.test.ts
+++ b/packages/warden/src/__tests__/surface-facet-coherence.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test';
+
+import { surfaceFacetCoherence } from '../rules/surface-facet-coherence.js';
+
+const check = (sourceCode: string) =>
+  surfaceFacetCoherence.check(sourceCode, 'src/mcp-options.ts');
+
+describe('surface-facet-coherence', () => {
+  test('allows explicit non-overlapping facet maps', () => {
+    const diagnostics = check(`
+import type { McpSurfaceFacetMap } from '@ontrails/mcp';
+
+export const facets = {
+  inspect: {
+    description: 'Inspect topo state.',
+    trails: ['survey', 'survey.brief'],
+  },
+  governance: {
+    description: 'Run diagnostics.',
+    trails: ['warden', 'doctor'],
+  },
+} satisfies McpSurfaceFacetMap;
+`);
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('flags selectors that overlap across facets', () => {
+    const diagnostics = check(`
+export const facets = {
+  inspect: {
+    description: 'Inspect topo state.',
+    trails: ['survey.*'],
+  },
+  detail: {
+    description: 'Inspect one topo detail.',
+    trails: ['survey.trail'],
+  },
+};
+`);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('overlaps selector');
+    expect(diagnostics[0]?.message).toContain('survey.trail');
+  });
+
+  test('flags missing descriptions and dynamic selectors', () => {
+    const diagnostics = check(`
+const selector = 'survey';
+export const facets = {
+  inspect: {
+    trails: selector,
+  },
+};
+`);
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics.map((item) => item.message).join('\n')).toContain(
+      'dynamic trails selector'
+    );
+    expect(diagnostics.map((item) => item.message).join('\n')).toContain(
+      'non-empty description'
+    );
+  });
+
+  test('flags public visibility widening without acceptance metadata', () => {
+    const diagnostics = check(`
+export const facets = {
+  inspect: {
+    description: 'Inspect topo state.',
+    trails: ['survey'],
+    visibility: 'public',
+  },
+};
+`);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('visibilityWideningAccepted');
+  });
+
+  test('requires stable description metadata when widening is accepted', () => {
+    const diagnostics = check(`
+export const facets = {
+  inspect: {
+    description: 'Inspect topo state.',
+    trails: ['survey'],
+    visibility: 'public',
+    visibilityWideningAccepted: true,
+  },
+};
+`);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('descriptionStableThrough');
+  });
+
+  test('recognizes inline facets options', () => {
+    const diagnostics = check(`
+export const options = {
+  facets: {
+    inspect: {
+      description: 'Inspect topo state.',
+      trails: ['survey'],
+    },
+    governance: {
+      description: 'Run diagnostics.',
+      trails: ['warden'],
+    },
+  },
+};
+`);
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('ignores non-facet objects that include trails summary counts', () => {
+    const diagnostics = check(`
+export const lockManifest = {
+  summary: {
+    contours: 1,
+    resources: 2,
+    signals: 3,
+    trails: 4,
+  },
+};
+`);
+
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -9,8 +9,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 61 rule trails', () => {
-    expect(wardenTopo.count).toBe(61);
+  test('contains all 62 rule trails', () => {
+    expect(wardenTopo.count).toBe(62);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -215,6 +215,7 @@ export {
   scheduledDestroyIntentTrail,
   signalGraphCoachingTrail,
   staticResourceAccessorPreferenceTrail,
+  surfaceFacetCoherenceTrail,
   unmaterializedActivationSourceTrail,
   topoAwareRuleInput,
   unreachableDetourShadowingTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -45,6 +45,7 @@ import { resourceMockCoverage } from './resource-mock-coverage.js';
 import { scheduledDestroyIntent } from './scheduled-destroy-intent.js';
 import { signalGraphCoaching } from './signal-graph-coaching.js';
 import { staticResourceAccessorPreference } from './static-resource-accessor-preference.js';
+import { surfaceFacetCoherence } from './surface-facet-coherence.js';
 import {
   forkWithoutPreservedBlaze,
   markerSchemaUnsupported,
@@ -147,6 +148,7 @@ export { resourceMockCoverage } from './resource-mock-coverage.js';
 export { scheduledDestroyIntent } from './scheduled-destroy-intent.js';
 export { signalGraphCoaching } from './signal-graph-coaching.js';
 export { staticResourceAccessorPreference } from './static-resource-accessor-preference.js';
+export { surfaceFacetCoherence } from './surface-facet-coherence.js';
 export {
   forkWithoutPreservedBlaze,
   markerSchemaUnsupported,
@@ -198,6 +200,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [resourceMockCoverage.name, resourceMockCoverage],
   [preferSchemaInference.name, preferSchemaInference],
   [staticResourceAccessorPreference.name, staticResourceAccessorPreference],
+  [surfaceFacetCoherence.name, surfaceFacetCoherence],
   [validDescribeRefs.name, validDescribeRefs],
   [noDevPermitInSource.name, noDevPermitInSource],
   [noDestructuredCompose.name, noDestructuredCompose],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -105,6 +105,7 @@ const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
   'scheduled-destroy-intent': 'lifecycle',
   'signal-graph-coaching': 'signals',
   'static-resource-accessor-preference': 'resources',
+  'surface-facet-coherence': 'meta',
   'unmaterialized-activation-source': 'lifecycle',
   'valid-detour-contract': 'results',
   'version-gap': 'lifecycle',
@@ -524,6 +525,27 @@ const builtinWardenRuleMetadataInput = {
     invariant:
       'Trail logic should prefer static resource helpers over dynamic accessors.',
     scope: 'advisory',
+    tier: 'source-static',
+  },
+  'surface-facet-coherence': {
+    ...durableExternal,
+    guidance: {
+      docs: [
+        {
+          label: 'Surface Facets ADR',
+          path: 'docs/adr/drafts/20260603-surface-facets-shape-dense-topos.md',
+        },
+      ],
+      steps: [
+        'Keep facet selectors as explicit string literals or literal arrays when possible.',
+        'Ensure each public trail belongs to one facet owner.',
+        'Record explicit visibility-widening acceptance and stable-description metadata when a facet intentionally widens visibility.',
+      ],
+      summary:
+        'Keep surface facet maps reviewable before they reach MCP projection.',
+    },
+    invariant:
+      'Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors.',
     tier: 'source-static',
   },
   'unmaterialized-activation-source': {

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -53,6 +53,7 @@ import { resourceMockCoverage } from './resource-mock-coverage.js';
 import { scheduledDestroyIntent } from './scheduled-destroy-intent.js';
 import { signalGraphCoaching } from './signal-graph-coaching.js';
 import { staticResourceAccessorPreference } from './static-resource-accessor-preference.js';
+import { surfaceFacetCoherence } from './surface-facet-coherence.js';
 import {
   forkWithoutPreservedBlaze,
   markerSchemaUnsupported,
@@ -129,6 +130,7 @@ export const registeredRuleNames: readonly string[] = [
   scheduledDestroyIntent.name,
   signalGraphCoaching.name,
   staticResourceAccessorPreference.name,
+  surfaceFacetCoherence.name,
   unmaterializedActivationSource.name,
   unreachableDetourShadowing.name,
   validDetourContract.name,

--- a/packages/warden/src/rules/surface-facet-coherence.ts
+++ b/packages/warden/src/rules/surface-facet-coherence.ts
@@ -1,0 +1,370 @@
+import { matchesTrailPattern } from '@ontrails/core';
+
+import {
+  extractStringOrTemplateLiteral,
+  findConfigProperty,
+  getPropertyName,
+  offsetToLine,
+  parse,
+  walk,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const RULE_NAME = 'surface-facet-coherence';
+
+interface FacetSelector {
+  readonly facetId: string;
+  readonly node: AstNode;
+  readonly value: string;
+}
+
+const unwrapExpression = (node: AstNode | undefined): AstNode | undefined => {
+  let current = node;
+  while (
+    current?.type === 'TSAsExpression' ||
+    current?.type === 'TSSatisfiesExpression'
+  ) {
+    current =
+      (current as unknown as { expression?: AstNode }).expression ??
+      (current as unknown as { argument?: AstNode }).argument;
+  }
+  return current;
+};
+
+const objectProperties = (node: AstNode): readonly AstNode[] =>
+  node.type === 'ObjectExpression'
+    ? ((node as unknown as { properties?: readonly AstNode[] }).properties ??
+      [])
+    : [];
+
+const propertyValue = (property: AstNode): AstNode | undefined =>
+  property.type === 'Property'
+    ? (property as unknown as { value?: AstNode }).value
+    : undefined;
+
+const literalBooleanValue = (node: AstNode | undefined): boolean | null => {
+  if (node?.type !== 'Literal') {
+    return null;
+  }
+  const { value } = node as unknown as { value?: unknown };
+  return typeof value === 'boolean' ? value : null;
+};
+
+const diagnostic = (
+  sourceCode: string,
+  filePath: string,
+  node: AstNode,
+  message: string
+): WardenDiagnostic => ({
+  filePath,
+  line: offsetToLine(sourceCode, node.start),
+  message,
+  rule: RULE_NAME,
+  severity: 'warn',
+});
+
+const isFacetDefinition = (node: AstNode): boolean =>
+  node.type === 'ObjectExpression' &&
+  findConfigProperty(node, 'trails') !== null;
+
+const isFacetMapCandidate = (node: AstNode): boolean =>
+  objectProperties(node).some((property) => {
+    const value = unwrapExpression(propertyValue(property));
+    return value !== undefined && isFacetDefinition(value);
+  });
+
+const isFacetMapBindingName = (name: string | null): boolean =>
+  name !== null &&
+  (name === 'facets' || name.endsWith('Facets') || name.endsWith('FacetMap'));
+
+const hasFacetMapTypeAnnotation = (
+  sourceCode: string,
+  node: AstNode
+): boolean => {
+  const { typeAnnotation } = node as unknown as {
+    readonly typeAnnotation?: AstNode;
+  };
+  return (
+    typeAnnotation !== undefined &&
+    /\b(?:McpSurfaceFacetMap|TopoGraphFacetDeclaration|FacetMap)\b/.test(
+      sourceCode.slice(typeAnnotation.start, typeAnnotation.end)
+    )
+  );
+};
+
+const selectorNodes = (trailsNode: AstNode): readonly AstNode[] | null => {
+  const value = unwrapExpression(trailsNode);
+  if (!value) {
+    return null;
+  }
+  if (value.type === 'ArrayExpression') {
+    return (
+      (value as unknown as { elements?: readonly (AstNode | null)[] })
+        .elements ?? []
+    ).filter((element) => element !== null);
+  }
+  return [value];
+};
+
+const collectLiteralSelectors = (
+  sourceCode: string,
+  filePath: string,
+  facetId: string,
+  trailsProp: AstNode,
+  diagnostics: WardenDiagnostic[]
+): readonly FacetSelector[] => {
+  const trailsValue = propertyValue(trailsProp);
+  const nodes = trailsValue ? selectorNodes(trailsValue) : null;
+  if (nodes === null || nodes.length === 0) {
+    diagnostics.push(
+      diagnostic(
+        sourceCode,
+        filePath,
+        trailsProp,
+        `Surface facet "${facetId}" uses a dynamic trails selector. Keep facet selectors as string literals so Warden can check overlap and drift.`
+      )
+    );
+    return [];
+  }
+
+  const selectors: FacetSelector[] = [];
+  for (const node of nodes) {
+    const selectorValue = extractStringOrTemplateLiteral(node);
+    if (selectorValue === null) {
+      diagnostics.push(
+        diagnostic(
+          sourceCode,
+          filePath,
+          node,
+          `Surface facet "${facetId}" uses a dynamic trails selector. Keep facet selectors as string literals so Warden can check overlap and drift.`
+        )
+      );
+      continue;
+    }
+    selectors.push({ facetId, node, value: selectorValue });
+  }
+  return selectors;
+};
+
+const hasNonEmptyDescription = (definition: AstNode): boolean => {
+  const descriptionProp = findConfigProperty(definition, 'description');
+  const value = unwrapExpression(propertyValue(descriptionProp ?? definition));
+  const description = extractStringOrTemplateLiteral(value);
+  return typeof description === 'string' && description.trim().length > 0;
+};
+
+const literalStringProperty = (
+  definition: AstNode,
+  propertyName: string
+): string | null => {
+  const prop = findConfigProperty(definition, propertyName);
+  if (!prop) {
+    return null;
+  }
+  return extractStringOrTemplateLiteral(unwrapExpression(propertyValue(prop)));
+};
+
+const literalBooleanProperty = (
+  definition: AstNode,
+  propertyName: string
+): boolean | null => {
+  const prop = findConfigProperty(definition, propertyName);
+  if (!prop) {
+    return null;
+  }
+  return literalBooleanValue(unwrapExpression(propertyValue(prop)));
+};
+
+const selectorsMayOverlap = (
+  first: FacetSelector,
+  second: FacetSelector
+): boolean =>
+  first.value === second.value ||
+  matchesTrailPattern(first.value, second.value) ||
+  matchesTrailPattern(second.value, first.value);
+
+const diagnoseFacetDefinition = (
+  sourceCode: string,
+  filePath: string,
+  facetId: string,
+  definition: AstNode
+): {
+  readonly diagnostics: readonly WardenDiagnostic[];
+  readonly selectors: readonly FacetSelector[];
+} => {
+  const diagnostics: WardenDiagnostic[] = [];
+  const trailsProp = findConfigProperty(definition, 'trails');
+  const selectors =
+    trailsProp === null
+      ? []
+      : collectLiteralSelectors(
+          sourceCode,
+          filePath,
+          facetId,
+          trailsProp,
+          diagnostics
+        );
+
+  if (!hasNonEmptyDescription(definition)) {
+    diagnostics.push(
+      diagnostic(
+        sourceCode,
+        filePath,
+        definition,
+        `Surface facet "${facetId}" needs a non-empty description so MCP clients and agents can choose it without guessing.`
+      )
+    );
+  }
+
+  const visibility = literalStringProperty(definition, 'visibility');
+  const wideningAccepted = literalBooleanProperty(
+    definition,
+    'visibilityWideningAccepted'
+  );
+  if (visibility === 'public' && wideningAccepted !== true) {
+    diagnostics.push(
+      diagnostic(
+        sourceCode,
+        filePath,
+        definition,
+        `Surface facet "${facetId}" explicitly sets public visibility without visibilityWideningAccepted: true. Facets must not accidentally widen hidden trails.`
+      )
+    );
+  }
+
+  if (
+    wideningAccepted === true &&
+    !literalStringProperty(definition, 'descriptionStableThrough')
+  ) {
+    diagnostics.push(
+      diagnostic(
+        sourceCode,
+        filePath,
+        definition,
+        `Surface facet "${facetId}" accepts visibility widening but does not record descriptionStableThrough review metadata.`
+      )
+    );
+  }
+
+  return { diagnostics, selectors };
+};
+
+const diagnoseFacetMap = (
+  sourceCode: string,
+  filePath: string,
+  facetMap: AstNode
+): readonly WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
+  const selectors: FacetSelector[] = [];
+
+  for (const property of objectProperties(facetMap)) {
+    const facetId = getPropertyName(
+      (property as unknown as { key?: AstNode }).key
+    );
+    const value = unwrapExpression(propertyValue(property));
+    if (!facetId || value === undefined || !isFacetDefinition(value)) {
+      continue;
+    }
+    const result = diagnoseFacetDefinition(
+      sourceCode,
+      filePath,
+      facetId,
+      value
+    );
+    diagnostics.push(...result.diagnostics);
+    selectors.push(...result.selectors);
+  }
+
+  for (let i = 0; i < selectors.length; i += 1) {
+    const first = selectors[i];
+    if (!first) {
+      continue;
+    }
+    for (let j = i + 1; j < selectors.length; j += 1) {
+      const second = selectors[j];
+      if (
+        !second ||
+        first.facetId === second.facetId ||
+        !selectorsMayOverlap(first, second)
+      ) {
+        continue;
+      }
+      diagnostics.push(
+        diagnostic(
+          sourceCode,
+          filePath,
+          second.node,
+          `Surface facet selector "${second.value}" in "${second.facetId}" overlaps selector "${first.value}" in "${first.facetId}". Narrow one facet so each public trail has one MCP owner.`
+        )
+      );
+    }
+  }
+
+  return diagnostics;
+};
+
+export const surfaceFacetCoherence: WardenRule = {
+  check(sourceCode, filePath) {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const seen = new Set<number>();
+    const diagnostics: WardenDiagnostic[] = [];
+    const diagnoseCandidate = (node: AstNode | undefined): void => {
+      const unwrapped = unwrapExpression(node);
+      if (
+        unwrapped === undefined ||
+        unwrapped.type !== 'ObjectExpression' ||
+        seen.has(unwrapped.start) ||
+        !isFacetMapCandidate(unwrapped)
+      ) {
+        return;
+      }
+      seen.add(unwrapped.start);
+      diagnostics.push(...diagnoseFacetMap(sourceCode, filePath, unwrapped));
+    };
+
+    walk(ast, (node) => {
+      if (node.type === 'Property') {
+        const propertyName = getPropertyName(
+          (node as unknown as { key?: AstNode }).key
+        );
+        if (propertyName === 'facets') {
+          diagnoseCandidate(propertyValue(node));
+        }
+        return;
+      }
+
+      if (node.type === 'VariableDeclarator') {
+        const bindingName =
+          (node as unknown as { id?: { name?: unknown } }).id?.name ?? null;
+        if (
+          typeof bindingName === 'string' &&
+          isFacetMapBindingName(bindingName)
+        ) {
+          diagnoseCandidate(
+            (node as unknown as { init?: AstNode }).init ?? undefined
+          );
+        }
+        return;
+      }
+
+      if (
+        (node.type === 'TSAsExpression' ||
+          node.type === 'TSSatisfiesExpression') &&
+        hasFacetMapTypeAnnotation(sourceCode, node)
+      ) {
+        diagnoseCandidate(node);
+      }
+    });
+
+    return diagnostics;
+  },
+  description:
+    'Coach surface facet maps away from selector overlap, hidden visibility widening, and drift-prone dynamic selectors.',
+  name: RULE_NAME,
+  severity: 'warn',
+};

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -49,6 +49,7 @@ export { resourceMockCoverageTrail } from './resource-mock-coverage.trail.js';
 export { scheduledDestroyIntentTrail } from './scheduled-destroy-intent.trail.js';
 export { signalGraphCoachingTrail } from './signal-graph-coaching.trail.js';
 export { staticResourceAccessorPreferenceTrail } from './static-resource-accessor-preference.trail.js';
+export { surfaceFacetCoherenceTrail } from './surface-facet-coherence.trail.js';
 export { unmaterializedActivationSourceTrail } from './unmaterialized-activation-source.trail.js';
 export { unreachableDetourShadowingTrail } from './unreachable-detour-shadowing.trail.js';
 export { validDetourContractTrail } from './valid-detour-contract.trail.js';

--- a/packages/warden/src/trails/surface-facet-coherence.trail.ts
+++ b/packages/warden/src/trails/surface-facet-coherence.trail.ts
@@ -1,0 +1,25 @@
+import { surfaceFacetCoherence } from '../rules/surface-facet-coherence.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const surfaceFacetCoherenceTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'mcp-options.ts',
+        sourceCode: `export const facets = {
+  inspect: {
+    description: "Inspect topo state.",
+    trails: ["survey", "survey.brief"],
+  },
+  governance: {
+    description: "Run diagnostics.",
+    trails: ["warden", "doctor"],
+  },
+};`,
+      },
+      name: 'Reviewable surface facet map',
+    },
+  ],
+  rule: surfaceFacetCoherence,
+});

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 61
+- Rule count: 62
 
 ## Agent Instructions
 
@@ -63,6 +63,10 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `unmaterialized-activation-source` (warn, topo/topo-aware, external): Activation sources have an available runtime materializer before runtime delivery is assumed.
 - `version-gap` (error, topo/topo-aware, external): Trail version coverage remains contiguous through the current version.
 - `version-without-examples` (warn, topo/topo-aware, external): Live historical version entries include examples.
+
+### Meta
+
+- `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep surface facet maps reviewable before they reach MCP projection.
 
 ### Permits
 


### PR DESCRIPTION
## Summary
- Adds the surface-facet-coherence Warden rule and wrapped rule trail.
- Coaches explicit selectors, non-empty descriptions, overlap avoidance, and visibility widening metadata.
- Syncs generated Warden skill guides and includes a false-positive regression for non-facet objects with trails summary counts.

## Verification
- bun test packages/warden/src/__tests__/surface-facet-coherence.test.ts
- bun run --cwd packages/warden lint
- bun run --cwd packages/warden typecheck
- bun run check
- bun run test
- bun run build
- bun run publish:check
- git diff --check
- gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
- real submit pre-push hook passed