### PR TITLE
ci(releases): require contract release disposition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,11 @@ jobs:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/setup
 
+      - name: Fetch PR base for contract release facts
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git fetch --no-tags --depth=1 origin "$BASE_SHA"
+
       - name: Collect PR file list
         env:
           GH_TOKEN: ${{ github.token }}
@@ -127,9 +132,10 @@ jobs:
 
       - name: Check changeset
         env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           RELEASE_NONE: ${{ contains(github.event.pull_request.labels.*.name, 'release:none') }}
         run: |
-          args=(--changed-files "$RUNNER_TEMP/changed-files.txt")
+          args=(--changed-files "$RUNNER_TEMP/changed-files.txt" --base-ref "$BASE_SHA")
           if [ "$RELEASE_NONE" = "true" ]; then
             args+=(--release-none)
           fi

--- a/docs/releases/contract-aware-changeset-check.md
+++ b/docs/releases/contract-aware-changeset-check.md
@@ -30,13 +30,15 @@ The first check can point future agents toward Wayfinder without making CI depen
 
 ### Graphite base helpers and branch locality
 
-The existing check uses the GitHub PR file list in CI and `origin/main...HEAD` for local ad hoc runs without `--changed-files`. The CI path is the important one for branch locality. Local reproduction should keep accepting an explicit PR file list:
+The existing check uses the GitHub PR file list in CI and `origin/main...HEAD` for local ad hoc runs without `--changed-files`. The CI path is the important one for branch locality. Local reproduction should pass an explicit PR file list and the immediate PR base:
 
 ```bash
-bun run changeset:check -- --changed-files /tmp/pr-files.txt
+base=$(gh pr view <pr-number> --repo outfitter-dev/trails --json baseRefOid --jq .baseRefOid)
+git fetch --no-tags --depth=1 origin "$base"
+bun run changeset:check -- --changed-files /tmp/pr-files.txt --base-ref "$base"
 ```
 
-Future local helpers may add a `--base-ref` option for source snapshots. The first implementation can remain deterministic in tests by passing before/after source content directly into a helper, then use best-effort `git show` only for CLI evidence enrichment when a base ref is available.
+`--base-ref` lets the source-static detector read before/after trail source with `git show` while keeping the branch-local PR file list as the source of truth. Focused tests still pass before/after source snapshots directly into the detector so the contract fact behavior stays deterministic without a full repo app compile.
 
 ## Chosen First Slice
 

--- a/scripts/__tests__/check-changeset-gate.test.ts
+++ b/scripts/__tests__/check-changeset-gate.test.ts
@@ -8,6 +8,7 @@ import {
   discoverWorkspaces,
 } from '../check-changeset-gate.ts';
 import type { WorkspaceInfo } from '../check-changeset-gate.ts';
