### PR TITLE
feat(wayfinder): add artifact loader provenance

### DIFF
--- a/.changeset/wayfinder-loader-provenance.md
+++ b/.changeset/wayfinder-loader-provenance.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/topographer": patch
+"@ontrails/wayfinder": patch
+---
+
+Add the read-only Wayfinder artifact loader and fact provenance envelope helpers, including cold topo-store schema preflight support.

--- a/bun.lock
+++ b/bun.lock
@@ -295,10 +295,6 @@
         "@ontrails/core": "workspace:^",
         "@ontrails/topographer": "workspace:^",
       },
-      "optionalPeers": [
-        "@ontrails/core",
-        "@ontrails/topographer",
-      ],
     },
   },
   "trustedDependencies": [

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -105,6 +105,7 @@ export {
   listTopoSnapshots,
   pinTopoSnapshot,
   topoStore,
+  TOPO_STORE_SCHEMA_VERSION,
   unpinTopoSnapshot,
 } from './topo-store.js';
 export type {

--- a/packages/topographer/src/topo-store.ts
+++ b/packages/topographer/src/topo-store.ts
@@ -75,6 +75,8 @@ export const __topoStoreMigrationStats = {
   writeEscalations: 0,
 };
 
+export const TOPO_STORE_SCHEMA_VERSION = TOPO_SCHEMA_VERSION;
+
 const peekTopoSchemaVersion = (
   options: TrailsDbLocationOptions | undefined
 ): number | undefined => {

--- a/packages/wayfinder/README.md
+++ b/packages/wayfinder/README.md
@@ -1,9 +1,11 @@
 # @ontrails/wayfinder
 
-Agent-shaped wayfinding trails over `@ontrails/topographer` artifacts.
+Agent-shaped wayfinding helpers and trails over `@ontrails/topographer` artifacts.
 
 `@ontrails/wayfinder` is the public package home for trails that let agents query a Trails app's resolved topo — overviews, searches, trail details, examples — without re-deriving the graph from `grep` plus file reads.
 
-**Status: shell only.** No trails ship yet.
+**Status: substrate only.** No query trails ship yet.
 
-This package currently exists to reserve the `@ontrails/wayfinder` namespace and give the v0 implementation a clean home. When wayfinding lands, trails such as `wayfind.overview`, `wayfind.search`, `wayfind.contract`, `wayfind.nearby`, `wayfind.impact`, and `wayfind.examples` will be exported from here.
+The package currently exports the cold artifact loader and fact provenance helpers that v0 graph-read trails will share. Those helpers read existing Topographer artifacts (`topo.lock`, `trails.lock`, and materialized current `trails.db` topo-store records) without starting apps, booting resources, reaching the network, or mutating local state.
+
+When the query catalog lands, trails such as `wayfind.overview`, `wayfind.search`, `wayfind.contract`, `wayfind.nearby`, `wayfind.impact`, and `wayfind.examples` will be exported from here.

--- a/packages/wayfinder/package.json
+++ b/packages/wayfinder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ontrails/wayfinder",
   "version": "1.0.0-beta.19",
-  "description": "Reserved shell for future agent wayfinding trails over @ontrails/topographer artifacts; no trails ship yet.",
+  "description": "Agent wayfinding substrate over @ontrails/topographer artifacts; no query trails ship yet.",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",
@@ -25,13 +25,5 @@
   "peerDependencies": {
     "@ontrails/core": "workspace:^",
     "@ontrails/topographer": "workspace:^"
-  },
-  "peerDependenciesMeta": {
-    "@ontrails/core": {
-      "optional": true
-    },
-    "@ontrails/topographer": {
-      "optional": true
-    }
   }
 }

--- a/packages/wayfinder/src/__tests__/loader.test.ts
+++ b/packages/wayfinder/src/__tests__/loader.test.ts
@@ -1,0 +1,346 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { z } from 'zod';
+
+import {
+  Result,
+  openReadTrailsDb,
+  openWriteTrailsDb,
+  topo,
+  trail,
+} from '@ontrails/core';
+import {
+  TOPO_GRAPH_SCHEMA_VERSION,
+  TOPO_STORE_SCHEMA_VERSION,
+  createTopoSnapshot,
+  deriveTopoGraph,
+  deriveTopoGraphHash,
+  writeLockManifest,
+  writeTopoGraph,
+} from '@ontrails/topographer';
+import type { LockManifest, TopoGraph } from '@ontrails/topographer';
+
+import {
+  loadWayfinderArtifacts,
+  wayfinderFact,
+  wayfinderTopoGraphSource,
+  wayfinderTopoStoreSource,
+} from '../index.js';
+
+let tempDir: string;
+
+const userShowTrail = trail('user.show', {
+  blaze: () => Result.ok({ ok: true }),
+  examples: [{ expected: { ok: true }, input: {}, name: 'Basic' }],
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ ok: z.boolean() }),
+});
+
+const accountListTrail = trail('account.list', {
+  blaze: () => Result.ok({ accounts: [] }),
+  examples: [{ expected: { accounts: [] }, input: {}, name: 'Basic' }],
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ accounts: z.array(z.object({ id: z.string() })) }),
+});
+
+const defaultTopoEntries = { userShowTrail };
+
+const makeTopo = (
+  entries: Record<
+    string,
+    typeof accountListTrail | typeof userShowTrail
+  > = defaultTopoEntries
+) => topo('demo', entries);
+
+const countEntries = (
+  topoGraph: TopoGraph,
+  kind: TopoGraph['entries'][number]['kind']
+): number => topoGraph.entries.filter((entry) => entry.kind === kind).length;
+
+const makeLockManifest = (
+  topoGraph: TopoGraph,
+  overrides?: Partial<LockManifest>
+): LockManifest => ({
+  artifacts: [
+    {
+      path: 'topo.lock',
+      role: 'topo',
+      sha256: deriveTopoGraphHash(topoGraph),
+    },
+  ],
+  scope: { app: 'demo' },
+  summary: {
+    contours: countEntries(topoGraph, 'contour'),
+    resources: countEntries(topoGraph, 'resource'),
+    signals: countEntries(topoGraph, 'signal'),
+    trails: countEntries(topoGraph, 'trail'),
+  },
+  version: 3,
+  ...overrides,
+});
+
+const artifactsDir = () => join(tempDir, '.trails');
+
+const makeTopoGraph = (
+  overrides?: Partial<TopoGraph>,
+  graph = makeTopo()
+): TopoGraph => ({
+  ...deriveTopoGraph(graph),
+  generatedAt: '2026-06-04T00:00:00.000Z',
+  ...overrides,
+});
+
+const writeFreshArtifacts = async (
+  overrides?: Partial<TopoGraph>,
+  graph = makeTopo()
+): Promise<TopoGraph> => {
+  const topoGraph = makeTopoGraph(overrides, graph);
+  await writeTopoGraph(topoGraph, { dir: artifactsDir() });
+  await writeLockManifest(makeLockManifest(topoGraph), { dir: artifactsDir() });
+  return topoGraph;
+};
+
+const seedTopoStore = (graph = makeTopo()) => {
+  const snapshot = createTopoSnapshot(graph, {
+    createdAt: '2026-06-04T00:00:00.000Z',
+    gitSha: 'abc123',
+    rootDir: tempDir,
+  });
+  if (snapshot.isErr()) {
+    throw snapshot.error;
+  }
+  return snapshot.value;
+};
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'wayfinder-loader-test-'));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { force: true, recursive: true });
+});
+
+describe('loadWayfinderArtifacts', () => {
+  test('loads fresh topo graph, lock manifest, and topo-store artifacts', async () => {
+    await writeFreshArtifacts();
+    const snapshot = seedTopoStore();
+
+    const loaded = await loadWayfinderArtifacts({ rootDir: tempDir });
+
+    expect(loaded.freshness).toEqual({ status: 'fresh' });
+    expect(loaded.topoGraph?.entries.map((entry) => entry.id)).toEqual([
+      'user.show',
+    ]);
+    expect(loaded.lockManifest?.version).toBe(3);
+    expect(loaded.topoStore?.schemaVersion).toBe(TOPO_STORE_SCHEMA_VERSION);
+    expect(loaded.topoStore?.snapshot.id).toBe(snapshot.id);
+    expect(loaded.topoStore?.trails.map((entry) => entry.id)).toEqual([
+      'user.show',
+    ]);
+  });
+
+  test('materializes topo-store records at load time', async () => {
+    await writeFreshArtifacts();
+    seedTopoStore();
+
+    const loaded = await loadWayfinderArtifacts({ rootDir: tempDir });
+    seedTopoStore(makeTopo({ accountListTrail }));
+
+    expect(loaded.topoStore?.trails.map((entry) => entry.id)).toEqual([
+      'user.show',
+    ]);
+  });
+
+  test('marks artifacts stale when the manifest hash no longer matches topo.lock', async () => {
+    const topoGraph = await writeFreshArtifacts();
+    await writeLockManifest(
+      makeLockManifest(topoGraph, {
+        artifacts: [
+          {
+            path: 'topo.lock',
+            role: 'topo',
+            sha256: '0'.repeat(64),
+          },
+        ],
+      }),
+      { dir: artifactsDir() }
+    );
+    seedTopoStore();
+
+    const loaded = await loadWayfinderArtifacts({ rootDir: tempDir });
+
+    expect(loaded.freshness.status).toBe('stale');
+    expect(
+      loaded.freshness.status === 'stale'
+        ? loaded.freshness.reasons.map((reason) => reason.reason)
+        : []
+    ).toContain('lock-manifest-hash-mismatch');
+    expect(loaded.topoGraph).not.toBeNull();
+    expect(loaded.topoStore).not.toBeNull();
+  });
+
+  test('marks artifacts stale when trails.db no longer matches topo.lock', async () => {
+    await writeFreshArtifacts();
+    seedTopoStore(makeTopo({ accountListTrail }));
+
+    const loaded = await loadWayfinderArtifacts({ rootDir: tempDir });
+
+    expect(loaded.freshness.status).toBe('stale');
+    expect(
+      loaded.freshness.status === 'stale'
+        ? loaded.freshness.reasons.map((reason) => reason.reason)
+        : []
+    ).toContain('topo-store-hash-mismatch');
+    expect(loaded.topoGraph?.entries.map((entry) => entry.id)).toEqual([
+      'user.show',
+    ]);
+    expect(loaded.topoStore?.trails.map((entry) => entry.id)).toEqual([
+      'account.list',
+    ]);
+  });
+
+  test('marks missing artifacts without creating or mutating local state', async () => {
+    const loaded = await loadWayfinderArtifacts({ rootDir: tempDir });
+
+    expect(loaded).toEqual({
+      freshness: {
+        artifacts: ['topoGraph', 'lockManifest', 'topoStore'],
+        status: 'missing',
+      },
+      lockManifest: null,
+      topoGraph: null,
+      topoStore: null,
+    });
+    expect(await readdir(tempDir)).toEqual([]);
+  });
+
+  test('marks topo-store missing when trails.db exists without topo state', async () => {
+    await writeFreshArtifacts();
+    const db = openWriteTrailsDb({ rootDir: tempDir });
+    db.close();
+
+    const loaded = await loadWayfinderArtifacts({ rootDir: tempDir });
+
+    expect(loaded.freshness).toEqual({
+      artifacts: ['topoStore'],
+      status: 'missing',
+    });
+    expect(loaded.topoGraph).not.toBeNull();
+    expect(loaded.lockManifest).not.toBeNull();
+    expect(loaded.topoStore).toBeNull();
+  });
+
+  test('marks schema-version drift when topo.lock uses an unsupported schema version', async () => {
+    await mkdir(artifactsDir(), { recursive: true });
+    await Bun.write(
+      join(artifactsDir(), 'topo.lock'),
+      `${JSON.stringify({
+        ...makeTopoGraph(),
+        topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION - 1,
+      })}\n`
+    );
+    await writeLockManifest(makeLockManifest(makeTopoGraph()), {
+      dir: artifactsDir(),
+    });
+
+    const loaded = await loadWayfinderArtifacts({ rootDir: tempDir });
+
+    expect(loaded.freshness).toMatchObject({
+      artifact: 'topoGraph',
+      status: 'schema-version-drift',
+    });
+    expect(loaded.topoGraph).toBeNull();
+    expect(loaded.lockManifest?.version).toBe(3);
+  });
+
+  test('marks schema-version drift when trails.lock uses an unsupported schema version', async () => {
+    const topoGraph = await writeFreshArtifacts();
+    await Bun.write(
+      join(artifactsDir(), 'trails.lock'),
+      `${JSON.stringify({ ...makeLockManifest(topoGraph), version: 2 })}\n`
+    );
+
+    const loaded = await loadWayfinderArtifacts({ rootDir: tempDir });
+
+    expect(loaded.freshness).toMatchObject({
+      artifact: 'lockManifest',
+      status: 'schema-version-drift',
+    });
+    expect(loaded.topoGraph).not.toBeNull();
+    expect(loaded.lockManifest).toBeNull();
+  });
+
+  test('marks schema-version drift without migrating a stale topo store', async () => {
+    await writeFreshArtifacts();
+    const db = openWriteTrailsDb({ rootDir: tempDir });
+    try {
+      db.run(
+        `INSERT INTO meta_schema_versions (subsystem, version, updated_at)
+         VALUES (?, ?, ?)`,
+        'topo',
+        TOPO_STORE_SCHEMA_VERSION - 1,
+        '2026-06-04T00:00:00.000Z'
+      );
+    } finally {
+      db.close();
+    }
+
+    const loaded = await loadWayfinderArtifacts({ rootDir: tempDir });
+
+    expect(loaded.freshness).toMatchObject({
+      artifact: 'topoStore',
+      status: 'schema-version-drift',
+    });
+    expect(loaded.topoStore).toBeNull();
+
+    const readDb = openReadTrailsDb({ rootDir: tempDir });
+    try {
+      const row = readDb
+        .query<{ version: number }, [string]>(
+          'SELECT version FROM meta_schema_versions WHERE subsystem = ?'
+        )
+        .get('topo');
+      expect(row?.version).toBe(TOPO_STORE_SCHEMA_VERSION - 1);
+    } finally {
+      readDb.close();
+    }
+  });
+});
+
+describe('wayfinderFact', () => {
+  test('carries category, source, freshness, and derivedFrom provenance', () => {
+    const freshness = { status: 'fresh' } as const;
+    const fact = wayfinderFact({
+      category: 'projected',
+      derivedFrom: { field: 'output', id: 'user.show', kind: 'trail' },
+      freshness,
+      source: wayfinderTopoStoreSource({ rootDir: tempDir }),
+      value: { hasOutput: true },
+    });
+
+    expect(fact).toEqual({
+      category: 'projected',
+      derivedFrom: { field: 'output', id: 'user.show', kind: 'trail' },
+      freshness,
+      source: {
+        kind: 'topoStore',
+        path: `${tempDir}/.trails/state/trails.db`,
+        schemaVersion: TOPO_STORE_SCHEMA_VERSION,
+      },
+      value: { hasOutput: true },
+    });
+  });
+
+  test('can point facts at topo.lock file provenance', () => {
+    expect(wayfinderTopoGraphSource({ rootDir: tempDir })).toEqual({
+      kind: 'topoGraph',
+      path: `${tempDir}/.trails/topo.lock`,
+      schemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
+    });
+  });
+});

