### PR TITLE
feat(trails): expose wayfinder cli dogfood surface

### DIFF
--- a/.changeset/trl-916-wayfinder-cli.md
+++ b/.changeset/trl-916-wayfinder-cli.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Expose selected Wayfinder graph-read queries through the local `trails wayfind` CLI command group for dogfooding saved topo artifacts.

--- a/apps/trails/README.md
+++ b/apps/trails/README.md
@@ -15,6 +15,8 @@ Common workflows:
 - `trails topo` inspects topo state and manages pins/history.
 - `trails compile` writes committed topo artifacts.
 - `trails validate` checks committed topo artifacts for drift.
+- `trails wayfind overview` and adjacent `trails wayfind ...` commands read
+  saved topo artifacts through Wayfinder for local graph navigation.
 - `trails warden` runs Trails governance checks for contract and architecture drift.
 - `trails guide` shows available trails and examples from a project.
 

--- a/apps/trails/__tests__/examples.test.ts
+++ b/apps/trails/__tests__/examples.test.ts
@@ -6,7 +6,7 @@ import { join, resolve } from 'node:path';
 import { WORKSPACE_GITIGNORE_CONTENT } from '@ontrails/core';
 import { testExamples } from '@ontrails/testing';
 
-import { app } from '../src/app.js';
+import { operatorApp } from '../src/app.js';
 
 const trailsWorkspaceDir = resolve(import.meta.dir, '..', '.trails');
 const trailsGitignorePath = join(trailsWorkspaceDir, '.gitignore');
@@ -30,4 +30,6 @@ afterAll(() => {
   resetTrailsWorkspace();
 });
 
-testExamples(app, { cwd: repoRoot });
+// Wayfinder CLI dogfood trails depend on saved topo artifacts; the repo-level
+// dogfood smoke covers them against exported operator artifacts.
+testExamples(operatorApp, { cwd: repoRoot });

