### PR TITLE
docs(trails): teach agents wayfinder-first navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,12 @@ The architecture is designed to make consistency easier than drift. Agents build
 3. Repo contribution guidance lives in [Contributing to Trails](docs/contributing/README.md), including [Language Styleguide](docs/contributing/language-styleguide.md), [Code Standards](docs/contributing/code-standards.md), [Codebase Navigation](docs/contributing/codebase-navigation.md), and [Warden Rules](docs/contributing/warden-rules.md).
 4. We keep a log of our working notes, session recaps, learnings, etc. in `.agents/notes/` (gitignored — local only) as a historical record of our journey.
 
+## Wayfinder First
+
+For Trails graph-navigation questions, use Wayfinder before reconstructing topo facts manually. Start with `trails wayfind overview --root-dir . --json` or the repo-local `bun apps/trails/bin/trails.ts wayfind overview --root-dir . --json` to check artifact source and freshness, then use `wayfind search`, `wayfind trails`, `wayfind contract`, `wayfind describe`, `wayfind nearby`, `wayfind impact`, or `wayfind examples` for saved graph facts.
+
+Fall back to `rg`, qmd, source reads, or a fresh compile when Wayfinder reports missing or stale artifacts, when the task needs source text that Topographer does not project, or when writing new artifacts would violate the current work authority. When you fall back, say why so the next agent does not silently repeat the same graph reconstruction.
+
 ## Lexicon
 
 Use the project language consistently:

--- a/docs/contributing/codebase-navigation.md
+++ b/docs/contributing/codebase-navigation.md
@@ -2,7 +2,28 @@
 
 This guide orients people and agents inside the Trails repository. Keep durable repo-map material here: important source-of-truth locations, generated artifacts, package layout notes, and tool setup that helps contributors navigate the code without guessing.
 
-For now, the main committed setup is symbolic navigation.
+For now, the main committed setup is Wayfinder for graph reads plus symbolic navigation for source reads.
+
+## Default Graph Navigation: Wayfinder
+
+When the question is about saved topo facts, use Wayfinder before rebuilding the graph from source search. It reads committed Topographer artifacts and returns source plus freshness metadata, so agents can tell whether they are looking at current graph evidence.
+
+Start with:
+
+```bash
+bun apps/trails/bin/trails.ts wayfind overview --root-dir . --json
+```
+
+Then narrow the graph read with the selected local CLI surface:
+
+```bash
+bun apps/trails/bin/trails.ts wayfind search --root-dir . --input-json '{"filters":{"kind":"trail","idPrefix":"wayfind."}}' --json
+bun apps/trails/bin/trails.ts wayfind contract wayfind.search --root-dir . --json
+bun apps/trails/bin/trails.ts wayfind nearby wayfind.search --root-dir . --json
+bun apps/trails/bin/trails.ts wayfind impact wayfind.search --root-dir . --json
+```
+
+Use source search, qmd, or symbol tools when Wayfinder reports missing or stale artifacts, when the task needs implementation text that Topographer does not project, or when the current authority does not allow generating fresh artifacts. If you compile to refresh artifacts, treat the generated `.trails` files as evidence and clean them up unless the branch intentionally owns them.
 
 ## Symbol Navigation
 

--- a/plugin/agents/trail-engineer.md
+++ b/plugin/agents/trail-engineer.md
@@ -13,13 +13,15 @@ You are a Trails engineer. You build features using the Trails framework — spe
 
 ### 1. Understand the Existing Topo
 
-Before adding anything, know what's already there.
+Before adding anything, know what's already there. Use Wayfinder first when saved artifacts can answer the question:
 
 ```bash
-rg "trail\(" --type ts -l
+trails wayfind overview --root-dir . --json
+trails wayfind search --root-dir . --input-json '{"filters":{"kind":"trail"}}' --json
+trails wayfind contract <trail-id> --root-dir . --json
 ```
 
