### PR TITLE
feat(wayfinder): add typed filter kit

### DIFF
--- a/.changeset/wayfinder-filter-kit.md
+++ b/.changeset/wayfinder-filter-kit.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/wayfinder": patch
+---
+
+Add the reusable typed Wayfinder entity filter kit for graph-read query trails.

--- a/packages/wayfinder/README.md
+++ b/packages/wayfinder/README.md
@@ -6,6 +6,8 @@ Agent-shaped wayfinding helpers and trails over `@ontrails/topographer` artifact
 
 **Status: substrate only.** No query trails ship yet.
 
-The package currently exports the cold artifact loader and fact provenance helpers that v0 graph-read trails will share. Those helpers read existing Topographer artifacts (`topo.lock`, `trails.lock`, and materialized current `trails.db` topo-store records) without starting apps, booting resources, reaching the network, or mutating local state.
+The package currently exports the cold artifact loader, fact provenance helpers, and typed filter kit that v0 graph-read trails will share. Those helpers read existing Topographer artifacts (`topo.lock`, `trails.lock`, and materialized current `trails.db` topo-store records) without starting apps, booting resources, reaching the network, or mutating local state.
+
+The typed filter kit supports entity kind, ID, prefix, namespace, intent, surface, facet, versioning, example coverage, resource usage, and signal usage predicates without introducing a generic query language. Use `createWayfinderGraphEntityPredicate` or `filterWayfinderEntityRefs` when matching relationship filters so facet membership and projected surfaces are evaluated with graph-derived context.
 
 When the query catalog lands, trails such as `wayfind.overview`, `wayfind.search`, `wayfind.contract`, `wayfind.nearby`, `wayfind.impact`, and `wayfind.examples` will be exported from here.

