### PR TITLE
feat(wayfinder): add wayfind errors

### DIFF
--- a/.changeset/trl-911-wayfind-errors.md
+++ b/.changeset/trl-911-wayfind-errors.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/trails': patch
+'@ontrails/wayfinder': patch
+---
+
+Add the `wayfind.errors` graph-read trail and expose it through the Trails CLI for local error-fact inspection.

--- a/apps/trails/src/__tests__/wayfind-cli.test.ts
+++ b/apps/trails/src/__tests__/wayfind-cli.test.ts
@@ -22,6 +22,7 @@ describe('Trails Wayfinder CLI surface', () => {
     expect(commandPaths).toContain('wayfind trails');
     expect(commandPaths).toContain('wayfind contract');
     expect(commandPaths).toContain('wayfind describe');
+    expect(commandPaths).toContain('wayfind errors');
     expect(commandPaths).toContain('wayfind nearby');
     expect(commandPaths).toContain('wayfind impact');
     expect(commandPaths).toContain('wayfind examples');
@@ -31,6 +32,7 @@ describe('Trails Wayfinder CLI surface', () => {
     expect(trailIds).toContain('wayfind.trails');
     expect(trailIds).toContain('wayfind.contract');
     expect(trailIds).toContain('wayfind.describe');
+    expect(trailIds).toContain('wayfind.errors');
     expect(trailIds).toContain('wayfind.nearby');
     expect(trailIds).toContain('wayfind.impact');
     expect(trailIds).toContain('wayfind.examples');
@@ -41,7 +43,6 @@ describe('Trails Wayfinder CLI surface', () => {
     const trailIds = commands.map((command) => command.trail.id);
 
     expect(trailIds).not.toContain('wayfind.adapters');
-    expect(trailIds).not.toContain('wayfind.errors');
     expect(trailIds).not.toContain('wayfind.query');
     expect(trailIds).not.toContain('wayfind.implications');
     expect(trailIds).not.toContain('wayfind.diff');

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -2,6 +2,7 @@ import { topo } from '@ontrails/core';
 import {
   wayfindContractTrail,
   wayfindDescribeTrail,
+  wayfindErrorsTrail,
   wayfindExamplesTrail,
   wayfindImpactTrail,
   wayfindNearbyTrail,
@@ -82,6 +83,7 @@ const operatorTrails = Object.fromEntries(
 const cliWayfinderTrails = {
   wayfindContractTrail,
   wayfindDescribeTrail,
+  wayfindErrorsTrail,
   wayfindExamplesTrail,
   wayfindImpactTrail,
   wayfindNearbyTrail,

--- a/docs/contributing/codebase-navigation.md
+++ b/docs/contributing/codebase-navigation.md
@@ -19,6 +19,7 @@ Then narrow the graph read with the selected local CLI surface:
 ```bash
 bun apps/trails/bin/trails.ts wayfind search --root-dir . --input-json '{"filters":{"kind":"trail","idPrefix":"wayfind."}}' --json
 bun apps/trails/bin/trails.ts wayfind contract wayfind.search --root-dir . --json
+bun apps/trails/bin/trails.ts wayfind errors --root-dir . --input-json '{"filters":{"kind":"trail","idPrefix":"wayfind."}}' --json
 bun apps/trails/bin/trails.ts wayfind nearby wayfind.search --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind impact wayfind.search --root-dir . --json
 ```

--- a/packages/wayfinder/README.md
+++ b/packages/wayfinder/README.md
@@ -20,6 +20,7 @@ The package exports `wayfinderTopo` plus individual graph-read trails.
 | `wayfind.facets` | List resolved surface facet metadata and members. |
 | `wayfind.versions` | List current and historical trail version records. |
 | `wayfind.examples` | List saved examples without executing trails. |
+| `wayfind.errors` | List saved trail error facts with provenance and completeness. |
 | `wayfind.describe` | Inspect the saved entity record for one ID. |
 | `wayfind.contract` | Inspect the input/output/intent contract for one trail or version. |
 | `wayfind.nearby` | Return direct typed relation edges around one entity. |
@@ -28,7 +29,7 @@ The package exports `wayfinderTopo` plus individual graph-read trails.
 
 Each trail is internal by default and returns provenance and freshness metadata with its result so callers can tell whether the answer came from fresh artifacts, stale artifacts, missing artifacts, or schema-version drift. Public surface exposure must be a deliberate host decision.
 
-The v0 catalog intentionally does not include `wayfind.errors`, `wayfind.adapters`, generic `wayfind.query`, semantic search, signposts, or `wayfind.implications`. Those require additional accepted substrates or field evidence before they can answer honestly.
+The v0 catalog intentionally does not include `wayfind.adapters`, generic `wayfind.query`, semantic search, signposts, or `wayfind.implications`. Those require additional accepted substrates or field evidence before they can answer honestly.
 
 ```ts
 import { wayfinderTopo } from '@ontrails/wayfinder';
@@ -83,6 +84,12 @@ const result = await wayfindSearchTrail.blaze(
 Supported filters include entity kind, exact ID, ID prefix, namespace, intent, surface, facet, versioning, example coverage, resource usage, and signal usage. Use `createWayfinderGraphEntityPredicate` or `filterWayfinderEntityRefs` when matching relationship filters directly in code so facet membership and projected surfaces are evaluated with graph-derived context.
 
 Example coverage filters are evaluated against the entity being returned. `wayfind.examples` widens parent trail matches to include current examples plus historical version examples, exact historical-version matches return only that version's examples, and exact current-version matches return the current entry examples. `exampleCoverage: false` is intentionally not widened into covered historical version examples.
+
+## Error Facts
+
+Use `wayfind.errors` when you need to inspect saved error facts for one trail or a filtered set of trails. The query reports documented error examples, handled detours, and later supplied inferred or observed facts with provenance and completeness metadata.
+
+The error facts are deliberately not an exhaustive emitted-error contract. A trail with no error facts still reports unknown emitted-error completeness rather than implying the trail cannot fail, and dynamic-category errors such as `RetryExhaustedError` do not receive fixed surface codes without wrapped-cause evidence.
 
 ## Describe And Contract
 

--- a/packages/wayfinder/src/__tests__/queries.test.ts
+++ b/packages/wayfinder/src/__tests__/queries.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { z } from 'zod';
 
 import {
+  ConflictError,
   Result,
   createTrailContext,
   resource,
@@ -30,6 +31,7 @@ import {
   wayfindContractTrail,
   wayfindDescribeTrail,
   wayfindDiffTrail,
+  wayfindErrorsTrail,
   wayfindExamplesTrail,
   wayfindImpactTrail,
   wayfindNearbyTrail,
@@ -238,6 +240,7 @@ describe('wayfinder graph-read query trails', () => {
       'wayfind.contract',
       'wayfind.describe',
       'wayfind.diff',
+      'wayfind.errors',
       'wayfind.examples',
       'wayfind.facets',
       'wayfind.impact',
@@ -414,6 +417,60 @@ describe('wayfinder graph-read query trails', () => {
       'invite.create',
       'invite.create@1',
       'user.show',
+    ]);
+  });
+
+  test('lists trail error facts without claiming exhaustive emitted errors', async () => {
+    await writeArtifacts((topoGraph) => ({
+      ...topoGraph,
+      entries: topoGraph.entries.map((entry) =>
+        entry.id === 'user.show'
+          ? {
+              ...entry,
+              detours: [{ maxAttempts: 1, on: ConflictError.name }],
+              examples: [
+                ...(entry.examples ?? []),
+                {
+                  error: 'NotFoundError',
+                  input: { id: 'missing' },
+                  kind: 'error' as const,
+                  name: 'Missing user',
+                  provenance: { source: 'trail.examples' as const },
+                },
+              ],
+            }
+          : entry
+      ),
+    }));
+
+    const errors = await expectOk(
+      wayfindErrorsTrail.blaze(
+        {
+          filters: { id: 'user.show', kind: 'trail' },
+          limit: 100,
+          rootDir: tempDir,
+        },
+        ctx()
+      )
+    );
+
+    expect(errors.errors).toHaveLength(1);
+    expect(errors.errors[0]).toMatchObject({
+      completeness: {
+        emitted: {
+          reason: 'no-exhaustive-emitted-error-contract',
+          status: 'unknown',
+        },
+      },
+      trailId: 'user.show',
+    });
+    expect(errors.errors[0]?.facts.map((fact) => fact.kind)).toEqual([
+      'documented',
+      'handled',
+    ]);
+    expect(errors.errors[0]?.facts.map((fact) => fact.taxonomy.name)).toEqual([
+      'NotFoundError',
+      'ConflictError',
     ]);
   });
 

--- a/packages/wayfinder/src/index.ts
+++ b/packages/wayfinder/src/index.ts
@@ -54,6 +54,7 @@ export {
   wayfindContoursTrail,
   wayfindDescribeTrail,
   wayfindDiffTrail,
+  wayfindErrorsTrail,
   wayfindExamplesTrail,
   wayfindFacetsTrail,
   wayfindImpactTrail,

--- a/packages/wayfinder/src/queries.ts
+++ b/packages/wayfinder/src/queries.ts
@@ -6,6 +6,8 @@ import {
   NotFoundError,
   Result,
   ValidationError,
+  errorCategories,
+  surfaceNames,
   topo,
   trail,
 } from '@ontrails/core';
@@ -27,6 +29,7 @@ import type {
   WayfinderArtifactLoad,
   WayfinderArtifactLoaderOptions,
 } from './loader.js';
+import { deriveTrailErrorFacts } from './error-facts.js';
 import {
   diffResult,
   edgeTouches,
@@ -220,6 +223,77 @@ const exampleSummarySchema = z.object({
   targetId: z.string(),
 });
 
+const errorFactsCompletenessSchema = z.discriminatedUnion('status', [
+  z.object({
+    reason: z.literal('authored-facts-exhausted'),
+    status: z.literal('complete'),
+  }),
+  z.object({
+    reason: z.enum(['inferred-facts-supplied', 'observed-facts-supplied']),
+    status: z.literal('partial'),
+  }),
+  z.object({
+    reason: z.enum(['no-exhaustive-emitted-error-contract', 'not-evaluated']),
+    status: z.literal('unknown'),
+  }),
+]);
+
+const errorSurfaceProjectionSchema = z.object({
+  category: z.enum(errorCategories),
+  code: z.number(),
+  name: z.string(),
+  retryable: z.boolean(),
+  surface: z.enum(surfaceNames),
+});
+
+const errorTaxonomyProjectionSchema = z.object({
+  category: z.enum(errorCategories).optional(),
+  dynamicCategory: z
+    .object({
+      inheritsCategoryFrom: z.literal('wrapped-error'),
+    })
+    .optional(),
+  known: z.boolean(),
+  name: z.string(),
+  retryable: z.boolean().optional(),
+  surfaces: z.array(errorSurfaceProjectionSchema).readonly(),
+});
+
+const errorFactProvenanceSchema = z.object({
+  detail: z.string().optional(),
+  detourIndex: z.number().optional(),
+  exampleName: z.string().optional(),
+  source: z.enum([
+    'runtime-observation',
+    'static-inference',
+    'trail.detours',
+    'trail.examples',
+    'trail.versions.detours',
+    'trail.versions.examples',
+  ]),
+  trailId: z.string(),
+  version: z.number().optional(),
+});
+
+const errorFactSchema = z.object({
+  completeness: errorFactsCompletenessSchema,
+  kind: z.enum(['documented', 'handled', 'inferred', 'observed']),
+  provenance: errorFactProvenanceSchema,
+  taxonomy: errorTaxonomyProjectionSchema,
+});
+
+const trailErrorFactsSchema = z.object({
+  completeness: z.object({
+    documented: errorFactsCompletenessSchema,
+    emitted: errorFactsCompletenessSchema,
+    handled: errorFactsCompletenessSchema,
+    inferred: errorFactsCompletenessSchema,
+    observed: errorFactsCompletenessSchema,
+  }),
+  facts: z.array(errorFactSchema).readonly(),
+  trailId: z.string(),
+});
+
 const describeOutputSchema = envelopeSchema.extend({
   entity: z.record(z.string(), z.unknown()),
 });
@@ -261,6 +335,10 @@ const diffResultOutputSchema = z.object({
 const diffOutputSchema = envelopeSchema.extend({
   against: envelopeSchema,
   diff: diffResultOutputSchema,
+});
+
+const errorsOutputSchema = envelopeSchema.extend({
+  errors: z.array(trailErrorFactsSchema).readonly(),
 });
 
 type SourceInput = z.output<typeof sourceInputSchema>;
@@ -888,6 +966,17 @@ const filteredIds = (
       .map((ref) => ref.id)
   );
 
+const filteredErrorFacts = (
+  graph: TopoGraph,
+  filters: WayfinderEntityFilterInput | undefined,
+  limit: number
+) => {
+  const ids = filteredIds(graph, 'trail', filters, limit);
+  return deriveTrailErrorFacts(graph)
+    .filter((entry) => ids.has(entry.trailId))
+    .slice(0, limit);
+};
+
 export const wayfindOverviewTrail = trail('wayfind.overview', {
   blaze: async (input, ctx) =>
     withGraph(input, ctx.cwd, (loaded) => {
@@ -1154,6 +1243,20 @@ export const wayfindExamplesTrail = trail('wayfind.examples', {
   visibility: 'internal',
 });
 
+export const wayfindErrorsTrail = trail('wayfind.errors', {
+  blaze: async (input, ctx) =>
+    withGraph(input, ctx.cwd, (loaded) => ({
+      ...envelope(loaded),
+      errors: filteredErrorFacts(loaded.graph, input.filters, input.limit),
+    })),
+  description: 'List saved trail error facts with provenance',
+  examples: [{ input: {}, name: 'List trail error facts' }],
+  input: filteredInputSchema,
+  intent: 'read',
+  output: errorsOutputSchema,
+  visibility: 'internal',
+});
+
 export const wayfindDescribeTrail = trail('wayfind.describe', {
   args: ['id'],
   blaze: async (input, ctx) => {
@@ -1317,6 +1420,7 @@ export const wayfinderTopo = topo('wayfinder', {
   wayfindContractTrail,
   wayfindDescribeTrail,
   wayfindDiffTrail,
+  wayfindErrorsTrail,
   wayfindExamplesTrail,
   wayfindFacetsTrail,
   wayfindImpactTrail,

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -87,10 +87,10 @@ trails wayfind contract <trail-id> --root-dir . --json
 ```
 
 - Start with `wayfind.overview` to learn artifact source, freshness, and graph counts.
-- Use `wayfind.search` or typed list trails (`wayfind.trails`, `wayfind.resources`, `wayfind.signals`, `wayfind.surfaces`, `wayfind.facets`, `wayfind.versions`, `wayfind.examples`) for filtered discovery.
+- Use `wayfind.search` or typed list trails (`wayfind.trails`, `wayfind.resources`, `wayfind.signals`, `wayfind.surfaces`, `wayfind.facets`, `wayfind.versions`, `wayfind.examples`, `wayfind.errors`) for filtered discovery.
 - Use `wayfind.describe` for a full saved entity record and `wayfind.contract` for a trail or version input/output/intent summary.
 - Use `wayfind.nearby`, `wayfind.impact`, and `wayfind.diff` for relation context, blast-radius reads, and explicit saved-baseline comparison.
-- Treat Wayfinder as graph-read only. Do not assume `wayfind.errors`, `wayfind.adapters`, generic `wayfind.query`, semantic search, signposts, or implications exist in v0.
+- Treat Wayfinder as graph-read only. Do not assume `wayfind.adapters`, generic `wayfind.query`, semantic search, signposts, or implications exist in v0.
 
 Wayfinder trails are internal by default. Host apps expose selected queries deliberately, usually as read-only operator tools or MCP resources protected by the host's authorization boundary. Fall back to `rg`, qmd, source reads, or a fresh compile when Wayfinder reports missing or stale artifacts, when the task needs source code that Topographer does not project, or when writing artifacts is outside your current authority.
 


### PR DESCRIPTION
## Summary
- Adds the `wayfind.errors` query trail over `TrailErrorFacts`.
- Exposes `wayfind.errors` through the Trails operator CLI.
- Documents that the query reports provenance and completeness without claiming exhaustive emitted-error knowledge.

## Verification
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`