### PR TITLE
chore: version packages to 1.0.0-beta.22

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -225,6 +225,7 @@
     "trl-936-release-check-cli",
     "trl-938-native-bun-release-binding",
     "trl-939-release-smoke-gates",
+    "trl-951-fresh-scaffold-format",
     "type-utils-and-follow-rule",
     "unified-observability-adr",
     "vocabulary-cutover",

--- a/adapters/commander/CHANGELOG.md
+++ b/adapters/commander/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/commander
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/cli@1.0.0-beta.22
+- @ontrails/core@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/adapters/commander/package.json
+++ b/adapters/commander/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/commander",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/drizzle/CHANGELOG.md
+++ b/adapters/drizzle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/drizzle
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.22
+- @ontrails/store@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/adapters/drizzle/package.json
+++ b/adapters/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/drizzle",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/hono/CHANGELOG.md
+++ b/adapters/hono/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/hono
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.22
+- @ontrails/http@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/adapters/hono/package.json
+++ b/adapters/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/hono",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/vite/CHANGELOG.md
+++ b/adapters/vite/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/vite
 
+## 1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ## 1.0.0-beta.20

--- a/adapters/vite/package.json
+++ b/adapters/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/vite",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/apps/trails/CHANGELOG.md
+++ b/apps/trails/CHANGELOG.md
@@ -1,5 +1,24 @@
 # trails
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- cdee4d0: Emit formatter-clean fresh scaffold files so generated apps pass their own
+  `format:check` script before any manual cleanup.
+  - @ontrails/commander@1.0.0-beta.22
+  - @ontrails/adapter-kit@1.0.0-beta.22
+  - @ontrails/cli@1.0.0-beta.22
+  - @ontrails/core@1.0.0-beta.22
+  - @ontrails/http@1.0.0-beta.22
+  - @ontrails/mcp@1.0.0-beta.22
+  - @ontrails/observe@1.0.0-beta.22
+  - @ontrails/permits@1.0.0-beta.22
+  - @ontrails/topographer@1.0.0-beta.22
+  - @ontrails/tracing@1.0.0-beta.22
+  - @ontrails/warden@1.0.0-beta.22
+  - @ontrails/wayfinder@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Minor Changes

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/trails",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "bin": {
     "trails": "./bin/trails.ts"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
     },
     "adapters/commander": {
       "name": "@ontrails/commander",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "dependencies": {
         "@ontrails/cli": "workspace:^",
         "@ontrails/core": "workspace:^",
@@ -39,7 +39,7 @@
     },
     "adapters/drizzle": {
       "name": "@ontrails/drizzle",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "dependencies": {
         "@ontrails/core": "workspace:^",
         "drizzle-orm": "^0.45.2",
@@ -51,7 +51,7 @@
     },
     "adapters/hono": {
       "name": "@ontrails/hono",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "dependencies": {
         "@ontrails/core": "workspace:^",
         "hono": "^4.7.0",
@@ -63,7 +63,7 @@
     },
     "adapters/vite": {
       "name": "@ontrails/vite",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "devDependencies": {
         "@ontrails/core": "workspace:^",
         "@ontrails/hono": "workspace:^",
@@ -72,7 +72,7 @@
     },
     "apps/trails": {
       "name": "@ontrails/trails",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "bin": {
         "trails": "./bin/trails.ts",
       },
@@ -123,11 +123,11 @@
     },
     "packages/adapter-kit": {
       "name": "@ontrails/adapter-kit",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
     },
     "packages/cli": {
       "name": "@ontrails/cli",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -137,7 +137,7 @@
     },
     "packages/config": {
       "name": "@ontrails/config",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -145,14 +145,14 @@
     },
     "packages/core": {
       "name": "@ontrails/core",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "peerDependencies": {
         "zod": "catalog:",
       },
     },
     "packages/http": {
       "name": "@ontrails/http",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -162,14 +162,14 @@
     },
     "packages/logtape": {
       "name": "@ontrails/logtape",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "peerDependencies": {
         "@ontrails/observe": "workspace:^",
       },
     },
     "packages/mcp": {
       "name": "@ontrails/mcp",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -180,21 +180,21 @@
     },
     "packages/observe": {
       "name": "@ontrails/observe",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
       },
     },
     "packages/oxlint-plugin": {
       "name": "@ontrails/oxlint-plugin",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "dependencies": {
         "@oxlint/plugins": "1.62.0",
       },
     },
     "packages/permits": {
       "name": "@ontrails/permits",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -202,14 +202,14 @@
     },
     "packages/pino": {
       "name": "@ontrails/pino",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "peerDependencies": {
         "@ontrails/observe": "workspace:^",
       },
     },
     "packages/regrade": {
       "name": "@ontrails/regrade",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "dependencies": {
         "@ontrails/core": "workspace:^",
         "@ontrails/warden": "workspace:^",
@@ -222,7 +222,7 @@
     },
     "packages/store": {
       "name": "@ontrails/store",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -232,7 +232,7 @@
     },
     "packages/testing": {
       "name": "@ontrails/testing",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "devDependencies": {
         "@ontrails/drizzle": "workspace:^",
         "@ontrails/store": "workspace:^",
@@ -253,7 +253,7 @@
     },
     "packages/topographer": {
       "name": "@ontrails/topographer",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -261,7 +261,7 @@
     },
     "packages/tracing": {
       "name": "@ontrails/tracing",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -269,7 +269,7 @@
     },
     "packages/warden": {
       "name": "@ontrails/warden",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "bin": {
         "warden": "./bin/warden.ts",
       },
@@ -293,7 +293,7 @@
     },
     "packages/wayfinder": {
       "name": "@ontrails/wayfinder",
-      "version": "1.0.0-beta.21",
+      "version": "1.0.0-beta.22",
       "dependencies": {
         "@ontrails/adapter-kit": "workspace:^",
       },

--- a/packages/adapter-kit/CHANGELOG.md
+++ b/packages/adapter-kit/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/adapter-kit
 
+## 1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/adapter-kit/package.json
+++ b/packages/adapter-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/adapter-kit",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "description": "Internal adapter authoring kit for Trails metadata, scaffolding, and checks.",
   "files": [
     "src/**/*.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/cli
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/cli",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/config
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/config",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/core
 
+## 1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/core",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/http
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/http",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/logtape/CHANGELOG.md
+++ b/packages/logtape/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/logtape
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/observe@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/logtape/package.json
+++ b/packages/logtape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/logtape",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/mcp
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/mcp",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/observe/CHANGELOG.md
+++ b/packages/observe/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/observe
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/observe/package.json
+++ b/packages/observe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/observe",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/oxlint-plugin/CHANGELOG.md
+++ b/packages/oxlint-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/oxlint-plugin
 
+## 1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ## 1.0.0-beta.20

--- a/packages/oxlint-plugin/package.json
+++ b/packages/oxlint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/oxlint-plugin",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/packages/permits/CHANGELOG.md
+++ b/packages/permits/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/permits
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/permits/package.json
+++ b/packages/permits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/permits",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/pino/CHANGELOG.md
+++ b/packages/pino/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/pino
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/observe@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/pino",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/regrade/CHANGELOG.md
+++ b/packages/regrade/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/regrade
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.22
+- @ontrails/warden@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/regrade/package.json
+++ b/packages/regrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/regrade",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "private": true,
   "description": "Experimental Regrade tracer proving whether transform units can be literal Trails trails.",
   "type": "module",

--- a/packages/store/CHANGELOG.md
+++ b/packages/store/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/store
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/store",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ontrails/testing
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/cli@1.0.0-beta.22
+- @ontrails/core@1.0.0-beta.22
+- @ontrails/http@1.0.0-beta.22
+- @ontrails/mcp@1.0.0-beta.22
+- @ontrails/observe@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/testing",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/topographer/CHANGELOG.md
+++ b/packages/topographer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/topographer
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/topographer/package.json
+++ b/packages/topographer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/topographer",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "description": "Durable graph substrate for Trails: deterministic TopoGraphs, lockfile helpers, and semantic diffing.",
   "files": [
     "src/**/*.ts",

--- a/packages/tracing/CHANGELOG.md
+++ b/packages/tracing/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/tracing
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/tracing",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/warden/CHANGELOG.md
+++ b/packages/warden/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ontrails/warden
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/adapter-kit@1.0.0-beta.22
+- @ontrails/cli@1.0.0-beta.22
+- @ontrails/core@1.0.0-beta.22
+- @ontrails/permits@1.0.0-beta.22
+- @ontrails/store@1.0.0-beta.22
+- @ontrails/topographer@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Minor Changes

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/warden",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "bin": {
     "warden": "./bin/warden.ts"
   },

--- a/packages/wayfinder/CHANGELOG.md
+++ b/packages/wayfinder/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/wayfinder
 
+## 1.0.0-beta.22
+
+### Patch Changes
+
+- @ontrails/adapter-kit@1.0.0-beta.22
+- @ontrails/core@1.0.0-beta.22
+- @ontrails/topographer@1.0.0-beta.22
+
 ## 1.0.0-beta.21
 
 ### Patch Changes

--- a/packages/wayfinder/package.json
+++ b/packages/wayfinder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/wayfinder",
-  "version": "1.0.0-beta.21",
+  "version": "1.0.0-beta.22",
   "description": "Agent wayfinding query trails over saved graph and package evidence.",
   "files": [
     "src/**/*.ts",


### PR DESCRIPTION
## Context

Version all publishable `@ontrails/*` packages to `1.0.0-beta.22` after beta.21 exposed a fresh-scaffold formatting regression. PR #719 fixed the generator; this version branch packages that fix so the external registry smoke can prove the corrected scaffold path.

## What changed

- Ran `bunx changeset version` to advance the prerelease set to `1.0.0-beta.22`.
- Updated generated package versions and changelogs across the lockstep package set.
- Updated `.changeset/pre.json` with `trl-951-fresh-scaffold-format`.
- Rewrote stale `bun.lock` workspace table versions from beta.21 to beta.22 after `bun install --lockfile-only --force` left them stale; `publish:check` caught this before submit.

## Verification

- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun apps/trails/bin/trails.ts release check --json`
- `bun run wayfinder:dogfood`
- `bun run dogfood:packed`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`
- Graphite pre-push hook: ADR, dead-code, format, lint, ast-grep, test, typecheck, Warden

## Registry note

`bun run publish:registry-check` currently fails because the registry `beta` dist-tag points to `1.0.0-beta.21`, while this branch is the candidate `1.0.0-beta.22`. That is expected before this version PR merges and `bun run publish:packages` runs.

## Rollout

After merge:

1. Run `bun run publish:packages`.
2. Run `bun run publish:registry-check:published`.
3. Run a fresh external consumer smoke through `bunx --package @ontrails/trails@beta trails create ...`, then generated project `format:check`, `typecheck`, `build`, `test`, `compile`, `validate`, and `warden`.
