### PR TITLE
docs(releases): document release dispositions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,7 @@ Before calling an issue done or moving a PR out of draft, check the affected dis
 - **Docs and examples:** update the nearest fieldguide, API docs, examples, ADRs, or runbooks that teach the behavior.
 - **Agent guidance:** update `AGENTS.md`, repo skills, plugin metadata, or tool-specific guidance when agents need new rules or vocabulary.
 - **Governance:** add or update Warden rules, generated Warden guide output, and drift checks when the behavior creates governable contract boundaries.
-- **Release path:** add a branch-local changeset for publishable package changes, or apply `release:none` only when the package-touching change is truly not user-visible.
+- **Release path:** add a branch-local changeset for publishable package changes, including public trail additions/removals, visibility transitions, input/output changes, and surface exposure changes, or apply `release:none` only when the package-touching change is truly not user-visible and carries a reason.
 - **Wayfinder dogfood:** run `bun run wayfinder:dogfood` when a branch changes framework surfaces, the Trails operator topo exposure, Topographer artifact export, Wayfinder queries, or fresh app loading. If it is not applicable, say why in the PR or handoff.
 - **Migration path:** document commands, compatibility windows, bridge steps, or intentional non-support when existing apps may have committed artifacts or source that need to move.
 - **Publication readiness:** run `bun run publish:check` for package-impacting work and record any first-time package, dist-tag, registry, or auth considerations before release.