--- a/apps/trails/src/__tests__/wayfind-cli.test.ts
+++ b/apps/trails/src/__tests__/wayfind-cli.test.ts
@@ -1,0 +1,54 @@
+import { deriveCliCommands } from '@ontrails/cli';
+import { describe, expect, test } from 'bun:test';
+
+import { app, operatorApp, trailsCliIncludedTrails } from '../app.js';
+
+const unwrapCommands = () => {
+  const result = deriveCliCommands(app, { include: trailsCliIncludedTrails });
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+describe('Trails Wayfinder CLI surface', () => {
+  test('projects selected Wayfinder queries as local CLI commands', () => {
+    const commands = unwrapCommands();
+    const commandPaths = commands.map((command) => command.path.join(' '));
+    const trailIds = commands.map((command) => command.trail.id);
+
+    expect(commandPaths).toContain('wayfind overview');
+    expect(commandPaths).toContain('wayfind search');
+    expect(commandPaths).toContain('wayfind trails');
+    expect(commandPaths).toContain('wayfind contract');
+    expect(commandPaths).toContain('wayfind describe');
+    expect(commandPaths).toContain('wayfind nearby');
+    expect(commandPaths).toContain('wayfind impact');
+    expect(commandPaths).toContain('wayfind examples');
+
+    expect(trailIds).toContain('wayfind.overview');
+    expect(trailIds).toContain('wayfind.search');
+    expect(trailIds).toContain('wayfind.trails');
+    expect(trailIds).toContain('wayfind.contract');
+    expect(trailIds).toContain('wayfind.describe');
+    expect(trailIds).toContain('wayfind.nearby');
+    expect(trailIds).toContain('wayfind.impact');
+    expect(trailIds).toContain('wayfind.examples');
+  });
+
+  test('does not expose deferred Wayfinder queries on the CLI', () => {
+    const commands = unwrapCommands();
+    const trailIds = commands.map((command) => command.trail.id);
+
+    expect(trailIds).not.toContain('wayfind.adapters');
+    expect(trailIds).not.toContain('wayfind.errors');
+    expect(trailIds).not.toContain('wayfind.query');
+    expect(trailIds).not.toContain('wayfind.implications');
+    expect(trailIds).not.toContain('wayfind.diff');
+  });
+
+  test('keeps the base operator topo separate from CLI Wayfinder exposure', () => {
+    expect(operatorApp.get('wayfind.overview')).toBeUndefined();
+    expect(app.get('wayfind.overview')).toBeDefined();
+  });
+});

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -1,4 +1,14 @@
 import { topo } from '@ontrails/core';
+import {
+  wayfindContractTrail,
+  wayfindDescribeTrail,
+  wayfindExamplesTrail,
+  wayfindImpactTrail,
+  wayfindNearbyTrail,
+  wayfindOverviewTrail,
+  wayfindSearchTrail,
+  wayfindTrailsTrail,
+} from '@ontrails/wayfinder';
 
 import * as addSurface from './trails/add-surface.js';
 import * as addTrail from './trails/add-trail.js';
@@ -30,7 +40,7 @@ import * as validate from './trails/validate.js';
 import * as warden from './trails/warden.js';
 import * as wardenGuide from './trails/warden-guide.js';
 
-export const app = topo(
+export const operatorApp = topo(
   'trails',
   run,
   runExamples,
@@ -62,3 +72,25 @@ export const app = topo(
   completions,
   completionsComplete
 );
+
+const operatorTrails = Object.fromEntries(
+  operatorApp.list().map((trailItem) => [trailItem.id, trailItem])
+);
+
+const cliWayfinderTrails = {
+  wayfindContractTrail,
+  wayfindDescribeTrail,
+  wayfindExamplesTrail,
+  wayfindImpactTrail,
+  wayfindNearbyTrail,
+  wayfindOverviewTrail,
+  wayfindSearchTrail,
+  wayfindTrailsTrail,
+};
+
+export const trailsCliIncludedTrails = [
+  ...operatorApp.list().map((trailItem) => trailItem.id),
+  ...Object.values(cliWayfinderTrails).map((trailItem) => trailItem.id),
+];
+
+export const app = topo('trails', operatorTrails, cliWayfinderTrails);

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -19,7 +19,7 @@ import { createProgram } from '@ontrails/commander';
 import { resolvePermitFromBearerToken } from '@ontrails/permits';
 import { deriveTopoGraph } from '@ontrails/topographer';
 
-import { app } from './app.js';
+import { app, trailsCliIncludedTrails } from './app.js';
 import { resolveInputWithClack } from './clack.js';
 import { getRetiredTopoCommandDiagnostic } from './retired-topo-command.js';
 import { attachCompletionsInstallCommand } from './run-completions-install.js';
@@ -287,6 +287,7 @@ const runSurfaceOnce = async (): Promise<void> => {
   try {
     const program = createProgram(app, {
       description: 'Agent-native, contract-first TypeScript framework',
+      include: trailsCliIncludedTrails,
       name: 'trails',
       onResult: buildOnResult(session),
       presets: [

--- a/apps/trails/src/mcp-app.ts
+++ b/apps/trails/src/mcp-app.ts
@@ -9,10 +9,10 @@ import {
   wayfindTrailsTrail,
 } from '@ontrails/wayfinder';
 
-import { app } from './app.js';
+import { operatorApp } from './app.js';
 
 const operatorTrails = Object.fromEntries(
-  app.list().map((trailItem) => [trailItem.id, trailItem])
+  operatorApp.list().map((trailItem) => [trailItem.id, trailItem])
 );
 
 export const trailsMcpApp = topo('trails', operatorTrails, {

--- a/docs/adr/drafts/20260503-wayfinding.md
+++ b/docs/adr/drafts/20260503-wayfinding.md
@@ -3,7 +3,7 @@ slug: wayfinding
 title: Wayfinding
 status: draft
 created: 2026-05-03
-updated: 2026-06-04
+updated: 2026-06-07
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [17, 27, 37, 42]
 description: "Introduces `@ontrails/wayfinder`: a package of trails over `@ontrails/topographer` artifacts giving agents queryable access to the topo graph via typed query catalog trails (overview, search, typed list filters, describe, contract, nearby, impact, examples, surfaces, facets, versions, diff)."
@@ -143,6 +143,10 @@ Wayfinder trails are operator and developer tools, not app-public verbs. The def
 - CLI exposure on the developer's own machine is the expected default; the
   CLI surface treats local invocation as implicitly authorized, consistent
   with [ADR-0027] Part 4.
+- The Trails operator CLI dogfoods v0 by exposing a selected read-only subset
+  through exact IDs (`overview`, `search`, typed contract/describe,
+  examples, nearby, and impact). This is not wildcard namespace exposure and
+  does not promote deferred queries.
 
 This means an app that mounts `@ontrails/wayfinder` does not accidentally hand its agents a self-documenting treasure chest. The graph stays locked unless the operator opts in. ADR-0027 already provides the levers; wayfinding leans on them.
 


### PR DESCRIPTION
## Context

Wayfinder should be usable from the Trails operator surface without asking agents to reconstruct topo facts manually from source search.

## Changes

- Expose a selected read-only Wayfinder subset through the Trails CLI.
- Keep the operator app split explicit so generic operator examples do not depend on saved Wayfinder artifacts.
- Add CLI coverage for the exposed Wayfinder commands.
- Update the Wayfinding draft ADR to document exact-ID operator CLI dogfood exposure.

## Verification

- `bun test apps/trails/src/__tests__/wayfind-cli.test.ts apps/trails/__tests__/examples.test.ts`
- `bun run wayfinder:dogfood`
- `bun scripts/adr.ts check`
- `bun run check`
- Hosted CI and Graphite AI Reviews are green.

## Risks

The CLI exposure is intentionally narrow: exact IDs only, read-only, and no wildcard namespace promotion for deferred query families.
