### PR TITLE
fix(trails): allow release check in generated apps

### DIFF
--- a/.changeset/trl-945-release-check-generated-app.md
+++ b/.changeset/trl-945-release-check-generated-app.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/trails': patch
+---
+
+Allow `trails release check` to pass as a no-op in generated single-package apps
+that do not declare package workspaces.

--- a/apps/trails/src/__tests__/release-check.test.ts
+++ b/apps/trails/src/__tests__/release-check.test.ts
@@ -460,9 +460,41 @@ export const userCreate = trail('user.create', {
       rmSync(repoRoot, { force: true, recursive: true });
     }
   });
+
+  test('passes as a no-op in non-workspace generated apps', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-app-'));
+
+    try {
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'fresh-app' })
+      );
+
+      await expect(runReleaseCheckCli(['--repo-root', repoRoot])).resolves.toBe(
+        0
+      );
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
 });
 
 describe('discoverWorkspaces', () => {
+  test('returns no workspaces for single-package apps', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-workspaces-'));
+
+    try {
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'fresh-app' })
+      );
+
+      await expect(discoverWorkspaces(repoRoot)).resolves.toEqual([]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
   test('discovers publish metadata from root workspace globs', async () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'trails-workspaces-'));
 

--- a/apps/trails/src/release/check.ts
+++ b/apps/trails/src/release/check.ts
@@ -170,7 +170,7 @@ export const discoverWorkspaces = async (
   const root = await readJson<PackageJson>(join(repoRoot, 'package.json'));
 
   if (!root.workspaces || root.workspaces.length === 0) {
-    throw new Error('Root package.json has no workspaces field');
+    return [];
   }
 
   const dirs = await discoverWorkspaceDirs(repoRoot, root.workspaces);
@@ -756,9 +756,19 @@ export const runReleaseCheck = async (
   const baseRef =
     options.baseRef ??
     (options.changedFilesPath === undefined ? 'origin/main' : undefined);
-  const changedFiles = options.changedFilesPath
-    ? readChangedFiles(options.changedFilesPath)
-    : readLocalChangedFiles(options.repoRoot, baseRef ?? 'origin/main');
+  let changedFiles: readonly string[];
+
+  if (options.changedFilesPath !== undefined) {
+    changedFiles = readChangedFiles(options.changedFilesPath);
+  } else if (workspaces.length > 0) {
+    changedFiles = readLocalChangedFiles(
+      options.repoRoot,
+      baseRef ?? 'origin/main'
+    );
+  } else {
+    changedFiles = [];
+  }
+
   const loadedConfig = await loadReleaseConfig({
     ...(options.configPath === undefined
       ? {}

--- a/docs/releases/stable-cutover.md
+++ b/docs/releases/stable-cutover.md
@@ -172,7 +172,8 @@ bun apps/trails/bin/trails.ts create docs-smoke \
   --dir "$tmp" \
   --surfaces cli mcp http \
   --verify \
-  --output json
+  --output json \
+  --permit '{"id":"stable-cutover-smoke","scopes":["project:write","entity:write"]}'
 
 (
   cd "$tmp/docs-smoke"


### PR DESCRIPTION
## Context

TRL-945 fresh external consumer smoke against the published `@ontrails/*` beta.22 package set found one small generated-app compatibility gap: `trails release check` assumed a workspace root and failed inside a normal single-package generated app. The same smoke also showed the stable cutover generated-app command needs an explicit create permit.

## Changes

- Allow release check to pass as a no-op when the repo root has no `workspaces` field.
- Add release-check coverage for generated single-package apps.
- Update the stable cutover smoke command to include the required create permit.
- Add a patch changeset for `@ontrails/trails`.

## Verification

Published beta.22 external smoke passed for fresh create/install/typecheck/test/compile/validate/Warden/Wayfinder/CLI/MCP/HTTP. The only published failure was `trails release check --json` in the generated app, now covered and fixed locally.

Local checks:

- `bun test apps/trails/src/__tests__/release-check.test.ts`
- `bun run docs:wrap-check`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `git diff --check`
- `bun run changeset:check`
- Graphite pre-push hook: adr, dead-code, format, lint, lint-ast-grep, test, typecheck, warden

## Risks

Low. In workspace repos, release check still reads changed files and applies package release rules. In non-workspace generated apps, there are no publishable workspaces to govern, so the command now reports the no-op case instead of throwing.