-Read the app's topo file to understand the current trail collection and naming conventions.
+Read the app's topo file or use `rg "trail\\(" --type ts -l` only when Wayfinder reports missing or stale artifacts, when you need implementation source that Topographer does not project, or when the current authority does not allow refreshing artifacts.
 
 ### 2. Design Contract First
 

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -3,7 +3,7 @@ name: trails
 description: Build with the Trails framework — define trail contracts, open CLI/MCP surfaces, test with examples, debug errors, migrate codebases, run governance. Use when creating trails, adding surfaces, testing, debugging Trails errors, migrating to Trails, running warden, or any work involving @ontrails/* packages.
 metadata:
   trails:
-    version: 1.0.0-beta.19
+    version: 1.0.0-beta.20
 ---
 
 # Trails
@@ -66,7 +66,13 @@ Current public packages are lockstep at the same Trails framework version.
 
 ## Agent Wayfinding
 
-When saved Topographer artifacts can answer a graph question, prefer Wayfinder before raw text search:
+When saved Topographer artifacts can answer a graph question, use Wayfinder before raw text search:
+
+```bash
+trails wayfind overview --root-dir . --json
+trails wayfind search --root-dir . --input-json '{"filters":{"kind":"trail"}}' --json
+trails wayfind contract <trail-id> --root-dir . --json
+```
 
 - Start with `wayfind.overview` to learn artifact source, freshness, and graph counts.
 - Use `wayfind.search` or typed list trails (`wayfind.trails`, `wayfind.resources`, `wayfind.signals`, `wayfind.surfaces`, `wayfind.facets`, `wayfind.versions`, `wayfind.examples`) for filtered discovery.
@@ -74,7 +80,7 @@ When saved Topographer artifacts can answer a graph question, prefer Wayfinder b
 - Use `wayfind.nearby`, `wayfind.impact`, and `wayfind.diff` for relation context, blast-radius reads, and explicit saved-baseline comparison.
 - Treat Wayfinder as graph-read only. Do not assume `wayfind.errors`, `wayfind.adapters`, generic `wayfind.query`, semantic search, signposts, or implications exist in v0.
 
-Wayfinder trails are internal by default. Host apps expose selected queries deliberately, usually as read-only operator tools or MCP resources protected by the host's authorization boundary.
+Wayfinder trails are internal by default. Host apps expose selected queries deliberately, usually as read-only operator tools or MCP resources protected by the host's authorization boundary. Fall back to `rg`, qmd, source reads, or a fresh compile when Wayfinder reports missing or stale artifacts, when the task needs source code that Topographer does not project, or when writing artifacts is outside your current authority.
 
 ## Creating Trails
 

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -79,6 +79,8 @@ Every piece of information has a clear ownership model.
 
 Warden uses inference to verify declarations match actual code. Topographer captures the resolved `TopoGraph`, semantic diff, lock manifest, and `topo.lock` artifacts for CI governance. Consumer artifact workflow uses the top-level CLI commands `trails compile`, `trails validate`, and `trails diff`; `trails topo` is for topo-store history and pin management.
 
+Wayfinder is the first agent navigation move over those saved artifacts. For graph questions, start with `trails wayfind overview --root-dir . --json`, then use search, contract, describe, nearby, impact, examples, or diff queries before reconstructing topo facts with raw source search. Source reads remain the right fallback for stale or missing artifacts and implementation details Topographer does not project.
+
 ## Package Layout
 
 ### Foundation


### PR DESCRIPTION
## Context

Agents working in Trails should reach for Wayfinder first when saved Topographer artifacts can answer graph questions, then fall back to raw source search when artifacts are stale or insufficient.

## Changes

- Update `AGENTS.md` and codebase navigation guidance with Wayfinder-first local navigation commands.
- Teach the bundled Trails plugin skill and trail-engineer agent to use Wayfinder before reconstructing topo facts manually.
- Clarify fallback conditions for stale/missing artifacts and implementation details outside Topographer projection.

## Verification

- `bun run plugin:metadata:check`
- `bun run docs:wrap-check`
- `bun run wayfinder:dogfood`
- `bun run check`
- Hosted CI is green.

## Risks

The installed global skill copies on this machine are still older than repo source; this PR updates the committed source only and does not mutate global installed skills.
