### PR TITLE
docs(releases): define release governance joins

### DIFF
--- a/docs/adr/drafts/20260608-release-provenance-as-lifecycle-projection.md
+++ b/docs/adr/drafts/20260608-release-provenance-as-lifecycle-projection.md
@@ -3,7 +3,7 @@ slug: release-provenance-as-lifecycle-projection
 title: Release Provenance as Lifecycle Projection
 status: draft
 created: 2026-06-08
-updated: 2026-06-08
+updated: 2026-06-09
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [47, 48]
 ---
@@ -65,6 +65,16 @@ The first implementation wedge is branch-local:
 
 This is intentionally narrower than full changelog automation. It makes the missing-release-story failure impossible to miss without asking the framework to write prose or choose semver intent by itself.
 
+### Governance joins stay staged
+
+Release checks, Warden, and Wayfinder support the same story without owning the same facts.
+
+`release.check` owns branch-local release-rule evaluation. It reads the PR file list, compares a branch to its immediate Graphite base, loads release rules, and decides whether release intent is missing. Warden should not duplicate GitHub or Graphite adapter shape.
+
+Warden may later add advisory release hygiene when the fact is answerable from source, topo, or owner-held data without PR metadata. Good candidates include missing release config, docs that contradict release rules, or stale generated release guidance. A Warden error rule should wait for a durable invariant that Warden alone can evaluate.
+
+Wayfinder remains a graph-read first slice. It helps reviewers inspect impact, nearby trails, and contracts during release review, but `release.check` does not require Wayfinder artifacts today. Future `wayfind.implications` queries may join graph facts with named Warden diagnostics, release-check output, or Distribution-Ready Done checklist facts, but those joins must cite their sources.
+
 ### Graphite branch locality is part of the contract
 
 Stacked branches make release provenance easy to smear. A top cleanup branch can add one changeset that appears to cover lower package-affecting work, but that destroys the owning-branch story. The check therefore uses the PR file list and the branch's immediate base. Reviewers and agents should fix missing release intent on the owning branch, then restack upward.
@@ -96,6 +106,8 @@ Stacked branches make release provenance easy to smear. A top cleanup branch can
 - Implementing per-surface, per-facet, per-channel, or per-stack-segment release targets.
 - Computing stack-cumulative release plans.
 - Inferring error-taxonomy or permit changes as release facts in the first slice.
+- Implementing a Warden release-rule error rule before Warden has a durable non-PR-metadata invariant to own.
+- Requiring Wayfinder artifacts before release-rule usage proves a graph-read or rule-join need.
 - Promoting this draft ADR to accepted status in the same implementation stack.
 
 ## Non-decisions

--- a/docs/releases/release-rules-check.md
+++ b/docs/releases/release-rules-check.md
@@ -95,6 +95,17 @@ For local reviews, missing branch-local release intent for package content or a 
 
 Log broader release ideas, such as imported schema tracing, error-taxonomy facts, permit facts, Warden joins, Wayfinder implications, or release targets, as follow-up P3s unless they expose a concrete user-visible release gap in the current branch.
 
+## Warden And Wayfinder
+
+`trails release check` owns branch-local release-rule evaluation. It reads the GitHub or local changed-file list, release config, Changesets intent, and first source-static public trail contract facts. Warden should not duplicate PR file-list logic or own Graphite and GitHub comparison state.
+
+Current recommendation:
+
+- **No Warden error rule yet.** Release-rule gaps already fail in CI through `release.check`, and Warden does not have the branch-local PR metadata needed to evaluate the same fact without a parallel adapter.
+- **Advisory Warden is a later option.** A future advisory rule may report repo-local release hygiene that Warden can answer from source, topo, or owner data alone, such as a missing release config, stale generated release guide output, or package docs that contradict declared release rules. It should cite `release.check` as the rule owner instead of reimplementing the check.
+- **Wayfinder is useful evidence now, not a required substrate.** Use `wayfind impact`, `wayfind nearby`, and `wayfind contract` during review when a release fact needs graph context. Do not make the first release check depend on Wayfinder artifacts.
+- **Rule joins are deferred.** Future `wayfind.implications` can join graph facts with named Warden diagnostics, release-check output, or Distribution-Ready Done checklist facts. That query must cite those sources rather than hand-roll release advice.
+
 ## Fixture Coverage
 
 Focused tests avoid compiling a full repo app:


### PR DESCRIPTION
## Context

Part of the Release Rules M3 follow-through for TRL-940.

This branch records where Warden and Wayfinder should join release-rule governance without forcing a premature Warden error rule or Wayfinder artifact dependency.

## What Changed

- Updated the release provenance draft ADR with staged governance-join guidance.
- Documented why `release check` owns branch-local release-rule evaluation for now.
- Documented when future Warden advisory rules and Wayfinder implication joins become appropriate.
- Kept release-rule evaluation separate from GitHub or Graphite metadata duplication.

## Verification

- `bun scripts/adr.ts check`
- `bun run docs:wrap-check`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`
- Real Graphite submit pre-push passed: dead-code, format, lint, ast-grep, test, typecheck, Warden.

Known Warden warnings are the existing internal `wayfind.*` reachability warnings.
