### PR TITLE
docs(surfaces): defer facet parity decisions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@
 - **[CLI Surface](./surfaces/cli.md)** — Shipped today. Flag derivation, output modes, exit codes, `--dry-run`
 - **[MCP Surface](./surfaces/mcp.md)** — Shipped today. Tool naming, annotations, progress bridge
 - **[HTTP Surface](./surfaces/http.md)** — Shipped today. Route derivation, Web Fetch kernel, Hono adapter, Bun-native serving, webhook activation
+- **[Surface Facet Parity](./surfaces/surface-facet-parity.md)** — Deferred CLI/HTTP parity decision after MCP proves grouped projection
 - **WebSocket Surface** — Planned, not yet implemented. See [Horizons](./horizons.md) for the current direction.
 
 ## Governing your codebase?

--- a/docs/surfaces/surface-facet-parity.md
+++ b/docs/surfaces/surface-facet-parity.md
@@ -1,0 +1,70 @@
+# Surface Facet Parity
+
+Surface facets start with MCP because MCP pays the tool-count and schema-context cost first. CLI and HTTP remain peer surfaces, but peer-ness does not mean every surface gets the same projection at the same time.
+
+## Current Verdict
+
+CLI and HTTP facet parity are deferred. The MCP implementation should not be weakened to make other surfaces easier, and no CLI or HTTP facet behavior ships with this decision.
+
+The same facet declaration may remain the conceptual source for future parity, but each surface must earn its own materialization:
+
+- CLI parity should be evaluated as command-group consolidation.
+- HTTP parity should be evaluated as route-group projection or explicitly rejected as a non-fit.
+- Per-surface overrides are allowed only when the surface economics differ in a way the shared declaration cannot express honestly.
+
+## CLI Evaluation
+
+MCP facets group many trails into one tool because agent clients pay for every tool schema they inspect. CLI already has a hierarchical command tree from dotted trail IDs, so a raw copy of MCP grouping would be awkward:
+
+```text
+trails governance --trail warden --input-json '{}'
+```
+
+That shape hides the command affordance a CLI user expects. A credible CLI facet would instead consolidate command groups while preserving normal command help and shell completion:
+
+```text
+trails governance warden --apps apps/trails/src/app.ts
+trails governance guide
+```
+
+Open questions before CLI parity:
+
+- Does the grouped command path reduce discoverability cost beyond the existing dotted ID command tree?
+- Can command aliases or help grouping solve the problem without a facet materialization?
+- How do positional args, structured input, and completions project when a group is editorial rather than ID-derived?
+
+## HTTP Evaluation
+
+HTTP does not pay MCP's schema-context cost, and route names are externally stable API contracts. A raw MCP-style route such as the following would be a poor fit:
+
+```http
+POST /facets/governance
+{ "trail": "warden", "input": {} }
+```
+
+That shape turns ordinary HTTP routes into a generic RPC envelope. A credible HTTP facet would need to be route-group projection, documentation grouping, or OpenAPI organization rather than a replacement for direct trail routes:
+
+```text
+/governance/warden
+/governance/guide
+```
+
+Open questions before HTTP parity:
+
+- Is there a route-grouping benefit that is not already handled by trail ID namespaces and `basePath`?
+- Does OpenAPI tag grouping provide the intended affordance without changing runtime routes?
+- Can a grouped route preserve stable URLs, verbs, request parsing, and error projection without inventing an HTTP-specific action envelope?
+
+## Shared Declaration And Overrides
+
+The preferred future path is one surface facet declaration interpreted by each surface that chooses to support it. Surface-specific hints may be added under surface-qualified keys such as `mcp`, `cli`, or `http` only when real evidence shows the shared declaration is insufficient.
+
+Do not add generic `overlapsWith`, `facet()`, or adapter-kit-owned facet configuration to make parity easier.
+
+## Follow-Up Trigger
+
+Create CLI or HTTP implementation issues only after one of these is true:
+
+- the MCP field notes show repeated agent wins that map cleanly to CLI or HTTP;
+- downstream apps ask for grouped surface affordances outside MCP;
+- Warden or Topographer evidence shows a durable projection pattern that surfaces can consume without weakening trail identity.


### PR DESCRIPTION
## Summary
- Records the current CLI/HTTP parity decision for surface facets after the MCP-first work.
- Defers broader parity until the framework has clearer evidence that those surfaces need facet grouping.
- Preserves the criteria for reopening CLI/HTTP facet projection later.

## Verification
- bun run check
- bun run test
- bun run build
- bun run publish:check
- git diff --check
- gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
- real submit pre-push hook passed