### PR TITLE
docs(adapter-kit): define surface projection seam

### DIFF
--- a/docs/adr/drafts/20260603-surface-facets-shape-dense-topos.md
+++ b/docs/adr/drafts/20260603-surface-facets-shape-dense-topos.md
@@ -176,10 +176,15 @@ Runtime adapter packages may need to understand surface projection metadata late
 The dependency direction is:
 
 - adapter-kit emits raw adapter evidence, such as `adapterType`;
-- topographer, Warden, or surface packages interpret that evidence against facet declarations;
+- topographer, Warden, or surface packages interpret that evidence against resolved facet declarations;
 - adapter-kit does not import topographer and does not learn the facet ontology.
 
-This leaves room for TRL-895 to add an adapter metadata seam without reversing package boundaries.
+The seam is intentionally asymmetric:
+
+- **contract-content conformance** remains adapter-kit's job. It answers whether an adapter package is placed correctly, declares its owner target, exports the expected entrypoints, and carries target conformance tests.
+- **surface-projection conformance** belongs to the surface or governance layer that already has the resolved projection. It may ask whether a grouped affordance is backed by resolved data such as facet ID, member trail IDs, effective visibility, description, member-set hash, and `{ trail, output }` correlation.
+
+No adapter target is required to support grouping. A future adapter can claim grouped affordances explicitly, but the validator for that claim should consume resolved surface projection evidence instead of adding facet authoring configuration to adapter-kit. The current adapter-kit seam is the existing raw subject evidence (`adapterType`, owner package, placement, target, conformance paths); it is sufficient for this stack because MCP facet projection is owned by `@ontrails/mcp` and Topographer, not by adapter authoring.
 
 ### Non-decisions
 

--- a/docs/migration/connector-to-adapter.md
+++ b/docs/migration/connector-to-adapter.md
@@ -33,6 +33,14 @@ Built-in adapter subpaths remain intentionally scoped to their owning package wh
 
 Do not extract `@ontrails/jwt` or `@ontrails/otel` as part of this migration.
 
+## Adapter Kit And Surface Projection Evidence
+
+`@ontrails/adapter-kit` checks adapter package readiness. It verifies package placement, owner target metadata, public exports, dependency direction, and conformance tests. That is **contract-content conformance**: the adapter package claims a target and proves it can be built and reviewed as that target.
+
+Surface facets introduce a separate kind of question: whether a surface adapter can support a grouped affordance over already-resolved trails. That is **surface-projection conformance**. It should consume resolved projection evidence such as the facet ID, member trail IDs, effective visibility, description, member-set hash, and `{ trail, output }` correlation shape.
+
+Do not add facet authoring configuration to adapter-kit. Adapter-kit may expose raw evidence such as `adapterType` and target conformance paths; the surface or governance layer that already has the resolved projection should validate any future grouped-affordance claim. No adapter target is required to support grouping unless it explicitly claims that capability.
+
 ## Code Imports
 
 Prefer direct imports of the canonical names:


### PR DESCRIPTION
## Summary
- Documents the adapter-kit seam for surface projection metadata.
- Keeps adapter-kit as an evidence consumer rather than a facet-authoring owner.
- Updates migration guidance so adapter authors have room to consume projection evidence without taking over surface policy.

## Verification
- bun run check
- bun run test
- bun run build
- bun run publish:check
- git diff --check
- gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
- real submit pre-push hook passed