### PR TITLE
docs(mcp): capture surface facet field notes

### DIFF
--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -170,6 +170,10 @@ await surface(graph, {
 
 `*` matches one dotted namespace segment and `**` matches any depth. Excludes apply before include narrowing, and trails marked `visibility: 'internal'` stay hidden unless you include their exact trail ID.
 
+## Surface Facet Field Notes
+
+Dense MCP surfaces can use surface facets to group related trails into fewer agent-facing tools. The current evidence ledger lives in [Surface Facet Field Notes](surface-facet-field-notes.md). Read it before generalizing facet behavior to another app or surface. It records the first Trails operator MCP shaping pass, the shortened evidence window, what survived contact, and what remains deferred.
+
 ## Server Configuration
 
 ```typescript

--- a/docs/surfaces/surface-facet-field-notes.md
+++ b/docs/surfaces/surface-facet-field-notes.md
@@ -1,0 +1,55 @@
+# Surface Facet Field Notes
+
+Surface facets should stay evidence-led. Use this file for lightweight notes from real MCP surface use before widening facet behavior to more surfaces or adding stronger governance.
+
+## Evidence Window
+
+TRL-890 originally called for two sprints between the ad-hoc Trails operator MCP surface and the reusable facet engine. Matt shortened that window during the Surface Facets & MCP Shaping sprint so the full stack could land together. Treat these notes as first-contact evidence plus a standing place for the next two sprints of follow-up, not as proof that every cross-surface question is settled.
+
+## Initial Trails Operator Surface
+
+The first shaped surface is `apps/trails/src/mcp-options.ts`. It projects the Trails operator app into seven deferred MCP facet tools:
+
+- `artifacts`
+- `authoring`
+- `execution`
+- `governance`
+- `inspect`
+- `shell`
+- `workspace`
+
+Each facet uses an explicit trail list instead of a broad namespace glob. That made review easier: agent reviewers could verify coverage of public trails, confirm that internal trails stayed hidden, and reason about the grouping without expanding a hidden selector mentally.
+
+## What Survived Contact
+
+- **Tool count:** seven tools is easier for agents to scan than one tool per Trails CLI trail.
+- **Invocation shape:** `{ trail, input }` keeps the underlying trail visible and avoids a new action vocabulary inside the facet.
+- **Output correlation:** `{ trail, output }` is necessary. Heterogeneous facet tools need the returned trail ID so an agent can connect a response to the selected contract without guessing from output fields.
+- **Cold context:** the resolved MCP surface map belongs in MCP resources. Agents can inspect grouped tools, member trail IDs, examples, and deferred hints without paying that context cost in every tool schema.
+- **Explicit selectors:** authored facet lists are boring, but boring helped. They made visibility and overlap review much more mechanical.
+
+## What To Keep Watching
+
+- **Schema size:** deferred loading is only a compatibility hint today. Clients that still load all schemas need to keep working, and large member schemas may still be expensive until richer MCP client support exists.
+- **Description drift:** descriptions can become false as member lists evolve. `descriptionStableThrough` should be reserved for intentional stability, not used as a routine silencer.
+- **Missing metadata:** the surface map should remain the place to look for member trail IDs, facet IDs, output schemas, examples, versions, and deferred hints. If agents still need to inspect source after reading it, the resource shape needs more work.
+- **Selector overlap:** overlap should stay visible as a Warden finding unless future evidence shows a precise, governed exception is needed.
+
+## Dropped Or Deferred
+
+- A generic `facet()` primitive is not justified.
+- `overlapsWith` is not justified; it would make drift too easy to silence.
+- CLI and HTTP parity are deferred. CLI should be evaluated as command-group consolidation, and HTTP as route-group projection or a rejected non-fit.
+- `mcp.search` and code-mode execution stay out of this slice.
+
+## Follow-Up Notes Template
+
+When adding future notes, include:
+
+- app or topo under test;
+- number of raw trails and projected facet tools;
+- client used;
+- whether agents found the right tool without source inspection;
+- confusing invocation or output cases;
+- schema/context cost observations;
+- any description, selector, or visibility drift found.


### PR DESCRIPTION
## Summary
- Captures field notes from the MCP facet shaping work before generalizing the primitive further.
- Records the shortened evidence window and the risks still worth watching.
- Links the notes into the MCP surface documentation trail.

## Verification
- bun run check
- bun run test
- bun run build
- bun run publish:check
- git diff --check
- gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
- real submit pre-push hook passed