### PR TITLE
docs(plugin): teach surface facet guidance

### DIFF
--- a/plugin/rules/lexicon.md
+++ b/plugin/rules/lexicon.md
@@ -21,6 +21,8 @@ Use Trails-branded terms consistently. These are non-negotiable in code, docs, a
 | `survey` | introspect, inspect, describe |
 | `guide` | docs, help, manual |
 | `adapter` | connector, bridge, transport shim |
+| `surface facet` | facet primitive, facet API, facet package |
+| `MCP resources` | Trails resources, dependencies, services (when referring to MCP protocol resources) |
 
 ## When Writing
 
@@ -31,3 +33,5 @@ Use Trails-branded terms consistently. These are non-negotiable in code, docs, a
 - Standard terms stay standard: `config`, `Result`, and `Error`.
 - `connector` is retired public taxonomy. Use `adapter` for a thin runtime-specific layer.
 - `resource` is a branded term: `resource()` defines a typed infrastructure dependency. Use `resources: [...]` on trail specs to declare dependencies. Do not use "resource" for generic helpers or utility classes.
+- `facet` is qualified projection vocabulary. Use `surface facet` for surface-side grouped projection and `schema facet` only as descriptive schema-slice prose. Do not invent a core `Facet` primitive, `facet()`, or adapter-kit facet config.
+- `MCP resources` are MCP protocol resources for cold context. Keep the qualifier when writing about `trails://surface-map` or example resources so they do not collide with Trails `resource()` declarations.

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -3,7 +3,7 @@ name: trails
 description: Build with the Trails framework — define trail contracts, open CLI/MCP surfaces, test with examples, debug errors, migrate codebases, run governance. Use when creating trails, adding surfaces, testing, debugging Trails errors, migrating to Trails, running warden, or any work involving @ontrails/* packages.
 metadata:
   trails:
-    version: 1.0.0-beta.18
+    version: 1.0.0-beta.19
 ---
 
 # Trails
@@ -126,6 +126,23 @@ await surface(graph);
 import { surface } from '@ontrails/mcp';
 await surface(graph);
 ```
+
+Dense MCP surfaces may use **surface facets** to group related trails into fewer agent-facing tools. A surface facet is surface-side projection configuration, not a core `Facet` primitive and not a new domain operation. Author it in MCP surface options, call it with `{ trail, input }`, and expect successful results as `{ trail, output }` so the underlying trail stays visible.
+
+```typescript
+await surface(graph, {
+  facets: {
+    governance: {
+      description: 'Run project diagnostics and Warden guidance.',
+      mcp: { loading: 'deferred' },
+      trails: ['doctor', 'warden', 'warden.guide'],
+    },
+  },
+  mcpResources: { examples: true, surfaceMap: true },
+});
+```
+
+Use `trails://surface-map` and per-trail MCP resources for cold context before guessing at grouped affordances. Adapter-kit may validate resolved projection evidence for future surface adapters, but it does not define or author facets. Do not invent `facet()`, `overlapsWith`, or adapter-kit facet config.
 
 **HTTP**: Routes from trail IDs (dots become path segments), verbs from intent, error responses from taxonomy. Use Hono for framework portability or Bun-native HTTP when you want Bun serving without a third-party runtime; both share the `@ontrails/http` route/fetch kernel.
 

--- a/plugin/skills/trails/references/mcp-surface.md
+++ b/plugin/skills/trails/references/mcp-surface.md
@@ -65,6 +65,71 @@ blaze: async (input, ctx) => {
 
 Trail `examples` are included in MCP tool metadata. Agents use these to understand expected input/output shapes and plan tool usage without trial and error.
 
+## Surface Facets
+
+Use surface facets only when a dense MCP surface needs grouped affordances. A surface facet is an MCP projection over existing trails, not a new trail, graph node, package category, or core `Facet` primitive.
+
+```typescript
+import type { McpSurfaceFacetMap } from '@ontrails/mcp';
+
+const facets = {
+  governance: {
+    description: 'Run project diagnostics and Warden guidance.',
+    mcp: { loading: 'deferred' },
+    trails: ['doctor', 'warden', 'warden.guide'],
+  },
+} satisfies McpSurfaceFacetMap;
+
+await surface(graph, {
+  facets,
+  mcpResources: { examples: true, surfaceMap: true },
+});
+```
+
+Facet tools are called with a trail discriminator and nested input:
+
+```json
+{
+  "trail": "warden",
+  "input": {
+    "apps": ["apps/trails/src/app.ts"]
+  }
+}
+```
+
+Successful outputs stay correlated:
+
+```json
+{
+  "trail": "warden",
+  "output": {
+    "errors": 0,
+    "warnings": 0
+  }
+}
+```
+
+Rules for agents:
+
+- Keep the underlying trail ID visible; do not flatten member trails into an action bag.
+- Prefer explicit selector lists for editorial groups.
+- Treat selector overlap and description drift as governance findings, not routine silencing candidates.
+- Do not invent `facet()`, `overlapsWith`, or adapter-kit facet config.
+- Do not assume CLI or HTTP parity; those surfaces have separate economics.
+
+## MCP Resources
+
+MCP resources are protocol resources for cold context. They are not Trails `resource()` declarations.
+
+By default, `surface(graph)` and `createServer(graph)` expose:
+
+- `trails://surface-map` for the resolved MCP projection, including facet IDs, member trail IDs, schemas, examples metadata, versions, and deferred hints.
+- `trails://examples/<trailId>` for structured examples on exposed trails.
+
+Use `mcpResources: false` only when the host intentionally wants no MCP resource capability. Use `mcpResources: { examples: false, surfaceMap: true }` to keep a narrower resource set.
+
+`mcp: { loading: 'deferred' }` is a compatibility hint under `_meta["ontrails/deferred"]`; required schemas still appear in `tools/list` for clients that do not understand deferred loading.
+
 ## CreateServerOptions
 
 ```typescript
@@ -75,10 +140,11 @@ await surface(graph, {
   version: '1.0.0',               // Server version
   description: 'Internal tools',  // Forwarded as MCP server instructions
   include: ['entity.**'],         // Optional trail filters
+  mcpResources: { surfaceMap: true, examples: true },
 });
 ```
 
-`surface(graph, options)` and `createServer(graph, options)` accept the same options bag: `name`, `version`, `description`, `include`, `exclude`, `intent`, `layers`, `createContext`, `configValues`, `resources`, and `validate`.
+`surface(graph, options)` and `createServer(graph, options)` accept the same options bag: `name`, `version`, `description`, `include`, `exclude`, `intent`, `layers`, `createContext`, `configValues`, `resources`, `facets`, `mcpResources`, and `validate`.
 
 ## Escape Hatch
 
@@ -102,5 +168,6 @@ Each `McpToolDefinition` includes:
 - `description` — trail description with first example appended
 - `handler` — async function that runs the full `executeTrail` pipeline
 - `trailId` — the original trail ID this tool was derived from (useful for filtering and introspection)
+- `facetId` / `memberTrailIds` — present when the tool was derived from a surface facet
 
 This gives you the raw tool definitions to register manually while still benefiting from automatic schema derivation and annotation mapping.


### PR DESCRIPTION
## Summary
- Updates the Trails plugin skill and MCP surface reference for surface facets.
- Teaches agents to prefer facets for MCP grouping while preserving one authored trail graph.
- Syncs plugin guidance with the beta.19 surface vocabulary and lexicon.

## Verification
- bun run check
- bun run test
- bun run build
- bun run publish:check
- git diff --check
- gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
- real submit pre-push hook passed