### PR TITLE
docs: align rc docs with binding vocabulary

### DIFF
--- a/.changeset/trl-946-rc-docs-binding.md
+++ b/.changeset/trl-946-rc-docs-binding.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/http": patch
+---
+
+Refresh HTTP docs for the stable RC pass so public package guidance uses the
+binding vocabulary and beta install guidance avoids stale copied pin examples.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -211,7 +211,7 @@ createFetchHandler(graph, options?)    // materialize a full topo Web Fetch disp
 CreateRouteHandlerOptions, CreateFetchHandlerOptions
 ```
 
-The fetch kernel owns query/body parsing, content-length checks, public HTTP error projection, diagnostics, request ID/header forwarding, abort propagation, and webhook verification/parsing semantics for HTTP materializers.
+The fetch kernel owns query/body parsing, content-length checks, public HTTP error projection, diagnostics, request ID/header forwarding, abort propagation, and webhook verification/parsing semantics for HTTP bindings.
 
 ## `@ontrails/http/bun`
 

--- a/docs/releases/beta-channel-policy.md
+++ b/docs/releases/beta-channel-policy.md
@@ -18,13 +18,16 @@ Scaffolded projects should prefer their generated package scripts, such as `bun 
 
 Use the beta channel deliberately:
 
-- Use explicit pins such as `@ontrails/core@1.0.0-beta.18` when a handoff,
-  fixture, generated app, or downstream migration must be reproducible.
+- Use explicit pins such as `@ontrails/core@1.0.0-beta.N` when a handoff,
+  fixture, generated app, or downstream migration must be reproducible. Use the
+  exact beta number from the release packet instead of copying an older guide's
+  example version.
 - Use `@beta` when you intentionally want the newest published beta.
 - Do not rely on unqualified `@ontrails/*` installs during the beta line unless
   release notes explicitly say `latest` has been advanced.
-- Keep public `@ontrails/*` packages on the same beta number. Do not mix
-  `beta.15`, `beta.18`, and `@beta` ranges in one app.
+- Keep public `@ontrails/*` packages on the same beta number. Do not mix exact
+  beta pins and `@beta` ranges in one app unless the migration guide for that
+  handoff explicitly says to.
 
 Example active-beta install:
 

--- a/docs/releases/beta15-to-beta19.md
+++ b/docs/releases/beta15-to-beta19.md
@@ -10,7 +10,7 @@ Read [Beta 15](./beta15.md) first if you are still on a pre-beta.15 line — tha
 
 ## What Changed In One Paragraph
 
-Beta 16 split `@ontrails/commander` out of `@ontrails/cli/commander`, moved the topo-store API into `@ontrails/topographer`, added typed layers as a real primitive with attachment scopes, renamed surface-map artifacts to `TopoGraph` / `.trails/topo.lock`, added the `unmockable` resource marker, and absorbed pagination and date shortcuts into CLI surface derivation. Beta 17 added the example-driven surface-parity helper and the HTTP surface harness, and projected `inputSchema` v1 minimums for shipped surface entrypoints. Beta 18 added `@ontrails/http/fetch` and `@ontrails/http/bun` as a Web Fetch kernel plus a Bun-native materializer. Beta 19 renamed the `cross` composition family to `compose`, promoted the topo artifact commands to top-level `trails compile` / `trails validate`, made trail versioning resolve at runtime across all surfaces, introduced the `@ontrails/adapter-kit` authoring toolchain, and added `warden --fix` for safe source fixes. Together those changes mean a downstream app upgrading from beta.15 should rethink CLI imports, MCP exposure, public output schemas, resource mocks, error taxonomy, observability, Topographer adoption, and trail-composition vocabulary — not just bump versions.
+Beta 16 split `@ontrails/commander` out of `@ontrails/cli/commander`, moved the topo-store API into `@ontrails/topographer`, added typed layers as a real primitive with attachment scopes, renamed surface-map artifacts to `TopoGraph` / `.trails/topo.lock`, added the `unmockable` resource marker, and absorbed pagination and date shortcuts into CLI surface derivation. Beta 17 added the example-driven surface-parity helper and the HTTP surface harness, and projected `inputSchema` v1 minimums for shipped surface entrypoints. Beta 18 added `@ontrails/http/fetch` and `@ontrails/http/bun` as a Web Fetch kernel plus a Bun-native HTTP binding. Beta 19 renamed the `cross` composition family to `compose`, promoted the topo artifact commands to top-level `trails compile` / `trails validate`, made trail versioning resolve at runtime across all surfaces, introduced the `@ontrails/adapter-kit` authoring toolchain, and added `warden --fix` for safe source fixes. Together those changes mean a downstream app upgrading from beta.15 should rethink CLI imports, MCP exposure, public output schemas, resource mocks, error taxonomy, observability, Topographer adoption, and trail-composition vocabulary, not just bump versions.
 
 ## Install
 
