### PR TITLE
feat(releases): derive public trail contract facts

### DIFF
--- a/docs/releases/contract-aware-changeset-check.md
+++ b/docs/releases/contract-aware-changeset-check.md
@@ -42,8 +42,10 @@ Future local helpers may add a `--base-ref` option for source snapshots. The fir
 
 The first implementation uses a source-static contract fact detector adjacent to the existing Changeset check.
 
-Slice-one public trail contract movement means a changed TypeScript source file contains a trail definition that is not explicitly `visibility: 'internal'`, and the branch changes at least one of these contract-bearing aspects:
+Slice-one public trail contract movement means a changed TypeScript source file contains a trail definition that is not explicitly `visibility: 'internal'` on both sides of the branch-local diff, and the branch changes at least one of these contract-bearing aspects:
 
+- public trail addition or removal;
+- `visibility` movement between internal and public;
 - `input` schema text;
 - `output` schema text;
 - `surfaces` declaration text.

--- a/scripts/__tests__/contract-release-facts.test.ts
+++ b/scripts/__tests__/contract-release-facts.test.ts
@@ -1,0 +1,250 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+import {
+  findPublicTrailContractChangeFacts,
+  findPublicTrailContractChangeFactsFromSnapshots,
+} from '../contract-release-facts.ts';
+
+const snapshot = (
+  baseSource: string,
+  currentSource: string,
+  path = 'packages/core/src/public-trail.ts'
+) => ({
+  baseSource,
+  changedFiles: [path],
+  currentSource,
+  packageName: '@ontrails/core',
+  path,
+  workspacePath: 'packages/core',
+});
+
+const publicTrail = (body: string): string => `
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const userCreate = trail('user.create', {
+  blaze: () => Result.ok({ id: 'u1' }),
+  ${body}
+});
+`;
+
+describe('findPublicTrailContractChangeFactsFromSnapshots', () => {
+  test('detects public input schema changes', () => {
+    const facts = findPublicTrailContractChangeFactsFromSnapshots([
+      snapshot(
+        publicTrail(`
+  input: z.object({ name: z.string() }),
+  output: z.object({ id: z.string() }),
+`),
+        publicTrail(`
+  input: z.object({ email: z.string(), name: z.string() }),
+  output: z.object({ id: z.string() }),
+`)
+      ),
+    ]);
+
+    expect(facts).toMatchObject([
+      {
+        aspect: 'input',
+        packageName: '@ontrails/core',
+        path: 'packages/core/src/public-trail.ts',
+        trailId: 'user.create',
+        workspacePath: 'packages/core',
+      },
+    ]);
+    expect(facts[0]?.baseHash).not.toBe(facts[0]?.currentHash);
+  });
+
+  test('detects public output schema changes', () => {
+    const facts = findPublicTrailContractChangeFactsFromSnapshots([
+      snapshot(
+        publicTrail(`
+  input: z.object({ name: z.string() }),
+  output: z.object({ id: z.string() }),
+`),
+        publicTrail(`
+  input: z.object({ name: z.string() }),
+  output: z.object({ email: z.string(), id: z.string() }),
+`)
+      ),
+    ]);
+
+    expect(facts.map((fact) => fact.aspect)).toEqual(['output']);
+  });
+
+  test('detects public surface exposure changes', () => {
+    const facts = findPublicTrailContractChangeFactsFromSnapshots([
+      snapshot(
+        publicTrail(`
+  input: z.object({ name: z.string() }),
+  output: z.object({ id: z.string() }),
+  surfaces: ['cli'],
+`),
+        publicTrail(`
+  input: z.object({ name: z.string() }),
+  output: z.object({ id: z.string() }),
+  surfaces: ['cli', 'mcp'],
+`)
+      ),
+    ]);
+
+    expect(facts.map((fact) => fact.aspect)).toEqual(['surfaces']);
+  });
+
+  test('detects public trail addition and removal', () => {
+    const baseSource = publicTrail(`
+  input: z.object({ name: z.string() }),
+  output: z.object({ id: z.string() }),
+`);
+    const currentSource = `
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const teamCreate = trail('team.create', {
+  blaze: () => Result.ok({ id: 't1' }),
+  input: z.object({ name: z.string() }),
+  output: z.object({ id: z.string() }),
+});
+`;
+
+    const facts = findPublicTrailContractChangeFactsFromSnapshots([
+      snapshot(baseSource, currentSource),
+    ]);
+
+    expect(facts.map((fact) => `${fact.trailId}:${fact.aspect}`)).toEqual([
+      'team.create:trail',
+      'user.create:trail',
+    ]);
+  });
+
+  test('detects visibility transitions involving public contracts', () => {
+    const facts = findPublicTrailContractChangeFactsFromSnapshots([
+      snapshot(
+        publicTrail(`
+  input: z.object({ name: z.string() }),
+  output: z.object({ id: z.string() }),
+  visibility: 'internal',
+`),
+        publicTrail(`
+  input: z.object({ name: z.string() }),
+  output: z.object({ id: z.string() }),
+`)
+      ),
+    ]);
+
+    expect(facts.map((fact) => fact.aspect)).toEqual(['visibility']);
+  });
+
+  test('ignores internal-only trail contract changes', () => {
+    const facts = findPublicTrailContractChangeFactsFromSnapshots([
+      snapshot(
+        publicTrail(`
+  input: z.object({ name: z.string() }),
+  output: z.object({ id: z.string() }),
+  visibility: 'internal',
+`),
+        publicTrail(`
+  input: z.object({ email: z.string(), name: z.string() }),
+  output: z.object({ email: z.string(), id: z.string() }),
+  visibility: 'internal',
+`)
+      ),
+    ]);
+
+    expect(facts).toEqual([]);
+  });
+
+  test('resolves same-file schema constants used by public trail contracts', () => {
+    const baseSource = `
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const inputSchema = z.object({ name: z.string() });
+const outputSchema = z.object({ id: z.string() });
+
+export const userCreate = trail('user.create', {
+  blaze: () => Result.ok({ id: 'u1' }),
+  input: inputSchema,
+  output: outputSchema,
+});
+`;
+    const currentSource = `
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const inputSchema = z.object({ email: z.string(), name: z.string() });
+const outputSchema = z.object({ id: z.string() });
+
+export const userCreate = trail('user.create', {
+  blaze: () => Result.ok({ id: 'u1' }),
+  input: inputSchema,
+  output: outputSchema,
+});
+`;
+
+    const facts = findPublicTrailContractChangeFactsFromSnapshots([
+      snapshot(baseSource, currentSource),
+    ]);
+
+    expect(facts.map((fact) => fact.aspect)).toEqual(['input']);
+  });
+
+  test('ignores non-contract package source changes', () => {
+    const facts = findPublicTrailContractChangeFactsFromSnapshots([
+      snapshot(
+        'export const version = "old";',
+        'export const version = "new";',
+        'packages/core/src/version.ts'
+      ),
+    ]);
+
+    expect(facts).toEqual([]);
+  });
+});
+
+describe('findPublicTrailContractChangeFacts', () => {
+  test('derives public contract facts from changed publishable workspace files', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-contract-facts-'));
+
+    try {
+      const workspaceRoot = join(repoRoot, 'packages/core');
+      const sourcePath = join(workspaceRoot, 'src/public-trail.ts');
+      mkdirSync(join(workspaceRoot, 'src'), { recursive: true });
+      writeFileSync(
+        sourcePath,
+        publicTrail(`
+  input: z.object({ name: z.string() }),
+  output: z.object({ id: z.string() }),
+`)
+      );
+
+      const facts = findPublicTrailContractChangeFacts({
+        changedFiles: ['packages/core/src/public-trail.ts'],
+        repoRoot,
+        workspaces: [
+          {
+            isPrivate: false,
+            name: '@ontrails/core',
+            relativePath: 'packages/core',
+          },
+        ],
+      });
+
+      expect(facts).toMatchObject([
+        {
+          aspect: 'trail',
+          packageName: '@ontrails/core',
+          path: 'packages/core/src/public-trail.ts',
+          trailId: 'user.create',
+          workspacePath: 'packages/core',
+        },
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/scripts/contract-release-facts.ts
+++ b/scripts/contract-release-facts.ts
@@ -1,0 +1,425 @@
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import ts from 'typescript';
+
+import type { WorkspaceInfo } from './check-changeset-gate.ts';
+
+export type ContractReleaseFactAspect =
+  | 'input'
+  | 'output'
+  | 'surfaces'
+  | 'trail'
+  | 'visibility';
+
+export interface ContractReleaseFact {
+  readonly aspect: ContractReleaseFactAspect;
+  readonly baseHash: string | null;
+  readonly changedFiles: readonly string[];
+  readonly currentHash: string | null;
+  readonly packageName?: string;
+  readonly path: string;
+  readonly trailId: string;
+  readonly workspacePath?: string;
+}
+
+export interface ContractReleaseFactInput {
+  readonly baseRef?: string;
+  readonly changedFiles: readonly string[];
+  readonly repoRoot: string;
+  readonly workspaces: readonly WorkspaceInfo[];
+}
+
+export interface ContractSourceSnapshot {
+  readonly baseSource: string | null;
+  readonly changedFiles?: readonly string[];
+  readonly currentSource: string | null;
+  readonly packageName?: string;
+  readonly path: string;
+  readonly workspacePath?: string;
+}
+
+interface TrailDefinition {
+  readonly aspects: Readonly<Record<ContractReleaseFactAspect, string | null>>;
+  readonly trailId: string;
+  readonly visibility: 'internal' | 'public';
+}
+
+const NON_SHIPPING_SOURCE_PATTERNS = [
+  /(?:^|\/)__tests__(?:\/|$)/u,
+  /(?:^|\/)__snapshots__(?:\/|$)/u,
+  /(?:^|\/)dist(?:\/|$)/u,
+  /(?:^|\/)\.turbo(?:\/|$)/u,
+  /(?:^|\/)node_modules(?:\/|$)/u,
+  /\.(?:test|spec|snap)\.[cm]?[jt]sx?$/u,
+  /\.test-d\.ts$/u,
+  /\.tsbuildinfo$/u,
+] as const;
+
+const SOURCE_PATH_PATTERN = /\.[cm]?[jt]sx?$/u;
+
+const normalizePath = (path: string): string =>
+  path.replaceAll('\\', '/').replace(/^\.\//u, '');
+
+const isPublishableOnTrailsWorkspace = (workspace: WorkspaceInfo): boolean =>
+  !workspace.isPrivate && workspace.name.startsWith('@ontrails/');
+
+const isUnderWorkspace = (filePath: string, workspacePath: string): boolean =>
+  filePath === workspacePath || filePath.startsWith(`${workspacePath}/`);
+
+const getWorkspaceRelativePath = (
+  filePath: string,
+  workspacePath: string
+): string => filePath.slice(workspacePath.length + 1);
+
+const isNonShippingSourcePath = (workspaceRelativePath: string): boolean =>
+  NON_SHIPPING_SOURCE_PATTERNS.some((pattern) =>
+    pattern.test(workspaceRelativePath)
+  );
+
+const hashSource = (source: string | null): string | null =>
+  source === null
+    ? null
+    : createHash('sha256').update(source).digest('hex').slice(0, 16);
+
+const readCurrentSource = (
+  repoRoot: string,
+  relativePath: string
+): string | null => {
+  const absolutePath = join(repoRoot, relativePath);
+  return existsSync(absolutePath) ? readFileSync(absolutePath, 'utf8') : null;
+};
+
+const readBaseSource = (
+  repoRoot: string,
+  baseRef: string | undefined,
+  relativePath: string
+): string | null => {
+  if (!baseRef) {
+    return null;
+  }
+
+  const result = Bun.spawnSync({
+    cmd: ['git', 'show', `${baseRef}:${relativePath}`],
+    cwd: repoRoot,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  return result.exitCode === 0 ? result.stdout.toString() : null;
+};
+
+const workspaceForFile = (
+  filePath: string,
+  workspaces: readonly WorkspaceInfo[]
+): WorkspaceInfo | undefined =>
+  workspaces
+    .filter(isPublishableOnTrailsWorkspace)
+    .find((workspace) => isUnderWorkspace(filePath, workspace.relativePath));
+
+export const createContractSourceSnapshots = (
+  input: ContractReleaseFactInput
+): readonly ContractSourceSnapshot[] => {
+  const snapshots: ContractSourceSnapshot[] = [];
+
+  for (const changedFile of input.changedFiles.map(normalizePath)) {
+    if (!SOURCE_PATH_PATTERN.test(changedFile)) {
+      continue;
+    }
+
+    const workspace = workspaceForFile(changedFile, input.workspaces);
+    if (!workspace) {
+      continue;
+    }
+
+    const workspaceRelativePath = getWorkspaceRelativePath(
+      changedFile,
+      workspace.relativePath
+    );
+    if (isNonShippingSourcePath(workspaceRelativePath)) {
+      continue;
+    }
+
+    const baseSource = readBaseSource(
+      input.repoRoot,
+      input.baseRef,
+      changedFile
+    );
+    const currentSource = readCurrentSource(input.repoRoot, changedFile);
+    if (baseSource === null && currentSource === null) {
+      continue;
+    }
+
+    snapshots.push({
+      baseSource,
+      changedFiles: [changedFile],
+      currentSource,
+      packageName: workspace.name,
+      path: changedFile,
+      workspacePath: workspace.relativePath,
+    });
+  }
+
+  return snapshots;
+};
+
+const isPropertyNamed = (
+  property: ts.ObjectLiteralElementLike,
+  name: string
+): property is ts.PropertyAssignment => {
+  if (!ts.isPropertyAssignment(property)) {
+    return false;
+  }
+
+  const propertyName = property.name;
+  return (
+    (ts.isIdentifier(propertyName) && propertyName.text === name) ||
+    (ts.isStringLiteral(propertyName) && propertyName.text === name)
+  );
+};
+
+const findProperty = (
+  object: ts.ObjectLiteralExpression,
+  name: string
+): ts.PropertyAssignment | undefined =>
+  object.properties.find((property) => isPropertyNamed(property, name));
+
+const isTrailCall = (node: ts.CallExpression): boolean =>
+  ts.isIdentifier(node.expression) && node.expression.text === 'trail';
+
+const literalText = (node: ts.Expression | undefined): string | undefined =>
+  node && ts.isStringLiteralLike(node) ? node.text : undefined;
+
+const normalizeText = (value: string): string =>
+  value.replaceAll(/\s+/gu, ' ').trim();
+
+const normalizeExpressionText = (
+  expression: ts.Expression | undefined,
+  sourceFile: ts.SourceFile,
+  constInitializers: ReadonlyMap<string, ts.Expression>
+): string | null => {
+  if (!expression) {
+    return null;
+  }
+
+  if (ts.isIdentifier(expression)) {
+    const initializer = constInitializers.get(expression.text);
+    if (initializer) {
+      return `${expression.text}=${normalizeText(
+        initializer.getText(sourceFile)
+      )}`;
+    }
+  }
+
+  return normalizeText(expression.getText(sourceFile));
+};
+
+const visibilityFor = (
+  object: ts.ObjectLiteralExpression
+): TrailDefinition['visibility'] => {
+  const visibility = findProperty(object, 'visibility');
+  const value = literalText(visibility?.initializer);
+  if (value === 'internal') {
+    return 'internal';
+  }
+  return 'public';
+};
+
+const collectConstInitializers = (
+  sourceFile: ts.SourceFile
+): ReadonlyMap<string, ts.Expression> => {
+  const initializers = new Map<string, ts.Expression>();
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer
+    ) {
+      initializers.set(node.name.text, node.initializer);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return initializers;
+};
+
+const collectTrailDefinitions = (
+  source: string
+): readonly TrailDefinition[] => {
+  const sourceFile = ts.createSourceFile(
+    'contract-release-facts.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS
+  );
+  const constInitializers = collectConstInitializers(sourceFile);
+  const definitions: TrailDefinition[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node) && isTrailCall(node)) {
+      const [idArgument, spec] = node.arguments;
+      const trailId = literalText(idArgument);
+
+      if (trailId && spec && ts.isObjectLiteralExpression(spec)) {
+        const visibility = visibilityFor(spec);
+        definitions.push({
+          aspects: {
+            input: normalizeExpressionText(
+              findProperty(spec, 'input')?.initializer,
+              sourceFile,
+              constInitializers
+            ),
+            output: normalizeExpressionText(
+              findProperty(spec, 'output')?.initializer,
+              sourceFile,
+              constInitializers
+            ),
+            surfaces: normalizeExpressionText(
+              findProperty(spec, 'surfaces')?.initializer,
+              sourceFile,
+              constInitializers
+            ),
+            trail: normalizeText(trailId),
+            visibility,
+          },
+          trailId,
+          visibility,
+        });
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return definitions;
+};
+
+const definitionsById = (
+  definitions: readonly TrailDefinition[]
+): ReadonlyMap<string, TrailDefinition> =>
+  new Map(definitions.map((definition) => [definition.trailId, definition]));
+
+const isPublicContract = (definition: TrailDefinition | undefined): boolean =>
+  definition !== undefined && definition.visibility !== 'internal';
+
+const fact = (
+  snapshot: ContractSourceSnapshot,
+  trailId: string,
+  aspect: ContractReleaseFactAspect,
+  baseValue: string | null,
+  currentValue: string | null
+): ContractReleaseFact => ({
+  aspect,
+  baseHash: hashSource(baseValue),
+  changedFiles: snapshot.changedFiles ?? [snapshot.path],
+  currentHash: hashSource(currentValue),
+  ...(snapshot.packageName ? { packageName: snapshot.packageName } : {}),
+  path: snapshot.path,
+  trailId,
+  ...(snapshot.workspacePath ? { workspacePath: snapshot.workspacePath } : {}),
+});
+
+const compareDefinitions = (
+  snapshot: ContractSourceSnapshot,
+  baseDefinition: TrailDefinition | undefined,
+  currentDefinition: TrailDefinition | undefined
+): readonly ContractReleaseFact[] => {
+  if (
+    !isPublicContract(baseDefinition) &&
+    !isPublicContract(currentDefinition)
+  ) {
+    return [];
+  }
+
+  const trailId =
+    currentDefinition?.trailId ?? baseDefinition?.trailId ?? '(unknown)';
+
+  if (!baseDefinition || !currentDefinition) {
+    return [
+      fact(
+        snapshot,
+        trailId,
+        'trail',
+        baseDefinition?.aspects.trail ?? null,
+        currentDefinition?.aspects.trail ?? null
+      ),
+    ];
+  }
+
+  const facts: ContractReleaseFact[] = [];
+
+  for (const aspect of ['input', 'output', 'surfaces'] as const) {
+    const baseValue = baseDefinition.aspects[aspect];
+    const currentValue = currentDefinition.aspects[aspect];
+    if (baseValue !== currentValue) {
+      facts.push(fact(snapshot, trailId, aspect, baseValue, currentValue));
+    }
+  }
+
+  if (baseDefinition.visibility !== currentDefinition.visibility) {
+    facts.push(
+      fact(
+        snapshot,
+        trailId,
+        'visibility',
+        baseDefinition.visibility,
+        currentDefinition.visibility
+      )
+    );
+  }
+
+  return facts;
+};
+
+export const findPublicTrailContractChangeFactsFromSnapshots = (
+  snapshots: readonly ContractSourceSnapshot[]
+): readonly ContractReleaseFact[] => {
+  const facts: ContractReleaseFact[] = [];
+
+  for (const snapshot of snapshots) {
+    const baseDefinitions = definitionsById(
+      snapshot.baseSource === null
+        ? []
+        : collectTrailDefinitions(snapshot.baseSource)
+    );
+    const currentDefinitions = definitionsById(
+      snapshot.currentSource === null
+        ? []
+        : collectTrailDefinitions(snapshot.currentSource)
+    );
+    const trailIds = new Set([
+      ...baseDefinitions.keys(),
+      ...currentDefinitions.keys(),
+    ]);
+
+    for (const trailId of [...trailIds].toSorted()) {
+      facts.push(
+        ...compareDefinitions(
+          snapshot,
+          baseDefinitions.get(trailId),
+          currentDefinitions.get(trailId)
+        )
+      );
+    }
+  }
+
+  return facts.toSorted(
+    (left, right) =>
+      left.path.localeCompare(right.path) ||
+      left.trailId.localeCompare(right.trailId) ||
+      left.aspect.localeCompare(right.aspect)
+  );
+};
+
+export const findPublicTrailContractChangeFacts = (
+  input: ContractReleaseFactInput
+): readonly ContractReleaseFact[] =>
+  findPublicTrailContractChangeFactsFromSnapshots(
+    createContractSourceSnapshots(input)
+  );


### PR DESCRIPTION
## Context

The changeset gate needs deterministic, branch-local facts about public trail
contract movement before it can require a release disposition.

## Changes

- Adds `scripts/contract-release-facts.ts`.
- Detects public trail add/remove, visibility transition, input schema change,
  output schema change, and surface exposure change in publishable
  `@ontrails/*` package source.
- Ignores private workspaces, test/build output, and internal-only trail changes.
- Resolves same-file schema constants so simple schema owner patterns are
  detected.
- Adds focused detector tests, including the top-level workspace-file entrypoint.

## Verification

- `bun test scripts/__tests__/contract-release-facts.test.ts`
- `bun run dead-code`
- `bun run check`

## Notes

This is intentionally source-static and branch-local. Imported schema tracing and
future fact families are deferred follow-up work, not blockers for this wedge.
