### PR TITLE
docs(surfaces): explain surface facets

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@
 
 - **[CLI Surface](./surfaces/cli.md)** — Shipped today. Flag derivation, output modes, exit codes, `--dry-run`
 - **[MCP Surface](./surfaces/mcp.md)** — Shipped today. Tool naming, annotations, progress bridge
+- **[Surface Facets](./surfaces/surface-facets.md)** — MCP shaping for dense topos without adding a core facet primitive
 - **[HTTP Surface](./surfaces/http.md)** — Shipped today. Route derivation, Web Fetch kernel, Hono adapter, Bun-native serving, webhook activation
 - **[Surface Facet Parity](./surfaces/surface-facet-parity.md)** — Deferred CLI/HTTP parity decision after MCP proves grouped projection
 - **WebSocket Surface** — Planned, not yet implemented. See [Horizons](./horizons.md) for the current direction.

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -458,7 +458,10 @@ A mechanically derived output from authored information. The topo store is a rel
 | `Result` | Ok/Err return type |
 | `error` | Error types |
 | `adapter` | Canonical public category for a package or subpath that connects Trails to a named external library, framework, tool, platform, format, or ecosystem |
-| `facet` | Projection slice of authored contract or surface data, such as a surface facet or schema facet; not a package category |
+| `facet` | Qualified projection-slice vocabulary; use `surface facet` or `schema facet`, not bare `facet` as a primitive |
+| `surface facet` | Surface-side projection slice over existing trails; not a graph node, package category, or core `Facet` primitive |
+| `schema facet` | Descriptive phrase for a schema-owned slice or view when docs need it; not a decided public API |
+| `MCP resources` | MCP protocol resources used for cold context; not Trails `resource()` infrastructure declarations |
 | `integration (colloquial)` | Ordinary English for places Trails integrates with an external system; not a public taxonomy category |
 | `logger` / `logging` | Structured logging — framework provides the interface; developers bring their own |
 | `health` | Health checks |

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -68,6 +68,16 @@ When a trail declares `output`, the MCP tool definition includes an `outputSchem
 
 Trail examples are exposed as structured tool metadata under `_meta["ontrails/examples"]`. Each example keeps the authored input, expected output or error, a success/error kind, and provenance pointing back to `trail.examples`; clients do not need to scrape example JSON from prose descriptions.
 
+## Surface Facets
+
+Dense MCP surfaces can use surface facets to group related trails into fewer agent-facing tools while preserving the underlying trail contracts. The full guide is [Surface Facets](surface-facets.md). The short version:
+
+- author a facet map in MCP surface options;
+- each facet becomes one MCP tool;
+- call the facet with `{ trail, input }`;
+- successful responses return `{ trail, output }`;
+- inspect `trails://surface-map` for facet IDs, member trail IDs, examples, and deferred-loading hints.
+
 ## MCP Resources For Cold Context
 
 Cold context belongs in **MCP resources**, not in extra tools and not in Trails `resource()` declarations. The MCP surface exposes resources by default when using `surface(graph)` or `createServer(graph)`:

