### PR TITLE
feat(wayfinder): add graph-read query catalog

### DIFF
--- a/.changeset/wayfinder-query-catalog.md
+++ b/.changeset/wayfinder-query-catalog.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/wayfinder": patch
+---
+
+Add the v0 graph-read Wayfinder query catalog for overview, search, entity lists,
+describe, and contract inspection over saved Topographer artifacts.

--- a/packages/wayfinder/README.md
+++ b/packages/wayfinder/README.md
@@ -1,13 +1,129 @@
 # @ontrails/wayfinder
 
-Agent-shaped wayfinding helpers and trails over `@ontrails/topographer` artifacts.
+Agent-shaped wayfinding query trails over `@ontrails/topographer` artifacts.
 
-`@ontrails/wayfinder` is the public package home for trails that let agents query a Trails app's resolved topo — overviews, searches, trail details, examples — without re-deriving the graph from `grep` plus file reads.
+`@ontrails/wayfinder` lets agents query a Trails app's resolved topo without
+re-deriving the graph from `grep` plus file reads. The v0 catalog is cold and
+deterministic: it reads existing Topographer artifacts (`topo.lock`,
+`trails.lock`, and materialized current `trails.db` topo-store records) without
+starting apps, booting resources, reaching the network, or mutating local state.
 
-**Status: substrate only.** No query trails ship yet.
+The package exports `wayfinderTopo` plus individual graph-read trails:
 
-The package currently exports the cold artifact loader, fact provenance helpers, and typed filter kit that v0 graph-read trails will share. Those helpers read existing Topographer artifacts (`topo.lock`, `trails.lock`, and materialized current `trails.db` topo-store records) without starting apps, booting resources, reaching the network, or mutating local state.
+- `wayfind.overview`
+- `wayfind.search`
+- `wayfind.trails`
+- `wayfind.contours`
+- `wayfind.resources`
+- `wayfind.signals`
+- `wayfind.surfaces`
+- `wayfind.facets`
+- `wayfind.versions`
+- `wayfind.examples`
+- `wayfind.describe`
+- `wayfind.contract`
 
-The typed filter kit supports entity kind, ID, prefix, namespace, intent, surface, facet, versioning, example coverage, resource usage, and signal usage predicates without introducing a generic query language. Use `createWayfinderGraphEntityPredicate` or `filterWayfinderEntityRefs` when matching relationship filters so facet membership and projected surfaces are evaluated with graph-derived context.
+Each trail is internal by default and returns provenance and freshness metadata
+with its result so callers can tell whether the answer came from fresh
+artifacts, stale artifacts, missing artifacts, or schema-version drift. Public
+surface exposure must be a deliberate host decision.
 
-When the query catalog lands, trails such as `wayfind.overview`, `wayfind.search`, `wayfind.contract`, `wayfind.nearby`, `wayfind.impact`, and `wayfind.examples` will be exported from here.
+```ts
+import { wayfinderTopo } from '@ontrails/wayfinder';
+import { surface } from '@ontrails/mcp';
+
+await surface(wayfinderTopo, {
+  include: ['wayfind.overview', 'wayfind.search', 'wayfind.describe'],
+});
+```
+
+Keep included Wayfinder trails behind a host-owned authorization boundary.
+Wildcard includes such as `['**']` do not expose internal trails.
+
+## Overview
+
+Use `wayfind.overview` to inspect the saved graph shape before asking narrower
+questions.
+
+```ts
+import { createTrailContext } from '@ontrails/core';
+import { wayfindOverviewTrail } from '@ontrails/wayfinder';
+
+const result = await wayfindOverviewTrail.blaze(
+  { rootDir: process.cwd() },
+  createTrailContext()
+);
+```
+
+The output includes counts for trails, contours, resources, signals, surfaces,
+facets, versions, and examples, along with the TopoGraph artifact source.
+
+## Typed Filtering
+
+`wayfind.search` and the list trails use the same typed filter kit. Filters are
+explicit fields, not a query mini-language.
+
+```ts
+import { wayfindSearchTrail } from '@ontrails/wayfinder';
+
+const result = await wayfindSearchTrail.blaze(
+  {
+    filters: {
+      kind: 'trail',
+      namespace: 'user',
+      surface: 'mcp',
+      usesResource: 'db.main',
+    },
+    limit: 50,
+    rootDir: process.cwd(),
+  },
+  createTrailContext()
+);
+```
+
+Supported filters include entity kind, exact ID, ID prefix, namespace, intent,
+surface, facet, versioning, example coverage, resource usage, and signal usage.
+Use `createWayfinderGraphEntityPredicate` or `filterWayfinderEntityRefs` when
+matching relationship filters directly in code so facet membership and projected
+surfaces are evaluated with graph-derived context.
+
+## Describe And Contract
+
+Use `wayfind.describe` when you need the saved topo entity and
+`wayfind.contract` when you only need the input/output contract shape.
+
+```ts
+import {
+  wayfindContractTrail,
+  wayfindDescribeTrail,
+} from '@ontrails/wayfinder';
+
+await wayfindDescribeTrail.blaze(
+  { id: 'user.create', kind: 'trail', rootDir: process.cwd() },
+  createTrailContext()
+);
+
+await wayfindContractTrail.blaze(
+  { id: 'user.create', rootDir: process.cwd() },
+  createTrailContext()
+);
+
+await wayfindContractTrail.blaze(
+  { id: 'user.create', kind: 'version', rootDir: process.cwd(), version: 1 },
+  createTrailContext()
+);
+```
+
+Missing IDs return `Result.err(new NotFoundError(...))`, preserving Trails'
+surface error mapping instead of returning ambiguous empty objects.
+
+## Surfaces, Facets, Versions, And Examples
+
+`wayfind.surfaces` includes both directly projected trail surfaces and
+facet-projected surfaces. `wayfind.facets` returns facet membership, visibility,
+and descriptions. `wayfind.versions` returns current and historical trail
+versions. `wayfind.examples` lists saved examples without executing any trail.
+
+These queries are intentionally graph-read only. They do not provide
+`wayfind.query`, semantic search, signposts, implications, nearby traversal, or
+impact analysis yet.

--- a/packages/wayfinder/package.json
+++ b/packages/wayfinder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ontrails/wayfinder",
   "version": "1.0.0-beta.19",