--- a/packages/wayfinder/src/__tests__/filters.test.ts
+++ b/packages/wayfinder/src/__tests__/filters.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { Result, resource, signal, topo, trail } from '@ontrails/core';
+import { deriveTopoGraph } from '@ontrails/topographer';
+import type { TopoGraph, TopoGraphEntry } from '@ontrails/topographer';
+
+import {
+  createWayfinderEntityPredicate,
+  createWayfinderFilterContext,
+  createWayfinderGraphEntityPredicate,
+  filterWayfinderEntityRefs,
+  listWayfinderEntityRefs,
+  wayfinderEntityFilterSchema,
+} from '../index.js';
+
+const db = resource('db.main', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+const userCreated = signal('user.created', {
+  payload: z.object({ id: z.string() }),
+});
+
+const userShow = trail('user.show', {
+  blaze: () => Result.ok({ id: 'u1' }),
+  examples: [{ expected: { id: 'u1' }, input: {}, name: 'Basic' }],
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ id: z.string() }),
+  resources: [db],
+});
+
+const userCreate = trail('user.create', {
+  blaze: () => Result.ok({ id: 'u1' }),
+  fires: [userCreated],
+  input: z.object({ name: z.string() }),
+  intent: 'write',
+  output: z.object({ id: z.string() }),
+  resources: [db],
+});
+
+const auditRebuild = trail('audit.rebuild', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  intent: 'destroy',
+  on: [userCreated],
+  output: z.object({ ok: z.boolean() }),
+});
+
+const inviteCreate = trail('invite.create', {
+  blaze: (input) => Result.ok({ greeting: `Hello, ${input.name}!` }),
+  input: z.object({ name: z.string() }),
+  output: z.object({ greeting: z.string() }),
+  version: 2,
+  versions: {
+    1: {
+      blaze: (input) => Result.ok({ greeting: `Hi, ${input.name}.` }),
+      examples: [
+        {
+          expected: { greeting: 'Hello, Ada!' },
+          input: { name: 'Ada' },
+          name: 'Legacy greeting',
+        },
+      ],
+      input: z.object({ name: z.string() }),
+      output: z.object({ greeting: z.string() }),
+      resources: [db],
+      status: { state: 'deprecated', successor: 2 },
+    },
+  },
+});
+
+const withSurfaces = (topoGraph: TopoGraph): TopoGraph => ({
+  ...topoGraph,
+  entries: topoGraph.entries.map((entry): TopoGraphEntry => {
+    if (entry.id === 'user.show') {
+      return { ...entry, surfaces: ['mcp'] };
+    }
+    if (entry.id === 'user.create') {
+      return { ...entry, surfaces: ['cli'] };
+    }
+    return entry;
+  }),
+});
+
+const makeGraph = (): TopoGraph =>
+  withSurfaces(
+    deriveTopoGraph(
+      topo('demo', {
+        auditRebuild,
+        db,
+        inviteCreate,
+        userCreate,
+        userCreated,
+        userShow,
+      }),
+      {
+        facets: [
+          {
+            description: 'User operations.',
+            id: 'users',
+            surfaces: ['mcp'],
+            trails: 'user.*',
+          },
+        ],
+      }
+    )
+  );
+
+const ids = (topoGraph: TopoGraph, filters = {}) =>
+  filterWayfinderEntityRefs(topoGraph, filters).map((ref) => ref.id);
+
+describe('wayfinder typed filters', () => {
+  test('schema accepts typed filters without a query mini-language', () => {
+    expect(
+      wayfinderEntityFilterSchema.parse({
+        exampleCoverage: true,
+        facet: 'users',
+        idPrefix: 'user.',
+        intent: ['read', 'write'],
+        kind: ['trail'],
+        namespace: 'user',
+        surface: 'mcp',
+        usesResource: 'db.main',
+        usesSignal: 'user.created',
+        versioned: false,
+      })
+    ).toEqual({
+      exampleCoverage: true,
+      facet: 'users',
+      idPrefix: 'user.',
+      intent: ['read', 'write'],
+      kind: ['trail'],
+      namespace: 'user',
+      surface: 'mcp',
+      usesResource: 'db.main',
+      usesSignal: 'user.created',
+      versioned: false,
+    });
+    expect(() =>
+      wayfinderEntityFilterSchema.parse({ query: 'kind:trail user.*' })
+    ).toThrow();
+  });
+
+  test('lists graph, facet, surface, and version entity refs', () => {
+    const refs = listWayfinderEntityRefs(makeGraph());
+
+    expect(refs.map((ref) => `${ref.kind}:${ref.id}`)).toContain('facet:users');
+    expect(refs.map((ref) => `${ref.kind}:${ref.id}`)).toContain('surface:mcp');
+    expect(refs.map((ref) => `${ref.kind}:${ref.id}`)).toContain(
+      'version:invite.create@1'
+    );
+  });
+
+  test('filters by kind, id, prefix, and namespace', () => {
+    const graph = makeGraph();
+
+    expect(ids(graph, { kind: 'trail', namespace: 'user' })).toEqual([
+      'user.create',
+      'user.show',
+    ]);
+    expect(ids(graph, { id: 'user.show' })).toEqual(['user.show']);
+    expect(ids(graph, { idPrefix: 'audit.' })).toEqual(['audit.rebuild']);
+  });
+
+  test('filters trails by intent, versioning, and example coverage', () => {
+    const graph = makeGraph();
+
+    expect(ids(graph, { intent: 'destroy' })).toEqual(['audit.rebuild']);
+    expect(ids(graph, { kind: 'trail', versioned: true })).toEqual([
+      'invite.create',
+    ]);
+    expect(ids(graph, { exampleCoverage: true, kind: 'trail' })).toEqual([
+      'user.show',
+    ]);
+  });
+
+  test('filters by surface and facet membership', () => {
+    const graph = makeGraph();
+
+    expect(ids(graph, { kind: 'trail', surface: 'mcp' })).toEqual([
+      'user.create',
+      'user.show',
+    ]);
+    expect(ids(graph, { facet: 'users', kind: 'trail' })).toEqual([
+      'user.create',
+      'user.show',
+    ]);
+    expect(ids(graph, { kind: 'surface', surface: 'mcp' })).toEqual(['mcp']);
+  });
+
+  test('filters by resource and signal usage where substrate exists', () => {
+    const graph = makeGraph();
+
+    expect(ids(graph, { kind: 'trail', usesResource: 'db.main' })).toEqual([
+      'user.create',
+      'user.show',
+    ]);
+    expect(ids(graph, { kind: 'version', usesResource: 'db.main' })).toEqual([
+      'invite.create@1',
+    ]);
+    expect(ids(graph, { kind: 'trail', usesSignal: 'user.created' })).toEqual([
+      'audit.rebuild',
+      'user.create',
+    ]);
+  });
+
+  test('returns empty sets as findings instead of errors', () => {
+    expect(
+      filterWayfinderEntityRefs(makeGraph(), { idPrefix: 'missing.' })
+    ).toEqual([]);
+  });
+
+  test('builds reusable predicates for future query trails', () => {
+    const graph = makeGraph();
+    const context = createWayfinderFilterContext(graph);
+    const predicate = createWayfinderEntityPredicate(context, {
+      kind: 'trail',
+      surface: 'mcp',
+    });
+    const graphPredicate = createWayfinderGraphEntityPredicate(graph, {
+      kind: 'trail',
+      namespace: 'user',
+    });
+
+    expect(
+      listWayfinderEntityRefs(graph)
+        .filter(predicate)
+        .map((ref) => ref.id)
+    ).toEqual(['user.create', 'user.show']);
+    expect(
+      listWayfinderEntityRefs(graph)
+        .filter(graphPredicate)
+        .map((ref) => ref.id)
+    ).toEqual(['user.create', 'user.show']);
+  });
+});