--- a/packages/wayfinder/src/index.ts
+++ b/packages/wayfinder/src/index.ts
@@ -5,12 +5,11 @@
  * query a Trails app's resolved topo without re-deriving it from `grep` and
  * file reads. A future catalog may include trails such as `wayfind.overview`,
  * `wayfind.search`, `wayfind.contract`, `wayfind.nearby`, and
- * `wayfind.examples`; this package currently ships as a marker only.
+ * `wayfind.examples`; this package currently ships as a substrate only.
  *
- * No trails are exported yet. The shell exists to reserve the namespace and
- * give the v0 trails a clean home when they land. Peer dependencies on
- * `@ontrails/core` and `@ontrails/topographer` are declared optional in
- * `peerDependenciesMeta` until real trails consume them.
+ * No query trails are exported yet. The exported loader and provenance helpers
+ * give the v0 trails a cold, deterministic, materialized artifact substrate
+ * when they land.
  */
 
 /**
@@ -21,3 +20,28 @@
  * are exported.
  */
 export const WAYFINDER_SHELL = true as const;
+
+export {
+  loadWayfinderArtifacts,
+  wayfinderTopoGraphSource,
+  wayfinderTopoStoreSource,
+} from './loader.js';
+export type {
+  WayfinderArtifactLoad,
+  WayfinderArtifactLoaderOptions,
+  WayfinderTopoStoreLoad,
+} from './loader.js';
+export { wayfinderFact } from './provenance.js';
+export type {
+  WayfinderArtifactKind,
+  WayfinderArtifactSource,
+  WayfinderContractRef,
+  WayfinderFact,
+  WayfinderFactCategory,
+  WayfinderFreshness,
+  WayfinderFreshnessFresh,
+  WayfinderFreshnessMissing,
+  WayfinderFreshnessSchemaVersionDrift,
+  WayfinderFreshnessStale,
+  WayfinderStaleReason,
+} from './provenance.js';