-  "description": "Agent wayfinding substrate over @ontrails/topographer artifacts; no query trails ship yet.",
+  "description": "Agent wayfinding query trails over @ontrails/topographer artifacts.",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/wayfinder/src/__tests__/queries.test.ts
+++ b/packages/wayfinder/src/__tests__/queries.test.ts
@@ -1,0 +1,572 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { z } from 'zod';
+
+import {
+  Result,
+  createTrailContext,
+  resource,
+  signal,
+  topo,
+  trail,
+} from '@ontrails/core';
+import {
+  deriveTopoGraph,
+  deriveTopoGraphHash,
+  createTopoSnapshot,
+  writeLockManifest,
+  writeTopoGraph,
+} from '@ontrails/topographer';
+import type {
+  LockManifest,
+  TopoGraph,
+  TopoGraphEntry,
+} from '@ontrails/topographer';
+
+import {
+  wayfindContractTrail,
+  wayfindDescribeTrail,
+  wayfindExamplesTrail,
+  wayfindOverviewTrail,
+  wayfindSearchTrail,
+  wayfindSurfacesTrail,
+  wayfindTrailsTrail,
+  wayfindVersionsTrail,
+  wayfinderTopo,
+} from '../index.js';
+
+let tempDir: string;
+
+const db = resource('db.main', {
+  create: () => Result.ok({}),
+  mock: () => ({}),
+});
+
+const userCreated = signal('user.created', {
+  payload: z.object({ id: z.string() }),
+});
+
+const userShow = trail('user.show', {
+  blaze: () => Result.ok({ id: 'u1' }),
+  examples: [{ expected: { id: 'u1' }, input: {}, name: 'Basic' }],
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ id: z.string() }),
+  resources: [db],
+});
+
+const userCreate = trail('user.create', {
+  blaze: () => Result.ok({ id: 'u1' }),
+  fires: [userCreated],
+  input: z.object({ name: z.string() }),
+  intent: 'write',
+  output: z.object({ id: z.string() }),
+  resources: [db],
+});
+
+const auditRebuild = trail('audit.rebuild', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  intent: 'destroy',
+  on: [userCreated],
+  output: z.object({ ok: z.boolean() }),
+});
+
+const inviteCreate = trail('invite.create', {
+  blaze: (input) => Result.ok({ greeting: `Hello, ${input.name}!` }),
+  input: z.object({ name: z.string() }),
+  output: z.object({ greeting: z.string() }),
+  version: 2,
+  versions: {
+    1: {
+      blaze: (input) => Result.ok({ greeting: `Hi, ${input.name}.` }),
+      examples: [
+        {
+          expected: { greeting: 'Hi, Ada.' },
+          input: { name: 'Ada' },
+          name: 'Legacy greeting',
+        },
+      ],
+      input: z.object({ name: z.string() }),
+      output: z.object({ greeting: z.string() }),
+      resources: [db],
+      status: { state: 'deprecated', successor: 2 },
+    },
+  },
+});
+
+const app = () =>
+  topo('demo', {
+    auditRebuild,
+    db,
+    inviteCreate,
+    userCreate,
+    userCreated,
+    userShow,
+  });
+
+const withSurfaces = (topoGraph: TopoGraph): TopoGraph => ({
+  ...topoGraph,
+  entries: topoGraph.entries.map((entry): TopoGraphEntry => {
+    if (entry.id === 'user.show') {
+      return { ...entry, surfaces: ['mcp'] };
+    }
+    if (entry.id === 'user.create') {
+      return { ...entry, surfaces: ['cli'] };
+    }
+    return entry;
+  }),
+  generatedAt: '2026-06-04T00:00:00.000Z',
+});
+
+const artifactsDir = () => join(tempDir, '.trails');
+
+const artifactsDirFor = (rootDir: string) => join(rootDir, '.trails');
+
+const countEntries = (
+  topoGraph: TopoGraph,
+  kind: TopoGraphEntry['kind']
+): number => topoGraph.entries.filter((entry) => entry.kind === kind).length;
+
+const lockManifestFor = (topoGraph: TopoGraph): LockManifest => ({
+  artifacts: [
+    {
+      path: 'topo.lock',
+      role: 'topo',
+      sha256: deriveTopoGraphHash(topoGraph),
+    },
+  ],
+  scope: { app: 'demo' },
+  summary: {
+    contours: countEntries(topoGraph, 'contour'),
+    resources: countEntries(topoGraph, 'resource'),
+    signals: countEntries(topoGraph, 'signal'),
+    trails: countEntries(topoGraph, 'trail'),
+  },
+  version: 3,
+});
+
+const writeArtifacts = async (
+  transform?: (topoGraph: TopoGraph) => TopoGraph
+): Promise<TopoGraph> => {
+  const baseTopoGraph = withSurfaces(
+    deriveTopoGraph(app(), {
+      facets: [
+        {
+          description: 'User operations.',
+          id: 'users',
+          surfaces: ['mcp'],
+          trails: 'user.*',
+        },
+      ],
+    })
+  );
+  const topoGraph = transform?.(baseTopoGraph) ?? baseTopoGraph;
+  await writeTopoGraph(topoGraph, { dir: artifactsDir() });
+  await writeLockManifest(lockManifestFor(topoGraph), { dir: artifactsDir() });
+  return topoGraph;
+};
+
+const writePlainArtifactsAt = async (rootDir: string) => {
+  const graph = app();
+  const topoGraph = deriveTopoGraph(graph);
+  await writeTopoGraph(topoGraph, { dir: artifactsDirFor(rootDir) });
+  await writeLockManifest(lockManifestFor(topoGraph), {
+    dir: artifactsDirFor(rootDir),
+  });
+  return graph;
+};
+
+const seedTopoStoreAt = (rootDir: string, graph = app()) => {
+  const snapshot = createTopoSnapshot(graph, {
+    createdAt: '2026-06-04T00:00:00.000Z',
+    gitSha: 'abc123',
+    rootDir,
+  });
+  if (snapshot.isErr()) {
+    throw snapshot.error;
+  }
+  return snapshot.value;
+};
+
+const ctx = () => createTrailContext({ cwd: tempDir, workspaceRoot: tempDir });
+
+const expectOk = async <TValue>(
+  result: Promise<Result<TValue, unknown>>
+): Promise<TValue> => {
+  const awaited = await result;
+  expect(awaited.isOk()).toBe(true);
+  if (awaited.isErr()) {
+    throw awaited.error;
+  }
+  return awaited.value;
+};
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'wayfinder-queries-test-'));
+  await writeArtifacts();
+});
+
+afterEach(async () => {
+  await rm(tempDir, { force: true, recursive: true });
+});
+
+describe('wayfinder graph-read query trails', () => {
+  test('exports the v0 query catalog as a topo', () => {
+    expect([...wayfinderTopo.ids()].toSorted()).toEqual([
+      'wayfind.contours',
+      'wayfind.contract',
+      'wayfind.describe',
+      'wayfind.examples',
+      'wayfind.facets',
+      'wayfind.overview',
+      'wayfind.resources',
+      'wayfind.search',
+      'wayfind.signals',
+      'wayfind.surfaces',
+      'wayfind.trails',
+      'wayfind.versions',
+    ]);
+  });
+
+  test('summarizes saved graph shape and provenance', async () => {
+    const overview = await expectOk(
+      wayfindOverviewTrail.blaze({ rootDir: tempDir }, ctx())
+    );
+
+    expect(overview.source.kind).toBe('topoGraph');
+    expect(overview.generatedAt).toBe('2026-06-04T00:00:00.000Z');
+    expect(overview.counts).toMatchObject({
+      examples: 2,
+      facets: 1,
+      resources: 1,
+      signals: 1,
+      surfaces: 2,
+      trails: 4,
+      versions: 2,
+    });
+  });
+
+  test('returns schema drift errors instead of missing-artifact errors', async () => {
+    await Bun.write(
+      join(artifactsDir(), 'topo.lock'),
+      `${JSON.stringify({
+        activationGraph: {
+          edgeCount: 0,
+          edges: [],
+          sourceCount: 0,
+          sourceKeys: [],
+          trailIds: [],
+        },
+        activationSources: {},
+        entries: [],
+        generatedAt: '2026-06-04T00:00:00.000Z',
+        topoGraphSchemaVersion: -1,
+      })}\n`
+    );
+
+    const result = await wayfindOverviewTrail.blaze(
+      { rootDir: tempDir },
+      ctx()
+    );
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() ? result.error.name : '').toBe('DerivationError');
+    expect(result.isErr() ? result.error.context : {}).toMatchObject({
+      artifact: 'topoGraph',
+      freshnessStatus: 'schema-version-drift',
+    });
+  });
+
+  test('returns derivation errors for invalid artifact paths', async () => {
+    const invalidDir = join(tempDir, 'not-a-directory');
+    await Bun.write(invalidDir, 'plain file');
+
+    const result = await wayfindOverviewTrail.blaze({ dir: invalidDir }, ctx());
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() ? result.error.name : '').toBe('DerivationError');
+    expect(result.isErr() ? result.error.context : {}).toMatchObject({
+      artifact: 'topoGraph',
+      path: join(invalidDir, 'topo.lock'),
+    });
+  });
+
+  test('keeps explicit artifact directories isolated from context cwd', async () => {
+    const artifactRoot = join(tempDir, 'artifact-root');
+    const cwdRoot = join(tempDir, 'cwd-root');
+    await mkdir(artifactRoot, { recursive: true });
+    await mkdir(cwdRoot, { recursive: true });
+    seedTopoStoreAt(artifactRoot, await writePlainArtifactsAt(artifactRoot));
+
+    const overview = await expectOk(
+      wayfindOverviewTrail.blaze(
+        { dir: artifactsDirFor(artifactRoot) },
+        createTrailContext({ cwd: cwdRoot, workspaceRoot: cwdRoot })
+      )
+    );
+
+    expect(overview.freshness).toEqual({ status: 'fresh' });
+  });
+
+  test('finds entities with typed filters', async () => {
+    const search = await expectOk(
+      wayfindSearchTrail.blaze(
+        {
+          filters: { kind: 'trail', surface: 'mcp' },
+          limit: 100,
+          rootDir: tempDir,
+        },
+        ctx()
+      )
+    );
+
+    expect(search.matches.map((match) => match.id)).toEqual([
+      'user.create',
+      'user.show',
+    ]);
+  });
+
+  test('finds current and historical versions with typed filters', async () => {
+    const search = await expectOk(
+      wayfindSearchTrail.blaze(
+        {
+          filters: { kind: 'version' },
+          limit: 100,
+          rootDir: tempDir,
+        },
+        ctx()
+      )
+    );
+
+    expect(search.matches.map((match) => match.id)).toEqual([
+      'invite.create@1',
+      'invite.create@2',
+    ]);
+  });
+
+  test('lists trail and surface summaries', async () => {
+    const trails = await expectOk(
+      wayfindTrailsTrail.blaze(
+        { filters: { usesResource: 'db.main' }, limit: 100, rootDir: tempDir },
+        ctx()
+      )
+    );
+    const surfaces = await expectOk(
+      wayfindSurfacesTrail.blaze(
+        { filters: {}, limit: 100, rootDir: tempDir },
+        ctx()
+      )
+    );
+
+    expect(trails.trails.map((entry) => entry.id)).toEqual([
+      'user.create',
+      'user.show',
+    ]);
+    expect(surfaces.surfaces).toEqual([
+      { facets: [], id: 'cli', trails: ['user.create'] },
+      { facets: ['users'], id: 'mcp', trails: ['user.create', 'user.show'] },
+    ]);
+  });
+
+  test('lists version and example records without executing trails', async () => {
+    const versions = await expectOk(
+      wayfindVersionsTrail.blaze(
+        { filters: {}, limit: 100, rootDir: tempDir },
+        ctx()
+      )
+    );
+    const examples = await expectOk(
+      wayfindExamplesTrail.blaze(
+        { filters: {}, limit: 100, rootDir: tempDir },
+        ctx()
+      )
+    );
+
+    expect(versions.versions.map((version) => version.id)).toEqual([
+      'invite.create@1',
+      'invite.create@2',
+    ]);
+    expect(examples.examples.map((example) => example.targetId)).toEqual([
+      'invite.create@1',
+      'user.show',
+    ]);
+  });
+
+  test('sorts version records by numeric version', async () => {
+    await writeArtifacts((topoGraph) => ({
+      ...topoGraph,
+      entries: topoGraph.entries.map((entry) =>
+        entry.id === 'invite.create'
+          ? {
+              ...entry,
+              versions: {
+                ...entry.versions,
+                10: {
+                  exampleCount: 0,
+                  input: entry.input,
+                  kind: 'revision',
+                  marker: entry.marker,
+                  output: entry.output,
+                  status: { state: 'deprecated', successor: 2 },
+                },
+              },
+            }
+          : entry
+      ),
+    }));
+
+    const versions = await expectOk(
+      wayfindVersionsTrail.blaze(
+        { filters: {}, limit: 100, rootDir: tempDir },
+        ctx()
+      )
+    );
+
+    expect(versions.versions.map((version) => version.id)).toEqual([
+      'invite.create@1',
+      'invite.create@2',
+      'invite.create@10',
+    ]);
+  });
+
+  test('describes entities and returns explicit not found results', async () => {
+    const described = await expectOk(
+      wayfindDescribeTrail.blaze(
+        { id: 'users', kind: 'facet', rootDir: tempDir },
+        ctx()
+      )
+    );
+    const missing = await wayfindDescribeTrail.blaze(
+      { id: 'missing.trail', kind: 'trail', rootDir: tempDir },
+      ctx()
+    );
+
+    expect(described.entity).toMatchObject({
+      id: 'users',
+      kind: 'facet',
+      memberIds: ['user.create', 'user.show'],
+    });
+    expect(missing.isErr()).toBe(true);
+    expect(missing.isErr() ? missing.error.name : '').toBe('NotFoundError');
+  });
+
+  test('describes non-entry entities by id when the kind is omitted', async () => {
+    const facet = await expectOk(
+      wayfindDescribeTrail.blaze({ id: 'users', rootDir: tempDir }, ctx())
+    );
+    const surface = await expectOk(
+      wayfindDescribeTrail.blaze({ id: 'cli', rootDir: tempDir }, ctx())
+    );
+    const version = await expectOk(
+      wayfindDescribeTrail.blaze(
+        { id: 'invite.create@1', rootDir: tempDir },
+        ctx()
+      )
+    );
+
+    expect(facet.entity).toMatchObject({ id: 'users', kind: 'facet' });
+    expect(surface.entity).toMatchObject({ id: 'cli', kind: 'surface' });
+    expect(version.entity).toMatchObject({
+      id: 'invite.create@1',
+      kind: 'version',
+    });
+  });
+
+  test('returns ambiguous errors when id-only lookup matches multiple kinds', async () => {
+    await writeArtifacts((topoGraph) => ({
+      ...topoGraph,
+      entries: topoGraph.entries.map((entry) =>
+        entry.id === 'user.show'
+          ? { ...entry, surfaces: [...entry.surfaces, 'user.show'] }
+          : entry
+      ),
+    }));
+
+    const described = await wayfindDescribeTrail.blaze(
+      { id: 'user.show', rootDir: tempDir },
+      ctx()
+    );
+    const contract = await wayfindContractTrail.blaze(
+      { id: 'user.show', rootDir: tempDir },
+      ctx()
+    );
+
+    expect(described.isErr()).toBe(true);
+    expect(described.isErr() ? described.error.name : '').toBe(
+      'AmbiguousError'
+    );
+    expect(contract.isErr()).toBe(true);
+    expect(contract.isErr() ? contract.error.name : '').toBe('AmbiguousError');
+  });
+
+  test('returns contract details for current and historical trail versions', async () => {
+    const current = await expectOk(
+      wayfindContractTrail.blaze({ id: 'user.show', rootDir: tempDir }, ctx())
+    );
+    const historical = await expectOk(
+      wayfindContractTrail.blaze(
+        { id: 'invite.create', kind: 'version', rootDir: tempDir, version: 1 },
+        ctx()
+      )
+    );
+
+    expect(current.contract).toMatchObject({
+      id: 'user.show',
+      kind: 'trail',
+      resources: ['db.main'],
+    });
+    expect(historical.contract).toMatchObject({
+      id: 'invite.create',
+      kind: 'version',
+      resources: ['db.main'],
+      version: 1,
+    });
+  });
+
+  test('returns contract details for non-entry entities by id when the kind is omitted', async () => {
+    const surface = await expectOk(
+      wayfindContractTrail.blaze({ id: 'cli', rootDir: tempDir }, ctx())
+    );
+    const version = await expectOk(
+      wayfindContractTrail.blaze(
+        { id: 'invite.create@1', rootDir: tempDir },
+        ctx()
+      )
+    );
+
+    expect(surface.contract).toMatchObject({ id: 'cli', kind: 'surface' });
+    expect(version.contract).toMatchObject({
+      id: 'invite.create',
+      kind: 'version',
+      version: 1,
+    });
+  });
+
+  test('contract lookup honors explicit surface kind when IDs collide', async () => {
+    await writeArtifacts((topoGraph) => ({
+      ...topoGraph,
+      entries: topoGraph.entries.map((entry) =>
+        entry.id === 'user.show'
+          ? { ...entry, surfaces: [...entry.surfaces, 'user.show'] }
+          : entry
+      ),
+    }));
+
+    const surface = await expectOk(
+      wayfindContractTrail.blaze(
+        { id: 'user.show', kind: 'surface', rootDir: tempDir },
+        ctx()
+      )
+    );
+
+    expect(surface.contract).toMatchObject({
+      id: 'user.show',
+      kind: 'surface',
+      trails: ['user.show'],
+    });
+  });
+});