--- a/packages/wayfinder/src/filters.ts
+++ b/packages/wayfinder/src/filters.ts
@@ -1,0 +1,374 @@
+import { z } from 'zod';
+
+import type {
+  TopoGraph,
+  TopoGraphEntry,
+  TopoGraphFacetEntry,
+  TopoGraphVersionEntry,
+} from '@ontrails/topographer';
+
+export const wayfinderEntityKindSchema = z.enum([
+  'contour',
+  'facet',
+  'resource',
+  'signal',
+  'surface',
+  'trail',
+  'version',
+]);
+
+export type WayfinderEntityKind = z.infer<typeof wayfinderEntityKindSchema>;
+
+export const wayfinderIntentSchema = z.enum(['destroy', 'read', 'write']);
+
+export type WayfinderIntent = z.infer<typeof wayfinderIntentSchema>;
+
+const stringListSchema = z.union([z.string(), z.array(z.string()).readonly()]);
+
+const entityKindListSchema = z.union([
+  wayfinderEntityKindSchema,
+  z.array(wayfinderEntityKindSchema).readonly(),
+]);
+
+const intentListSchema = z.union([
+  wayfinderIntentSchema,
+  z.array(wayfinderIntentSchema).readonly(),
+]);
+
+export const wayfinderEntityFilterSchema = z
+  .object({
+    exampleCoverage: z.boolean().optional(),
+    facet: stringListSchema.optional(),
+    id: stringListSchema.optional(),
+    idPrefix: stringListSchema.optional(),
+    intent: intentListSchema.optional(),
+    kind: entityKindListSchema.optional(),
+    namespace: stringListSchema.optional(),
+    surface: stringListSchema.optional(),
+    usesResource: stringListSchema.optional(),
+    usesSignal: stringListSchema.optional(),
+    versioned: z.boolean().optional(),
+  })
+  .strict();
+
+export type WayfinderEntityFilterInput = z.input<
+  typeof wayfinderEntityFilterSchema
+>;
+
+export type WayfinderEntityFilters = z.output<
+  typeof wayfinderEntityFilterSchema
+>;
+
+export interface WayfinderEntityRef {
+  readonly entry?: TopoGraphEntry | undefined;
+  readonly facet?: TopoGraphFacetEntry | undefined;
+  readonly id: string;
+  readonly kind: WayfinderEntityKind;
+  readonly trailId?: string | undefined;
+  readonly version?: TopoGraphVersionEntry | undefined;
+  readonly versionKey?: string | undefined;
+}
+
+export interface WayfinderFilterContext {
+  readonly facetsById: ReadonlyMap<string, TopoGraphFacetEntry>;
+  readonly facetIdsByTrailId: ReadonlyMap<string, readonly string[]>;
+  readonly facetSurfacesByTrailId: ReadonlyMap<string, readonly string[]>;
+}
+
+const toArray = <TValue>(
+  value: TValue | readonly TValue[] | undefined
+): readonly TValue[] => {
+  if (value === undefined) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value as readonly TValue[];
+  }
+  return [value as TValue];
+};
+
+const includesAny = (
+  values: readonly string[] | undefined,
+  expected: readonly string[]
+): boolean =>
+  expected.length === 0 ||
+  (values ?? []).some((value) => expected.includes(value));
+
+const namespaceMatches = (id: string, namespace: string): boolean =>
+  id === namespace || id.startsWith(`${namespace}.`);
+
+const entryHasVersioning = (entry: TopoGraphEntry): boolean =>
+  entry.version !== undefined ||
+  entry.versions !== undefined ||
+  (entry.supports?.length ?? 0) > 0;
+
+const entryHasExamples = (entry: TopoGraphEntry): boolean =>
+  entry.exampleCount > 0 || (entry.examples?.length ?? 0) > 0;
+
+const versionHasExamples = (version: TopoGraphVersionEntry): boolean =>
+  version.exampleCount > 0 || (version.examples?.length ?? 0) > 0;
+
+const entrySignalIds = (entry: TopoGraphEntry): readonly string[] => [
+  ...(entry.fires ?? []),
+  ...(entry.on ?? []),
+  ...(entry.from ?? []),
+  ...(entry.producers ?? []),
+  ...(entry.consumers ?? []),
+];
+
+const entrySurfaces = (
+  ref: WayfinderEntityRef,
+  context: WayfinderFilterContext
+): readonly string[] => {
+  if (ref.kind === 'facet') {
+    return ref.facet?.surfaces ?? [];
+  }
+  if (ref.kind === 'surface') {
+    return [ref.id];
+  }
+  return [
+    ...(ref.entry?.surfaces ?? context.facetsById.get(ref.id)?.surfaces ?? []),
+    ...(context.facetSurfacesByTrailId.get(ref.trailId ?? ref.id) ?? []),
+  ];
+};
+
+const refHasExamples = (ref: WayfinderEntityRef): boolean => {
+  if (ref.version !== undefined) {
+    return versionHasExamples(ref.version);
+  }
+  return ref.entry === undefined ? false : entryHasExamples(ref.entry);
+};
+
+const refHasVersioning = (ref: WayfinderEntityRef): boolean => {
+  if (ref.kind === 'version') {
+    return true;
+  }
+  return ref.entry === undefined ? false : entryHasVersioning(ref.entry);
+};
+
+const refResourceIds = (ref: WayfinderEntityRef): readonly string[] =>
+  [
+    ...(ref.entry?.resources ?? []),
+    ...(ref.version?.resources ?? []),
+    ...(ref.kind === 'resource' ? [ref.id] : []),
+  ].toSorted();
+
+const refSignalIds = (ref: WayfinderEntityRef): readonly string[] => {
+  if (ref.entry !== undefined) {
+    return entrySignalIds(ref.entry);
+  }
+  return ref.kind === 'signal' ? [ref.id] : [];
+};
+
+const refFacetIds = (
+  ref: WayfinderEntityRef,
+  context: WayfinderFilterContext
+): readonly string[] => {
+  if (ref.kind === 'facet') {
+    return [ref.id];
+  }
+  return context.facetIdsByTrailId.get(ref.trailId ?? ref.id) ?? [];
+};
+
+export const createWayfinderFilterContext = (
+  topoGraph: TopoGraph
+): WayfinderFilterContext => {
+  const facetsById = new Map<string, TopoGraphFacetEntry>();
+  const facetIdsByTrailId = new Map<string, string[]>();
+  const facetSurfacesByTrailId = new Map<string, string[]>();
+
+  for (const facet of topoGraph.facets ?? []) {
+    facetsById.set(facet.id, facet);
+    for (const memberId of facet.memberIds) {
+      const current = facetIdsByTrailId.get(memberId) ?? [];
+      current.push(facet.id);
+      facetIdsByTrailId.set(memberId, current);
+
+      const currentSurfaces = facetSurfacesByTrailId.get(memberId) ?? [];
+      currentSurfaces.push(...facet.surfaces);
+      facetSurfacesByTrailId.set(
+        memberId,
+        [...new Set(currentSurfaces)].toSorted()
+      );
+    }
+  }
+
+  return {
+    facetIdsByTrailId,
+    facetSurfacesByTrailId,
+    facetsById,
+  };
+};
+
+export const listWayfinderEntityRefs = (
+  topoGraph: TopoGraph
+): readonly WayfinderEntityRef[] => {
+  const refs: WayfinderEntityRef[] = topoGraph.entries.map((entry) => ({
+    entry,
+    id: entry.id,
+    kind: entry.kind,
+  }));
+
+  for (const facet of topoGraph.facets ?? []) {
+    refs.push({ facet, id: facet.id, kind: 'facet' });
+  }
+
+  const surfaceIds = new Set<string>();
+  for (const entry of topoGraph.entries) {
+    for (const surface of entry.surfaces) {
+      surfaceIds.add(surface);
+    }
+  }
+  for (const facet of topoGraph.facets ?? []) {
+    for (const surface of facet.surfaces) {
+      surfaceIds.add(surface);
+    }
+  }
+  for (const surface of [...surfaceIds].toSorted()) {
+    refs.push({ id: surface, kind: 'surface' });
+  }
+
+  for (const entry of topoGraph.entries) {
+    if (entry.kind !== 'trail') {
+      continue;
+    }
+    for (const [versionKey, version] of Object.entries(entry.versions ?? {})) {
+      refs.push({
+        entry,
+        id: `${entry.id}@${versionKey}`,
+        kind: 'version',
+        trailId: entry.id,
+        version,
+        versionKey,
+      });
+    }
+  }
+
+  return refs;
+};
+
+const matchesIdentityFilters = (
+  ref: WayfinderEntityRef,
+  filters: {
+    readonly idPrefixes: readonly string[];
+    readonly ids: readonly string[];
+    readonly namespaces: readonly string[];
+  }
+): boolean => {
+  if (filters.ids.length > 0 && !filters.ids.includes(ref.id)) {
+    return false;
+  }
+  if (
+    filters.idPrefixes.length > 0 &&
+    !filters.idPrefixes.some((prefix) => ref.id.startsWith(prefix))
+  ) {
+    return false;
+  }
+  return (
+    filters.namespaces.length === 0 ||
+    filters.namespaces.some((namespace) => namespaceMatches(ref.id, namespace))
+  );
+};
+
+const matchesTrailFilters = (
+  ref: WayfinderEntityRef,
+  filters: {
+    readonly exampleCoverage?: boolean | undefined;
+    readonly intents: readonly WayfinderIntent[];
+    readonly versioned?: boolean | undefined;
+  }
+): boolean => {
+  if (
+    filters.intents.length > 0 &&
+    (ref.entry?.kind !== 'trail' ||
+      !filters.intents.includes(ref.entry.intent ?? 'write'))
+  ) {
+    return false;
+  }
+  if (
+    filters.versioned !== undefined &&
+    refHasVersioning(ref) !== filters.versioned
+  ) {
+    return false;
+  }
+  return (
+    filters.exampleCoverage === undefined ||
+    refHasExamples(ref) === filters.exampleCoverage
+  );
+};
+
+const matchesRelationshipFilters = (
+  ref: WayfinderEntityRef,
+  context: WayfinderFilterContext,
+  filters: {
+    readonly facets: readonly string[];
+    readonly resources: readonly string[];
+    readonly signals: readonly string[];
+    readonly surfaces: readonly string[];
+  }
+): boolean =>
+  includesAny(entrySurfaces(ref, context), filters.surfaces) &&
+  includesAny(refFacetIds(ref, context), filters.facets) &&
+  includesAny(refResourceIds(ref), filters.resources) &&
+  includesAny(refSignalIds(ref), filters.signals);
+
+export const createWayfinderEntityPredicate = (
+  context: WayfinderFilterContext,
+  filters: WayfinderEntityFilterInput = {}
+): ((ref: WayfinderEntityRef) => boolean) => {
+  const parsed = wayfinderEntityFilterSchema.parse(filters);
+  const kinds = toArray(parsed.kind);
+  const ids = toArray(parsed.id);
+  const idPrefixes = toArray(parsed.idPrefix);
+  const namespaces = toArray(parsed.namespace);
+  const intents = toArray(parsed.intent);
+  const surfaces = toArray(parsed.surface);
+  const facets = toArray(parsed.facet);
+  const resources = toArray(parsed.usesResource);
+  const signals = toArray(parsed.usesSignal);
+  return (ref) => {
+    if (kinds.length > 0 && !kinds.includes(ref.kind)) {
+      return false;
+    }
+    if (!matchesIdentityFilters(ref, { idPrefixes, ids, namespaces })) {
+      return false;
+    }
+    if (
+      !matchesTrailFilters(ref, {
+        exampleCoverage: parsed.exampleCoverage,
+        intents,
+        versioned: parsed.versioned,
+      })
+    ) {
+      return false;
+    }
+    if (
+      !matchesRelationshipFilters(ref, context, {
+        facets,
+        resources,
+        signals,
+        surfaces,
+      })
+    ) {
+      return false;
+    }
+    return true;
+  };
+};
+
+export const createWayfinderGraphEntityPredicate = (
+  topoGraph: TopoGraph,
+  filters: WayfinderEntityFilterInput = {}
+): ((ref: WayfinderEntityRef) => boolean) =>
+  createWayfinderEntityPredicate(
+    createWayfinderFilterContext(topoGraph),
+    filters
+  );
+
+export const filterWayfinderEntityRefs = (
+  topoGraph: TopoGraph,
+  filters: WayfinderEntityFilterInput = {}
+): readonly WayfinderEntityRef[] =>
+  listWayfinderEntityRefs(topoGraph).filter(
+    createWayfinderGraphEntityPredicate(topoGraph, filters)
+  );