--- a/packages/wayfinder/src/loader.ts
+++ b/packages/wayfinder/src/loader.ts
@@ -1,0 +1,389 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import {
+  NotFoundError,
+  deriveTrailsDbPath,
+  openReadTrailsDb,
+} from '@ontrails/core';
+import type { TrailsDbLocationOptions } from '@ontrails/core';
+import {
+  TOPO_GRAPH_SCHEMA_VERSION,
+  TOPO_STORE_SCHEMA_VERSION,
+  createTopoStore,
+  deriveTopoGraphHash,
+  isTopoArtifactRegenerationError,
+  readLockManifest,
+  readTopoGraph,
+} from '@ontrails/topographer';
+import type {
+  LockManifest,
+  LockManifestSummary,
+  ReadOptions,
+  TopoGraph,
+  TopoStoreContourRecord,
+  TopoStoreExportRecord,
+  TopoStoreResourceRecord,
+  TopoStoreSignalDetailRecord,
+  TopoStoreTopoGraphEntryRecord,
+  TopoStoreTopoGraphRecord,
+  TopoStoreTrailDetailRecord,
+  TopoSnapshot,
+} from '@ontrails/topographer';
+
+import type {
+  WayfinderArtifactKind,
+  WayfinderFreshness,
+  WayfinderStaleReason,
+} from './provenance.js';
+
+export type WayfinderArtifactLoaderOptions = ReadOptions &
+  TrailsDbLocationOptions;
+
+export interface WayfinderTopoStoreLoad {
+  readonly contours: readonly TopoStoreContourRecord[];
+  readonly entries: readonly TopoStoreTopoGraphEntryRecord[];
+  readonly export: TopoStoreExportRecord | null;
+  readonly path: string;
+  readonly resources: readonly TopoStoreResourceRecord[];
+  readonly schemaVersion: number;
+  readonly signals: readonly TopoStoreSignalDetailRecord[];
+  readonly snapshot: TopoSnapshot;
+  readonly topoGraph: TopoStoreTopoGraphRecord | null;
+  readonly trails: readonly TopoStoreTrailDetailRecord[];
+}
+
+export interface WayfinderArtifactLoad {
+  readonly freshness: WayfinderFreshness;
+  readonly lockManifest: LockManifest | null;
+  readonly topoGraph: TopoGraph | null;
+  readonly topoStore: WayfinderTopoStoreLoad | null;
+}
+
+type ArtifactRead<TValue> =
+  | {
+      readonly kind: 'ok';
+      readonly value: TValue | null;
+    }
+  | {
+      readonly artifact: WayfinderArtifactKind;
+      readonly kind: 'schema-version-drift';
+      readonly message: string;
+    };
+
+const resolveArtifactReadOptions = (
+  options?: WayfinderArtifactLoaderOptions
+): ReadOptions | undefined => {
+  if (options?.dir !== undefined) {
+    return { dir: options.dir };
+  }
+  if (options?.rootDir !== undefined) {
+    return { dir: join(options.rootDir, '.trails') };
+  }
+  return undefined;
+};
+
+const resolveTopoStoreLocation = (
+  options?: WayfinderArtifactLoaderOptions
+): TrailsDbLocationOptions => {
+  if (options?.path !== undefined) {
+    return options.rootDir === undefined
+      ? { path: options.path }
+      : { path: options.path, rootDir: options.rootDir };
+  }
+  if (options?.rootDir !== undefined) {
+    return { rootDir: options.rootDir };
+  }
+  if (options?.dir !== undefined) {
+    return { path: join(options.dir, 'state', 'trails.db') };
+  }
+  return {};
+};
+
+const readTopoArtifact = async (
+  options?: WayfinderArtifactLoaderOptions
+): Promise<ArtifactRead<TopoGraph>> => {
+  try {
+    return {
+      kind: 'ok',
+      value: await readTopoGraph(resolveArtifactReadOptions(options)),
+    };
+  } catch (error) {
+    if (isTopoArtifactRegenerationError(error)) {
+      return {
+        artifact: 'topoGraph',
+        kind: 'schema-version-drift',
+        message: error.message,
+      };
+    }
+    throw error;
+  }
+};
+
+const readLockArtifact = async (
+  options?: WayfinderArtifactLoaderOptions
+): Promise<ArtifactRead<LockManifest>> => {
+  try {
+    return {
+      kind: 'ok',
+      value: await readLockManifest(resolveArtifactReadOptions(options)),
+    };
+  } catch (error) {
+    if (isTopoArtifactRegenerationError(error)) {
+      return {
+        artifact: 'lockManifest',
+        kind: 'schema-version-drift',
+        message: error.message,
+      };
+    }
+    throw error;
+  }
+};
+
+const readTopoStoreArtifact = (
+  options?: WayfinderArtifactLoaderOptions
+): ArtifactRead<WayfinderTopoStoreLoad> => {
+  const location = resolveTopoStoreLocation(options);
+  const path = deriveTrailsDbPath(location);
+  if (!existsSync(path)) {
+    return { kind: 'ok', value: null };
+  }
+
+  let actualVersion: number | undefined;
+  let db: ReturnType<typeof openReadTrailsDb> | undefined;
+  try {
+    db = openReadTrailsDb(location);
+    const row = db
+      .query<{ version: number }, [string]>(
+        'SELECT version FROM meta_schema_versions WHERE subsystem = ?'
+      )
+      .get('topo');
+    actualVersion = row?.version;
+  } catch {
+    return {
+      artifact: 'topoStore',
+      kind: 'schema-version-drift',
+      message: `Unsupported trails.db topo store schema; regenerate with \`trails compile\`. Expected ${TOPO_STORE_SCHEMA_VERSION}.`,
+    };
+  } finally {
+    db?.close();
+  }
+
+  if (actualVersion === undefined) {
+    return { kind: 'ok', value: null };
+  }
+
+  if (actualVersion !== TOPO_STORE_SCHEMA_VERSION) {
+    return {
+      artifact: 'topoStore',
+      kind: 'schema-version-drift',
+      message: `Unsupported trails.db topo store schema; regenerate with \`trails compile\`. Expected ${TOPO_STORE_SCHEMA_VERSION}, found ${actualVersion}.`,
+    };
+  }
+
+  const store = createTopoStore(location);
+  let snapshot: TopoSnapshot | undefined;
+  try {
+    snapshot = store.snapshots.latest();
+  } catch (error) {
+    if (error instanceof NotFoundError) {
+      return { kind: 'ok', value: null };
+    }
+    throw error;
+  }
+
+  if (snapshot === undefined) {
+    return { kind: 'ok', value: null };
+  }
+
+  const ref = { snapshotId: snapshot.id };
+  return {
+    kind: 'ok',
+    value: {
+      contours: store.contours.list({ snapshot: ref }),
+      entries: store.entries.list({ snapshot: ref }),
+      export: store.exports.get(ref) ?? null,
+      path,
+      resources: store.resources.list({ snapshot: ref }),
+      schemaVersion: TOPO_STORE_SCHEMA_VERSION,
+      signals: store.signals
+        .list({ snapshot: ref })
+        .map((signal) => store.signals.get(signal.id, { snapshot: ref }))
+        .filter(
+          (signal): signal is TopoStoreSignalDetailRecord =>
+            signal !== undefined
+        ),
+      snapshot,
+      topoGraph: store.topoGraph.get(ref) ?? null,
+      trails: store.trails
+        .list({ snapshot: ref })
+        .map((trail) => store.trails.get(trail.id, { snapshot: ref }))
+        .filter(
+          (trail): trail is TopoStoreTrailDetailRecord => trail !== undefined
+        ),
+    },
+  };
+};
+
+const countEntries = (
+  topoGraph: TopoGraph,
+  kind: TopoGraph['entries'][number]['kind']
+): number => topoGraph.entries.filter((entry) => entry.kind === kind).length;
+
+const summarizeTopoGraph = (topoGraph: TopoGraph): LockManifestSummary => ({
+  contours: countEntries(topoGraph, 'contour'),
+  resources: countEntries(topoGraph, 'resource'),
+  signals: countEntries(topoGraph, 'signal'),
+  trails: countEntries(topoGraph, 'trail'),
+});
+
+const summariesEqual = (
+  left: LockManifestSummary,
+  right: LockManifestSummary
+): boolean =>
+  left.contours === right.contours &&
+  left.resources === right.resources &&
+  left.signals === right.signals &&
+  left.trails === right.trails;
+
+const staleReasons = (
+  topoGraph: TopoGraph,
+  lockManifest: LockManifest,
+  topoStore: WayfinderTopoStoreLoad
+): readonly WayfinderStaleReason[] => {
+  const reasons: WayfinderStaleReason[] = [];
+  const actualHash = deriveTopoGraphHash(topoGraph);
+  const topoArtifact = lockManifest.artifacts.find(
+    (artifact) => artifact.role === 'topo' && artifact.path === 'topo.lock'
+  );
+
+  if (topoArtifact === undefined) {
+    reasons.push({ reason: 'lock-manifest-topo-artifact-missing' });
+  } else if (topoArtifact.sha256 !== actualHash) {
+    reasons.push({
+      actual: actualHash,
+      expected: topoArtifact.sha256,
+      reason: 'lock-manifest-hash-mismatch',
+    });
+  }
+
+  const storeExport = topoStore.export;
+  if (storeExport === null) {
+    reasons.push({ reason: 'topo-store-export-missing' });
+  } else if (storeExport.topoGraphHash !== actualHash) {
+    reasons.push({
+      actual: storeExport.topoGraphHash,
+      expected: actualHash,
+      reason: 'topo-store-hash-mismatch',
+      snapshotId: storeExport.snapshot.id,
+    });
+  }
+
+  const actualSummary = summarizeTopoGraph(topoGraph);
+  if (!summariesEqual(lockManifest.summary, actualSummary)) {
+    reasons.push({
+      actual: actualSummary,
+      expected: lockManifest.summary,
+      reason: 'lock-manifest-summary-mismatch',
+    });
+  }
+
+  return reasons;
+};
+
+export const loadWayfinderArtifacts = async (
+  options?: WayfinderArtifactLoaderOptions
+): Promise<WayfinderArtifactLoad> => {
+  const [topoGraphRead, lockManifestRead, topoStoreRead] = await Promise.all([
+    readTopoArtifact(options),
+    readLockArtifact(options),
+    readTopoStoreArtifact(options),
+  ]);
+
+  if (topoGraphRead.kind === 'schema-version-drift') {
+    return {
+      freshness: {
+        artifact: topoGraphRead.artifact,
+        message: topoGraphRead.message,
+        status: 'schema-version-drift',
+      },
+      lockManifest:
+        lockManifestRead.kind === 'ok' ? lockManifestRead.value : null,
+      topoGraph: null,
+      topoStore: topoStoreRead.kind === 'ok' ? topoStoreRead.value : null,
+    };
+  }
+
+  if (lockManifestRead.kind === 'schema-version-drift') {
+    return {
+      freshness: {
+        artifact: lockManifestRead.artifact,
+        message: lockManifestRead.message,
+        status: 'schema-version-drift',
+      },
+      lockManifest: null,
+      topoGraph: topoGraphRead.value,
+      topoStore: topoStoreRead.kind === 'ok' ? topoStoreRead.value : null,
+    };
+  }
+
+  if (topoStoreRead.kind === 'schema-version-drift') {
+    return {
+      freshness: {
+        artifact: topoStoreRead.artifact,
+        message: topoStoreRead.message,
+        status: 'schema-version-drift',
+      },
+      lockManifest: lockManifestRead.value,
+      topoGraph: topoGraphRead.value,
+      topoStore: null,
+    };
+  }
+
+  const topoGraph = topoGraphRead.value;
+  const lockManifest = lockManifestRead.value;
+  const topoStore = topoStoreRead.value;
+  if (topoGraph === null || lockManifest === null || topoStore === null) {
+    const missing: WayfinderArtifactKind[] = [];
+    if (topoGraph === null) {
+      missing.push('topoGraph');
+    }
+    if (lockManifest === null) {
+      missing.push('lockManifest');
+    }
+    if (topoStore === null) {
+      missing.push('topoStore');
+    }
+    return {
+      freshness: { artifacts: missing, status: 'missing' },
+      lockManifest,
+      topoGraph,
+      topoStore,
+    };
+  }
+
+  const reasons = staleReasons(topoGraph, lockManifest, topoStore);
+  return {
+    freshness:
+      reasons.length === 0 ? { status: 'fresh' } : { reasons, status: 'stale' },
+    lockManifest,
+    topoGraph,
+    topoStore,
+  };
+};
+
+export const wayfinderTopoGraphSource = (
+  options?: WayfinderArtifactLoaderOptions
+) => ({
+  kind: 'topoGraph' as const,
+  path: `${resolveArtifactReadOptions(options)?.dir ?? '.trails'}/topo.lock`,
+  schemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
+});
+
+export const wayfinderTopoStoreSource = (
+  options?: WayfinderArtifactLoaderOptions
+) => ({
+  kind: 'topoStore' as const,
+  path: deriveTrailsDbPath(resolveTopoStoreLocation(options)),
+  schemaVersion: TOPO_STORE_SCHEMA_VERSION,
+});

