### PR TITLE
test(trails): add wayfinder dogfood smoke

### DIFF
--- a/.changeset/trl-918-wayfinder-dogfood-smoke.md
+++ b/.changeset/trl-918-wayfinder-dogfood-smoke.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/trails": patch
+---
+
+Add a repo-level Wayfinder dogfood smoke command that exercises the local
+Trails CLI against exported operator topo artifacts.

--- a/apps/trails/scripts/wayfinder-dogfood.ts
+++ b/apps/trails/scripts/wayfinder-dogfood.ts
@@ -1,0 +1,148 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { trailsMcpApp } from '../src/mcp-app.js';
+import { exportCurrentTopo } from '../src/trails/topo-store-support.js';
+
+const repoRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));
+const trailsBin = join(repoRoot, 'apps/trails/bin/trails.ts');
+
+type JsonObject = Record<string, unknown>;
+
+const assertObject = (value: unknown, label: string): JsonObject => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} did not return a JSON object`);
+  }
+  return value as JsonObject;
+};
+
+const assertFreshSource = (value: JsonObject, label: string): void => {
+  const freshness = assertObject(value['freshness'], `${label}.freshness`);
+  if (freshness['status'] !== 'fresh') {
+    throw new Error(`${label} did not read fresh artifacts`);
+  }
+  const source = assertObject(value['source'], `${label}.source`);
+  if (source['kind'] !== 'topoGraph') {
+    throw new Error(`${label} did not read the TopoGraph source`);
+  }
+};
+
+const parseJson = (stdout: string, label: string): JsonObject => {
+  try {
+    return assertObject(JSON.parse(stdout) as unknown, label);
+  } catch (error) {
+    throw new Error(`${label} did not produce valid JSON`, { cause: error });
+  }
+};
+
+const runWayfind = (tempRoot: string, args: readonly string[]): JsonObject => {
+  const command = [
+    process.execPath,
+    trailsBin,
+    'wayfind',
+    ...args,
+    '--root-dir',
+    tempRoot,
+    '--json',
+  ];
+  const result = Bun.spawnSync({
+    cmd: command,
+    cwd: repoRoot,
+    env: { ...process.env, NO_COLOR: '1' } as Record<
+      string,
+      string | undefined
+    >,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  const stdout = result.stdout.toString();
+  const stderr = result.stderr.toString();
+  if (result.exitCode !== 0) {
+    throw new Error(
+      [
+        `Wayfinder dogfood command failed: ${command.join(' ')}`,
+        `exitCode: ${result.exitCode}`,
+        `stdout: ${stdout}`,
+        `stderr: ${stderr}`,
+      ].join('\n')
+    );
+  }
+  return parseJson(stdout, `trails ${args.join(' ')}`);
+};
+
+const assertSearchFindsWayfinder = (search: JsonObject): void => {
+  const { matches } = search;
+  if (!Array.isArray(matches)) {
+    throw new TypeError('wayfind search did not return matches');
+  }
+  const ids = matches
+    .map((match) => assertObject(match, 'wayfind search match')['id'])
+    .filter((id): id is string => typeof id === 'string');
+  if (!ids.includes('wayfind.search')) {
+    throw new Error('wayfind search did not find wayfind.search');
+  }
+};
+
+const assertContractForSearch = (contractResult: JsonObject): void => {
+  const contract = assertObject(contractResult['contract'], 'contract');
+  if (contract['id'] !== 'wayfind.search') {
+    throw new Error('wayfind contract did not inspect wayfind.search');
+  }
+};
+
+const assertResolvedTarget = (value: JsonObject, label: string): void => {
+  const target = assertObject(value['target'], `${label}.target`);
+  if (target['id'] !== 'wayfind.search') {
+    throw new Error(`${label} did not resolve wayfind.search`);
+  }
+};
+
+const main = async (): Promise<void> => {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'trails-wayfinder-dogfood-'));
+
+  try {
+    const exported = await exportCurrentTopo(trailsMcpApp, {
+      rootDir: tempRoot,
+    });
+    if (exported.isErr()) {
+      throw exported.error;
+    }
+
+    const overview = runWayfind(tempRoot, ['overview']);
+    assertFreshSource(overview, 'wayfind overview');
+    const counts = assertObject(overview['counts'], 'wayfind overview counts');
+    if (typeof counts['trails'] !== 'number' || counts['trails'] < 1) {
+      throw new Error('wayfind overview did not report trail counts');
+    }
+
+    const search = runWayfind(tempRoot, [
+      'search',
+      '--input-json',
+      '{"filters":{"kind":"trail","idPrefix":"wayfind."}}',
+    ]);
+    assertFreshSource(search, 'wayfind search');
+    assertSearchFindsWayfinder(search);
+
+    const contract = runWayfind(tempRoot, ['contract', 'wayfind.search']);
+    assertFreshSource(contract, 'wayfind contract');
+    assertContractForSearch(contract);
+
+    const nearby = runWayfind(tempRoot, ['nearby', 'wayfind.search']);
+    assertFreshSource(nearby, 'wayfind nearby');
+    assertResolvedTarget(nearby, 'wayfind nearby');
+
+    const impact = runWayfind(tempRoot, ['impact', 'wayfind.search']);
+    assertFreshSource(impact, 'wayfind impact');
+    assertResolvedTarget(impact, 'wayfind impact');
+
+    console.log(
+      `Wayfinder dogfood smoke passed: ${String(counts['trails'])} trails inspected from saved operator topo artifacts.`
+    );
+  } finally {
+    await rm(tempRoot, { force: true, recursive: true });
+  }
+};
+
+await main();

--- a/docs/releases/wayfinder-v0.md
+++ b/docs/releases/wayfinder-v0.md
@@ -16,6 +16,10 @@ Existing apps do not expose Wayfinder automatically. Wayfinder trails are intern
 
 Agents should try Wayfinder first when the question is about saved graph facts: which trails exist, what a contract looks like, which resources/signals/surfaces touch a trail, what is nearby, and what changed between two saved TopoGraphs. Raw file search remains the fallback when artifacts are missing, stale beyond the task's tolerance, or when the question is about source code that Topographer does not yet project.
 
+## Dogfood Smoke
+
+Run `bun run wayfinder:dogfood` after changes to Wayfinder, the Trails operator MCP topo, Topographer artifact export, the Trails CLI Wayfinder commands, or the fresh app loader. The smoke exports the real Trails operator topo into an isolated temporary root, reads those saved artifacts through `trails wayfind ...`, asserts fresh source metadata, and removes the temporary artifacts before exiting.
+
 ## Non-Goals
 
 V0 does not ship `wayfind.errors`, `wayfind.adapters`, generic `wayfind.query`, semantic search, signposts, or `wayfind.implications`. Those need additional accepted substrates or field evidence before they can answer honestly.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "scaffold-versions:check": "bun scripts/sync-scaffold-versions.ts --check",
     "scratch:import-to-notion": "bun scripts/import-scratch-to-notion.ts",
     "scratch:manifest": "bun scripts/scratch-inventory/build-manifest.ts",
+    "wayfinder:dogfood": "bun apps/trails/scripts/wayfinder-dogfood.ts",
     "plugin:metadata:sync": "bun scripts/sync-plugin-metadata.ts",
     "plugin:metadata:check": "bun scripts/sync-plugin-metadata.ts --check",
     "plugin:installed-skill:check": "bun scripts/check-installed-trails-skill.ts",


### PR DESCRIPTION
## Context

Wayfinder needs a repo-level dogfood smoke so new framework surfaces prove they can be inspected from saved operator topo artifacts, not only from unit-level fixtures.

## Changes

- Add `bun run wayfinder:dogfood` over exported Trails operator topo artifacts.
- Keep the dogfood script inside the `@ontrails/trails` app package boundary.
- Document the v0 Wayfinder release smoke path.
- Add branch-local changeset coverage for the package-affecting dogfood command.

## Verification

- `bun run wayfinder:dogfood`
- `bun run changeset:check -- --changed-files /tmp/trl-690-pr-files-fixed.txt`
- `bun run check`
- `bun run test`
- Hosted CI is green, including the previously failing Changeset job.

## Risks

This is a smoke/gate addition. It writes only temporary exported artifacts and removes them before exit.