--- a/docs/surfaces/surface-facets.md
+++ b/docs/surfaces/surface-facets.md
@@ -1,0 +1,143 @@
+# Surface Facets
+
+Surface facets group related trails into a surface affordance without changing the trails themselves. They are useful when a dense topo is still semantically clear but a surface becomes hard to scan.
+
+MCP hits this pressure first. MCP clients often load tool names, descriptions, input schemas, output schemas, and examples into agent context. A flat one-trail-one-tool projection stays faithful, but it can make a dense operator surface expensive to inspect. A surface facet lets the surface say "these trails belong together here" while the trail contracts remain the source of truth.
+
+Surface facets are not a core `Facet` primitive. Do not look for `facet()`, do not create a shared `Facet` type, and do not add facet authoring configuration to adapter-kit.
+
+## When To Use One
+
+Use a surface facet when:
+
+- the underlying trails are still the right product boundary;
+- a surface has too many adjacent affordances for agents or users to scan cheaply;
+- the grouped affordance can keep the original trail ID visible at invocation and response time;
+- the surface can expose resolved metadata so agents can inspect membership without reading source.
+
+Do not use a surface facet when:
+
+- you are really trying to create a new domain operation;
+- grouping would hide important trail identity or output shape;
+- direct trail projection is already clear enough;
+- you need CLI or HTTP parity before MCP has proved the pattern for your app.
+
+## MCP Authoring Shape
+
+`@ontrails/mcp` accepts `facets` in the surface options:
+
+```typescript
+import type { McpSurfaceFacetMap } from '@ontrails/mcp';
+import { surface } from '@ontrails/mcp';
+import { graph } from './app';
+
+const facets = {
+  governance: {
+    description:
+      'Run project diagnostics, adapter readiness checks, and Warden guidance.',
+    mcp: { loading: 'deferred' },
+    trails: ['doctor', 'adapter.check', 'warden', 'warden.guide'],
+  },
+  inspect: {
+    description:
+      'Inspect topo structure, contracts, resources, signals, surfaces, and diffs.',
+    mcp: { loading: 'deferred' },
+    trails: ['survey', 'diff', 'topo', 'guide'],
+  },
+} satisfies McpSurfaceFacetMap;
+
+await surface(graph, {
+  facets,
+  mcpResources: { examples: true, surfaceMap: true },
+});
+```
+
+Prefer explicit lists for editorial groups. Glob selectors such as `topo.*` reuse the normal surface filtering grammar, but broad selectors need more care: membership drift can make descriptions stale and can create facet overlap.
+
+## MCP Projection Shape
+
+Each MCP surface facet projects as one MCP tool named from the topo name and facet ID. A `governance` facet in topo `trails` derives `trails_governance`.
+
+The input schema requires a trail discriminator plus the selected trail input:
+
+```json
+{
+  "trail": "warden",
+  "input": {
+    "apps": ["apps/trails/src/app.ts"]
+  }
+}
+```
+
+The handler runs the selected constituent trail through the same MCP execution path as an ordinary one-trail-one-tool projection. It does not call a blaze directly.
+
+Successful outputs are correlated with the selected trail:
+
+```json
+{
+  "trail": "warden",
+  "output": {
+    "errors": 0,
+    "warnings": 0
+  }
+}
+```
+
+That envelope is intentional. A facet can contain trails with different output schemas, so the returned trail ID must stay visible for agents and downstream readers.
+
+## Visibility And Overlap
+
+Trail visibility remains authoritative. A facet may narrow the projection, but it cannot make an internal trail public. If a public facet selector matches an internal trail, runtime projection omits that internal member.
+
+Facet selector overlap is treated as drift. Narrow the selectors instead of adding an escape hatch. The rejected shape is `overlapsWith`; it would let a facet map silence ambiguity without clarifying ownership.
+
+When a facet intentionally spans visibility tiers, record the acknowledgement:
+
+```typescript
+const facets = {
+  ops: {
+    description: 'Operator-only diagnostics.',
+    trails: ['doctor', 'dev.*'],
+    visibilityWideningAccepted: true,
+  },
+} satisfies McpSurfaceFacetMap;
+```
+
+The acknowledgement does not widen runtime behavior. It only tells governance that the author saw the mixed-visibility grouping.
+
+## Description Drift
+
+Facet descriptions are authored prose over resolved membership. If the member set changes, the description may become false even when every individual trail is valid.
+
+Use `descriptionStableThrough` only when the description is intentionally stable through a known member-set hash. Do not use it as routine noise suppression.
+
+```typescript
+const facets = {
+  inspect: {
+    description: 'Inspect topo state and generated artifacts.',
+    descriptionStableThrough: 'sha256:...',
+    trails: ['survey', 'topo.*'],
+  },
+} satisfies McpSurfaceFacetMap;
+```
+
+## MCP Resources
+
+Use MCP resources for cold context. The default MCP surface exposes:
+
+- `trails://surface-map` for the resolved MCP surface projection;
+- `trails://examples/<trailId>` for structured examples on exposed trails.
+
+The surface map includes ordinary tools and facet tools. Facet entries expose `facetId`, `memberTrailIds`, input/output schemas, annotations, versions, and deferred-loading hints.
+
+The phrase is **MCP resources**. Trails `resource()` still means an infrastructure dependency declared on a trail contract.
+
+## Adapter-Kit Boundary
+
+Adapter-kit does not author surface facets. It may expose raw adapter evidence, such as `adapterType` and target conformance paths, that future surface or governance checks can interpret against resolved projection metadata.
+
+If an adapter claims grouped affordances later, the validator should consume resolved surface data: facet ID, member trail IDs, effective visibility, description, member-set hash, and `{ trail, output }` correlation shape. No adapter target is required to support grouping unless it explicitly claims that capability.
+
+## CLI And HTTP
+
+CLI and HTTP parity are deferred. CLI should be evaluated as command-group consolidation, not as an MCP-style generic action tool. HTTP should be evaluated as route-group projection, OpenAPI organization, or a rejected non-fit. See [Surface Facet Parity](surface-facet-parity.md) for the current decision.


### PR DESCRIPTION
## Summary
- Adds developer-facing surface facets documentation.
- Updates the docs index, lexicon, and MCP surface docs so the new primitive is discoverable.
- Explains authoring expectations without introducing a second trail contract.

## Verification
- bun run check
- bun run test
- bun run build
- bun run publish:check
- git diff --check
- gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
- real submit pre-push hook passed