--- a/packages/wayfinder/src/index.ts
+++ b/packages/wayfinder/src/index.ts
@@ -7,9 +7,9 @@
  * `wayfind.search`, `wayfind.contract`, `wayfind.nearby`, and
  * `wayfind.examples`; this package currently ships as a substrate only.
  *
- * No query trails are exported yet. The exported loader and provenance helpers
- * give the v0 trails a cold, deterministic, materialized artifact substrate
- * when they land.
+ * No query trails are exported yet. The exported loader, provenance helpers,
+ * and typed filter kit give the v0 trails a cold, deterministic, materialized
+ * artifact substrate when they land.
  */
 
 /**
@@ -21,6 +21,24 @@
  */
 export const WAYFINDER_SHELL = true as const;
 
+export {
+  createWayfinderEntityPredicate,
+  createWayfinderFilterContext,
+  createWayfinderGraphEntityPredicate,
+  filterWayfinderEntityRefs,
+  listWayfinderEntityRefs,
+  wayfinderEntityFilterSchema,
+  wayfinderEntityKindSchema,
+  wayfinderIntentSchema,
+} from './filters.js';
+export type {
+  WayfinderEntityFilterInput,
+  WayfinderEntityFilters,
+  WayfinderEntityKind,
+  WayfinderEntityRef,
+  WayfinderFilterContext,
+  WayfinderIntent,
+} from './filters.js';
 export {
   loadWayfinderArtifacts,
   wayfinderTopoGraphSource,


### PR DESCRIPTION
## Context

Adds the typed predicate/filter kit for TRL-905. This is the shared query substrate used by later Wayfinder search and listing trails.

## What Changed

- Added typed entity filter schemas for Wayfinder graph entities.
- Added predicate helpers for matching entity kind, IDs, namespace, intent, surfaces, facets, versioning, examples, resources, and signals.
- Added graph-aware predicate context so surface/facet/resource/signal filters can be evaluated from saved Topographer facts.
- Added focused filter tests and README examples.
- Added a changeset for the filter kit.

## Verification

- Branch-local Codex review completed with no remaining P2+ findings.
- `bun run format:check`
- `bun run docs:links`
- `bun run docs:snippets`
- `bun run publish:check`
- `bun run build`
- `bun run test`
- Pre-push hook passed during `gt submit`.

## Risks / Rollout

- Filters are explicit fields rather than a query mini-language. This keeps the v0 surface typeable and reviewable, at the cost of deferring free-form/semantic query behavior.