+import type { ContractReleaseFact } from '../contract-release-facts.ts';
 
 const workspaces: readonly WorkspaceInfo[] = [
   {
@@ -31,6 +32,19 @@ const workspaces: readonly WorkspaceInfo[] = [
     relativePath: 'apps/demo',
   },
 ];
+
+const contractFact = (
+  aspect: ContractReleaseFact['aspect'] = 'input'
+): ContractReleaseFact => ({
+  aspect,
+  baseHash: 'base-hash',
+  changedFiles: ['packages/core/src/user.ts'],
+  currentHash: 'current-hash',
+  packageName: '@ontrails/core',
+  path: 'packages/core/src/user.ts',
+  trailId: 'user.create',
+  workspacePath: 'packages/core',
+});
 
 const withTempRepo = <T>(
   setup: (repoRoot: string) => T
@@ -263,6 +277,76 @@ describe('checkChangesetGate', () => {
       expect(contradiction.passed).toBe(false);
       expect(contradiction.errors).toEqual([
         '`release:none` conflicts with changed changeset files. Remove the label or the changeset.',
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('reports uncovered public trail contract facts with trail evidence', () => {
+    const { repoRoot } = withTempRepo(() => {});
+
+    try {
+      const result = checkChangesetGate({
+        changedFiles: ['packages/core/src/user.ts'],
+        contractFacts: [contractFact('output')],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.uncoveredContractFacts).toHaveLength(1);
+      expect(result.errors).toContain(
+        'Public trail contract changes need release disposition: user.create output (@ontrails/core)'
+      );
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('passes public trail contract facts with matching changeset coverage', () => {
+    const { repoRoot } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'core-contract.md'),
+        "---\n'@ontrails/core': patch\n---\n\nUpdate user contract.\n"
+      );
+    });
+
+    try {
+      const result = checkChangesetGate({
+        changedFiles: [
+          'packages/core/src/user.ts',
+          '.changeset/core-contract.md',
+        ],
+        contractFacts: [contractFact('input')],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.contractFacts).toHaveLength(1);
+      expect(result.uncoveredContractFacts).toEqual([]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('allows release:none as an explicit public contract disposition', () => {
+    const { repoRoot } = withTempRepo(() => {});
+
+    try {
+      const result = checkChangesetGate({
+        changedFiles: ['packages/core/src/user.ts'],
+        contractFacts: [contractFact('surfaces')],
+        releaseNone: true,
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.releaseNone).toBe(true);
+      expect(result.contractFacts.map((fact) => fact.aspect)).toEqual([
+        'surfaces',
       ]);
     } finally {
       rmSync(repoRoot, { force: true, recursive: true });

--- a/scripts/check-changeset-gate.ts
+++ b/scripts/check-changeset-gate.ts
@@ -2,6 +2,9 @@ import { existsSync, readFileSync } from 'node:fs';
 import { readdir } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 
+import { findPublicTrailContractChangeFacts } from './contract-release-facts.ts';
+import type { ContractReleaseFact } from './contract-release-facts.ts';
+
 interface PackageJson {
   readonly name?: string;
   readonly private?: boolean;
@@ -15,7 +18,9 @@ export interface WorkspaceInfo {
 }
 
 export interface ChangesetGateInput {
+  readonly baseRef?: string;
   readonly changedFiles: readonly string[];
+  readonly contractFacts?: readonly ContractReleaseFact[];
   readonly releaseNone?: boolean;
   readonly repoRoot: string;
   readonly workspaces: readonly WorkspaceInfo[];
@@ -24,14 +29,17 @@ export interface ChangesetGateInput {
 export interface ChangesetGateResult {
   readonly affectedPackages: readonly string[];
   readonly changedChangesets: readonly string[];
+  readonly contractFacts: readonly ContractReleaseFact[];
   readonly coveredPackages: readonly string[];
   readonly errors: readonly string[];
   readonly passed: boolean;
   readonly releaseNone: boolean;
+  readonly uncoveredContractFacts: readonly ContractReleaseFact[];
   readonly versionRelease: boolean;
 }
 
 interface CliOptions {
+  readonly baseRef?: string;
   readonly changedFilesPath?: string;
   readonly releaseNone: boolean;
   readonly repoRoot: string;
@@ -289,6 +297,26 @@ const findChangedChangesets = (
     return packages.length === 0 ? [] : [{ packages, path }];
   });
 
+const findGateContractFacts = (
+  input: ChangesetGateInput
+): readonly ContractReleaseFact[] =>
+  input.contractFacts ??
+  findPublicTrailContractChangeFacts({
+    baseRef: input.baseRef,
+    changedFiles: input.changedFiles,
+    repoRoot: input.repoRoot,
+    workspaces: input.workspaces,
+  });
+
+const isContractFactCovered = (
+  fact: ContractReleaseFact,
+  coveredPackages: readonly string[]
+): boolean =>
+  fact.packageName !== undefined && coveredPackages.includes(fact.packageName);
+
+const formatContractFact = (fact: ContractReleaseFact): string =>
+  `${fact.trailId} ${fact.aspect} (${fact.packageName ?? fact.path})`;
+
 export const checkChangesetGate = (
   input: ChangesetGateInput
 ): ChangesetGateResult => {
@@ -302,6 +330,7 @@ export const checkChangesetGate = (
   const coveredPackages = [
     ...new Set(changesets.flatMap((changeset) => changeset.packages)),
   ].toSorted();
+  const contractFacts = findGateContractFacts(input);
   const versionRelease = isVersionReleaseChangeSet(
     input.changedFiles,
     input.workspaces,
@@ -309,6 +338,9 @@ export const checkChangesetGate = (
   );
   const uncoveredPackages = affectedPackages.filter(
     (packageName) => !coveredPackages.includes(packageName)
+  );
+  const uncoveredContractFacts = contractFacts.filter(
+    (fact) => !isContractFactCovered(fact, coveredPackages)
   );
   const errors: string[] = [];
 
@@ -324,13 +356,23 @@ export const checkChangesetGate = (
     );
   }
 
+  if (!releaseNone && !versionRelease && uncoveredContractFacts.length > 0) {
+    errors.push(
+      `Public trail contract changes need release disposition: ${uncoveredContractFacts
+        .map(formatContractFact)
+        .join(', ')}`
+    );
+  }
+
   return {
     affectedPackages,
     changedChangesets,
+    contractFacts,
     coveredPackages,
     errors,
     passed: errors.length === 0,
     releaseNone,
+    uncoveredContractFacts,
     versionRelease,
   };
 };
@@ -373,6 +415,7 @@ const readLocalChangedFiles = (repoRoot: string): readonly string[] => {
 };
 
 const parseArgs = (args: readonly string[]): CliOptions => {
+  let baseRef: string | undefined;
   let changedFilesPath: string | undefined;
   let releaseNone = false;
   let repoRoot = resolve(import.meta.dir, '..');
@@ -382,6 +425,18 @@ const parseArgs = (args: readonly string[]): CliOptions => {
 
     if (arg === '--release-none') {
       releaseNone = true;
+      continue;
+    }
+
+    if (arg === '--base-ref') {
+      const value = args[index + 1];
+
+      if (!value) {
+        throw new Error('--base-ref requires a git ref or commit');
+      }
+
+      baseRef = value;
+      index += 1;
       continue;
     }
 
@@ -413,6 +468,7 @@ const parseArgs = (args: readonly string[]): CliOptions => {
   }
 
   return {
+    baseRef,
     changedFilesPath,
     releaseNone,
     repoRoot,
@@ -457,6 +513,14 @@ const renderResult = (result: ChangesetGateResult): void => {
     console.error(`Affected packages: ${result.affectedPackages.join(', ')}`);
   }
 
+  if (result.contractFacts.length > 0) {
+    console.error(
+      `Public trail contract facts: ${result.contractFacts
+        .map(formatContractFact)
+        .join(', ')}`
+    );
+  }
+
   if (result.changedChangesets.length > 0) {
     console.error(`Changed changesets: ${result.changedChangesets.join(', ')}`);
   }
@@ -470,6 +534,9 @@ const main = async (): Promise<number> => {
     ? readChangedFiles(options.changedFilesPath)
     : readLocalChangedFiles(options.repoRoot);
   const result = checkChangesetGate({
+    baseRef:
+      options.baseRef ??
+      (options.changedFilesPath === undefined ? 'origin/main' : undefined),
     changedFiles,
     releaseNone: options.releaseNone,
     repoRoot: options.repoRoot,


### PR DESCRIPTION
## Context

Package-affecting changes already require a changeset or `release:none`. This
branch extends that rule to public trail contract facts so release impact cannot
silently bypass the release process.

## Changes

- Wires public trail contract facts into `scripts/check-changeset-gate.ts`.
- Adds `--base-ref` support so CI can compare a PR branch against its actual
  base SHA.
- Fails when public trail contract facts are present without a branch-local
  changeset or explicit `release:none`.
- Prints uncovered facts in the failure output.
- Updates CI Changeset job to pass the PR base SHA.
- Adds tests for uncovered facts, matching changesets, `release:none`, and
  source-file derivation.

## Verification

- `bun test scripts/__tests__/check-changeset-gate.test.ts scripts/__tests__/contract-release-facts.test.ts`
- `bun run check`

## Notes

The check remains branch-local by design to keep Graphite stacks reviewable one
PR at a time.
