### PR TITLE
feat(wayfinder): add trail error facts substrate

### DIFF
--- a/.changeset/trl-910-trail-error-facts.md
+++ b/.changeset/trl-910-trail-error-facts.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/wayfinder': patch
+---
+
+Add a TrailErrorFacts substrate that derives documented and handled trail error facts from saved topo artifacts while preserving explicit provenance and unknown emitted-error completeness.

--- a/packages/wayfinder/src/__tests__/error-facts.test.ts
+++ b/packages/wayfinder/src/__tests__/error-facts.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import {
+  ConflictError,
+  Result,
+  RetryExhaustedError,
+  ValidationError,
+  topo,
+  trail,
+} from '@ontrails/core';
+import { deriveTopoGraph } from '@ontrails/topographer';
+
+import { deriveTrailErrorFacts } from '../error-facts.js';
+
+const findTrailFacts = (
+  facts: ReturnType<typeof deriveTrailErrorFacts>,
+  trailId: string
+) => {
+  const trailFacts = facts.find((entry) => entry.trailId === trailId);
+  if (trailFacts === undefined) {
+    throw new Error(`Missing facts for ${trailId}`);
+  }
+  return trailFacts;
+};
+
+describe('deriveTrailErrorFacts', () => {
+  test('projects documented error examples and handled detours with taxonomy', () => {
+    const audited = trail('audit.save', {
+      blaze: () => Result.err(new ValidationError('Invalid audit')),
+      detours: [
+        {
+          maxAttempts: 1,
+          on: ConflictError,
+          recover: () => Result.ok({ ok: true }),
+        },
+      ],
+      examples: [
+        {
+          error: 'ValidationError',
+          input: { id: '' },
+          name: 'Invalid id',
+        },
+      ],
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    });
+    const graph = deriveTopoGraph(topo('errors', { audited }));
+
+    const facts = findTrailFacts(deriveTrailErrorFacts(graph), 'audit.save');
+
+    expect(facts.completeness.emitted).toEqual({
+      reason: 'no-exhaustive-emitted-error-contract',
+      status: 'unknown',
+    });
+    expect(facts.facts).toHaveLength(2);
+    expect(facts.facts).toContainEqual(
+      expect.objectContaining({
+        kind: 'documented',
+        provenance: {
+          exampleName: 'Invalid id',
+          source: 'trail.examples',
+          trailId: 'audit.save',
+        },
+        taxonomy: expect.objectContaining({
+          category: 'validation',
+          known: true,
+          name: 'ValidationError',
+        }),
+      })
+    );
+    expect(facts.facts).toContainEqual(
+      expect.objectContaining({
+        kind: 'handled',
+        provenance: {
+          detourIndex: 0,
+          source: 'trail.detours',
+          trailId: 'audit.save',
+        },
+        taxonomy: expect.objectContaining({
+          category: 'conflict',
+          known: true,
+          name: 'ConflictError',
+        }),
+      })
+    );
+    expect(
+      facts.facts.find((fact) => fact.taxonomy.name === 'ValidationError')
+        ?.taxonomy.surfaces
+    ).toContainEqual(
+      expect.objectContaining({
+        code: 1,
+        name: 'ValidationError',
+        surface: 'cli',
+      })
+    );
+  });
+
+  test('does not invent fixed surface codes for dynamic-category errors', () => {
+    const withDynamic = trail('batch.retry', {
+      blaze: () => Result.ok({ ok: true }),
+      detours: [
+        {
+          maxAttempts: 1,
+          on: RetryExhaustedError,
+          recover: () => Result.ok({ ok: true }),
+        },
+      ],
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+    });
+    const graph = deriveTopoGraph(topo('errors', { withDynamic }));
+
+    const facts = findTrailFacts(deriveTrailErrorFacts(graph), 'batch.retry');
+    const [dynamic] = facts.facts;
+
+    expect(dynamic?.taxonomy).toEqual({
+      dynamicCategory: { inheritsCategoryFrom: 'wrapped-error' },
+      known: true,
+      name: 'RetryExhaustedError',
+      retryable: false,
+      surfaces: [],
+    });
+  });
+
+  test('represents supplied inferred and observed facts without source scanning', () => {
+    const read = trail('user.read', {
+      blaze: () => Result.ok({ id: 'u1' }),
+      input: z.object({ id: z.string() }),
+      output: z.object({ id: z.string() }),
+    });
+    const graph = deriveTopoGraph(topo('errors', { read }));
+
+    const facts = findTrailFacts(
+      deriveTrailErrorFacts(graph, {
+        inferred: [
+          {
+            detail: 'static Result.err branch in fixture',
+            errorName: 'NotFoundError',
+            trailId: 'user.read',
+          },
+        ],
+        observed: [
+          {
+            detail: 'trace sample 2026-06-09',
+            errorName: 'ServiceSpecificError',
+            trailId: 'user.read',
+          },
+        ],
+      }),
+      'user.read'
+    );
+
+    expect(facts.completeness.inferred).toEqual({
+      reason: 'inferred-facts-supplied',
+      status: 'partial',
+    });
+    expect(facts.completeness.observed).toEqual({
+      reason: 'observed-facts-supplied',
+      status: 'partial',
+    });
+    expect(facts.facts).toContainEqual(
+      expect.objectContaining({
+        kind: 'inferred',
+        taxonomy: expect.objectContaining({
+          category: 'not_found',
+          known: true,
+          name: 'NotFoundError',
+        }),
+      })
+    );
+    expect(facts.facts).toContainEqual(
+      expect.objectContaining({
+        kind: 'observed',
+        taxonomy: {
+          known: false,
+          name: 'ServiceSpecificError',
+          surfaces: [],
+        },
+      })
+    );
+  });
+
+  test('keeps empty trails explicit about unknown emitted-error completeness', () => {
+    const empty = trail('empty.read', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+    });
+    const graph = deriveTopoGraph(topo('errors', { empty }));
+
+    const facts = findTrailFacts(deriveTrailErrorFacts(graph), 'empty.read');
+
+    expect(facts.facts).toEqual([]);
+    expect(facts.completeness).toEqual({
+      documented: { reason: 'authored-facts-exhausted', status: 'complete' },
+      emitted: {
+        reason: 'no-exhaustive-emitted-error-contract',
+        status: 'unknown',
+      },
+      handled: { reason: 'authored-facts-exhausted', status: 'complete' },
+      inferred: { reason: 'not-evaluated', status: 'unknown' },
+      observed: { reason: 'not-evaluated', status: 'unknown' },
+    });
+  });
+});

