### PR TITLE
docs(mcp): document resources and deferred loading

### DIFF
--- a/.changeset/trl-891-mcp-resource-docs.md
+++ b/.changeset/trl-891-mcp-resource-docs.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/mcp': patch
+---
+
+Document MCP resource projection and deferred-loading options for cold surface context.

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -68,6 +68,49 @@ When a trail declares `output`, the MCP tool definition includes an `outputSchem
 
 Trail examples are exposed as structured tool metadata under `_meta["ontrails/examples"]`. Each example keeps the authored input, expected output or error, a success/error kind, and provenance pointing back to `trail.examples`; clients do not need to scrape example JSON from prose descriptions.
 
+## MCP Resources For Cold Context
+
+Cold context belongs in **MCP resources**, not in extra tools and not in Trails `resource()` declarations. The MCP surface exposes resources by default when using `surface(graph)` or `createServer(graph)`:
+
+| Resource URI | Contents |
+| --- | --- |
+| `trails://surface-map` | Resolved MCP surface projection: tool names, trail IDs, facet IDs, member trail IDs, input/output schemas, versions, annotations, and deferred hints |
+| `trails://examples/<trailId>` | Structured examples for an exposed trail, when the trail defines examples |
+
+Use `mcpResources: false` to disable MCP resource registration:
+
+```typescript
+await surface(graph, { mcpResources: false });
+```
+
+Use `mcpResources` to keep only a subset:
+
+```typescript
+await surface(graph, {
+  mcpResources: { examples: false, surfaceMap: true },
+});
+```
+
+The resource naming is intentionally qualified: `McpResource`, `McpResources`, and `mcpResources` refer to MCP protocol resources. Trails `resource()` remains the infrastructure dependency primitive.
+
+## Deferred Loading Hint
+
+Facet tools may opt into deferred loading:
+
+```typescript
+await surface(graph, {
+  facets: {
+    governance: {
+      description: 'Run project diagnostics and Warden guidance.',
+      mcp: { loading: 'deferred' },
+      trails: ['doctor', 'warden', 'warden.guide'],
+    },
+  },
+});
+```
+
+Deferred loading is a compatibility hint under `_meta["ontrails/deferred"]`. It does not omit required tool schemas from `tools/list` in this release, so older MCP clients still receive a complete tool definition. Clients that understand the hint can prefer the surface-map resource and defer expensive schema inspection until they need the facet.
+
 ## Annotations
 
 Trail intent maps directly to MCP tool annotations:

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -54,6 +54,7 @@ for (const tool of result.value) {
 | --- | --- |
 | `surface(graph, options?)` | Start an MCP server with all trails as tools |
 | `deriveMcpTools(graph, options?)` | Build tool definitions without starting a server |
+| `buildMcpResources(graph, tools, config?)` | Build MCP resource listings and read handlers for cold context |
 | `deriveToolName(appName, trailId)` | Compute the MCP tool name from app and trail IDs |
 | `deriveAnnotations(trail)` | Extract MCP annotations from trail intent, idempotency, and description |
 | `createMcpProgressCallback(server)` | Bridge `ctx.progress` to MCP `notifications/progress` |
@@ -78,6 +79,29 @@ No manual annotation definitions. The contract is the source of truth.
 MCP tool definitions include the trail's input schema, and trails with an `output` schema also project that schema into MCP `outputSchema`. Non-object trail outputs are wrapped in a `{ data: ... }` object because MCP structured tool results are object-shaped.
 
 Trail examples are projected as structured metadata under `_meta["ontrails/examples"]`. Each projected example preserves its input, expected output or error, a success/error kind, and provenance pointing back to the authored `trail.examples` field.
+
+## MCP resources and deferred loading
+
+Cold context is projected through MCP resources, not extra Trails resources. `surface(graph)` and `createServer(graph)` expose MCP resources by default:
+
+- `trails://surface-map` lists the resolved MCP tool projection, including ordinary tools, facet tools, schemas, versions, deferred hints, and member trail IDs.
+- `trails://examples/<trailId>` exposes structured examples for exposed trails that define examples.
+
+Disable resource projection only when the host needs a minimal MCP capability surface:
+
+```typescript
+await surface(graph, { mcpResources: false });
+```
+
+Or choose a narrower resource set:
+
+```typescript
+await surface(graph, {
+  mcpResources: { examples: false, surfaceMap: true },
+});
+```
+
+Facet definitions may set `mcp: { loading: 'deferred' }`. In this release, deferred loading is a compatibility hint under `_meta["ontrails/deferred"]`; the MCP tool schema remains present so clients that do not understand deferred loading continue to work.
 
 ## Tool naming
 


### PR DESCRIPTION
## Summary
- Documents MCP cold-context resources for surface maps and trail examples.
- Explains deferred loading metadata for clients that support leaner MCP startup.
- Adds changeset coverage for the public MCP docs and package surface update.

## Verification
- bun run check
- bun run test
- bun run build
- bun run publish:check
- git diff --check
- gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
- real submit pre-push hook passed