--- a/packages/wayfinder/src/__tests__/shell.test.ts
+++ b/packages/wayfinder/src/__tests__/shell.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, test } from 'bun:test';
 
-import { WAYFINDER_SHELL } from '../index.ts';
+import { wayfindOverviewTrail, wayfinderTopo } from '../index.ts';
 
-describe('@ontrails/wayfinder shell', () => {
-  test('exports the shell marker', () => {
-    expect(WAYFINDER_SHELL).toBe(true);
+describe('@ontrails/wayfinder public catalog', () => {
+  test('exports graph-read trails', () => {
+    expect(wayfindOverviewTrail.id).toBe('wayfind.overview');
+    expect([...wayfinderTopo.ids()]).toContain('wayfind.overview');
+  });
+
+  test('keeps graph-read trails internal by default', () => {
+    for (const id of wayfinderTopo.ids()) {
+      expect(wayfinderTopo.get(id)?.visibility).toBe('internal');
+    }
   });
 });

--- a/packages/wayfinder/src/filters.ts
+++ b/packages/wayfinder/src/filters.ts
@@ -232,8 +232,20 @@ export const listWayfinderEntityRefs = (
     if (entry.kind !== 'trail') {
       continue;
     }
+    const versionRefs: WayfinderEntityRef[] =
+      entry.version === undefined
+        ? []
+        : [
+            {
+              entry,
+              id: `${entry.id}@${entry.version}`,
+              kind: 'version',
+              trailId: entry.id,
+              versionKey: String(entry.version),
+            },
+          ];
     for (const [versionKey, version] of Object.entries(entry.versions ?? {})) {
-      refs.push({
+      versionRefs.push({
         entry,
         id: `${entry.id}@${versionKey}`,
         kind: 'version',
@@ -242,6 +254,7 @@ export const listWayfinderEntityRefs = (
         versionKey,
       });
     }
+    refs.push(...versionRefs.toSorted((a, b) => a.id.localeCompare(b.id)));
   }
 
   return refs;

--- a/packages/wayfinder/src/index.ts
+++ b/packages/wayfinder/src/index.ts
@@ -2,24 +2,13 @@
  * Agent-shaped wayfinding API for Trails.
  *
  * `@ontrails/wayfinder` is the public package home for trails that let agents
- * query a Trails app's resolved topo without re-deriving it from `grep` and
- * file reads. A future catalog may include trails such as `wayfind.overview`,
- * `wayfind.search`, `wayfind.contract`, `wayfind.nearby`, and
- * `wayfind.examples`; this package currently ships as a substrate only.
+ * query a Trails app's resolved topo without re-deriving it from `grep` plus
+ * file reads.
  *
- * No query trails are exported yet. The exported loader, provenance helpers,
- * and typed filter kit give the v0 trails a cold, deterministic, materialized
- * artifact substrate when they land.
+ * The v0 graph-read catalog is cold and deterministic: it reads existing
+ * Topographer artifacts and topo-store provenance, but it does not boot apps,
+ * resolve resources, reach the network, or mutate local state.
  */
-
-/**
- * Indicates the wayfinder shell is loaded but ships no trails yet.
- *
- * Consumers can branch on this to detect when the v0 catalog lands without
- * inspecting the package version directly. Will be removed once real trails
- * are exported.
- */
-export const WAYFINDER_SHELL = true as const;
 
 export {
   createWayfinderEntityPredicate,
@@ -49,6 +38,21 @@ export type {
   WayfinderArtifactLoaderOptions,
   WayfinderTopoStoreLoad,
 } from './loader.js';
+export {
+  wayfindContractTrail,
+  wayfindContoursTrail,
+  wayfindDescribeTrail,
+  wayfindExamplesTrail,
+  wayfindFacetsTrail,
+  wayfindOverviewTrail,
+  wayfindResourcesTrail,
+  wayfindSearchTrail,
+  wayfindSignalsTrail,
+  wayfindSurfacesTrail,
+  wayfindTrailsTrail,
+  wayfindVersionsTrail,
+  wayfinderTopo,
+} from './queries.js';
 export { wayfinderFact } from './provenance.js';
 export type {
   WayfinderArtifactKind,

--- a/packages/wayfinder/src/queries.ts
+++ b/packages/wayfinder/src/queries.ts
@@ -1,0 +1,1041 @@
+import { join } from 'node:path';
+
+import {
+  AmbiguousError,
+  DerivationError,
+  NotFoundError,
+  Result,
+  topo,
+  trail,
+} from '@ontrails/core';
+import type { TrailsError } from '@ontrails/core';
+import type { TopoGraph, TopoGraphEntry } from '@ontrails/topographer';
+import { z } from 'zod';
+
+import {
+  filterWayfinderEntityRefs,
+  wayfinderEntityFilterSchema,
+} from './filters.js';
+import type {
+  WayfinderEntityFilterInput,
+  WayfinderEntityKind,
+  WayfinderEntityRef,
+} from './filters.js';
+import { loadWayfinderArtifacts } from './loader.js';
+import type {
+  WayfinderArtifactLoad,
+  WayfinderArtifactLoaderOptions,
+} from './loader.js';
+
+const artifactSourceSchema = z.object({
+  kind: z.enum(['lockManifest', 'topoGraph', 'topoStore']),
+  path: z.string().optional(),
+  schemaVersion: z.number().optional(),
+});
+
+const freshnessSchema = z.discriminatedUnion('status', [
+  z.object({ status: z.literal('fresh') }),
+  z.object({
+    artifacts: z
+      .array(z.enum(['lockManifest', 'topoGraph', 'topoStore']))
+      .readonly(),
+    status: z.literal('missing'),
+  }),
+  z.object({
+    reasons: z.array(z.record(z.string(), z.unknown())).readonly(),
+    status: z.literal('stale'),
+  }),
+  z.object({
+    artifact: z.enum(['lockManifest', 'topoGraph', 'topoStore']),
+    message: z.string(),
+    status: z.literal('schema-version-drift'),
+  }),
+]);
+
+const envelopeSchema = z.object({
+  freshness: freshnessSchema,
+  source: artifactSourceSchema,
+});
+
+const sourceInputSchema = z
+  .object({
+    dir: z
+      .string()
+      .optional()
+      .describe('Directory containing topo.lock and trails.lock'),
+    rootDir: z.string().optional().describe('Workspace root directory'),
+    trailsDbPath: z.string().optional().describe('Path to trails.db'),
+  })
+  .strict();
+
+const filteredInputSchema = sourceInputSchema.extend({
+  filters: wayfinderEntityFilterSchema.optional(),
+  limit: z.number().int().positive().max(500).default(100),
+});
+
+const inspectKindSchema = z.enum([
+  'contour',
+  'facet',
+  'resource',
+  'signal',
+  'surface',
+  'trail',
+  'version',
+]);
+
+const inspectInputSchema = sourceInputSchema.extend({
+  id: z.string().min(1).describe('Entity ID to inspect'),
+  kind: inspectKindSchema.optional().describe('Optional entity kind'),
+});
+
+const contractInputSchema = inspectInputSchema.extend({
+  version: z.number().int().positive().optional(),
+});
+
+const refOutputSchema = z.object({
+  id: z.string(),
+  kind: inspectKindSchema,
+  trailId: z.string().optional(),
+  versionKey: z.string().optional(),
+});
+
+const entrySummarySchema = z.object({
+  exampleCount: z.number(),
+  id: z.string(),
+  surfaces: z.array(z.string()).readonly(),
+});
+
+const trailSummarySchema = entrySummarySchema.extend({
+  composes: z.array(z.string()).readonly(),
+  intent: z.enum(['destroy', 'read', 'write']),
+  kind: z.literal('trail'),
+  resources: z.array(z.string()).readonly(),
+  signals: z.array(z.string()).readonly(),
+  version: z.number().nullable(),
+});
+
+const contourSummarySchema = entrySummarySchema.extend({
+  identity: z.string().optional(),
+  kind: z.literal('contour'),
+  references: z.array(z.unknown()).readonly(),
+});
+
+const resourceSummarySchema = entrySummarySchema.extend({
+  kind: z.literal('resource'),
+  usedBy: z.array(z.string()).readonly(),
+});
+
+const signalSummarySchema = entrySummarySchema.extend({
+  consumers: z.array(z.string()).readonly(),
+  kind: z.literal('signal'),
+  producers: z.array(z.string()).readonly(),
+});
+
+const surfaceSummarySchema = z.object({
+  facets: z.array(z.string()).readonly(),
+  id: z.string(),
+  trails: z.array(z.string()).readonly(),
+});
+
+const facetSummarySchema = z.object({
+  description: z.string(),
+  id: z.string(),
+  memberIds: z.array(z.string()).readonly(),
+  surfaces: z.array(z.string()).readonly(),
+  visibility: z.enum(['internal', 'public']).optional(),
+});
+
+const versionSummarySchema = z.object({
+  current: z.boolean(),
+  exampleCount: z.number(),
+  id: z.string(),
+  kind: z.enum(['current', 'fork', 'revision']),
+  marker: z.string().optional(),
+  resources: z.array(z.string()).readonly(),
+  status: z.unknown().optional(),
+  trailId: z.string(),
+  version: z.number(),
+});
+
+const exampleSummarySchema = z.object({
+  example: z.unknown(),
+  index: z.number(),
+  source: z.enum(['entry', 'version']),
+  targetId: z.string(),
+});
+
+const describeOutputSchema = envelopeSchema.extend({
+  entity: z.record(z.string(), z.unknown()),
+});
+
+const contractOutputSchema = envelopeSchema.extend({
+  contract: z.record(z.string(), z.unknown()),
+});
+
+type SourceInput = z.output<typeof sourceInputSchema>;
+type InspectInput = z.output<typeof inspectInputSchema>;
+type ContractInput = z.output<typeof contractInputSchema>;
+
+interface LoadedWayfinderGraph {
+  readonly graph: TopoGraph;
+  readonly load: WayfinderArtifactLoad;
+  readonly source: {
+    readonly kind: 'topoGraph';
+    readonly path: string;
+    readonly schemaVersion: number;
+  };
+}
+
+const toLoaderOptions = (
+  input: SourceInput,
+  cwd: string | undefined
+): WayfinderArtifactLoaderOptions => {
+  const rootDir = input.rootDir ?? (input.dir === undefined ? cwd : undefined);
+  return {
+    ...(input.dir === undefined ? {} : { dir: input.dir }),
+    ...(rootDir === undefined ? {} : { rootDir }),
+    ...(input.trailsDbPath === undefined ? {} : { path: input.trailsDbPath }),
+  };
+};
+
+const topoLockPath = (
+  input: SourceInput,
+  cwd: string | undefined
+): string | undefined => {
+  if (input.dir !== undefined) {
+    return join(input.dir, 'topo.lock');
+  }
+  const rootDir = input.rootDir ?? cwd;
+  return rootDir === undefined
+    ? undefined
+    : join(rootDir, '.trails', 'topo.lock');
+};
+
+const loadGraph = async (
+  input: SourceInput,
+  cwd: string | undefined
+): Promise<Result<LoadedWayfinderGraph, TrailsError>> => {
+  let load: WayfinderArtifactLoad;
+  try {
+    load = await loadWayfinderArtifacts(toLoaderOptions(input, cwd));
+  } catch (error) {
+    const cause = error instanceof Error ? error : new Error(String(error));
+    return Result.err(
+      new DerivationError('Unable to load Wayfinder artifacts.', {
+        cause,
+        context: {
+          artifact: 'topoGraph',
+          path: topoLockPath(input, cwd) ?? 'topo.lock',
+        },
+      })
+    );
+  }
+  if (
+    load.freshness.status === 'schema-version-drift' &&
+    load.freshness.artifact === 'topoGraph'
+  ) {
+    return Result.err(
+      new DerivationError(load.freshness.message, {
+        context: {
+          artifact: load.freshness.artifact,
+          freshnessStatus: load.freshness.status,
+        },
+      })
+    );
+  }
+  if (load.topoGraph === null) {
+    return Result.err(
+      new NotFoundError(
+        'No wayfinder TopoGraph artifact found. Run `trails compile` first.'
+      )
+    );
+  }
+  return Result.ok({
+    graph: load.topoGraph,
+    load,
+    source: {
+      kind: 'topoGraph',
+      path: topoLockPath(input, cwd) ?? 'topo.lock',
+      schemaVersion: load.topoGraph.topoGraphSchemaVersion,
+    },
+  });
+};
+
+const envelope = (
+  loaded: LoadedWayfinderGraph
+): z.output<typeof envelopeSchema> => ({
+  freshness: loaded.load.freshness,
+  source: loaded.source,
+});
+
+const entrySignals = (entry: TopoGraphEntry): readonly string[] =>
+  [
+    ...(entry.fires ?? []),
+    ...(entry.on ?? []),
+    ...(entry.from ?? []),
+    ...(entry.producers ?? []),
+    ...(entry.consumers ?? []),
+  ].toSorted();
+
+const entryExamples = (entry: TopoGraphEntry): readonly unknown[] =>
+  entry.examples ?? [];
+
+const entryById = (
+  graph: TopoGraph,
+  id: string,
+  kind?: TopoGraphEntry['kind']
+): TopoGraphEntry | undefined =>
+  graph.entries.find(
+    (entry) => entry.id === id && (kind === undefined || entry.kind === kind)
+  );
+
+const usedByResource = (
+  graph: TopoGraph,
+  resourceId: string
+): readonly string[] =>
+  graph.entries
+    .filter(
+      (entry) =>
+        entry.kind === 'trail' && (entry.resources ?? []).includes(resourceId)
+    )
+    .map((entry) => entry.id)
+    .toSorted();
+
+const trailSummaries = (graph: TopoGraph) =>
+  graph.entries
+    .filter((entry) => entry.kind === 'trail')
+    .map((entry) => ({
+      composes: entry.composes ?? [],
+      exampleCount: entry.exampleCount,
+      id: entry.id,
+      intent: entry.intent ?? 'write',
+      kind: 'trail' as const,
+      resources: entry.resources ?? [],
+      signals: entrySignals(entry),
+      surfaces: entry.surfaces,
+      version: entry.version ?? null,
+    }));
+
+const contourSummaries = (graph: TopoGraph) =>
+  graph.entries
+    .filter((entry) => entry.kind === 'contour')
+    .map((entry) => ({
+      exampleCount: entry.exampleCount,
+      id: entry.id,
+      identity: entry.identity,
+      kind: 'contour' as const,
+      references: entry.references ?? [],
+      surfaces: entry.surfaces,
+    }));
+
+const resourceSummaries = (graph: TopoGraph) =>
+  graph.entries
+    .filter((entry) => entry.kind === 'resource')
+    .map((entry) => ({
+      exampleCount: entry.exampleCount,
+      id: entry.id,
+      kind: 'resource' as const,
+      surfaces: entry.surfaces,
+      usedBy: usedByResource(graph, entry.id),
+    }));
+
+const signalSummaries = (graph: TopoGraph) =>
+  graph.entries
+    .filter((entry) => entry.kind === 'signal')
+    .map((entry) => ({
+      consumers: entry.consumers ?? [],
+      exampleCount: entry.exampleCount,
+      id: entry.id,
+      kind: 'signal' as const,
+      producers: entry.producers ?? [],
+      surfaces: entry.surfaces,
+    }));
+
+const surfaceSummaries = (graph: TopoGraph) => {
+  const surfaceIds = new Set<string>();
+  for (const entry of graph.entries) {
+    for (const surface of entry.surfaces) {
+      surfaceIds.add(surface);
+    }
+  }
+  for (const facet of graph.facets ?? []) {
+    for (const surface of facet.surfaces) {
+      surfaceIds.add(surface);
+    }
+  }
+  return [...surfaceIds].toSorted().map((surface) => ({
+    facets: (graph.facets ?? [])
+      .filter((facet) => facet.surfaces.includes(surface))
+      .map((facet) => facet.id)
+      .toSorted(),
+    id: surface,
+    trails: filterWayfinderEntityRefs(graph, {
+      kind: 'trail',
+      surface,
+    }).map((ref) => ref.id),
+  }));
+};
+
+const facetSummaries = (graph: TopoGraph) =>
+  (graph.facets ?? []).map((facet) => ({
+    description: facet.description,
+    id: facet.id,
+    memberIds: facet.memberIds,
+    surfaces: facet.surfaces,
+    visibility: facet.visibility,
+  }));
+
+const versionSummaries = (graph: TopoGraph) =>
+  graph.entries
+    .filter((entry) => entry.kind === 'trail' && entry.version !== undefined)
+    .flatMap((entry) => {
+      const current = {
+        current: true,
+        exampleCount: entry.exampleCount,
+        id: `${entry.id}@${entry.version as number}`,
+        kind: 'current' as const,
+        marker: entry.marker,
+        resources: entry.resources ?? [],
+        trailId: entry.id,
+        version: entry.version as number,
+      };
+      const historical = Object.entries(entry.versions ?? {}).map(
+        ([versionKey, version]) => ({
+          current: false,
+          exampleCount: version.exampleCount,
+          id: `${entry.id}@${versionKey}`,
+          kind: version.kind,
+          marker: version.marker,
+          resources: version.resources ?? [],
+          status: version.status,
+          trailId: entry.id,
+          version: Number(versionKey),
+        })
+      );
+      return [current, ...historical].toSorted(
+        (a, b) => a.trailId.localeCompare(b.trailId) || a.version - b.version
+      );
+    });
+
+const exampleSummaries = (graph: TopoGraph) =>
+  graph.entries.flatMap((entry) => {
+    const current = entryExamples(entry).map((example, index) => ({
+      example,
+      index,
+      source: 'entry' as const,
+      targetId: entry.id,
+    }));
+    const versions = Object.entries(entry.versions ?? {}).flatMap(
+      ([versionKey, version]) =>
+        (version.examples ?? []).map((example, index) => ({
+          example,
+          index,
+          source: 'version' as const,
+          targetId: `${entry.id}@${versionKey}`,
+        }))
+    );
+    return [...current, ...versions];
+  });
+
+const kindFilter = (
+  kind: WayfinderEntityKind,
+  filters: WayfinderEntityFilterInput | undefined
+): WayfinderEntityFilterInput => ({ ...filters, kind });
+
+const filteredExampleSummaries = (
+  graph: TopoGraph,
+  filters: WayfinderEntityFilterInput | undefined,
+  limit: number
+) => {
+  if (filters === undefined || Object.keys(filters).length === 0) {
+    return exampleSummaries(graph).slice(0, limit);
+  }
+  const ids = new Set(
+    filterWayfinderEntityRefs(graph, filters).map((ref) => ref.id)
+  );
+  return exampleSummaries(graph)
+    .filter((example) => ids.has(example.targetId))
+    .slice(0, limit);
+};
+
+const filteredVersionSummaries = (
+  graph: TopoGraph,
+  filters: WayfinderEntityFilterInput | undefined,
+  limit: number
+) => {
+  const summaries = versionSummaries(graph);
+  if (filters === undefined || Object.keys(filters).length === 0) {
+    return summaries.slice(0, limit);
+  }
+  const ids = new Set(
+    filterWayfinderEntityRefs(graph, kindFilter('version', filters)).map(
+      (ref) => ref.id
+    )
+  );
+  const trailIds = new Set(
+    filterWayfinderEntityRefs(graph, kindFilter('trail', filters)).map(
+      (ref) => ref.id
+    )
+  );
+  return summaries
+    .filter(
+      (summary) =>
+        ids.has(summary.id) ||
+        (summary.current && trailIds.has(summary.trailId))
+    )
+    .slice(0, limit);
+};
+
+const refSummary = (ref: WayfinderEntityRef) => ({
+  id: ref.id,
+  kind: ref.kind,
+  ...(ref.trailId === undefined ? {} : { trailId: ref.trailId }),
+  ...(ref.versionKey === undefined ? {} : { versionKey: ref.versionKey }),
+});
+
+const describeSurface = (graph: TopoGraph, id: string) => {
+  const surface = surfaceSummaries(graph).find(
+    (candidate) => candidate.id === id
+  );
+  return surface === undefined ? undefined : { ...surface, kind: 'surface' };
+};
+
+const describeFacet = (graph: TopoGraph, id: string) => {
+  const facet = facetSummaries(graph).find((candidate) => candidate.id === id);
+  return facet === undefined ? undefined : { ...facet, kind: 'facet' };
+};
+
+const describeVersion = (graph: TopoGraph, id: string) => {
+  const version = versionSummaries(graph).find(
+    (candidate) => candidate.id === id
+  );
+  return version === undefined ? undefined : { ...version, kind: 'version' };
+};
+
+type ResolvedEntity = Readonly<Record<string, unknown>>;
+
+interface ResolvedEntityCandidate {
+  readonly kind: WayfinderEntityKind;
+  readonly value: ResolvedEntity;
+}
+
+const ambiguousId = (
+  id: string,
+  candidates: readonly ResolvedEntityCandidate[]
+): AmbiguousError =>
+  new AmbiguousError(
+    `Wayfinder id "${id}" matched multiple entity kinds: ${candidates
+      .map((candidate) => candidate.kind)
+      .join(', ')}. Pass kind to disambiguate.`
+  );
+
+const singleCandidate = (
+  id: string,
+  candidates: readonly ResolvedEntityCandidate[]
+): Result<ResolvedEntity | undefined, AmbiguousError> => {
+  if (candidates.length > 1) {
+    return Result.err(ambiguousId(id, candidates));
+  }
+  return Result.ok(candidates[0]?.value);
+};
+
+const describeCandidates = (
+  graph: TopoGraph,
+  id: string
+): readonly ResolvedEntityCandidate[] => {
+  const candidates: ResolvedEntityCandidate[] = [];
+  const entry = entryById(graph, id);
+  if (entry !== undefined) {
+    candidates.push({
+      kind: entry.kind,
+      value: entry as unknown as ResolvedEntity,
+    });
+  }
+  const facet = describeFacet(graph, id);
+  if (facet !== undefined) {
+    candidates.push({ kind: 'facet', value: facet });
+  }
+  const surface = describeSurface(graph, id);
+  if (surface !== undefined) {
+    candidates.push({ kind: 'surface', value: surface });
+  }
+  const version = describeVersion(graph, id);
+  if (version !== undefined) {
+    candidates.push({ kind: 'version', value: version });
+  }
+  return candidates;
+};
+
+const describeEntry = (
+  graph: TopoGraph,
+  input: InspectInput
+): Result<ResolvedEntity | undefined, AmbiguousError> => {
+  if (input.kind === 'surface') {
+    return Result.ok(describeSurface(graph, input.id));
+  }
+  if (input.kind === 'facet') {
+    return Result.ok(describeFacet(graph, input.id));
+  }
+  if (input.kind === 'version') {
+    return Result.ok(describeVersion(graph, input.id));
+  }
+  if (input.kind === undefined) {
+    return singleCandidate(input.id, describeCandidates(graph, input.id));
+  }
+  const entry = entryById(graph, input.id, input.kind);
+  return Result.ok(
+    entry === undefined ? undefined : (entry as unknown as ResolvedEntity)
+  );
+};
+
+const contractVersionFor = (
+  graph: TopoGraph,
+  input: ContractInput
+): Readonly<Record<string, unknown>> | undefined => {
+  const versionId =
+    input.version === undefined ? input.id : `${input.id}@${input.version}`;
+  const described = describeVersion(graph, versionId);
+  if (described === undefined) {
+    return undefined;
+  }
+  const entry = entryById(graph, described.trailId, 'trail');
+  const version = entry?.versions?.[String(described.version)];
+  return {
+    id: described.trailId,
+    input: version?.input ?? entry?.input ?? null,
+    kind: 'version',
+    output: version?.output ?? entry?.output ?? null,
+    resources: version?.resources ?? entry?.resources ?? [],
+    version: described.version,
+  };
+};
+
+const contractEntryKind = (
+  kind: ContractInput['kind']
+): TopoGraphEntry['kind'] | undefined =>
+  kind === undefined ||
+  kind === 'facet' ||
+  kind === 'surface' ||
+  kind === 'version'
+    ? undefined
+    : kind;
+
+const contractEntry = (
+  entry: TopoGraphEntry
+): Readonly<Record<string, unknown>> => ({
+  id: entry.id,
+  input: entry.input ?? null,
+  kind: entry.kind,
+  output: entry.output ?? null,
+  payload: entry.payload ?? null,
+  resources: entry.resources ?? [],
+  schema: entry.schema ?? null,
+  version: entry.version ?? null,
+});
+
+const contractSurfaceOrFacet = (
+  graph: TopoGraph,
+  input: ContractInput
+): ResolvedEntity | undefined => {
+  if (input.kind === 'facet') {
+    return describeFacet(graph, input.id);
+  }
+  if (input.kind === 'surface') {
+    return describeSurface(graph, input.id);
+  }
+  return undefined;
+};
+
+const contractFor = (
+  graph: TopoGraph,
+  input: ContractInput
+): Result<ResolvedEntity | undefined, AmbiguousError> => {
+  if (input.kind === 'version' || input.version !== undefined) {
+    return Result.ok(contractVersionFor(graph, input));
+  }
+  if (input.kind === 'surface' || input.kind === 'facet') {
+    return Result.ok(contractSurfaceOrFacet(graph, input));
+  }
+  if (input.kind === undefined) {
+    const candidates: ResolvedEntityCandidate[] = [];
+    const entry = entryById(graph, input.id);
+    if (entry !== undefined) {
+      candidates.push({ kind: entry.kind, value: contractEntry(entry) });
+    }
+    const facet = describeFacet(graph, input.id);
+    if (facet !== undefined) {
+      candidates.push({ kind: 'facet', value: facet });
+    }
+    const surface = describeSurface(graph, input.id);
+    if (surface !== undefined) {
+      candidates.push({ kind: 'surface', value: surface });
+    }
+    const version = contractVersionFor(graph, { ...input, kind: 'version' });
+    if (version !== undefined) {
+      candidates.push({ kind: 'version', value: version });
+    }
+    return singleCandidate(input.id, candidates);
+  }
+
+  const entry = entryById(graph, input.id, contractEntryKind(input.kind));
+  if (entry === undefined) {
+    return Result.ok(contractSurfaceOrFacet(graph, input));
+  }
+  return Result.ok(contractEntry(entry));
+};
+
+const withGraph = async <TValue>(
+  input: SourceInput,
+  cwd: string | undefined,
+  project: (loaded: LoadedWayfinderGraph) => TValue
+): Promise<Result<TValue, TrailsError>> => {
+  const loaded = await loadGraph(input, cwd);
+  if (loaded.isErr()) {
+    return loaded;
+  }
+  return Result.ok(project(loaded.value));
+};
+
+const notFound = (kind: string, id: string): NotFoundError =>
+  new NotFoundError(`No Wayfinder ${kind} found for "${id}".`);
+
+const filteredIds = (
+  graph: TopoGraph,
+  kind: WayfinderEntityKind,
+  filters: WayfinderEntityFilterInput | undefined,
+  limit: number
+): ReadonlySet<string> =>
+  new Set(
+    filterWayfinderEntityRefs(graph, kindFilter(kind, filters))
+      .slice(0, limit)
+      .map((ref) => ref.id)
+  );
+
+export const wayfindOverviewTrail = trail('wayfind.overview', {
+  blaze: async (input, ctx) =>
+    withGraph(input, ctx.cwd, (loaded) => {
+      const { graph } = loaded;
+      return {
+        ...envelope(loaded),
+        counts: {
+          contours: contourSummaries(graph).length,
+          examples: exampleSummaries(graph).length,
+          facets: facetSummaries(graph).length,
+          resources: resourceSummaries(graph).length,
+          signals: signalSummaries(graph).length,
+          surfaces: surfaceSummaries(graph).length,
+          trails: trailSummaries(graph).length,
+          versions: versionSummaries(graph).length,
+        },
+        generatedAt: graph.generatedAt,
+        workspace:
+          graph.workspace === undefined
+            ? null
+            : {
+                collisionCount: graph.workspace.collisions?.length ?? 0,
+                trailCount: Object.keys(graph.workspace.trails).length,
+              },
+      };
+    }),
+  description: 'Summarize the saved Wayfinder topo graph',
+  examples: [{ input: {}, name: 'Overview' }],
+  input: sourceInputSchema,
+  intent: 'read',
+  output: envelopeSchema.extend({
+    counts: z.object({
+      contours: z.number(),
+      examples: z.number(),
+      facets: z.number(),
+      resources: z.number(),
+      signals: z.number(),
+      surfaces: z.number(),
+      trails: z.number(),
+      versions: z.number(),
+    }),
+    generatedAt: z.string(),
+    workspace: z
+      .object({
+        collisionCount: z.number(),
+        trailCount: z.number(),
+      })
+      .nullable(),
+  }),
+  visibility: 'internal',
+});
+
+export const wayfindSearchTrail = trail('wayfind.search', {
+  blaze: async (input, ctx) =>
+    withGraph(input, ctx.cwd, (loaded) => ({
+      ...envelope(loaded),
+      matches: filterWayfinderEntityRefs(loaded.graph, input.filters ?? {})
+        .slice(0, input.limit)
+        .map(refSummary),
+    })),
+  description: 'Find topo graph entities with typed filters',
+  examples: [{ input: { filters: { kind: 'trail' } }, name: 'Find trails' }],
+  input: filteredInputSchema,
+  intent: 'read',
+  output: envelopeSchema.extend({
+    matches: z.array(refOutputSchema).readonly(),
+  }),
+  visibility: 'internal',
+});
+
+export const wayfindTrailsTrail = trail('wayfind.trails', {
+  blaze: async (input, ctx) =>
+    withGraph(input, ctx.cwd, (loaded) => {
+      const ids = filteredIds(
+        loaded.graph,
+        'trail',
+        input.filters,
+        input.limit
+      );
+      return {
+        ...envelope(loaded),
+        trails: trailSummaries(loaded.graph).filter((entry) =>
+          ids.has(entry.id)
+        ),
+      };
+    }),
+  description: 'List saved trail contracts',
+  examples: [{ input: {}, name: 'List trails' }],
+  input: filteredInputSchema,
+  intent: 'read',
+  output: envelopeSchema.extend({
+    trails: z.array(trailSummarySchema).readonly(),
+  }),
+  visibility: 'internal',
+});
+
+export const wayfindContoursTrail = trail('wayfind.contours', {
+  blaze: async (input, ctx) =>
+    withGraph(input, ctx.cwd, (loaded) => {
+      const ids = filteredIds(
+        loaded.graph,
+        'contour',
+        input.filters,
+        input.limit
+      );
+      return {
+        ...envelope(loaded),
+        contours: contourSummaries(loaded.graph).filter((entry) =>
+          ids.has(entry.id)
+        ),
+      };
+    }),
+  description: 'List saved contour contracts',
+  examples: [{ input: {}, name: 'List contours' }],
+  input: filteredInputSchema,
+  intent: 'read',
+  output: envelopeSchema.extend({
+    contours: z.array(contourSummarySchema).readonly(),
+  }),
+  visibility: 'internal',
+});
+
+export const wayfindResourcesTrail = trail('wayfind.resources', {
+  blaze: async (input, ctx) =>
+    withGraph(input, ctx.cwd, (loaded) => {
+      const ids = filteredIds(
+        loaded.graph,
+        'resource',
+        input.filters,
+        input.limit
+      );
+      return {
+        ...envelope(loaded),
+        resources: resourceSummaries(loaded.graph).filter((entry) =>
+          ids.has(entry.id)
+        ),
+      };
+    }),
+  description: 'List saved resource contracts and usage',
+  examples: [{ input: {}, name: 'List resources' }],
+  input: filteredInputSchema,
+  intent: 'read',
+  output: envelopeSchema.extend({
+    resources: z.array(resourceSummarySchema).readonly(),
+  }),
+  visibility: 'internal',
+});
+
+export const wayfindSignalsTrail = trail('wayfind.signals', {
+  blaze: async (input, ctx) =>
+    withGraph(input, ctx.cwd, (loaded) => {
+      const ids = filteredIds(
+        loaded.graph,
+        'signal',
+        input.filters,
+        input.limit
+      );
+      return {
+        ...envelope(loaded),
+        signals: signalSummaries(loaded.graph).filter((entry) =>
+          ids.has(entry.id)
+        ),
+      };
+    }),
+  description: 'List saved signal contracts and graph usage',
+  examples: [{ input: {}, name: 'List signals' }],
+  input: filteredInputSchema,
+  intent: 'read',
+  output: envelopeSchema.extend({
+    signals: z.array(signalSummarySchema).readonly(),
+  }),
+  visibility: 'internal',
+});
+
+export const wayfindSurfacesTrail = trail('wayfind.surfaces', {
+  blaze: async (input, ctx) =>
+    withGraph(input, ctx.cwd, (loaded) => {
+      const ids = filteredIds(
+        loaded.graph,
+        'surface',
+        input.filters,
+        input.limit
+      );
+      return {
+        ...envelope(loaded),
+        surfaces: surfaceSummaries(loaded.graph).filter((entry) =>
+          ids.has(entry.id)
+        ),
+      };
+    }),
+  description: 'List saved direct and facet-projected surfaces',
+  examples: [{ input: {}, name: 'List surfaces' }],
+  input: filteredInputSchema,
+  intent: 'read',
+  output: envelopeSchema.extend({
+    surfaces: z.array(surfaceSummarySchema).readonly(),
+  }),
+  visibility: 'internal',
+});
+
+export const wayfindFacetsTrail = trail('wayfind.facets', {
+  blaze: async (input, ctx) =>
+    withGraph(input, ctx.cwd, (loaded) => {
+      const ids = filteredIds(
+        loaded.graph,
+        'facet',
+        input.filters,
+        input.limit
+      );
+      return {
+        ...envelope(loaded),
+        facets: facetSummaries(loaded.graph).filter((entry) =>
+          ids.has(entry.id)
+        ),
+      };
+    }),
+  description: 'List saved facet membership',
+  examples: [{ input: {}, name: 'List facets' }],
+  input: filteredInputSchema,
+  intent: 'read',
+  output: envelopeSchema.extend({
+    facets: z.array(facetSummarySchema).readonly(),
+  }),
+  visibility: 'internal',
+});
+
+export const wayfindVersionsTrail = trail('wayfind.versions', {
+  blaze: async (input, ctx) =>
+    withGraph(input, ctx.cwd, (loaded) => ({
+      ...envelope(loaded),
+      versions: filteredVersionSummaries(
+        loaded.graph,
+        input.filters,
+        input.limit
+      ),
+    })),
+  description: 'List saved trail version contracts',
+  examples: [{ input: {}, name: 'List versions' }],
+  input: filteredInputSchema,
+  intent: 'read',
+  output: envelopeSchema.extend({
+    versions: z.array(versionSummarySchema).readonly(),
+  }),
+  visibility: 'internal',
+});
+
+export const wayfindExamplesTrail = trail('wayfind.examples', {
+  blaze: async (input, ctx) =>
+    withGraph(input, ctx.cwd, (loaded) => ({
+      ...envelope(loaded),
+      examples: filteredExampleSummaries(
+        loaded.graph,
+        input.filters,
+        input.limit
+      ),
+    })),
+  description: 'List saved examples without executing trails',
+  examples: [{ input: {}, name: 'List examples' }],
+  input: filteredInputSchema,
+  intent: 'read',
+  output: envelopeSchema.extend({
+    examples: z.array(exampleSummarySchema).readonly(),
+  }),
+  visibility: 'internal',
+});
+
+export const wayfindDescribeTrail = trail('wayfind.describe', {
+  args: ['id'],
+  blaze: async (input, ctx) => {
+    const loaded = await loadGraph(input, ctx.cwd);
+    if (loaded.isErr()) {
+      return loaded;
+    }
+    const entity = describeEntry(loaded.value.graph, input);
+    if (entity.isErr()) {
+      return entity;
+    }
+    if (entity.value === undefined) {
+      return Result.err(notFound(input.kind ?? 'entity', input.id));
+    }
+    return Result.ok({ ...envelope(loaded.value), entity: entity.value });
+  },
+  description: 'Inspect one saved topo graph entity',
+  examples: [{ input: { id: 'user.create' }, name: 'Describe entity' }],
+  input: inspectInputSchema,
+  intent: 'read',
+  output: describeOutputSchema,
+  visibility: 'internal',
+});
+
+export const wayfindContractTrail = trail('wayfind.contract', {
+  args: ['id'],
+  blaze: async (input, ctx) => {
+    const loaded = await loadGraph(input, ctx.cwd);
+    if (loaded.isErr()) {
+      return loaded;
+    }
+    const contract = contractFor(loaded.value.graph, input);
+    if (contract.isErr()) {
+      return contract;
+    }
+    if (contract.value === undefined) {
+      return Result.err(notFound(input.kind ?? 'contract', input.id));
+    }
+    return Result.ok({ ...envelope(loaded.value), contract: contract.value });
+  },
+  description: 'Inspect one saved input/output contract',
+  examples: [{ input: { id: 'user.create' }, name: 'Inspect contract' }],
+  input: contractInputSchema,
+  intent: 'read',
+  output: contractOutputSchema,
+  visibility: 'internal',
+});
+
+export const wayfinderTopo = topo('wayfinder', {
+  wayfindContoursTrail,
+  wayfindContractTrail,
+  wayfindDescribeTrail,
+  wayfindExamplesTrail,
+  wayfindFacetsTrail,
+  wayfindOverviewTrail,
+  wayfindResourcesTrail,
+  wayfindSearchTrail,
+  wayfindSignalsTrail,
+  wayfindSurfacesTrail,
+  wayfindTrailsTrail,
+  wayfindVersionsTrail,
+});


### PR DESCRIPTION
## Context

Implements TRL-906: the initial Wayfinder graph-read query catalog for finding and inspecting saved topo facts.

## What Changed

- Added `wayfinderTopo` and the graph-read trails for overview, search/listing, describe, contract, surfaces, facets, versions, examples, resources, and signals.
- Added output schemas and examples so MCP/HTTP hosts have explicit contracts when selected trails are exposed.
- Added tests for the catalog, shell behavior, contracts, filtering, and not-found/error paths.
- Updated the Wayfinder README to document the v0 query surface.
- Added a changeset for the query catalog.

## Verification

- Branch-local Codex review loop completed with no remaining P2+ findings; lower-priority follow-ups are logged in `/tmp/trails-wayfinder-p3-findings.md`.
- `bun run format:check`
- `bun run docs:links`
- `bun run docs:snippets`
- `bun run publish:check`
- `bun run build`
- `bun run test`
- Pre-push hook passed during `gt submit`.

## Risks / Rollout

- The query catalog is intentionally internal by default. Hosts must opt in to exact trail IDs when exposing query trails on a surface.
- Warden currently warns that the internal `wayfind.*` query trails are not composed by another trail. This is logged as P3 follow-up because selected host exposure is intentional for v0.
