### PR TITLE
feat(trails): project wayfinder into operator mcp

### DIFF
--- a/.changeset/trails-wayfinder-mcp.md
+++ b/.changeset/trails-wayfinder-mcp.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Project selected Wayfinder graph-read trails into the Trails operator MCP surface alongside clearer first-class operator tools.

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -34,6 +34,7 @@
     "@ontrails/topographer": "workspace:^",
     "@ontrails/tracing": "workspace:^",
     "@ontrails/warden": "workspace:^",
+    "@ontrails/wayfinder": "workspace:^",
     "commander": "catalog:",
     "zod": "catalog:"
   },

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -8,8 +8,12 @@ import {
   deriveMcpTools,
 } from '@ontrails/mcp';
 
-import { app } from '../app.js';
-import { trailsMcpFacets, trailsMcpSurfaceOptions } from '../mcp-options.js';
+import { trailsMcpApp } from '../mcp-app.js';
+import {
+  trailsMcpFacets,
+  trailsMcpIncludedTrails,
+  trailsMcpSurfaceOptions,
+} from '../mcp-options.js';
 
 const unwrapTools = (...args: Parameters<typeof deriveMcpTools>) => {
   const result = deriveMcpTools(...args);
@@ -24,63 +28,150 @@ const parseJson = (text: string | undefined): unknown => {
   return JSON.parse(text ?? 'null');
 };
 
+const requireTool = (
+  tools: ReturnType<typeof unwrapTools>,
+  name: string
+): ReturnType<typeof unwrapTools>[number] => {
+  const tool = tools.find((item) => item.name === name);
+  expect(tool).toBeDefined();
+  return tool as ReturnType<typeof unwrapTools>[number];
+};
+
 describe('Trails MCP surface shaping', () => {
-  test('projects the Trails operator app as deferred facet tools', () => {
-    const tools = unwrapTools(app, trailsMcpSurfaceOptions);
+  test('projects selected high-signal operator and Wayfinder tools directly', () => {
+    const tools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
 
     expect(tools.map((tool) => tool.name).toSorted()).toEqual([
-      'trails_artifacts',
-      'trails_authoring',
-      'trails_execution',
-      'trails_governance',
+      'trails_adapter_check',
+      'trails_add_surface',
+      'trails_add_trail',
+      'trails_compile',
+      'trails_create',
+      'trails_create_adapter',
+      'trails_deprecate',
+      'trails_dev_clean',
+      'trails_dev_reset',
+      'trails_dev_stats',
+      'trails_doctor',
+      'trails_draft_promote',
       'trails_inspect',
-      'trails_shell',
-      'trails_workspace',
+      'trails_revise',
+      'trails_run',
+      'trails_run_example',
+      'trails_run_examples',
+      'trails_topo_pin',
+      'trails_topo_unpin',
+      'trails_validate',
+      'trails_warden',
+      'trails_warden_guide',
+      'trails_wayfind_contract',
+      'trails_wayfind_examples',
+      'trails_wayfind_impact',
+      'trails_wayfind_nearby',
+      'trails_wayfind_overview',
+      'trails_wayfind_search',
+      'trails_wayfind_trails',
     ]);
 
-    for (const tool of tools) {
-      expect(tool.trailId).toBeUndefined();
-      expect(tool.facetId).toBeDefined();
-      expect(tool.memberTrailIds?.length).toBeGreaterThan(0);
-      expect(tool._meta?.[MCP_TOOL_DEFERRED_META_KEY]).toBe(true);
-      expect(tool.inputSchema).toMatchObject({
-        required: ['trail', 'input'],
-        type: 'object',
-      });
+    const inspectTool = requireTool(tools, 'trails_inspect');
+    expect(inspectTool?.trailId).toBeUndefined();
+    expect(inspectTool?.facetId).toBe('inspect');
+    expect(inspectTool?.memberTrailIds?.toSorted()).toEqual([
+      'diff',
+      'guide',
+      'survey',
+      'survey.brief',
+      'survey.diff',
+      'survey.resource',
+      'survey.signal',
+      'survey.surfaces',
+      'survey.trail',
+      'topo',
+      'topo.history',
+    ]);
+    expect(inspectTool?._meta?.[MCP_TOOL_DEFERRED_META_KEY]).toBe(true);
+    expect(inspectTool?.inputSchema).toMatchObject({
+      required: ['trail', 'input'],
+      type: 'object',
+    });
+
+    for (const tool of tools.filter((item) => item.name !== 'trails_inspect')) {
+      expect(tool.trailId).toBeDefined();
+      expect(tool.facetId).toBeUndefined();
+      expect(tool.memberTrailIds).toBeUndefined();
+      expect(tool._meta?.[MCP_TOOL_DEFERRED_META_KEY]).toBeUndefined();
     }
   });
 
-  test('accounts for every public operator trail without widening internal trails', () => {
-    const rawTools = unwrapTools(app);
-    const shapedTools = unwrapTools(app, trailsMcpSurfaceOptions);
-    const rawTrailIds = rawTools
-      .map((tool) => tool.trailId)
-      .filter((trailId) => trailId !== undefined)
-      .toSorted();
+  test('preserves MCP descriptions and permission annotations', () => {
+    const tools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
+    const wayfindSearch = requireTool(tools, 'trails_wayfind_search');
+    const warden = requireTool(tools, 'trails_warden');
+    const devClean = requireTool(tools, 'trails_dev_clean');
+    const topoUnpin = requireTool(tools, 'trails_topo_unpin');
+    const inspect = requireTool(tools, 'trails_inspect');
+
+    expect(wayfindSearch.description).toBe(
+      'Find topo graph entities with typed filters'
+    );
+    expect(wayfindSearch.annotations).toMatchObject({
+      readOnlyHint: true,
+      title: 'Find topo graph entities with typed filters',
+    });
+
+    expect(warden.description).toBe('Run governance checks (lint + drift)');
+    expect(warden.annotations).toEqual({
+      title: 'Run governance checks (lint + drift)',
+    });
+
+    expect(devClean.annotations).toMatchObject({
+      destructiveHint: true,
+      title: 'Prune unpinned topo snapshots and old trace records',
+    });
+    expect(topoUnpin.annotations).toMatchObject({
+      destructiveHint: true,
+      title: 'Remove a named topo pin',
+    });
+    expect(inspect.description).toBe(
+      'Inspect saved topo structure, resources, signals, surfaces, and diffs.'
+    );
+    expect(inspect.annotations).toMatchObject({
+      readOnlyHint: true,
+      title:
+        'Inspect saved topo structure, resources, signals, surfaces, and diffs.',
+    });
+  });
+
+  test('projects only the selected trail IDs without shell or generic Wayfinder tools', () => {
+    const shapedTools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
     const shapedTrailIds = shapedTools
-      .flatMap((tool) => tool.memberTrailIds ?? [])
+      .flatMap((tool) =>
+        tool.trailId === undefined ? (tool.memberTrailIds ?? []) : tool.trailId
+      )
       .toSorted();
 
-    expect(shapedTrailIds).toEqual(rawTrailIds);
+    expect(shapedTrailIds).toEqual([...trailsMcpIncludedTrails].toSorted());
     expect(shapedTrailIds).not.toContain('add.verify');
     expect(shapedTrailIds).not.toContain('create.scaffold');
+    expect(shapedTrailIds).not.toContain('completions');
+    expect(shapedTrailIds).not.toContain('completions.__complete');
+    expect(shapedTrailIds).not.toContain('wayfind.adapters');
+    expect(shapedTrailIds).not.toContain('wayfind.errors');
+    expect(shapedTrailIds).not.toContain('wayfind.query');
   });
 
   test('keeps app-authored facet selectors explicit enough for review', () => {
     expect(trailsMcpFacets.inspect.trails).toContain('survey');
     expect(trailsMcpFacets.inspect.trails).not.toContain('survey.*');
-    expect(trailsMcpFacets.authoring.trails).toContain('draft.promote');
-    expect(trailsMcpFacets.workspace.trails).toEqual([
-      'dev.stats',
-      'dev.clean',
-      'dev.reset',
-    ]);
+    expect(Object.keys(trailsMcpFacets)).toEqual(['inspect']);
+    expect(trailsMcpIncludedTrails).toContain('warden');
+    expect(trailsMcpIncludedTrails).toContain('wayfind.search');
   });
 
   test('exposes cold context resources for the shaped surface', () => {
-    const tools = unwrapTools(app, trailsMcpSurfaceOptions);
+    const tools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
     const resources = buildMcpResources(
-      app,
+      trailsMcpApp,
       tools,
       trailsMcpSurfaceOptions.mcpResources
     );
@@ -93,20 +184,32 @@ describe('Trails MCP surface shaping', () => {
     expect(resources.list.map((resource) => resource.uri)).toContain(
       runExampleUri
     );
+    expect(resources.list.map((resource) => resource.uri)).toContain(
+      `${MCP_EXAMPLES_RESOURCE_PREFIX}${encodeURIComponent('wayfind.search')}`
+    );
     const projectedMap = parseJson(surfaceMap?.text) as {
       readonly tools?: readonly {
         readonly deferred?: boolean | undefined;
         readonly facetId?: string | undefined;
         readonly name?: string | undefined;
+        readonly trailId?: string | undefined;
       }[];
     };
     expect(
-      projectedMap.tools?.find((tool) => tool.facetId === 'artifacts')
+      projectedMap.tools?.find((tool) => tool.facetId === 'inspect')
     ).toEqual(
       expect.objectContaining({
         deferred: true,
-        facetId: 'artifacts',
-        name: 'trails_artifacts',
+        facetId: 'inspect',
+        name: 'trails_inspect',
+      })
+    );
+    expect(
+      projectedMap.tools?.find((tool) => tool.name === 'trails_wayfind_search')
+    ).toEqual(
+      expect.objectContaining({
+        name: 'trails_wayfind_search',
+        trailId: 'wayfind.search',
       })
     );
   });

--- a/apps/trails/src/mcp-app.ts
+++ b/apps/trails/src/mcp-app.ts
@@ -1,0 +1,26 @@
+import { topo } from '@ontrails/core';
+import {
+  wayfindContractTrail,
+  wayfindExamplesTrail,
+  wayfindImpactTrail,
+  wayfindNearbyTrail,
+  wayfindOverviewTrail,
+  wayfindSearchTrail,
+  wayfindTrailsTrail,
+} from '@ontrails/wayfinder';
+
+import { app } from './app.js';
+
+const operatorTrails = Object.fromEntries(
+  app.list().map((trailItem) => [trailItem.id, trailItem])
+);
+
+export const trailsMcpApp = topo('trails', operatorTrails, {
+  wayfindContractTrail,
+  wayfindExamplesTrail,
+  wayfindImpactTrail,
+  wayfindNearbyTrail,
+  wayfindOverviewTrail,
+  wayfindSearchTrail,
+  wayfindTrailsTrail,
+});

--- a/apps/trails/src/mcp-options.ts
+++ b/apps/trails/src/mcp-options.ts
@@ -1,41 +1,51 @@
 import type { CreateServerOptions, McpSurfaceFacetMap } from '@ontrails/mcp';
 
+export const trailsMcpIncludedTrails = [
+  'adapter.check',
+  'add.surface',
+  'add.trail',
+  'compile',
+  'create',
+  'create.adapter',
+  'deprecate',
+  'dev.clean',
+  'dev.reset',
+  'dev.stats',
+  'diff',
+  'doctor',
+  'draft.promote',
+  'guide',
+  'revise',
+  'run',
+  'run.example',
+  'run.examples',
+  'survey',
+  'survey.brief',
+  'survey.diff',
+  'survey.resource',
+  'survey.signal',
+  'survey.surfaces',
+  'survey.trail',
+  'topo',
+  'topo.history',
+  'topo.pin',
+  'topo.unpin',
+  'validate',
+  'warden',
+  'warden.guide',
+  'wayfind.contract',
+  'wayfind.examples',
+  'wayfind.impact',
+  'wayfind.nearby',
+  'wayfind.overview',
+  'wayfind.search',
+  'wayfind.trails',
+] as const;
+
 export const trailsMcpFacets = {
-  artifacts: {
-    description:
-      'Compile, validate, and manage local topo artifacts for a Trails workspace.',
-    mcp: { loading: 'deferred' },
-    trails: ['compile', 'validate', 'topo.history', 'topo.pin', 'topo.unpin'],
-  },
-  authoring: {
-    description:
-      'Create and evolve Trails projects, surfaces, trails, and version entries.',
-    mcp: { loading: 'deferred' },
-    trails: [
-      'create',
-      'create.adapter',
-      'add.surface',
-      'add.trail',
-      'revise',
-      'deprecate',
-      'draft.promote',
-    ],
-  },
-  execution: {
-    description:
-      'Run trails and examples from a Trails workspace with traceable outcomes.',
-    mcp: { loading: 'deferred' },
-    trails: ['run', 'run.examples', 'run.example'],
-  },
-  governance: {
-    description:
-      'Run project diagnostics, adapter readiness checks, and Warden guidance.',
-    mcp: { loading: 'deferred' },
-    trails: ['doctor', 'adapter.check', 'warden', 'warden.guide'],
-  },
   inspect: {
     description:
-      'Inspect topo structure, contracts, resources, signals, surfaces, and diffs.',
+      'Inspect saved topo structure, resources, signals, surfaces, and diffs.',
     mcp: { loading: 'deferred' },
     trails: [
       'survey',
@@ -48,25 +58,16 @@ export const trailsMcpFacets = {
       'survey.signal',
       'survey.surfaces',
       'survey.trail',
+      'topo.history',
     ],
-  },
-  shell: {
-    description: 'Render and complete Trails shell completions.',
-    mcp: { loading: 'deferred' },
-    trails: ['completions', 'completions.__complete'],
-  },
-  workspace: {
-    description:
-      'Inspect and maintain local Trails developer state such as snapshots and traces.',
-    mcp: { loading: 'deferred' },
-    trails: ['dev.stats', 'dev.clean', 'dev.reset'],
   },
 } satisfies McpSurfaceFacetMap;
 
 export const trailsMcpSurfaceOptions = {
   description:
-    'Trails framework operator surface. Use MCP resources for cold context, then call a facet tool with a trail ID and input payload.',
+    'Trails framework operator surface. Use MCP resources for cold context, direct tools for high-signal work, and the inspect facet for saved topo reads.',
   facets: trailsMcpFacets,
+  include: trailsMcpIncludedTrails,
   mcpResources: { examples: true, surfaceMap: true },
   name: 'trails',
 } satisfies CreateServerOptions;

--- a/apps/trails/src/mcp.ts
+++ b/apps/trails/src/mcp.ts
@@ -2,7 +2,7 @@
 /* oxlint-disable eslint-plugin-jest/require-hook -- MCP stdio entrypoints execute at module scope */
 import { surface } from '@ontrails/mcp';
 
-import { app } from './app.js';
+import { trailsMcpApp } from './mcp-app.js';
 import { trailsMcpSurfaceOptions } from './mcp-options.js';
 
-await surface(app, trailsMcpSurfaceOptions);
+await surface(trailsMcpApp, trailsMcpSurfaceOptions);

--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,7 @@
         "@ontrails/topographer": "workspace:^",
         "@ontrails/tracing": "workspace:^",
         "@ontrails/warden": "workspace:^",
+        "@ontrails/wayfinder": "workspace:^",
         "commander": "catalog:",
         "zod": "catalog:",
       },

--- a/docs/surfaces/surface-facet-field-notes.md
+++ b/docs/surfaces/surface-facet-field-notes.md
@@ -6,9 +6,9 @@ Surface facets should stay evidence-led. Use this file for lightweight notes fro
 
 TRL-890 originally called for two sprints between the ad-hoc Trails operator MCP surface and the reusable facet engine. Matt shortened that window during the Surface Facets & MCP Shaping sprint so the full stack could land together. Treat these notes as first-contact evidence plus a standing place for the next two sprints of follow-up, not as proof that every cross-surface question is settled.
 
-## Initial Trails Operator Surface
+## Trails Operator Surface
 
-The first shaped surface is `apps/trails/src/mcp-options.ts`. It projects the Trails operator app into seven deferred MCP facet tools:
+The first shaped surface was `apps/trails/src/mcp-options.ts`. It projected the Trails operator app into seven deferred MCP facet tools:
 
 - `artifacts`
 - `authoring`
@@ -20,13 +20,16 @@ The first shaped surface is `apps/trails/src/mcp-options.ts`. It projects the Tr
 
 Each facet uses an explicit trail list instead of a broad namespace glob. That made review easier: agent reviewers could verify coverage of public trails, confirm that internal trails stayed hidden, and reason about the grouping without expanding a hidden selector mentally.
 
+TRL-908 revised the dogfood surface around permission boundaries. The Trails operator MCP server now keeps high-signal and permission-sensitive affordances as direct tools, removes shell completion trails from MCP, and uses one deferred `inspect` facet for saved read-only topo inspection. Selected Wayfinder graph-read trails are explicitly included as direct tools on the operator MCP topo, rather than hidden behind a generic Wayfinder bucket.
+
 ## What Survived Contact
 
-- **Tool count:** seven tools is easier for agents to scan than one tool per Trails CLI trail.
+- **Tool count:** a smaller tool surface still matters, but permission boundaries matter more than minimizing count.
 - **Invocation shape:** `{ trail, input }` keeps the underlying trail visible and avoids a new action vocabulary inside the facet.
 - **Output correlation:** `{ trail, output }` is necessary. Heterogeneous facet tools need the returned trail ID so an agent can connect a response to the selected contract without guessing from output fields.
 - **Cold context:** the resolved MCP surface map belongs in MCP resources. Agents can inspect grouped tools, member trail IDs, examples, and deferred hints without paying that context cost in every tool schema.
 - **Explicit selectors:** authored facet lists are boring, but boring helped. They made visibility and overlap review much more mechanical.
+- **Direct sensitive tools:** Warden, run, compile, authoring, topo pinning, and developer-state mutation are clearer as direct MCP tools than as members of broad facets.
 
 ## What To Keep Watching
 


### PR DESCRIPTION
## Context

Implements TRL-908 by projecting a selected Wayfinder subset into the Trails operator MCP surface.

## What Changed

- Added a dedicated operator MCP app composition that includes the existing Trails operator topo plus Wayfinder.
- Exposed selected read-only Wayfinder tools directly by exact trail ID:
  - `wayfind.overview`
  - `wayfind.search`
  - `wayfind.trails`
  - `wayfind.contract`
  - `wayfind.examples`
  - `wayfind.nearby`
  - `wayfind.impact`
- Kept broader saved-topo inspection behind existing `inspect` facet grouping and avoided wildcard exposure of internal `wayfind.*`.
- Added MCP shaping tests for selected tools, exclusions, annotations, descriptions, and cold context resources.
- Added docs and a changeset for the operator MCP projection.

## Verification

- Branch-local Codex review loop completed at 5/5 with no remaining P2+ findings.
- `bun run format:check`
- `bun run docs:links`
- `bun run docs:snippets`
- `bun run publish:check`
- `bun run build`
- `bun run test`
- Pre-push hook passed during `gt submit`.

## Risks / Rollout

- This intentionally exposes only selected internal Wayfinder trails. Hosts should not copy this as a blanket `wayfind.*` wildcard; exact IDs keep the MCP tool surface reviewable.
