### PR TITLE
docs: refresh trails plugin rc guidance

### DIFF
--- a/docs/releases/plugin-release.md
+++ b/docs/releases/plugin-release.md
@@ -2,7 +2,7 @@
 
 This runbook covers the Trails Claude plugin and bundled skills under `plugin/` plus the marketplace manifest at `.claude-plugin/marketplace.json`. It is separate from the framework package publish path in [Stable Cutover Runbook](./stable-cutover.md).
 
-The current plugin manifest version is `0.3.1`. The bundled `trails` skill targets Trails framework `1.0.0-beta.18` through `metadata.trails.version`. Those versions are intentionally independent: plugin version names the Claude plugin bundle, while the skill target names the framework package line the guidance was refreshed against.
+The current plugin manifest version is `0.3.1`. The bundled `trails` skill targets the current Trails framework package version through `metadata.trails.version`. Those versions are intentionally independent: plugin version names the Claude plugin bundle, while the skill target names the framework package line the guidance was refreshed against.
 
 ## Stop Rules
 
@@ -43,18 +43,14 @@ Passing means local installed copies match the repo-bundled plugin skill. Failin
 
 ## Dogfood Gate
 
-Use the latest dogfood report from the active release packet before release. For this refresh stack, that report is:
-
-- `.agents/plans/2026-05-21-plugin-skills-refresh-stack/reports/trl-752-dogfood.md`
-
-Every future release packet should replace or supersede that pointer with fresh dogfood evidence. The report must cover:
+Use the latest dogfood report from the active release packet before release. Every release packet should name fresh dogfood evidence. The report must cover:
 
 - registry `bun install` succeeds for scaffolded package ranges;
 - a repaired disposable app passes typecheck, tests, build, lint, format, CLI smoke, Warden, `testAllEstablished` from `@ontrails/testing/established`, `testSurfaceParity` from `@ontrails/testing/surface-parity`, and the CLI, MCP, and HTTP harness helpers from their matching testing subpaths;
 - raw scaffold output findings are recorded, including any lint, format, typecheck, or Warden coaching needed before the disposable app is clean;
 - published CLI command coverage is compared against current repo CLI command coverage.
 
-Current refresh evidence records two release-readiness risks that must be refreshed before future publication: raw scaffold output was not clean without edits, and published `@ontrails/trails@1.0.0-beta.18` exposed `warden` but not `compile`/`validate`. These do not require publishing the plugin to stop, but release notes and install docs must not imply a published CLI already has commands that only exist in the repo.
+The stable-RC refresh has newer framework evidence than the older beta.18 plugin refresh: generated apps install from the public registry, `trails release check --json` works in generated apps without workspace files, and the published beta line exposes top-level `compile`, `validate`, `diff`, `warden`, and release-check surfaces. Do not carry old beta.18 risk language forward without re-running the current dogfood gate.
 
 ## Plugin 0.3.1 Bundle
 
@@ -76,6 +72,8 @@ The `0.3.1` bundle includes:
 - installed-skill drift checker;
 - tested Claude `SessionStart` project detection and non-mutating Warden
   guidance;
+- stable-RC refreshes for release rules, Wayfinder-first navigation, current
+  skill metadata, and binding vocabulary;
 - disposable dogfood report and release-risk findings.
 
 ## Manual / External Checks

--- a/plugin/hooks/__fixtures__/detect-trails/ontrails-dependency/package.json
+++ b/plugin/hooks/__fixtures__/detect-trails/ontrails-dependency/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trails-dependency-app",
   "dependencies": {
-    "@ontrails/core": "1.0.0-beta.18"
+    "@ontrails/core": "1.0.0-beta.22"
   }
 }

--- a/plugin/skills/trails-dogfood-check/SKILL.md
+++ b/plugin/skills/trails-dogfood-check/SKILL.md
@@ -9,7 +9,8 @@ Use this skill when framework-owned trails, CLI helpers, loaders, or generators 
 
 ## Workflow
 
-1. Locate the trail blaze, helper, loader, or materializer under review.
+1. Locate the trail blaze, helper, loader, surface binding, or runtime boundary
+   under review.
 2. Decide which boundary it lives on:
    - Trail runtime behavior should return `Result` and specific `TrailsError` values.
    - Host construction, parser setup, and programmer-error boundaries may throw when documented.

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -3,7 +3,7 @@ name: trails
 description: Build with the Trails framework — define trail contracts, open CLI/MCP surfaces, test with examples, debug errors, migrate codebases, run governance. Use when creating trails, adding surfaces, testing, debugging Trails errors, migrating to Trails, running warden, or any work involving @ontrails/* packages.
 metadata:
   trails:
-    version: 1.0.0-beta.21
+    version: 1.0.0-beta.22
 ---
 
 # Trails

--- a/plugin/skills/trails/references/http-surface.md
+++ b/plugin/skills/trails/references/http-surface.md
@@ -1,6 +1,6 @@
 # HTTP Surface Reference
 
-Trails HTTP support has a shared core plus runtime materializers:
+Trails HTTP support has a shared core plus HTTP bindings:
 
 - `@ontrails/http` owns route derivation, OpenAPI projection, and the shared Web Fetch request kernel.
 - `@ontrails/hono` opens the derived routes through Hono.
@@ -33,7 +33,7 @@ import { graph } from './app.js';
 await surface(graph, { port: 3000 });
 ```
 
-The Bun-native materializer uses Bun's native serving fast path and falls back to the shared Web Fetch handler where needed. It does not add a third-party runtime dependency.
+The Bun-native binding uses Bun's native serving fast path and falls back to the shared Web Fetch handler where needed. It does not add a third-party runtime dependency.
 
 ## Route Derivation
 


### PR DESCRIPTION
## Context

Stable RC prep needs the bundled plugin and skill guidance to match the current framework line and doctrine before we pressure-test the release candidate. The repo source should be current even if local/global installed copies remain operator-owned.

## What changed

- Synced `plugin/skills/trails/SKILL.md` metadata to `1.0.0-beta.22`.
- Refreshed plugin release guidance so it no longer points at beta.18-era dogfood risk language.
- Aligned plugin HTTP reference and dogfood skill language with binding-primary vocabulary.
- Updated the Trails dependency detection fixture to use the current beta.22 package line.

## Verification

- `bun run plugin:metadata:check`
- `bun run warden:skills:check`
- `bun test scripts/__tests__/sync-plugin-metadata.test.ts scripts/__tests__/check-installed-trails-skill.test.ts scripts/__tests__/detect-trails-hook.test.ts`
- `bun run docs:wrap-check`
- `bun run format:check`
- `bun run changeset:check`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`

## Installed Skill Drift

`bun run plugin:installed-skill:check` is intentionally read-only and currently reports local/global installed copies at `1.0.0-beta.18` under `/Users/mg/.agents/skills/trails` and the Claude symlink. This branch does not mutate `$HOME`; per the plugin release runbook, refreshing installed copies remains an explicit operator action.

## Notes

This is RC polish only. It does not publish the Claude plugin, refresh global installed skills, publish npm packages, or run the stable 1.0 cutover.