--- a/packages/wayfinder/src/error-facts.ts
+++ b/packages/wayfinder/src/error-facts.ts
@@ -1,0 +1,363 @@
+import {
+  errorClasses,
+  projectErrorClassSurface,
+  surfaceNames,
+} from '@ontrails/core';
+import type {
+  ErrorCategory,
+  ErrorClassRegistryEntry,
+  ErrorClassSurfaceProjection,
+  SurfaceName,
+} from '@ontrails/core';
+import type {
+  TopoGraph,
+  TopoGraphEntry,
+  TopoGraphVersionEntry,
+} from '@ontrails/topographer';
+
+export type TrailErrorFactKind =
+  | 'documented'
+  | 'handled'
+  | 'inferred'
+  | 'observed';
+
+export type TrailErrorFactsCompleteness =
+  | {
+      readonly reason: 'authored-facts-exhausted';
+      readonly status: 'complete';
+    }
+  | {
+      readonly reason: 'inferred-facts-supplied' | 'observed-facts-supplied';
+      readonly status: 'partial';
+    }
+  | {
+      readonly reason: 'no-exhaustive-emitted-error-contract' | 'not-evaluated';
+      readonly status: 'unknown';
+    };
+
+export interface TrailErrorTaxonomyProjection {
+  readonly category?: ErrorCategory | undefined;
+  readonly dynamicCategory?:
+    | {
+        readonly inheritsCategoryFrom: 'wrapped-error';
+      }
+    | undefined;
+  readonly known: boolean;
+  readonly name: string;
+  readonly retryable?: boolean | undefined;
+  readonly surfaces: readonly ErrorClassSurfaceProjection[];
+}
+
+export type TrailErrorFactProvenance =
+  | {
+      readonly exampleName: string;
+      readonly source: 'trail.examples' | 'trail.versions.examples';
+      readonly trailId: string;
+      readonly version?: number | undefined;
+    }
+  | {
+      readonly detourIndex: number;
+      readonly source: 'trail.detours' | 'trail.versions.detours';
+      readonly trailId: string;
+      readonly version?: number | undefined;
+    }
+  | {
+      readonly detail?: string | undefined;
+      readonly source: 'static-inference';
+      readonly trailId: string;
+      readonly version?: number | undefined;
+    }
+  | {
+      readonly detail?: string | undefined;
+      readonly source: 'runtime-observation';
+      readonly trailId: string;
+      readonly version?: number | undefined;
+    };
+
+export interface TrailErrorFact {
+  readonly completeness: TrailErrorFactsCompleteness;
+  readonly kind: TrailErrorFactKind;
+  readonly provenance: TrailErrorFactProvenance;
+  readonly taxonomy: TrailErrorTaxonomyProjection;
+}
+
+export interface TrailErrorFacts {
+  readonly completeness: {
+    readonly emitted: TrailErrorFactsCompleteness;
+    readonly handled: TrailErrorFactsCompleteness;
+    readonly documented: TrailErrorFactsCompleteness;
+    readonly inferred: TrailErrorFactsCompleteness;
+    readonly observed: TrailErrorFactsCompleteness;
+  };
+  readonly facts: readonly TrailErrorFact[];
+  readonly trailId: string;
+}
+
+export interface TrailErrorEvidenceInput {
+  readonly detail?: string | undefined;
+  readonly errorName: string;
+  readonly trailId: string;
+  readonly version?: number | undefined;
+}
+
+export interface TrailErrorFactsOptions {
+  readonly inferred?: readonly TrailErrorEvidenceInput[] | undefined;
+  readonly observed?: readonly TrailErrorEvidenceInput[] | undefined;
+  readonly surfaces?: readonly SurfaceName[] | undefined;
+}
+
+const errorClassByName: ReadonlyMap<string, ErrorClassRegistryEntry> = new Map(
+  errorClasses.map((entry) => [entry.name, entry])
+);
+
+const taxonomyProjection = (
+  errorName: string,
+  surfaces: readonly SurfaceName[]
+): TrailErrorTaxonomyProjection => {
+  const registryEntry = errorClassByName.get(errorName);
+  if (registryEntry === undefined) {
+    return {
+      known: false,
+      name: errorName,
+      surfaces: [],
+    };
+  }
+
+  if (registryEntry.category === 'dynamic') {
+    return {
+      dynamicCategory: {
+        inheritsCategoryFrom: registryEntry.inheritsCategoryFrom,
+      },
+      known: true,
+      name: registryEntry.name,
+      retryable: registryEntry.retryable,
+      surfaces: [],
+    };
+  }
+
+  return {
+    category: registryEntry.category,
+    known: true,
+    name: registryEntry.name,
+    retryable: registryEntry.retryable,
+    surfaces: surfaces.flatMap((surface) => {
+      const projected = projectErrorClassSurface(surface, errorName);
+      return projected === undefined ? [] : [projected];
+    }),
+  };
+};
+
+const authoredCompleteness: TrailErrorFactsCompleteness = {
+  reason: 'authored-facts-exhausted',
+  status: 'complete',
+};
+
+const emittedCompleteness: TrailErrorFactsCompleteness = {
+  reason: 'no-exhaustive-emitted-error-contract',
+  status: 'unknown',
+};
+
+const notEvaluatedCompleteness: TrailErrorFactsCompleteness = {
+  reason: 'not-evaluated',
+  status: 'unknown',
+};
+
+const inferredCompleteness: TrailErrorFactsCompleteness = {
+  reason: 'inferred-facts-supplied',
+  status: 'partial',
+};
+
+const observedCompleteness: TrailErrorFactsCompleteness = {
+  reason: 'observed-facts-supplied',
+  status: 'partial',
+};
+
+const documentedFacts = (
+  entry: TopoGraphEntry,
+  surfaces: readonly SurfaceName[]
+): TrailErrorFact[] =>
+  (entry.examples ?? []).flatMap((example): TrailErrorFact[] => {
+    if (example.kind !== 'error' || example.error === undefined) {
+      return [];
+    }
+    return [
+      {
+        completeness: authoredCompleteness,
+        kind: 'documented',
+        provenance: {
+          exampleName: example.name,
+          source: 'trail.examples',
+          trailId: entry.id,
+        },
+        taxonomy: taxonomyProjection(example.error, surfaces),
+      },
+    ];
+  });
+
+const handledFacts = (
+  entry: TopoGraphEntry,
+  surfaces: readonly SurfaceName[]
+): TrailErrorFact[] =>
+  (entry.detours ?? []).map(
+    (detour, detourIndex): TrailErrorFact => ({
+      completeness: authoredCompleteness,
+      kind: 'handled',
+      provenance: {
+        detourIndex,
+        source: 'trail.detours',
+        trailId: entry.id,
+      },
+      taxonomy: taxonomyProjection(detour.on, surfaces),
+    })
+  );
+
+const versionDocumentedFacts = (
+  trailId: string,
+  version: number,
+  entry: TopoGraphVersionEntry,
+  surfaces: readonly SurfaceName[]
+): TrailErrorFact[] =>
+  (entry.examples ?? []).flatMap((example): TrailErrorFact[] => {
+    if (example.kind !== 'error' || example.error === undefined) {
+      return [];
+    }
+    return [
+      {
+        completeness: authoredCompleteness,
+        kind: 'documented',
+        provenance: {
+          exampleName: example.name,
+          source: 'trail.versions.examples',
+          trailId,
+          version,
+        },
+        taxonomy: taxonomyProjection(example.error, surfaces),
+      },
+    ];
+  });
+
+const versionHandledFacts = (
+  trailId: string,
+  version: number,
+  entry: TopoGraphVersionEntry,
+  surfaces: readonly SurfaceName[]
+): TrailErrorFact[] =>
+  (entry.detours ?? []).map(
+    (detour, detourIndex): TrailErrorFact => ({
+      completeness: authoredCompleteness,
+      kind: 'handled',
+      provenance: {
+        detourIndex,
+        source: 'trail.versions.detours',
+        trailId,
+        version,
+      },
+      taxonomy: taxonomyProjection(detour.on, surfaces),
+    })
+  );
+
+const versionFacts = (
+  entry: TopoGraphEntry,
+  surfaces: readonly SurfaceName[]
+): TrailErrorFact[] =>
+  Object.entries(entry.versions ?? {}).flatMap(([versionKey, versionEntry]) => {
+    const version = Number.parseInt(versionKey, 10);
+    if (!Number.isFinite(version)) {
+      return [];
+    }
+    return [
+      ...versionDocumentedFacts(entry.id, version, versionEntry, surfaces),
+      ...versionHandledFacts(entry.id, version, versionEntry, surfaces),
+    ];
+  });
+
+const inputFact = (
+  input: TrailErrorEvidenceInput,
+  kind: 'inferred' | 'observed',
+  surfaces: readonly SurfaceName[]
+): TrailErrorFact => ({
+  completeness:
+    kind === 'inferred' ? inferredCompleteness : observedCompleteness,
+  kind,
+  provenance: {
+    ...(input.detail === undefined ? {} : { detail: input.detail }),
+    source: kind === 'inferred' ? 'static-inference' : 'runtime-observation',
+    trailId: input.trailId,
+    ...(input.version === undefined ? {} : { version: input.version }),
+  },
+  taxonomy: taxonomyProjection(input.errorName, surfaces),
+});
+
+const byTrail = (
+  inputs: readonly TrailErrorEvidenceInput[] | undefined
+): ReadonlyMap<string, readonly TrailErrorEvidenceInput[]> => {
+  const map = new Map<string, TrailErrorEvidenceInput[]>();
+  for (const input of inputs ?? []) {
+    const existing = map.get(input.trailId) ?? [];
+    existing.push(input);
+    map.set(input.trailId, existing);
+  }
+  return map;
+};
+
+const sortFacts = (
+  facts: readonly TrailErrorFact[]
+): readonly TrailErrorFact[] =>
+  [...facts].toSorted((left, right) => {
+    const leftVersion = left.provenance.version ?? 0;
+    const rightVersion = right.provenance.version ?? 0;
+    return (
+      leftVersion - rightVersion ||
+      left.kind.localeCompare(right.kind) ||
+      left.taxonomy.name.localeCompare(right.taxonomy.name)
+    );
+  });
+
+export const deriveTrailErrorFacts = (
+  topoGraph: TopoGraph,
+  options: TrailErrorFactsOptions = {}
+): readonly TrailErrorFacts[] => {
+  const surfaces = options.surfaces ?? surfaceNames;
+  const inferredByTrail = byTrail(options.inferred);
+  const observedByTrail = byTrail(options.observed);
+
+  return topoGraph.entries
+    .filter(
+      (entry): entry is TopoGraphEntry & { readonly kind: 'trail' } =>
+        entry.kind === 'trail'
+    )
+    .map((entry): TrailErrorFacts => {
+      const inferredInputs = inferredByTrail.get(entry.id) ?? [];
+      const observedInputs = observedByTrail.get(entry.id) ?? [];
+      const facts = sortFacts([
+        ...documentedFacts(entry, surfaces),
+        ...handledFacts(entry, surfaces),
+        ...versionFacts(entry, surfaces),
+        ...inferredInputs.map((input) =>
+          inputFact(input, 'inferred', surfaces)
+        ),
+        ...observedInputs.map((input) =>
+          inputFact(input, 'observed', surfaces)
+        ),
+      ]);
+
+      return {
+        completeness: {
+          documented: authoredCompleteness,
+          emitted: emittedCompleteness,
+          handled: authoredCompleteness,
+          inferred:
+            inferredInputs.length > 0
+              ? inferredCompleteness
+              : notEvaluatedCompleteness,
+          observed:
+            observedInputs.length > 0
+              ? observedCompleteness
+              : notEvaluatedCompleteness,
+        },
+        facts,
+        trailId: entry.id,
+      };
+    })
+    .toSorted((left, right) => left.trailId.localeCompare(right.trailId));
+};

--- a/packages/wayfinder/src/index.ts
+++ b/packages/wayfinder/src/index.ts
@@ -10,6 +10,17 @@
  * resolve resources, reach the network, or mutate local state.
  */
 
+export { deriveTrailErrorFacts } from './error-facts.js';
+export type {
+  TrailErrorEvidenceInput,
+  TrailErrorFact,
+  TrailErrorFactKind,
+  TrailErrorFactProvenance,
+  TrailErrorFacts,
+  TrailErrorFactsCompleteness,
+  TrailErrorFactsOptions,
+  TrailErrorTaxonomyProjection,
+} from './error-facts.js';
 export {
   createWayfinderEntityPredicate,
   createWayfinderFilterContext,


### PR DESCRIPTION
## Summary
- Adds the `TrailErrorFacts` substrate in `@ontrails/wayfinder`.
- Derives documented error examples and handled detours from saved topo artifacts.
- Keeps emitted-error completeness explicit as unknown when no exhaustive contract exists.

## Verification
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`