@@ -122,14 +122,14 @@ Public MCP and HTTP trails require an `output` schema. The Warden rule `public-o
 
 ## HTTP Surface
 
-Beta 18 split the HTTP surface around a shared Web Fetch kernel and a Bun-native materializer:
+Beta 18 split the HTTP surface around a shared Web Fetch kernel and a Bun-native HTTP binding:
 
 - `@ontrails/http` keeps the framework-agnostic route model and the derived OpenAPI helper (`deriveOpenApiSpec`, moved from `@ontrails/schema` in beta.16).
-- `@ontrails/http/fetch` is the shared request/response kernel that surface materializers use.
-- `@ontrails/http/bun` is the Bun-native HTTP surface materializer that uses the fetch kernel.
-- `@ontrails/hono` remains the Hono adapter.
+- `@ontrails/http/fetch` is the shared request/response kernel that HTTP bindings use.
+- `@ontrails/http/bun` is the native Bun HTTP binding that uses the fetch kernel.
+- `@ontrails/hono` remains the Hono adapter binding.
 
-Pick the materializer that matches the deployment target. Hono apps stay on `@ontrails/hono`; Bun-native apps can use `@ontrails/http/bun`. Layer `input` schemas project onto request query (reads) or body (writes), and topo-scope and surface-scope layers compose through HTTP handlers the same way they do on CLI and MCP.
+Pick the binding that matches the deployment target. Hono apps stay on `@ontrails/hono`; Bun-native apps can use `@ontrails/http/bun`. Layer `input` schemas project onto request query (reads) or body (writes), and topo-scope and surface-scope layers compose through HTTP handlers the same way they do on CLI and MCP.
 
 HTTP also gained webhook activation: declared webhook routes participate in topo and Warden coverage. The Warden rule `webhook-route-collision` keeps webhook routes from colliding with each other or with direct HTTP trail routes.
 

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -34,17 +34,18 @@ await surface(graph, { port: 3000 });
 
 `@ontrails/hono` is the portable Hono integration. `@ontrails/http/bun` uses Bun's native `routes` fast path, keeps a Fetch fallback for unmatched requests, and adds no third-party HTTP framework dependency.
 
-## Projection and runtime materialization
+## Projection and runtime binding
 
 HTTP follows the surface naming split:
 
 - `deriveHttpRoutes()` and `deriveOpenApiSpec()` are `derive*` projections from
   the topo. They do not open a server.
 - `createRouteHandler()` and `createFetchHandler()` from
-  `@ontrails/http/fetch` are `create*` runtime materializers. They return Web
+  `@ontrails/http/fetch` are `create*` runtime helpers. They return Web
   Standard `Request` -> `Response` handlers without listening on a port.
-- `surface()` opens the boundary: `@ontrails/hono` starts Hono;
-  `@ontrails/http/bun` starts `Bun.serve()`.
+- `surface()` opens the boundary: `@ontrails/hono` starts the adapter binding
+  to Hono; `@ontrails/http/bun` starts the native Bun HTTP binding through
+  `Bun.serve()`.
 
 The shared Fetch kernel owns query/body parsing, content-length validation, public error projection, diagnostics, request ID/header forwarding, abort propagation, and webhook verification/parsing. Hono and Bun consume the same kernel so those behaviors stay in parity.
 

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -22,7 +22,7 @@ await surface(graph, { port: 3000 });
 
 This starts a Hono-based HTTP server. The `greet` trail becomes `GET /greet?name=...` because its `intent` is `'read'`.
 
-For Bun-native HTTP without Hono, use the Bun runtime materializer subpath:
+For Bun-native HTTP without Hono, use the Bun-native HTTP binding subpath:
 
 ```typescript
 import { surface } from '@ontrails/http/bun';
