### PR TITLE
docs(trails): define wayfinder dogfood release gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,7 @@ Before calling an issue done or moving a PR out of draft, check the affected dis
 - **Agent guidance:** update `AGENTS.md`, repo skills, plugin metadata, or tool-specific guidance when agents need new rules or vocabulary.
 - **Governance:** add or update Warden rules, generated Warden guide output, and drift checks when the behavior creates governable contract boundaries.
 - **Release path:** add a branch-local changeset for publishable package changes, or apply `release:none` only when the package-touching change is truly not user-visible.
+- **Wayfinder dogfood:** run `bun run wayfinder:dogfood` when a branch changes framework surfaces, the Trails operator topo exposure, Topographer artifact export, Wayfinder queries, or fresh app loading. If it is not applicable, say why in the PR or handoff.
 - **Migration path:** document commands, compatibility windows, bridge steps, or intentional non-support when existing apps may have committed artifacts or source that need to move.
 - **Publication readiness:** run `bun run publish:check` for package-impacting work and record any first-time package, dist-tag, registry, or auth considerations before release.
 

--- a/docs/adr/drafts/20260603-surface-facets-shape-dense-topos.md
+++ b/docs/adr/drafts/20260603-surface-facets-shape-dense-topos.md
@@ -248,5 +248,5 @@ This decision is not distribution-ready until the implementation stack updates:
 - [ADR-0035: Surface APIs Render the Graph](../0035-surface-apis-render-the-graph.md) - `derive*`, `create*`, and `surface()` projection ladder
 - [ADR-0042: Core/Topographer Boundary Doctrine](../0042-core-topographer-boundary-doctrine.md) - durable graph artifacts belong to topographer
 - [ADR-0046: Lock v3 Artifact Family](../0046-lock-v3-artifact-family.md) - `.trails/topo.lock` as the inspectable topo content artifact
-- [Surface Facets proto-ADR](../../../.scratch/adr/surface-facets.md) - planning capture this ADR formalizes
-- [MCP Shaping proto-ADR](../../../.scratch/adr/mcp-shaping.md) - MCP resources and deferred-loading context
+
+This draft formalizes the earlier scratch planning captures for surface facets and MCP shaping. Those scratch notes are local planning state, not committed reference material.

--- a/docs/releases/stable-cutover.md
+++ b/docs/releases/stable-cutover.md
@@ -147,6 +147,7 @@ bun apps/trails/bin/trails.ts compile --root-dir apps/trails --module ./src/app.
 bun apps/trails/bin/trails.ts diff --forces --root-dir apps/trails --module ./src/app.ts
 bun apps/trails/bin/trails.ts doctor --root-dir apps/trails --module ./src/app.ts
 bun apps/trails/bin/trails.ts warden --pre-push --depth all --lock skip --root-dir apps/trails --apps ./src/app.ts
+bun run wayfinder:dogfood
 bun run check
 bun run build
 bun run publish:check

--- a/docs/releases/surface-facets.md
+++ b/docs/releases/surface-facets.md
@@ -106,5 +106,6 @@ Before cutting the beta that includes surface facets, confirm:
 - docs include the user-facing facet guide, MCP resource/deferred guidance, and CLI/HTTP parity decision;
 - Trails skill/plugin guidance teaches facets as governed surface projection, not a new primitive;
 - Warden generated guidance is refreshed and checked;
+- `bun run wayfinder:dogfood` proves the Trails operator topo remains inspectable through saved Wayfinder graph facts;
 - all branch-local changesets are present;
 - `bun run check`, `bun run test`, `bun run build`, and `bun run publish:check` pass.

--- a/docs/releases/wayfinder-v0.md
+++ b/docs/releases/wayfinder-v0.md
@@ -16,9 +16,11 @@ Existing apps do not expose Wayfinder automatically. Wayfinder trails are intern
 
 Agents should try Wayfinder first when the question is about saved graph facts: which trails exist, what a contract looks like, which resources/signals/surfaces touch a trail, what is nearby, and what changed between two saved TopoGraphs. Raw file search remains the fallback when artifacts are missing, stale beyond the task's tolerance, or when the question is about source code that Topographer does not yet project.
 
-## Dogfood Smoke
+## Dogfood Release Gate
 
 Run `bun run wayfinder:dogfood` after changes to Wayfinder, the Trails operator MCP topo, Topographer artifact export, the Trails CLI Wayfinder commands, or the fresh app loader. The smoke exports the real Trails operator topo into an isolated temporary root, reads those saved artifacts through `trails wayfind ...`, asserts fresh source metadata, and removes the temporary artifacts before exiting.
+
+Treat this as a release-time gate for new framework surfaces that should be visible to agents through saved graph facts. The gate should pass before a surface-shaping branch leaves draft; if a branch deliberately skips it, the PR or handoff must explain why Wayfinder cannot yet inspect the changed surface.
 
 ## Non-Goals
 


### PR DESCRIPTION
## Context

New framework surfaces should not be considered distribution-ready until their Wayfinder posture is documented, gated, and connected to the release path.

## Changes

- Define the release-time Wayfinder dogfood gate for new framework surfaces.
- Update stable cutover and surface facets release docs with the dogfood expectation.
- Bring the surface facets draft ADR references into portable committed context.
- Update agent guidance around distribution-ready done.

## Verification

- `bun scripts/adr.ts check`
- `bun run docs:wrap-check`
- `bun run check`
- `bun run test`
- Hosted CI is green.

## Risks

Docs-only behavior change, but it intentionally raises the release bar for future framework surface work.
