### PR TITLE
feat(adapter-kit): expose adapter facts

### DIFF
--- a/.changeset/trl-912-adapter-facts.md
+++ b/.changeset/trl-912-adapter-facts.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/adapter-kit": patch
+---
+
+Add adapter fact projections to the shared adapter readiness report so downstream tooling can distinguish available targets, configured adapter packages, and conformance-backed usage evidence.

--- a/packages/adapter-kit/src/__tests__/dogfood.test.ts
+++ b/packages/adapter-kit/src/__tests__/dogfood.test.ts
@@ -25,6 +25,42 @@ describe('first-party adapter dogfood', () => {
         'adapters/hono/src/__tests__/conformance.test.ts'
       ),
     ]);
+    expect(report.facts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: '@ontrails/http:http:available',
+          kind: 'available',
+          ownerPackage: '@ontrails/http',
+          target: 'http',
+          targetKey: '@ontrails/http:http',
+        }),
+        expect.objectContaining({
+          key: '@ontrails/hono:http:configured',
+          kind: 'configured',
+          packageName: '@ontrails/hono',
+          target: 'http',
+          targetKey: '@ontrails/http:http',
+        }),
+        expect.objectContaining({
+          key: '@ontrails/hono:http:used',
+          kind: 'used',
+          packageName: '@ontrails/hono',
+          provenance: expect.objectContaining({
+            paths: [
+              expect.stringContaining(
+                'adapters/hono/src/__tests__/conformance.test.ts'
+              ),
+            ],
+            source: 'conformance-test',
+          }),
+          target: 'http',
+          targetKey: '@ontrails/http:http',
+        }),
+      ])
+    );
+    expect(report.facts).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ kind: 'observed' })])
+    );
     expect(report.diagnostics).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/packages/adapter-kit/src/check.ts
+++ b/packages/adapter-kit/src/check.ts
@@ -59,8 +59,36 @@ export interface AdapterCheckSubject {
   readonly testingImport?: string | undefined;
 }
 
+export type AdapterFactKind = 'available' | 'configured' | 'observed' | 'used';
+
+export type AdapterFactProvenanceSource =
+  | 'adapter-package-manifest'
+  | 'conformance-test'
+  | 'owner-package-manifest'
+  | 'runtime-observation';
+
+export interface AdapterFactProvenance {
+  readonly packageJsonPath?: string | undefined;
+  readonly paths?: readonly string[] | undefined;
+  readonly source: AdapterFactProvenanceSource;
+}
+
+export interface AdapterFact {
+  readonly adapterType?: string | undefined;
+  readonly key: string;
+  readonly kind: AdapterFactKind;
+  readonly ownerPackage?: string | undefined;
+  readonly packageName?: string | undefined;
+  readonly placement?: AdapterTargetPlacement | undefined;
+  readonly placements?: readonly AdapterTargetPlacement[] | undefined;
+  readonly provenance: AdapterFactProvenance;
+  readonly target: string;
+  readonly targetKey?: string | undefined;
+}
+
 export interface AdapterCheckReport {
   readonly diagnostics: readonly AdapterCheckDiagnostic[];
+  readonly facts: readonly AdapterFact[];
   readonly subjects: readonly AdapterCheckSubject[];
   readonly targets: readonly AdapterTargetCatalogEntry[];
 }
@@ -323,6 +351,64 @@ const targetEntriesByTarget = (
   targets: readonly AdapterTargetCatalogEntry[]
 ): ReadonlyMap<string, AdapterTargetCatalogEntry> =>
   new Map(targets.map((target) => [target.target, target]));
+
+const adapterFacts = (
+  targets: readonly AdapterTargetCatalogEntry[],
+  subjects: readonly AdapterCheckSubject[]
+): readonly AdapterFact[] => {
+  const facts: AdapterFact[] = [];
+
+  for (const target of targets) {
+    facts.push({
+      key: `${target.key}:available`,
+      kind: 'available',
+      ownerPackage: target.ownerPackage,
+      placements: target.placements,
+      provenance: {
+        packageJsonPath: target.packageJsonPath,
+        source: 'owner-package-manifest',
+      },
+      target: target.target,
+      targetKey: target.key,
+    });
+  }
+
+  for (const subject of subjects) {
+    facts.push({
+      key: `${subject.key}:${subject.target}:configured`,
+      kind: 'configured',
+      ownerPackage: subject.ownerPackage,
+      packageName: subject.packageName,
+      placement: subject.placement,
+      provenance: {
+        packageJsonPath: subject.packageJsonPath,
+        source: 'adapter-package-manifest',
+      },
+      target: subject.target,
+      targetKey: subject.targetKey,
+      ...(subject.adapterType ? { adapterType: subject.adapterType } : {}),
+    });
+
+    if (subject.conformanceTestPaths.length > 0) {
+      facts.push({
+        key: `${subject.key}:${subject.target}:used`,
+        kind: 'used',
+        ownerPackage: subject.ownerPackage,
+        packageName: subject.packageName,
+        placement: subject.placement,
+        provenance: {
+          paths: subject.conformanceTestPaths,
+          source: 'conformance-test',
+        },
+        target: subject.target,
+        targetKey: subject.targetKey,
+        ...(subject.adapterType ? { adapterType: subject.adapterType } : {}),
+      });
+    }
+  }
+
+  return facts;
+};
 
 const collectSourceFiles = (dir: string): readonly string[] => {
   if (!existsSync(dir)) {
@@ -2058,11 +2144,14 @@ export const checkAdapters = (rootDir: string): AdapterCheckReport => {
     }
   }
 
+  const sortedSubjects = subjects.toSorted((left, right) =>
+    left.key.localeCompare(right.key)
+  );
+
   return {
     diagnostics,
-    subjects: subjects.toSorted((left, right) =>
-      left.key.localeCompare(right.key)
-    ),
+    facts: adapterFacts(catalog.targets, sortedSubjects),
+    subjects: sortedSubjects,
     targets: catalog.targets,
   };
 };

--- a/packages/adapter-kit/src/index.ts
+++ b/packages/adapter-kit/src/index.ts
@@ -3,6 +3,10 @@ export type {
   AdapterCheckDiagnostic,
   AdapterCheckDiagnosticCode,
   AdapterCheckDiagnosticSeverity,
+  AdapterFact,
+  AdapterFactKind,
+  AdapterFactProvenance,
+  AdapterFactProvenanceSource,
   AdapterCheckReport,
   AdapterCheckSubject,
 } from './check.js';


### PR DESCRIPTION
## Summary
- Adds adapter fact projections to the shared `@ontrails/adapter-kit` report.
- Distinguishes available targets, configured adapter packages, and conformance-backed usage.
- Leaves runtime observations at zero until a real runtime evidence source exists.

## Verification
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun apps/trails/bin/trails.ts wayfind adapters --root-dir . --json`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`