--- a/packages/wayfinder/src/provenance.ts
+++ b/packages/wayfinder/src/provenance.ts
@@ -1,0 +1,81 @@
+export type WayfinderFactCategory =
+  | 'authored'
+  | 'projected'
+  | 'inferred'
+  | 'observed';
+
+export type WayfinderArtifactKind = 'lockManifest' | 'topoGraph' | 'topoStore';
+
+export interface WayfinderArtifactSource {
+  readonly kind: WayfinderArtifactKind;
+  readonly path?: string | undefined;
+  readonly schemaVersion?: number | undefined;
+}
+
+export interface WayfinderContractRef {
+  readonly id: string;
+  readonly kind: 'contour' | 'facet' | 'resource' | 'signal' | 'topo' | 'trail';
+  readonly field?: string | undefined;
+}
+
+export interface WayfinderFreshnessFresh {
+  readonly status: 'fresh';
+}
+
+export interface WayfinderFreshnessMissing {
+  readonly artifacts: readonly WayfinderArtifactKind[];
+  readonly status: 'missing';
+}
+
+export type WayfinderStaleReason =
+  | {
+      readonly actual: string;
+      readonly expected: string;
+      readonly reason: 'lock-manifest-hash-mismatch';
+    }
+  | {
+      readonly actual: Readonly<Record<string, number>>;
+      readonly expected: Readonly<Record<string, number>>;
+      readonly reason: 'lock-manifest-summary-mismatch';
+    }
+  | {
+      readonly reason: 'lock-manifest-topo-artifact-missing';
+    }
+  | {
+      readonly actual: string;
+      readonly expected: string;
+      readonly reason: 'topo-store-hash-mismatch';
+      readonly snapshotId: string;
+    }
+  | {
+      readonly reason: 'topo-store-export-missing';
+    };
+
+export interface WayfinderFreshnessStale {
+  readonly reasons: readonly WayfinderStaleReason[];
+  readonly status: 'stale';
+}
+
+export interface WayfinderFreshnessSchemaVersionDrift {
+  readonly artifact: WayfinderArtifactKind;
+  readonly message: string;
+  readonly status: 'schema-version-drift';
+}
+
+export type WayfinderFreshness =
+  | WayfinderFreshnessFresh
+  | WayfinderFreshnessMissing
+  | WayfinderFreshnessStale
+  | WayfinderFreshnessSchemaVersionDrift;
+
+export interface WayfinderFact<TValue> {
+  readonly category: WayfinderFactCategory;
+  readonly derivedFrom: WayfinderContractRef | null;
+  readonly freshness: WayfinderFreshness;
+  readonly source: WayfinderArtifactSource;
+  readonly value: TValue;
+}
+
+export const wayfinderFact = <TValue>(
+  fact: WayfinderFact<TValue>
+): WayfinderFact<TValue> => fact;