@@ -324,7 +324,7 @@ bun run publish:check
 bun run publish:packages
 ```
 
-Every PR that changes publishable `@ontrails/*` package contents must include a branch-local `.changeset/*.md` entry for the affected package unless the PR is explicitly labeled `release:none`. The CI changeset gate reads the GitHub PR file list, so stacked PRs are checked against their immediate PR diff rather than the whole local stack. Use `release:none` only for package-touching changes that truly do not ship user-visible package content.
+Every PR that changes publishable `@ontrails/*` package contents must include a branch-local `.changeset/*.md` entry for the affected package unless the PR is explicitly labeled `release:none`. The CI changeset check reads the GitHub PR file list, so stacked PRs are checked against their immediate PR diff rather than the whole local stack. Public trail additions/removals, visibility transitions, input schema changes, output schema changes, or surface exposure changes are release facts and need the same branch-local disposition. Use `release:none` only for package-touching changes that truly do not ship user-visible package content, and write the reason in the PR, issue, or handoff so reviewers can audit it. Fix missing release dispositions on the owning Graphite branch; do not paper over lower-branch release gaps with a top-stack cleanup changeset.
 
 To exit pre-release mode for a stable release: `bunx changeset pre exit`, then version as usual. Stable 1.x release doctrine is captured in [ADR-0047](docs/adr/0047-stable-release-line-discipline.md), and the copy-pasteable beta-to-1.0 operator sequence lives in [Stable Cutover Runbook](docs/releases/stable-cutover.md).
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -12,5 +12,9 @@ If you are building an app with Trails, start with the user-facing docs in [`doc
   source-of-truth locations, generated files, and symbol navigation.
 - [Warden Rules](./warden-rules.md) — how to author and audit durable Warden
   and repo-local correctness rules.
+- [Beta Channel Policy](../releases/beta-channel-policy.md) and
+  [Contract-Aware Changeset Check](../releases/contract-aware-changeset-check.md)
+  — release dispositions, branch-local changesets, and public trail contract
+  release facts.
 
 The split is intentional: framework concepts stay in the public docs, while repo maintenance standards live here.

--- a/docs/releases/beta-channel-policy.md
+++ b/docs/releases/beta-channel-policy.md
@@ -79,6 +79,22 @@ That command is read-only. It should show whether `latest` and `beta` point at d
 
 Every PR that changes publishable `@ontrails/*` package contents needs a branch-local changeset unless the PR is explicitly labeled `release:none`.
 
+## Release Dispositions
+
+A branch-local changeset is the normal release disposition. It says the branch changes user-visible package content and should flow into Changesets, package changelogs, and the next version plan. Use it for public API changes, generated-app changes, public trail contract changes, docs or examples that ship in a public package, and migration guidance that users need after upgrading.
+
+`release:none` is the explicit no-release disposition. Use it only when the branch touches package files but does not change user-visible package content. A good `release:none` rationale names the affected files and explains why users do not need a package changelog entry. A bad rationale merely says "internal" or "test only" while the branch also changes public trail additions/removals, visibility, input, output, surface exposure, generated artifacts, or package docs.
+
+Trail versions and package semver are separate axes. A trail version entry preserves or exposes capability contracts inside a topo. A package version distributes framework bits through npm. Changing a public trail contract is a release fact even when the trail's own `version` field does not move, and a trail version migration still needs package release disposition when publishable package contents change.
+
+The current check enforces the first contract-aware slice: public trail additions/removals, visibility transitions, input schema changes, output schema changes, or surface exposure changes need a branch-local changeset or an explicit `release:none` disposition. The check is intentionally branch-local in Graphite stacks. Fix missing dispositions on the owning branch, then restack upward; do not add a top-stack cleanup changeset to hide a lower branch's missing release story.
+
+Examples:
+
+- Good changeset prose: "Expose `wayfind.contract` through the Trails operator CLI so agents can inspect saved input/output contracts before source reads."
+- Good `release:none` rationale: "Only updates non-shipping fixture source under `packages/core/src/__tests__`; no public package files or public trail contracts changed."
+- Bad `release:none` rationale: "No release needed" on a branch that changes `output: z.object(...)` for an exposed trail.
+
 After substantial stacks merge to `main`:
 
 1. Confirm all package-affecting PRs carried changesets or an explicit

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -64,6 +64,16 @@ Current public packages are lockstep at the same Trails framework version.
 - **Ecosystem:** `@ontrails/testing` provides contract tests and surface harnesses; `@ontrails/topographer` owns TopoGraphs, semantic diffing, lock manifests, and topo-store persistence; `@ontrails/warden` owns governance rules; `@ontrails/wayfinder` owns graph-read query trails over saved Topographer artifacts.
 - **Beta install policy:** While `.changeset/pre.json` is in prerelease mode, install published Trails packages with exact `1.0.0-beta.N` pins or `@beta`; do not rely on unqualified `latest` unless release notes explicitly advance it.
 
+## Release Dispositions
+
+Feature work that changes publishable `@ontrails/*` package contents needs a branch-local release disposition before the PR leaves draft. The normal disposition is a `.changeset/*.md` entry for each affected public package. `release:none` is allowed only when the branch touches package files but truly has no user-visible package content change, and the PR, issue, or handoff explains why.
+
+Public trail contract changes are release facts. If a branch adds or removes a public trail, changes public visibility, changes an exposed trail's input schema or output schema, or changes surface exposure, add a changeset on the owning branch unless the branch has an explicit and reviewable `release:none` reason. Trail version entries and package semver are distinct: trail versions preserve capability contracts inside a topo, while package semver distributes framework bits through npm.
+
+In Graphite stacks, keep release dispositions branch-local. If the check reports a missing disposition for a lower branch, check out that owning branch, add the changeset or `release:none` rationale there, restack, and re-run the check upward. Do not hide lower-branch release gaps with a top-stack cleanup changeset.
+
+Good changeset prose names the user-visible change: "Expose `wayfind.contract` through the Trails operator CLI so agents can inspect saved input/output contracts before source reads." Good `release:none` rationale names the non-user-visible scope: "Only updates non-shipping test fixtures under `packages/core/src/__tests__`; no public package files or public trail contracts changed." A bare "internal" is not enough when public contracts, generated artifacts, package docs, or migrations move.
+
 ## Agent Wayfinding
 
 When saved Topographer artifacts can answer a graph question, use Wayfinder before raw text search:


### PR DESCRIPTION
## Context

Humans and agents need to understand what to do when the gate reports a public
trail contract fact. Otherwise the check is technically correct but hostile DX.

## Changes

- Documents release dispositions in the beta channel policy.
- Updates `AGENTS.md` distribution-ready/releasing guidance.
- Updates the Trails skill guidance so agents know a public trail contract fact
  needs a branch-local changeset or justified `release:none`.
- Links the release-disposition docs from contributing guidance.

## Verification

- `bun run docs:wrap-check`
- `bun run plugin:metadata:check`
- `bun run check`

## Notes

This branch teaches the behavior; it does not change the gate itself.