@@ -32,13 +32,16 @@ await surface(graph, { port: 3000 });
 
 `@ontrails/http/bun` uses Bun's native `Bun.serve({ routes })` fast path and keeps the shared Web Fetch handler as the fallback. It requires Bun `>=1.2.3` and does not add a third-party runtime dependency.
 
-## Projection and materialization
+## Projection and runtime binding
 
 The HTTP package follows the surface API naming split:
 
 - `derive*` exports are pure projections from the topo. Use `deriveHttpRoutes()` for route definitions and `deriveOpenApiSpec()` for the OpenAPI contract.
-- `create*` exports materialize runtime objects without opening a network boundary. `@ontrails/http/fetch` exports `createRouteHandler()` for one route and `createFetchHandler()` for a full topo dispatcher.
-- `surface()` opens the runtime boundary. `@ontrails/hono` opens a Hono server; `@ontrails/http/bun` opens Bun's native HTTP server.
+- `create*` exports build runtime objects without opening a network boundary.
+  `@ontrails/http/fetch` exports `createRouteHandler()` for one route and
+  `createFetchHandler()` for a full topo dispatcher.
+- `surface()` opens the runtime boundary. `@ontrails/hono` opens an adapter
+  binding to Hono; `@ontrails/http/bun` opens the native Bun HTTP binding.
 
 The shared `@ontrails/http/fetch` kernel owns query/body parsing, content-length validation, public error projection, diagnostics, request IDs, headers, abort propagation, and webhook verification/parsing behavior. Hono and Bun both consume that kernel so route semantics stay aligned.
 
@@ -73,7 +76,7 @@ const spec = deriveOpenApiSpec(graph, { basePath: '/api' });
 | `deriveHttpRoutes(graph, options?)` | Build framework-agnostic route definitions from a topo |
 | `deriveOpenApiSpec(graph, options?)` | Generate an OpenAPI 3.1 document for the HTTP surface |
 | `@ontrails/http/fetch` | Shared Web Fetch `createRouteHandler()` and `createFetchHandler()` kernel |
-| `@ontrails/http/bun` | Bun-native `createApp()` and `surface()` materializer |
+| `@ontrails/http/bun` | Bun-native `createApp()` and `surface()` binding |
 | `@ontrails/http/testing` | Owner-owned adapter conformance factory for HTTP adapter authors |
 
 ## Adapter authoring


### PR DESCRIPTION
## Context

Stable RC prep found active HTTP and release docs still using stale beta-pin examples and the old HTTP "materializer" wording. The lexicon now leads with binding vocabulary: native bindings for Trails-owned subpaths and adapter bindings for extracted third-party boundaries.

## What changed

- Updated active HTTP docs and the `@ontrails/http` README to teach native HTTP binding and adapter binding wording.
- Replaced the beta-channel policy's copied `1.0.0-beta.18` pin example with `1.0.0-beta.N` guidance tied to the release packet.
- Added branch-local release intent for the shipped `@ontrails/http` README change.

## Verification

- `bun run docs:links`
- `bun run docs:wrap-check`
- `bun run changeset:check`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`

## Notes

This is RC polish only. It does not exit prerelease mode, publish packages, move `latest`, or run the stable 1.0 cutover.
