### PR TITLE
feat(wayfinder): add adapter facts query

### DIFF
--- a/.changeset/trl-913-wayfind-adapters.md
+++ b/.changeset/trl-913-wayfind-adapters.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/trails": patch
+"@ontrails/wayfinder": patch
+---
+
+Expose `wayfind.adapters` over adapter-kit fact reports and add it to the Trails operator CLI Wayfinder surface.

--- a/apps/trails/src/__tests__/wayfind-cli.test.ts
+++ b/apps/trails/src/__tests__/wayfind-cli.test.ts
@@ -18,6 +18,7 @@ describe('Trails Wayfinder CLI surface', () => {
     const trailIds = commands.map((command) => command.trail.id);
 
     expect(commandPaths).toContain('wayfind overview');
+    expect(commandPaths).toContain('wayfind adapters');
     expect(commandPaths).toContain('wayfind search');
     expect(commandPaths).toContain('wayfind trails');
     expect(commandPaths).toContain('wayfind contract');
@@ -28,6 +29,7 @@ describe('Trails Wayfinder CLI surface', () => {
     expect(commandPaths).toContain('wayfind examples');
 
     expect(trailIds).toContain('wayfind.overview');
+    expect(trailIds).toContain('wayfind.adapters');
     expect(trailIds).toContain('wayfind.search');
     expect(trailIds).toContain('wayfind.trails');
     expect(trailIds).toContain('wayfind.contract');
@@ -42,7 +44,6 @@ describe('Trails Wayfinder CLI surface', () => {
     const commands = unwrapCommands();
     const trailIds = commands.map((command) => command.trail.id);
 
-    expect(trailIds).not.toContain('wayfind.adapters');
     expect(trailIds).not.toContain('wayfind.query');
     expect(trailIds).not.toContain('wayfind.implications');
     expect(trailIds).not.toContain('wayfind.diff');

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -1,5 +1,6 @@
 import { topo } from '@ontrails/core';
 import {
+  wayfindAdaptersTrail,
   wayfindContractTrail,
   wayfindDescribeTrail,
   wayfindErrorsTrail,
@@ -81,6 +82,7 @@ const operatorTrails = Object.fromEntries(
 );
 
 const cliWayfinderTrails = {
+  wayfindAdaptersTrail,
   wayfindContractTrail,
   wayfindDescribeTrail,
   wayfindErrorsTrail,

--- a/bun.lock
+++ b/bun.lock
@@ -293,6 +293,9 @@
     "packages/wayfinder": {
       "name": "@ontrails/wayfinder",
       "version": "1.0.0-beta.20",
+      "dependencies": {
+        "@ontrails/adapter-kit": "workspace:^",
+      },
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "@ontrails/topographer": "workspace:^",

--- a/docs/adr/drafts/20260503-wayfinding.md
+++ b/docs/adr/drafts/20260503-wayfinding.md
@@ -118,11 +118,13 @@ The v0 catalog is deliberately narrow. The test for inclusion: every query must 
 | `wayfind.nearby` | Direct typed relation context around one graph entity | edge indexes derived from composes, contours, resources, signals, surfaces, facets, and versions | v0 |
 | `wayfind.impact` | Directional and multi-hop reachability for "what is upstream/downstream from this thing?" | typed relation edges oriented from contract substrate to affected graph members | v0 |
 | `wayfind.examples` | Return examples for a trail or contour | `TopoGraphEntry.examples`, `TopoStoreExampleRecord` | v0 |
+| `wayfind.errors` | Return saved trail error facts with provenance and completeness metadata | `TrailErrorFacts` derived from examples, detours, taxonomy, and supplied evidence | v0 |
+| `wayfind.adapters` | Return adapter target and adapter-package facts with provenance | `@ontrails/adapter-kit` readiness report facts | v0 |
 | `wayfind.diff` | Compare two explicit saved graph snapshots | `DiffResult` from `deriveTopoGraphDiff` | v0 |
 
-The proto's `wayfind.errors` is **deferred**. Today's `TopoGraphEntry` and `TopoStoreTrailRecord` preserve error examples and detour declarations, and core owns the taxonomy registry, but that is not an exhaustive per-trail emitted-error graph. Reintroduce when a `TrailErrorFacts` substrate can report taxonomy, documented, handled, inferred, and observed facts with explicit completeness semantics.
+`wayfind.errors` is intentionally not an exhaustive emitted-error graph. It reports documented, handled, inferred, and observed facts with explicit completeness semantics, and marks emitted-error completeness unknown unless a future substrate proves otherwise.
 
-The proto's `wayfind.adapters` is **deferred**. Adapter-kit already owns adapter catalog and readiness checks, but Wayfinder cannot pretend that "available adapter" means "configured" or "used." Reintroduce after adapter-kit exposes a stable report that distinguishes `available`, `configured`, `used`, and `observed` adapter facts.
+`wayfind.adapters` reads adapter-kit evidence and keeps available targets, configured adapter packages, conformance-backed usage, and future runtime observations distinct. It must not collapse "available" into "used."
 
 Complete CLI/MCP/HTTP projection inventory is **deferred** until Topographer owns it as durable graph artifact. v0 `wayfind.surfaces` may include operational projection rows only when it labels their source and partialness; it cannot treat today's topo-store projection rows as the canonical surface graph.
 
@@ -246,11 +248,6 @@ Avoid introducing a top-level `wayfind()` function — "wayfind" is unusual as a
   separate MCP tools or through a narrower façade is an MCP projection ergonomics
   decision, made in the wayfinder package — the catalog of trails is the
   same either way.
-- **`wayfind.errors`.** Returns when the substrate carries per-trail error
-  facts with provenance and completeness semantics; not v0.
-- **`wayfind.adapters`.** Returns when adapter-kit exposes a stable report that
-  distinguishes available, configured, used, and observed adapter facts; not
-  v0.
 - **`wayfind.query`.** A generic query endpoint waits until typed filter/list
   queries prove the shared predicate grammar.
 - **`wayfind.projections`.** v0 has no projections endpoint and no projections

--- a/docs/contributing/codebase-navigation.md
+++ b/docs/contributing/codebase-navigation.md
@@ -20,6 +20,7 @@ Then narrow the graph read with the selected local CLI surface:
 bun apps/trails/bin/trails.ts wayfind search --root-dir . --input-json '{"filters":{"kind":"trail","idPrefix":"wayfind."}}' --json
 bun apps/trails/bin/trails.ts wayfind contract wayfind.search --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind errors --root-dir . --input-json '{"filters":{"kind":"trail","idPrefix":"wayfind."}}' --json
+bun apps/trails/bin/trails.ts wayfind adapters --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind nearby wayfind.search --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind impact wayfind.search --root-dir . --json
 ```

--- a/docs/releases/wayfinder-v0.md
+++ b/docs/releases/wayfinder-v0.md
@@ -4,8 +4,8 @@ Wayfinder is now a real graph-read package, not just a reserved shell. The v0 ca
 
 ## What Ships
 
-- `@ontrails/wayfinder` exports `wayfinderTopo` and the v0 `wayfind.*` query trails for overview, typed search/listing, describe/contract inspection, examples, nearby relation reads, impact traversal, and explicit saved-baseline diffing.
-- Every query reads existing Topographer artifacts or topo-store records. V0 does not boot apps, resolve resources, reach the network, or mutate local state.
+- `@ontrails/wayfinder` exports `wayfinderTopo` and the v0 `wayfind.*` query trails for overview, typed search/listing, describe/contract inspection, examples, error facts, adapter facts, nearby relation reads, impact traversal, and explicit saved-baseline diffing.
+- Graph queries read existing Topographer artifacts or topo-store records. Adapter facts read package and conformance evidence through `@ontrails/adapter-kit`. V0 does not boot apps, resolve resources, reach the network, or mutate local state.
 - Query results include source and freshness metadata so agents can distinguish fresh artifacts from missing, stale, or schema-drifted artifacts.
 - Version and example listings preserve trail-version semantics: version records sort numerically, parent trail example filters include current and historical version examples, and `exampleCoverage: false` stays scoped to uncovered entities.
 - The Trails operator MCP surface exposes a selected read-only subset as direct tools and keeps broader saved-topo inspection behind the `inspect` facet.
@@ -24,4 +24,4 @@ Treat this as a release-time gate for new framework surfaces that should be visi
 
 ## Non-Goals
 
-V0 does not ship `wayfind.errors`, `wayfind.adapters`, generic `wayfind.query`, semantic search, signposts, or `wayfind.implications`. Those need additional accepted substrates or field evidence before they can answer honestly.
+V0 does not ship generic `wayfind.query`, semantic search, signposts, or `wayfind.implications`. Those need additional accepted substrates or field evidence before they can answer honestly.

--- a/packages/wayfinder/README.md
+++ b/packages/wayfinder/README.md
@@ -1,8 +1,8 @@
 # @ontrails/wayfinder
 
-Agent-shaped wayfinding query trails over `@ontrails/topographer` artifacts.
+Agent-shaped wayfinding query trails over saved graph and package evidence.
 
-`@ontrails/wayfinder` lets agents query a Trails app's resolved topo without re-deriving the graph from `grep` plus file reads. The v0 catalog is cold and deterministic: it reads existing Topographer artifacts (`topo.lock`, `trails.lock`, and materialized current `trails.db` topo-store records) without starting apps, booting resources, reaching the network, or mutating local state.
+`@ontrails/wayfinder` lets agents query a Trails app's resolved topo and package-level authoring facts without re-deriving the graph from `grep` plus file reads. The v0 catalog is cold and deterministic: graph queries read existing Topographer artifacts (`topo.lock`, `trails.lock`, and materialized current `trails.db` topo-store records), while adapter queries read `@ontrails/adapter-kit` package and conformance evidence. Wayfinder does not start apps, boot resources, reach the network, or mutate local state.
 
 The package exports `wayfinderTopo` plus individual graph-read trails.
 
@@ -21,15 +21,16 @@ The package exports `wayfinderTopo` plus individual graph-read trails.
 | `wayfind.versions` | List current and historical trail version records. |
 | `wayfind.examples` | List saved examples without executing trails. |
 | `wayfind.errors` | List saved trail error facts with provenance and completeness. |
+| `wayfind.adapters` | List adapter target and conformance facts with provenance. |
 | `wayfind.describe` | Inspect the saved entity record for one ID. |
 | `wayfind.contract` | Inspect the input/output/intent contract for one trail or version. |
 | `wayfind.nearby` | Return direct typed relation edges around one entity. |
 | `wayfind.impact` | Walk upstream, downstream, or both relation directions. |
 | `wayfind.diff` | Compare two explicit saved TopoGraph baselines. |
 
-Each trail is internal by default and returns provenance and freshness metadata with its result so callers can tell whether the answer came from fresh artifacts, stale artifacts, missing artifacts, or schema-version drift. Public surface exposure must be a deliberate host decision.
+Each graph-read trail is internal by default and returns provenance and freshness metadata with its result so callers can tell whether the answer came from fresh artifacts, stale artifacts, missing artifacts, or schema-version drift. Adapter facts carry package and conformance provenance instead. Public surface exposure must be a deliberate host decision.
 
-The v0 catalog intentionally does not include `wayfind.adapters`, generic `wayfind.query`, semantic search, signposts, or `wayfind.implications`. Those require additional accepted substrates or field evidence before they can answer honestly.
+The v0 catalog intentionally does not include generic `wayfind.query`, semantic search, signposts, or `wayfind.implications`. Those require additional accepted substrates or field evidence before they can answer honestly.
 
 ```ts
 import { wayfinderTopo } from '@ontrails/wayfinder';
@@ -90,6 +91,12 @@ Example coverage filters are evaluated against the entity being returned. `wayfi
 Use `wayfind.errors` when you need to inspect saved error facts for one trail or a filtered set of trails. The query reports documented error examples, handled detours, and later supplied inferred or observed facts with provenance and completeness metadata.
 
 The error facts are deliberately not an exhaustive emitted-error contract. A trail with no error facts still reports unknown emitted-error completeness rather than implying the trail cannot fail, and dynamic-category errors such as `RetryExhaustedError` do not receive fixed surface codes without wrapped-cause evidence.
+
+## Adapter Facts
+
+Use `wayfind.adapters` when you need to inspect adapter targets and adapter-package evidence. The query reads the `@ontrails/adapter-kit` readiness report and distinguishes available owner targets, configured adapter packages, and conformance-backed usage facts.
+
+Runtime observations are not inferred from package metadata. `observed` remains part of the fact vocabulary, but the current query reports zero observed facts until a future runtime evidence source supplies them.
 
 ## Describe And Contract
 

--- a/packages/wayfinder/package.json
+++ b/packages/wayfinder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ontrails/wayfinder",
   "version": "1.0.0-beta.20",
-  "description": "Agent wayfinding query trails over @ontrails/topographer artifacts.",
+  "description": "Agent wayfinding query trails over saved graph and package evidence.",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",
@@ -21,6 +21,9 @@
     "typecheck": "tsc --noEmit",
     "lint": "oxlint ./src",
     "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "dependencies": {
+    "@ontrails/adapter-kit": "workspace:^"
   },
   "peerDependencies": {
     "@ontrails/core": "workspace:^",

--- a/packages/wayfinder/src/__tests__/queries.test.ts
+++ b/packages/wayfinder/src/__tests__/queries.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import { z } from 'zod';
 
@@ -28,6 +28,7 @@ import type {
 } from '@ontrails/topographer';
 
 import {
+  wayfindAdaptersTrail,
   wayfindContractTrail,
   wayfindDescribeTrail,
   wayfindDiffTrail,
@@ -199,6 +200,95 @@ const writePlainArtifactsAt = async (rootDir: string) => {
   return graph;
 };
 
+const writeFile = async (
+  rootDir: string,
+  path: string,
+  value: string
+): Promise<void> => {
+  const filePath = join(rootDir, path);
+  await mkdir(dirname(filePath), { recursive: true });
+  await Bun.write(filePath, value);
+};
+
+const writeJson = async (
+  rootDir: string,
+  path: string,
+  value: Readonly<Record<string, unknown>>
+): Promise<void> =>
+  writeFile(rootDir, path, `${JSON.stringify(value, null, 2)}\n`);
+
+const writeAdapterWorkspace = async (rootDir: string): Promise<void> => {
+  await writeJson(rootDir, 'package.json', {
+    name: 'fixture-root',
+    workspaces: ['packages/*', 'adapters/*'],
+  });
+  await writeJson(rootDir, 'packages/http/package.json', {
+    exports: {
+      '.': './src/index.ts',
+      './package.json': './package.json',
+      './testing': './src/testing.ts',
+    },
+    name: '@demo/http',
+    trails: {
+      adapterTargets: {
+        http: {
+          conformance: {
+            adapterType: 'HttpAdapterConformanceAdapter',
+            casesFactory: 'createHttpAdapterConformanceCases',
+            runner: 'runConformance',
+          },
+          placements: ['extracted'],
+          testingImport: '@demo/http/testing',
+        },
+      },
+    },
+  });
+  await writeFile(
+    rootDir,
+    'packages/http/src/index.ts',
+    'export const http = {};\n'
+  );
+  await writeFile(
+    rootDir,
+    'packages/http/src/testing.ts',
+    [
+      'export interface HttpAdapterConformanceAdapter {}',
+      'export const createHttpAdapterConformanceCases = () => [];',
+      'export const runConformance = () => undefined;',
+      '',
+    ].join('\n')
+  );
+  await writeJson(rootDir, 'adapters/hono/package.json', {
+    dependencies: {
+      '@ontrails/core': 'workspace:^',
+      hono: '^4.7.0',
+    },
+    exports: {
+      '.': './src/index.ts',
+      './package.json': './package.json',
+    },
+    name: '@demo/hono',
+    peerDependencies: {
+      '@demo/http': 'workspace:^',
+    },
+    trails: {
+      adapter: {
+        target: 'http',
+      },
+    },
+  });
+  await writeFile(
+    rootDir,
+    'adapters/hono/src/index.ts',
+    'export const honoAdapter = {};\n'
+  );
+  await writeFile(
+    rootDir,
+    'adapters/hono/src/__tests__/conformance.test.ts',
+    "import { createHttpAdapterConformanceCases, runConformance } from '@demo/http/testing';\n\nrunConformance({ name: '@demo/hono' }, createHttpAdapterConformanceCases());\n"
+  );
+};
+
 const seedTopoStoreAt = (rootDir: string, graph = app()) => {
   const snapshot = createTopoSnapshot(graph, {
     createdAt: '2026-06-04T00:00:00.000Z',
@@ -236,6 +326,7 @@ afterEach(async () => {
 describe('wayfinder graph-read query trails', () => {
   test('exports the v0 query catalog as a topo', () => {
     expect([...wayfinderTopo.ids()].toSorted()).toEqual([
+      'wayfind.adapters',
       'wayfind.contours',
       'wayfind.contract',
       'wayfind.describe',
@@ -252,6 +343,67 @@ describe('wayfinder graph-read query trails', () => {
       'wayfind.surfaces',
       'wayfind.trails',
       'wayfind.versions',
+    ]);
+  });
+
+  test('lists adapter facts from workspace package evidence', async () => {
+    await writeAdapterWorkspace(tempDir);
+
+    const result = await expectOk(
+      wayfindAdaptersTrail.blaze({ rootDir: tempDir }, ctx())
+    );
+
+    expect(result.counts).toEqual({
+      available: 1,
+      configured: 1,
+      diagnostics: 0,
+      observed: 0,
+      used: 1,
+    });
+    expect(result.adapters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: '@demo/http:http:available',
+          kind: 'available',
+          ownerPackage: '@demo/http',
+          target: 'http',
+          targetKey: '@demo/http:http',
+        }),
+        expect.objectContaining({
+          key: '@demo/hono:http:configured',
+          kind: 'configured',
+          packageName: '@demo/hono',
+          target: 'http',
+          targetKey: '@demo/http:http',
+        }),
+        expect.objectContaining({
+          key: '@demo/hono:http:used',
+          kind: 'used',
+          packageName: '@demo/hono',
+          provenance: expect.objectContaining({
+            paths: [
+              expect.stringContaining(
+                'adapters/hono/src/__tests__/conformance.test.ts'
+              ),
+            ],
+            source: 'conformance-test',
+          }),
+          target: 'http',
+          targetKey: '@demo/http:http',
+        }),
+      ])
+    );
+    expect(
+      result.adapters.filter((entry) => entry.kind === 'configured')
+    ).toHaveLength(1);
+    const configured = await expectOk(
+      wayfindAdaptersTrail.blaze(
+        { filters: { kind: 'configured' }, rootDir: tempDir },
+        ctx()
+      )
+    );
+    expect(configured.adapters.map((entry) => entry.kind)).toEqual([
+      'configured',
     ]);
   });
 

--- a/packages/wayfinder/src/index.ts
+++ b/packages/wayfinder/src/index.ts
@@ -2,12 +2,13 @@
  * Agent-shaped wayfinding API for Trails.
  *
  * `@ontrails/wayfinder` is the public package home for trails that let agents
- * query a Trails app's resolved topo without re-deriving it from `grep` plus
- * file reads.
+ * query a Trails app's resolved topo and package-level authoring facts without
+ * re-deriving them from `grep` plus file reads.
  *
  * The v0 graph-read catalog is cold and deterministic: it reads existing
- * Topographer artifacts and topo-store provenance, but it does not boot apps,
- * resolve resources, reach the network, or mutate local state.
+ * Topographer artifacts, topo-store provenance, and adapter-kit package
+ * evidence, but it does not boot apps, resolve resources, reach the network, or
+ * mutate local state.
  */
 
 export { deriveTrailErrorFacts } from './error-facts.js';
@@ -50,6 +51,7 @@ export type {
   WayfinderTopoStoreLoad,
 } from './loader.js';
 export {
+  wayfindAdaptersTrail,
   wayfindContractTrail,
   wayfindContoursTrail,
   wayfindDescribeTrail,

--- a/packages/wayfinder/src/queries.ts
+++ b/packages/wayfinder/src/queries.ts
@@ -1,5 +1,7 @@
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
+import { adapterTargetPlacements, checkAdapters } from '@ontrails/adapter-kit';
+import type { AdapterFact } from '@ontrails/adapter-kit';
 import {
   AmbiguousError,
   DerivationError,
@@ -88,6 +90,27 @@ const filteredInputSchema = sourceInputSchema.extend({
   filters: wayfinderEntityFilterSchema.optional(),
   limit: z.number().int().positive().max(500).default(100),
 });
+
+const adapterFactKindSchema = z.enum([
+  'available',
+  'configured',
+  'observed',
+  'used',
+]);
+
+const adapterFactsInputSchema = z
+  .object({
+    filters: z
+      .object({
+        kind: adapterFactKindSchema.optional(),
+        packageName: z.string().optional(),
+        target: z.string().optional(),
+      })
+      .optional(),
+    limit: z.number().int().positive().max(500).default(100),
+    rootDir: z.string().optional().describe('Workspace root directory'),
+  })
+  .strict();
 
 const inspectKindSchema = z.enum([
   'contour',
@@ -341,7 +364,59 @@ const errorsOutputSchema = envelopeSchema.extend({
   errors: z.array(trailErrorFactsSchema).readonly(),
 });
 
+const adapterPlacementSchema = z.enum(adapterTargetPlacements);
+
+const adapterFactProvenanceSchema = z.object({
+  packageJsonPath: z.string().optional(),
+  paths: z.array(z.string()).readonly().optional(),
+  source: z.enum([
+    'adapter-package-manifest',
+    'conformance-test',
+    'owner-package-manifest',
+    'runtime-observation',
+  ]),
+});
+
+const adapterFactSchema = z.object({
+  adapterType: z.string().optional(),
+  key: z.string(),
+  kind: adapterFactKindSchema,
+  ownerPackage: z.string().optional(),
+  packageName: z.string().optional(),
+  placement: adapterPlacementSchema.optional(),
+  placements: z.array(adapterPlacementSchema).readonly().optional(),
+  provenance: adapterFactProvenanceSchema,
+  target: z.string(),
+  targetKey: z.string().optional(),
+});
+
+const adapterFactCountsSchema = z.object({
+  available: z.number(),
+  configured: z.number(),
+  diagnostics: z.number(),
+  observed: z.number(),
+  used: z.number(),
+});
+
+const adapterDiagnosticSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  packageJsonPath: z.string(),
+  packageName: z.string().optional(),
+  placement: adapterPlacementSchema.optional(),
+  severity: z.enum(['error', 'warn']),
+  target: z.string().optional(),
+});
+
+const adaptersOutputSchema = z.object({
+  adapters: z.array(adapterFactSchema).readonly(),
+  counts: adapterFactCountsSchema,
+  diagnostics: z.array(adapterDiagnosticSchema).readonly(),
+  rootDir: z.string(),
+});
+
 type SourceInput = z.output<typeof sourceInputSchema>;
+type AdapterFactsInput = z.output<typeof adapterFactsInputSchema>;
 type InspectInput = z.output<typeof inspectInputSchema>;
 type ContractInput = z.output<typeof contractInputSchema>;
 type DiffInput = z.output<typeof diffInputSchema>;
@@ -428,6 +503,63 @@ const loadGraph = async (
       path: topoLockPath(input, cwd) ?? 'topo.lock',
       schemaVersion: load.topoGraph.topoGraphSchemaVersion,
     },
+  });
+};
+
+const adapterFactsRootDir = (
+  input: AdapterFactsInput,
+  cwd: string | undefined
+): Result<string, ValidationError> => {
+  const rootDir = input.rootDir ?? cwd;
+  return rootDir === undefined
+    ? Result.err(
+        new ValidationError(
+          'Provide rootDir or run wayfind.adapters from a workspace directory.'
+        )
+      )
+    : Result.ok(resolve(rootDir));
+};
+
+const filteredAdapterFacts = (
+  input: AdapterFactsInput,
+  cwd: string | undefined
+): Result<z.output<typeof adaptersOutputSchema>, ValidationError> => {
+  const rootDir = adapterFactsRootDir(input, cwd);
+  if (rootDir.isErr()) {
+    return rootDir;
+  }
+
+  const report = checkAdapters(rootDir.value);
+  const facts = report.facts
+    .filter(
+      (fact: AdapterFact) =>
+        (input.filters?.kind === undefined ||
+          fact.kind === input.filters.kind) &&
+        (input.filters?.target === undefined ||
+          fact.target === input.filters.target) &&
+        (input.filters?.packageName === undefined ||
+          fact.packageName === input.filters.packageName)
+    )
+    .slice(0, input.limit);
+
+  return Result.ok({
+    adapters: facts,
+    counts: {
+      available: report.facts.filter(
+        (fact: AdapterFact) => fact.kind === 'available'
+      ).length,
+      configured: report.facts.filter(
+        (fact: AdapterFact) => fact.kind === 'configured'
+      ).length,
+      diagnostics: report.diagnostics.length,
+      observed: report.facts.filter(
+        (fact: AdapterFact) => fact.kind === 'observed'
+      ).length,
+      used: report.facts.filter((fact: AdapterFact) => fact.kind === 'used')
+        .length,
+    },
+    diagnostics: [...report.diagnostics],
+    rootDir: rootDir.value,
   });
 };
 
@@ -1257,6 +1389,16 @@ export const wayfindErrorsTrail = trail('wayfind.errors', {
   visibility: 'internal',
 });
 
+export const wayfindAdaptersTrail = trail('wayfind.adapters', {
+  blaze: (input, ctx) => filteredAdapterFacts(input, ctx.cwd),
+  description: 'List adapter facts with package and conformance provenance',
+  examples: [{ input: {}, name: 'List adapter facts' }],
+  input: adapterFactsInputSchema,
+  intent: 'read',
+  output: adaptersOutputSchema,
+  visibility: 'internal',
+});
+
 export const wayfindDescribeTrail = trail('wayfind.describe', {
   args: ['id'],
   blaze: async (input, ctx) => {
@@ -1416,6 +1558,7 @@ export const wayfindDiffTrail = trail('wayfind.diff', {
 });
 
 export const wayfinderTopo = topo('wayfinder', {
+  wayfindAdaptersTrail,
   wayfindContoursTrail,
   wayfindContractTrail,
   wayfindDescribeTrail,

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -87,10 +87,10 @@ trails wayfind contract <trail-id> --root-dir . --json
 ```
 
 - Start with `wayfind.overview` to learn artifact source, freshness, and graph counts.
-- Use `wayfind.search` or typed list trails (`wayfind.trails`, `wayfind.resources`, `wayfind.signals`, `wayfind.surfaces`, `wayfind.facets`, `wayfind.versions`, `wayfind.examples`, `wayfind.errors`) for filtered discovery.
+- Use `wayfind.search` or typed list trails (`wayfind.trails`, `wayfind.resources`, `wayfind.signals`, `wayfind.surfaces`, `wayfind.facets`, `wayfind.versions`, `wayfind.examples`, `wayfind.errors`, `wayfind.adapters`) for filtered discovery.
 - Use `wayfind.describe` for a full saved entity record and `wayfind.contract` for a trail or version input/output/intent summary.
 - Use `wayfind.nearby`, `wayfind.impact`, and `wayfind.diff` for relation context, blast-radius reads, and explicit saved-baseline comparison.
-- Treat Wayfinder as graph-read only. Do not assume `wayfind.adapters`, generic `wayfind.query`, semantic search, signposts, or implications exist in v0.
+- Treat Wayfinder as graph-read only. Do not assume generic `wayfind.query`, semantic search, signposts, or implications exist in v0.
 
 Wayfinder trails are internal by default. Host apps expose selected queries deliberately, usually as read-only operator tools or MCP resources protected by the host's authorization boundary. Fall back to `rg`, qmd, source reads, or a fresh compile when Wayfinder reports missing or stale artifacts, when the task needs source code that Topographer does not project, or when writing artifacts is outside your current authority.
 


### PR DESCRIPTION
## Summary
- Adds `wayfind.adapters` over adapter-kit package and conformance evidence.
- Adds the adapter-kit dependency to `@ontrails/wayfinder` and exports the query trail.
- Exposes the command through the Trails operator CLI with docs and release notes.

## Verification
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun apps/trails/bin/trails.ts wayfind adapters --root-dir . --json`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`