### PR TITLE
docs(contributing): define script graduation doctrine and binding vocabulary

### DIFF
--- a/.agents/memory/decisions.md
+++ b/.agents/memory/decisions.md
@@ -98,3 +98,55 @@
 - CLI-only checks - rejected because adapter drift belongs in governance and CI.
 
 **Follow-up:** Use `.agents/notes/2026-05-28-adapter-authoring-paved-path.md` as the execution-shape note. Promote into an ADR before implementation. Sequence the stack as ADR -> internal adapter tooling substrate -> one-owner HTTP tracer combining owner conformance plus shared check engine -> Warden and `trails adapter check` surfaces -> `create.adapter` scaffolding -> dogfood existing adapters -> catalog/describe read views and docs. Keep the tooling package internal and not author-facing; if public CLI or Warden packages depend on it, publish it as tooling while enforcing that runtime adapters do not import it. Generated conformance tests stay thin calls into owner-owned dynamic factories.
+
+### 2026-06-09 Script graduation doctrine: derive-vs-consume
+
+**Question:** What rule decides whether repo behavior belongs in root `scripts/` versus a Trails concept (package API, app surface, Warden, Wayfinder, release rules)? Matt was stuck on a three-tier audience model whose middle tier ("contributor confidence") was undecidable.
+
+**Decision:** Replace the audience-tier model with a single binding test. The mental model is a 2x2 matrix on two independent axes — (A) is it a Trails *concept*? and (B) who is it for: Trails users vs. building Trails itself. Axis B does NOT decide the home; it only names trajectory (the "Trails-concept x building-Trails" quadrant is the dogfooding nursery where capabilities like `release.check` are born and graduate). Axis A decides the home, sharpened to one question:
+
+> **Does this own logic that *derives* facts from a Trails concept's contract?**
+>
+> - Derives → the logic belongs *in the concept*, exposed as a trail/surface/rule. Graduate.
+> - Only *consumes* already-derived output to do file/repo work → it may stay a script.
+
+A script may consume Trails concepts; it may not own their derivation. The bug that bloated `scripts/` was letting "we only use it ourselves" (axis B) override axis A. General heuristic underneath, for any repo: `scripts/` = things you run *on* the repo; `src/` = what the repo *is*. Trails is the unusual case where the repo's plumbing IS the product's domain, so "is it plumbing?" stops discriminating and must be replaced by the derive test.
+
+**Applied this session (TRL-942/943):** scaffold-version sync *derives* the `create` scaffold contract → graduate to the create surface (tell: the generated file already lives in-app). public-API example coverage *derives* a public-surface contract fact → graduate to a Warden advisory rule. The warden-guide and error-taxonomy syncs only *render* facts their concept already owns → shrink to thin callers, no new home. publish.ts / registry-preflight derive only npm facts, so they do not belong in *core* — but they fill the release lifecycle's publisher/emitter seam, so they belong as **adapters** (bun-publish, npm-publish, changesets), with our own publish.ts as the dogfood consumer. This revealed a third doctrine home (see refinement below).
+
+**Refinement (the consume side has its own graduation path — adapters):** The original derive-vs-consume test was binary (derive → graduate; consume → stay). Matt's TRL-938 input completes it: a *consumer* that wires an external system into a **declared Trails lifecycle/extension seam** is an **adapter**, not a script. So the test routes to three homes, not two: (1) derives concept facts → into the concept (core trail/surface/rule); (2) consumes facts to fill a declared seam → adapter (extensible; third-party deps → standalone package per ADR-0029, zero-dep → subpath); (3) consumes facts for a repo chore with no seam → stays a script (or shrinks to a caller if it only renders concept output). This aligns release/publish with the established adapter paved-path doctrine (2026-05-28 decision; ADR-0029).
+
+**Watch-item (release rules vs Warden):** `releaseRuleSchema` ({id, enabled, severity, description, facts, intent}) is structurally a governance rule, mirroring Warden without being Warden. ADR draft (release-provenance-as-lifecycle-projection) consciously framed release as a lifecycle *projection* (diff-provenance) distinct from Warden's state-validation axis, and exposed it as a `release.check` trail rather than a new primitive — which is correct and accepted. But two parallel rule-eval vocabularies is the ceiling. **Trigger: if a third "rules" engine appears, unify them under one governance substrate.** Two is coincidence; three is fragmentation (fights "additions strengthen primitives, not fragment them").
+
+**Confidence:** High on the derive-vs-consume test and the accept-with-watch posture on release rules. Medium on exact graduation homes (create.versions trail shape; warden rule severity).
+
+**Basis:** Tenets — evaluation hierarchy (strengthen before introduce), "add with intent not trend," the information-architecture Authored/Projected split (derivation is Projected and belongs to the concept). Builds on memory `feedback_gate_on_unmet_need_not_substrate` and `feedback_evaluation_hierarchy_application`.
+
+**LOCKED MODEL (Clark + Lewis aligned, 2026-06-09) — two questions, in order:**
+
+1. **Whose truth is it?** A *durable Trails-contract fact* (a concept — trail, surface, error taxonomy, topo, scaffold output, warden rule-set — should own it) vs. a *transient repo fact* (this repo's state, history, build health, one-time migration; no concept to own it).
+   - Transient → **tooling** (script, or a contributor package if shared/large). Stop here *even if it derives* (e.g. `vocab-cutover-rewrite` derives rename mappings but the truth is transient → stays tooling).
+   - Durable → graduates into the concept. Go to Q2.
+2. **Relationship + audience?**
+   - *Derives* the fact → **concept core.** Audience sets the tier: Trails users → public surface/rule; building Trails → **repo-local** rule/internal command (cf. `warden-export-symmetry`, `warden-rules-use-ast`).
+   - *Consumes* the fact to fill a **declared** seam → it's a **binding** (the role: connecting a Trails surface/contract to a concrete runtime, tool, or publisher). The ADR-0029 dependency-boundary test sets the *kind*: **native binding** = Trails-owned built-in path (subpath/same package, ambient runtime, no foreign boundary; `@ontrails/http/fetch`+`/bun`, a built-in release publisher); **adapter binding** = extracted package/integration crossing a third-party/foreign framework/tool/runtime (`@ontrails/hono`, invoking `@changesets/cli`); **reading authored input** (`.changeset/*.md` as intent) = **neither**. Both kinds share the **adapter seam** (paved scaffold + conformance), but a native binding is not called "an adapter" in prose. Three axes: kind (native/adapter), placement (subpath/extracted), why (Trails-owned/foreign-boundary). Guardrails: bindings fill declared seams only; don't promote an adjacent tool to an adapter binding just because it appears in the flow.
+
+     (Vocabulary evolution → LOCKED, Clark+Lewis 2026-06-09. (1) Matt: a "bun-publish adapter" is wrong — Bun is the ambient runtime. (2) Subagent verified `@ontrails/http`: lexicon defines `adapter`="package or subpath" and conformance type is `...Adapter`, so a flat "NOT an adapter" is also wrong; intermediate ruling was materializer-primary. (3) Matt dislikes "materializer" as prose; Lewis proposed **binding** as the genus. Sanity-check confirmed `binding`/"adapter binding" ALREADY in the lexicon (store, L426/443/445) and "Bun-native" already in HTTP docs — so binding-primary STRENGTHENS an existing term, not a new mint (best evaluation-hierarchy outcome). Final: **binding** genus; **native binding** vs **adapter binding** kinds; "materializer" demoted to HTTP implementation/ADR quote only; reject "internal vs external" as primary. Follow-ups: TRL-862 calls `fetch`/`bun` "real adapters" (stale → native bindings); lexicon L426/443/445 treat adapter≈binding (tighten to binding-as-genus). Likely a lexicon entry / ADR note.)
+   - *Consumes* to render concept output → thin **caller** (shrink).
+
+The single derive-vs-consume test was insufficient (Matt's correction): derivation over *transient* truth is still tooling. Purpose ("building Trails") sets the public-vs-repo-local *tier*, not whether something graduates.
+
+**Why (the bite):** contract-first. The framework must own derivation of its *durable* facts so no ungoverned shadow contract forms. Transient repo facts have no contract to shadow, so tooling is the honest home.
+
+**Canonical binding definition (Lewis, final 2026-06-09):** "A binding is a concrete realization of an authored Trails declaration or contract against a backend, runtime, tool, surface, or publisher. Bindings should be qualified by role when possible. A native binding is Trails-owned and built in. An adapter binding is extracted and crosses a foreign framework/tool/runtime boundary. The adapter seam is the shared extension/conformance path, not the public noun for every binding."
+
+**Prose guardrail:** `binding` is the lexicon genus, but in prose prefer **qualified** forms — `surface binding`, `native binding`, `adapter binding`, `store binding`, eventually `release binding` — so the bare word does not collide with local-variable/import "binding" noise (Warden/source-analysis land). `@ontrails/http/fetch`+`/bun` = native HTTP/surface bindings; `@ontrails/hono` = adapter binding; reading `.changeset/*.md` = not a binding (consuming authored release intent); invoking `@changesets/cli` = adapter-binding territory.
+
+**Follow-up / operational rulings (Lewis):**
+
+- **Fold the lexicon edits into TRL-933** as explicit acceptance criteria — NOT a separate issue. The vocabulary is part of making TRL-933 executable so agents don't re-open the naming question. (Add `binding` genus + qualified forms + canonical definition to lexicon; reconcile store L426/443/445 from adapter≈binding to binding-as-genus.)
+- **Patch TRL-862** (Done) — "real adapters (`fetch`, `bun`)" → "native bindings"; Done issues act as fossilized prompts for agents.
+- **TRL-939 stays narrow** — consume-only dogfood scripts (packed-artifacts, wayfinder); must not absorb this doctrine.
+- **Move TRL-933 into current sprint/project visibility** — it is now upstream of the release-rules work being clean; do not leave it parked in the "future emitters" milestone.
+- TRL-942 = scaffold versions (durable/derive/users → public). TRL-943 = public-API example coverage → repo-local Warden rule. TRL-938 = release publisher/emitter seam; native Bun binding default, adapter bindings for foreign boundaries; npm mechanics never core.
+- (2026-06-09: Linear API had a transient 502 outage mid-session; TRL Linear edits for the binding rewrite were queued and applied on recovery.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ The architecture is designed to make consistency easier than drift. Agents build
 1. Contracts are at the core of how Trails works, and the contract for how Trails is worked on is governed by our [Tenets](docs/tenets.md).
 2. Decisions that define what Trails is, and what it is not, are defined by our [ADRs](docs/adr/README.md).
    - Future directions for Trails are outlined in speculative or [draft ADRs](docs/adr/drafts/README.md).
-3. Repo contribution guidance lives in [Contributing to Trails](docs/contributing/README.md), including [Language Styleguide](docs/contributing/language-styleguide.md), [Code Standards](docs/contributing/code-standards.md), [Codebase Navigation](docs/contributing/codebase-navigation.md), and [Warden Rules](docs/contributing/warden-rules.md).
+3. Repo contribution guidance lives in [Contributing to Trails](docs/contributing/README.md), including [Language Styleguide](docs/contributing/language-styleguide.md), [Code Standards](docs/contributing/code-standards.md), [Codebase Navigation](docs/contributing/codebase-navigation.md), [Warden Rules](docs/contributing/warden-rules.md), and [Script Graduation](docs/contributing/script-graduation.md) — root scripts never own derivation of durable Trails-contract facts, and new or heavily edited root scripts get the script-graduation review check.
 4. We keep a log of our working notes, session recaps, learnings, etc. in `.agents/notes/` (gitignored — local only) as a historical record of our journey.
 
 ## Wayfinder First

--- a/docs/adr/0029-connector-extraction-and-the-with-packaging-model.md
+++ b/docs/adr/0029-connector-extraction-and-the-with-packaging-model.md
@@ -4,7 +4,7 @@ slug: connector-extraction-and-the-with-packaging-model
 title: Adapter Extraction and Composition Around Core Contracts
 status: accepted
 created: 2026-04-09
-updated: 2026-05-16
+updated: 2026-06-09
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [5, 9, 16, 22, 23]
 ---
@@ -246,6 +246,7 @@ The return type is identical. The topo registration is identical. The trail's `r
 - 2026-04-16: In-place vocabulary update per ADR-0035 Cutover 3 — title updated to drop `with-*` prefix convention, naming rules revised for extracted connectors, migration table and composition layer table aligned with surface API grammar.
 - 2026-05-08: Connector-to-adapter taxonomy cutover — `adapter` becomes the canonical public package category, `integration` is retained only as colloquial prose, `facet` is reserved for projection slices, and the historical `connectors/` workspace root is superseded by `adapters/`.
 - 2026-05-16: Web Fetch kernel amendment — runtime materializers with no third-party dependency may stay as subpaths on the owning projection package, covering `@ontrails/http/fetch` and `@ontrails/http/bun` while preserving `@ontrails/hono` as the extracted Hono adapter.
+- 2026-06-09: Binding vocabulary note — this ADR's built-in-materializer vs extracted-adapter distinction is the `native binding` vs `adapter binding` distinction now defined in [the lexicon](../lexicon.md#binding); the dependency-boundary test in this ADR sets the kind.
 
 [^1]: [ADR-0009: First-Class Resources](0009-first-class-resources.md)
 [^2]: See the evaluation hierarchy in [Tenets: Primitives](../tenets.md#the-bar-for-new-primitives)

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -12,6 +12,9 @@ If you are building an app with Trails, start with the user-facing docs in [`doc
   source-of-truth locations, generated files, and symbol navigation.
 - [Warden Rules](./warden-rules.md) — how to author and audit durable Warden
   and repo-local correctness rules.
+- [Script Graduation](./script-graduation.md) — when root-script behavior must
+  graduate into a Trails concept, and the binding vocabulary (native binding,
+  adapter binding, adapter seam).
 - [Beta Channel Policy](../releases/beta-channel-policy.md) and
   [Release Rules Check](../releases/release-rules-check.md) — release rules,
   branch-local release intent, and public trail contract release facts.

--- a/docs/contributing/script-graduation.md
+++ b/docs/contributing/script-graduation.md
@@ -1,0 +1,73 @@
+# Script Graduation
+
+This guide gives Trails contributors and agents one clean rule for whether a behavior belongs in root `scripts/` or graduates into a Trails concept: a package API, an app trail or surface, a Warden rule, a native binding, or an adapter binding. Durable framework behavior must not hide in scripts just because a script was the quickest first implementation.
+
+## The one line
+
+A Trails concept owns the derivation of its own durable facts. Tooling may consume those facts but must never re-derive them. `scripts/` is for repo-as-a-project work and named-exit dogfooding, never for shadow derivation of framework facts.
+
+## Why this bites
+
+Trails is contract-first: the contract is the one source of truth, one write feeding many reads. A script that derives durable framework facts is an ungoverned shadow contract — a second source of truth the framework cannot see, govern, or keep aligned. Script graduation is the contract-first principle applied to our own tooling, not folder tidiness.
+
+## The general heuristic, then the Trails replacement
+
+For newcomers, the ordinary repo heuristic is the toolshed and the house: `scripts/` is the toolshed (things you run *on* the repo), while `src/` and packages are the house (what the repo *is*). Trails is the rare repo where the plumbing is the product domain — release checking, scaffolding, governance, and graph tooling are themselves framework concepts. So "is it plumbing?" is replaced by two questions, asked in order.
+
+## The decision: two questions, in order
+
+### Q1: Whose truth is it?
+
+- **Durable Trails-contract fact** — a concept (trail, surface, error taxonomy, topo, scaffold output, Warden rule set) should own it going forward. Go to Q2.
+- **Transient repo fact** — this repo's state, history, build health, or a one-time migration. No concept should own it. **Transient → tooling**: a script, or a contributor package if shared or large. Stop here **even if it derives**.
+
+The transient branch is the case that makes the model click: "derives a fact" is not what forces graduation. `scripts/vocab-cutover-rewrite.ts` derives rename mappings with real AST analysis, but the truth it derives — a one-time vocabulary migration — is transient, so it stays tooling.
+
+### Q2: What is the relationship to the fact, and who is the audience?
+
+- **Derives** the fact → **concept core.** Audience sets the tier: for Trails users, a public surface or rule; for building Trails, a **repo-local** rule or internal command, as with `warden-export-symmetry` and `warden-rules-use-ast`.
+- **Consumes** the fact to fill a **declared seam** → a **binding** (see vocabulary below).
+- **Consumes** the fact to render concept output → keep a thin **caller** and shrink the script to a call.
+
+The mental model underneath is a 2×2 of *(durable vs transient truth)* × *(serves users vs serves building Trails)*. The first axis decides whether it graduates; the second only sets the public-vs-repo-local tier.
+
+## Binding vocabulary
+
+A **binding** is a concrete realization of an authored Trails declaration or contract against a backend, runtime, tool, surface, or publisher. Use `binding` as the lexicon genus, and prefer qualified forms in prose — `native binding`, `adapter binding`, `surface binding`, `store binding`, `release binding` — so the bare word does not collide with local-variable or import "binding" noise in Warden and source-analysis contexts.
+
+The ADR-0029 dependency-boundary test sets the kind:
+
+- **Native binding** — Trails-owned, built-in path (subpath or same package) that uses only the ambient runtime or a Trails-owned mechanism and crosses no foreign tool or framework boundary. `@ontrails/http/fetch` and `@ontrails/http/bun` are native HTTP bindings. A built-in release publisher is a native release binding.
+- **Adapter binding** — an extracted package or integration that crosses into a third-party or foreign framework, tool, or runtime contract. `@ontrails/hono` is an adapter binding. Invoking `@changesets/cli` tool behavior would be adapter-binding territory.
+- Merely reading authored input, such as `.changeset/*.md` as release intent, is **neither**. That is just consuming input.
+
+Both kinds may share the **adapter seam**: the paved scaffold plus conformance extension point. The adapter seam is the shared extension and conformance path, not the public noun for every binding — a native binding is not called "an adapter" in prose.
+
+Keep three axes distinct: native vs adapter is the *kind*; subpath/built-in vs extracted is the *placement*; Trails-owned vs foreign-boundary is the *why*. Use "materializer" only when quoting existing HTTP implementation or ADR wording.
+
+## Worked examples
+
+| Behavior | Q1 | Q2 | Home |
+| --- | --- | --- | --- |
+| release check (`release.check`) | durable | derives, serves users | public surface |
+| scaffold version pins (TRL-942) | durable | derives, serves users | public `create` surface |
+| public-API example coverage (TRL-943) | durable | derives, serves building Trails | repo-local Warden rule |
+| release publish via Bun (TRL-938) | durable | fills seam, ambient runtime | native Bun release binding |
+| changesets-CLI or foreign registry (TRL-938) | durable | fills seam, foreign boundary | adapter binding, extracted |
+| `.changeset/*.md` as release intent | durable | consumes authored input | neither — an intent source |
+| warden-guide / error-taxonomy doc sync | durable, concept owns it | consumes, renders | thin caller |
+| `vocab-cutover-rewrite` | transient | not applicable | tooling, stays |
+| trail-input type-cost guard | transient build metric | not applicable | tooling, stays |
+| publish/registry npm mechanics | npm facts, not Trails facts | not applicable | inside the binding, never core |
+
+`release.check` is the derives-and-graduates example: release rules are durable Trails-contract facts, so the script-era checker graduated into the `trails release check` surface, and package scripts became thin callers. `vocab-cutover-rewrite` is the derives-but-stays-tooling example: real derivation over a transient truth.
+
+## After graduation
+
+Scripts may remain as compatibility wrappers or thin callers after their logic graduates — CI entry points and `bun run` ergonomics are reasons to keep a named exit. Not every script becomes a public CLI command: repo-local Warden rules, internal commands, native bindings, adapter bindings, and plain tooling are all valid homes. The test is who owns the derivation, not whether a file still exists under `scripts/`.
+
+## Review checklist
+
+For any new root script, or a large edit to an existing one, the reviewer asks:
+
+- Does this script derive a durable Trails-contract fact? If yes, it must graduate into the owning concept (public surface, repo-local rule, or binding) and the script may remain only as a thin caller.

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -423,7 +423,7 @@ await surface(graph);
 
 ### `store`
 
-A persistence declaration. `store(definition)` declares what is persisted for a domain object — schema, identity, generated fields, relationships, and fixtures — without choosing how that persistence is realized. The store itself is backend-agnostic. An adapter binding interprets it for a specific backend and persistence shape.
+A persistence declaration. `store(definition)` declares what is persisted for a domain object — schema, identity, generated fields, relationships, and fixtures — without choosing how that persistence is realized. The store itself is backend-agnostic. A binding (native or adapter) interprets it for a specific backend and persistence shape.
 
 ```typescript
 const db = store({
@@ -438,11 +438,24 @@ const db = store({
 
 A store is infrastructure declared as data. A resource is how that infrastructure reaches blazes. A store becomes usable through a resource; they are complementary, not interchangeable.
 
+### `binding`
+
+A concrete realization of an authored Trails declaration or contract against a backend, runtime, tool, surface, or publisher. `binding` is the genus; the ADR-0029 dependency-boundary test sets the kind:
+
+- **`native binding`** — Trails-owned, built-in path (subpath or same package) that uses only the ambient runtime or a Trails-owned mechanism and crosses no foreign tool or framework boundary. `@ontrails/http/fetch` and `@ontrails/http/bun` are native HTTP bindings.
+- **`adapter binding`** — an extracted package or integration that crosses into a third-party or foreign framework, tool, or runtime contract. `@ontrails/hono` is an adapter binding.
+
+Merely reading authored input — for example, consuming `.changeset/*.md` as release intent — is neither kind. That is just consuming input.
+
+In prose, prefer qualified forms such as `native binding`, `adapter binding`, `surface binding`, `store binding`, and `release binding` so the bare word does not collide with local-variable or import "binding" noise in Warden and source-analysis contexts.
+
+Both kinds may share the **adapter seam**: the paved scaffold plus conformance extension point. The adapter seam is the shared extension and conformance path, not the public noun for every binding — a native binding is not called "an adapter" in prose. Use "materializer" only when quoting existing HTTP implementation or ADR wording. See [Script Graduation](contributing/script-graduation.md) for how bindings fit the graduation doctrine.
+
 ### `kind`
 
-The plain word for the persistence shape an adapter binds a store through. Current examples include `tabular`, `document`, `file`, `kv`, and `cache`.
+The plain word for the persistence shape a binding realizes a store through. Current examples include `tabular`, `document`, `file`, `kv`, and `cache`.
 
-The store declaration stays kind-agnostic. The adapter or binding chooses the kind and interprets the store schema accordingly.
+The store declaration stays kind-agnostic. The binding (native or adapter) chooses the kind and interprets the store schema accordingly.
 
 ### `projection`
 


### PR DESCRIPTION
## Summary

Defines the script-graduation doctrine for Trails tooling and lands the binding vocabulary (TRL-933).

- Adds `docs/contributing/script-graduation.md`: the two-question graduation model (whose truth is it; relationship + audience), the contract-first "shadow contract" rationale, the toolshed/house newcomer heuristic, worked examples (`vocab-cutover-rewrite` derives-but-stays-tooling; `release.check` derives-and-graduates), post-graduation wrapper guidance, and a review-checklist line for new/heavily-edited root scripts.
- Adds `binding` to `docs/lexicon.md` as the genus, with `native binding` and `adapter binding` kinds set by the ADR-0029 dependency-boundary test, qualified-prose guidance, and the adapter-seam note (the seam is the shared extension and conformance path, not the public noun for every binding).
- Reconciles the `store` and `kind` lexicon entries to binding-as-genus phrasing.
- Adds a one-line ADR-0029 amendment note mapping the materializer/extracted distinction onto native binding vs adapter binding.
- Wires pointers from `docs/contributing/README.md` and `AGENTS.md`.

Docs-only; no publishable package content (release check passes with no changeset for this branch).

Linear: TRL-933

## Verification

- `bun run check`, `bun run docs:wrap-check`, `bun run docs:links`, `bun run vocab:audit` all green at the stack tip.