### PR DESCRIPTION
## Context

Adds the Wayfinder artifact-loading foundation for TRL-904. The goal is to let Wayfinder answer graph questions from saved Topographer artifacts and topo-store records without booting apps, resolving resources, touching the network, or mutating local state.

## What Changed

- Added `loadWayfinderArtifacts` with file-artifact and topo-store loading paths.
- Added provenance/freshness helpers that identify fresh, stale, missing, and schema-drifted sources.
- Exposed `TOPO_STORE_SCHEMA_VERSION` through the public topographer topo-store API so loader freshness checks do not depend on private internals.
- Added loader/provenance tests and updated `@ontrails/wayfinder` package metadata.
- Added a changeset for the Wayfinder loader/provenance behavior and Topographer public schema-version export.

## Verification

- Focused Topographer verification after the Warden export-boundary fix:
  - `bun run --cwd packages/topographer typecheck`
  - `bun test packages/topographer/src/__tests__/topo-store.test.ts packages/topographer/src/__tests__/topo-store-read.test.ts`
  - `bun apps/trails/bin/trails.ts warden --pre-push`
- Full-stack verification:
  - `bun run publish:check`
  - `bun run build`
  - `bun run test`
  - Pre-push hook passed during `gt submit`.

## Risks / Rollout

- This is a new public export path for a topo-store schema version. It is intentionally exposed from the public `topo-store` module rather than re-exporting private internals.
- Loader results are intentionally conservative: missing or stale artifacts are represented in freshness metadata instead of silently pretending the graph is current.
