### PR TITLE
docs(reviews): classify release disposition gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,7 @@ Use Graphite for source control operations.
 - Keep PRs small, isolate mechanical changes when possible, and keep PRs in draft until CI is green.
 - Treat a Greptile error comment (`Greptile encountered an error while reviewing this PR`) as a blocker, not as a completed review.
 - When performing fixes across stacked branches, prefer the owning branch: check it out, make the focused fix there, `gt modify`, restack, and verify upward. Use `gt absorb -a` only when the stack owner explicitly chooses a top-branch absorption workflow.
+- During local review, a missing release disposition for public trail additions/removals, visibility transitions, input/output changes, or surface exposure changes is a P2 release-quality blocker. Identify the owning branch, add the changeset or explicit `release:none` reason there, restack, and re-run the check upward.
 - For Codex/Crew worktree farming, the worker worktree must have a real branch checked out. `gt create` does not work from detached `HEAD`. A zero-diff Graphite-tracked base branch under `main` is acceptable as the worker lane base; workers may create child branches from that lane and hold before submit.
 
 ## Subagent Rules

--- a/docs/releases/contract-aware-changeset-check.md
+++ b/docs/releases/contract-aware-changeset-check.md
@@ -83,6 +83,14 @@ Out of scope for this first check:
 
 For local reviews, a missing release disposition for a public trail contract fact is a P2. It can block downstream release quality even when code, tests, and package-file checks are green.
 
+Use this checklist when reviewing a stack:
+
+1. Identify the owning branch for each public contract fact. In Graphite, that is the lowest branch whose PR file list contains the source change.
+2. Check that the owning branch carries a matching changeset for the affected package, or an explicit `release:none` reason that explains why the fact is not user-visible.
+3. Treat `release:none` without a reason as incomplete. It is a disposition label without the authored disposition.
+4. Do not paper over a lower branch's missing reason in a top-stack cleanup branch. Fix the owning branch, restack, then re-run the check upward.
+5. If the review finds release ideas outside slice one, such as imported schema tracing, error-taxonomy facts, permit facts, or release targets, log them as follow-up P3s unless they create a concrete user-visible release gap in the current branch.
+
 ## Local Reproduction
 
 The Changeset job validates the branch-local PR file list. To reproduce a hosted failure locally, save the PR file list and pass the branch base explicitly:

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -74,6 +74,8 @@ In Graphite stacks, keep release dispositions branch-local. If the check reports
 
 Good changeset prose names the user-visible change: "Expose `wayfind.contract` through the Trails operator CLI so agents can inspect saved input/output contracts before source reads." Good `release:none` rationale names the non-user-visible scope: "Only updates non-shipping test fixtures under `packages/core/src/__tests__`; no public package files or public trail contracts changed." A bare "internal" is not enough when public contracts, generated artifacts, package docs, or migrations move.
 
+During local review, classify a missing branch-local disposition for a public trail contract fact as P2. Selected P3 release ideas, such as imported schema tracing or future release targets, should be logged for follow-up rather than folded into the current branch unless they expose a concrete user-visible release gap.
+
 ## Agent Wayfinding
 
 When saved Topographer artifacts can answer a graph question, use Wayfinder before raw text search:


### PR DESCRIPTION
## Context

The stack also needs local-review guidance so future agents classify release
disposition misses correctly before handing a PR to remote reviewers.

## Changes

- Adds local review checklist guidance for contract-aware changeset failures.
- Classifies missing public trail contract release disposition as P2.
- Clarifies that selected P3 ideas should be logged unless they are concrete
  current-stack blockers.
- Records this sprint's local review note in `.agents/notes/` as ignored
  historical context.

## Verification

- `bun run docs:wrap-check`
- `bun run plugin:metadata:check`
- `bun run check`

## Notes

The ignored review note records deferred related P3s; no fully unrelated P3s
were found in this pass.
