### PR TITLE
chore: version packages to 1.0.0-beta.23

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -225,6 +225,8 @@
     "trl-936-release-check-cli",
     "trl-938-native-bun-release-binding",
     "trl-939-release-smoke-gates",
+    "trl-945-release-check-generated-app",
+    "trl-946-rc-docs-binding",
     "trl-951-fresh-scaffold-format",
     "type-utils-and-follow-rule",
     "unified-observability-adr",

--- a/adapters/commander/CHANGELOG.md
+++ b/adapters/commander/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/commander
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/cli@1.0.0-beta.23
+- @ontrails/core@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/adapters/commander/package.json
+++ b/adapters/commander/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/commander",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/drizzle/CHANGELOG.md
+++ b/adapters/drizzle/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/drizzle
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.23
+- @ontrails/store@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/adapters/drizzle/package.json
+++ b/adapters/drizzle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/drizzle",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/hono/CHANGELOG.md
+++ b/adapters/hono/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/hono
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- Updated dependencies [9c5ecdc]
+  - @ontrails/http@1.0.0-beta.23
+  - @ontrails/core@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/adapters/hono/package.json
+++ b/adapters/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/hono",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/vite/CHANGELOG.md
+++ b/adapters/vite/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/vite
 
+## 1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ## 1.0.0-beta.21

--- a/adapters/vite/package.json
+++ b/adapters/vite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/vite",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/apps/trails/CHANGELOG.md
+++ b/apps/trails/CHANGELOG.md
@@ -1,5 +1,25 @@
 # trails
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- 7c037a0: Allow `trails release check` to pass as a no-op in generated single-package apps
+  that do not declare package workspaces.
+- Updated dependencies [9c5ecdc]
+  - @ontrails/http@1.0.0-beta.23
+  - @ontrails/commander@1.0.0-beta.23
+  - @ontrails/adapter-kit@1.0.0-beta.23
+  - @ontrails/cli@1.0.0-beta.23
+  - @ontrails/core@1.0.0-beta.23
+  - @ontrails/mcp@1.0.0-beta.23
+  - @ontrails/observe@1.0.0-beta.23
+  - @ontrails/permits@1.0.0-beta.23
+  - @ontrails/topographer@1.0.0-beta.23
+  - @ontrails/tracing@1.0.0-beta.23
+  - @ontrails/warden@1.0.0-beta.23
+  - @ontrails/wayfinder@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/trails",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "bin": {
     "trails": "./bin/trails.ts"
   },

--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
     },
     "adapters/commander": {
       "name": "@ontrails/commander",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "dependencies": {
         "@ontrails/cli": "workspace:^",
         "@ontrails/core": "workspace:^",
@@ -39,7 +39,7 @@
     },
     "adapters/drizzle": {
       "name": "@ontrails/drizzle",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "dependencies": {
         "@ontrails/core": "workspace:^",
         "drizzle-orm": "^0.45.2",
@@ -51,7 +51,7 @@
     },
     "adapters/hono": {
       "name": "@ontrails/hono",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "dependencies": {
         "@ontrails/core": "workspace:^",
         "hono": "^4.7.0",
@@ -63,7 +63,7 @@
     },
     "adapters/vite": {
       "name": "@ontrails/vite",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "devDependencies": {
         "@ontrails/core": "workspace:^",
         "@ontrails/hono": "workspace:^",
@@ -72,7 +72,7 @@
     },
     "apps/trails": {
       "name": "@ontrails/trails",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "bin": {
         "trails": "./bin/trails.ts",
       },
@@ -123,11 +123,11 @@
     },
     "packages/adapter-kit": {
       "name": "@ontrails/adapter-kit",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
     },
     "packages/cli": {
       "name": "@ontrails/cli",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -137,7 +137,7 @@
     },
     "packages/config": {
       "name": "@ontrails/config",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -145,14 +145,14 @@
     },
     "packages/core": {
       "name": "@ontrails/core",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "peerDependencies": {
         "zod": "catalog:",
       },
     },
     "packages/http": {
       "name": "@ontrails/http",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -162,14 +162,14 @@
     },
     "packages/logtape": {
       "name": "@ontrails/logtape",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "peerDependencies": {
         "@ontrails/observe": "workspace:^",
       },
     },
     "packages/mcp": {
       "name": "@ontrails/mcp",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -180,21 +180,21 @@
     },
     "packages/observe": {
       "name": "@ontrails/observe",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
       },
     },
     "packages/oxlint-plugin": {
       "name": "@ontrails/oxlint-plugin",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "dependencies": {
         "@oxlint/plugins": "1.62.0",
       },
     },
     "packages/permits": {
       "name": "@ontrails/permits",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -202,14 +202,14 @@
     },
     "packages/pino": {
       "name": "@ontrails/pino",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "peerDependencies": {
         "@ontrails/observe": "workspace:^",
       },
     },
     "packages/regrade": {
       "name": "@ontrails/regrade",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "dependencies": {
         "@ontrails/core": "workspace:^",
         "@ontrails/warden": "workspace:^",
@@ -222,7 +222,7 @@
     },
     "packages/store": {
       "name": "@ontrails/store",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "dependencies": {
         "@ontrails/core": "workspace:^",
       },
@@ -232,7 +232,7 @@
     },
     "packages/testing": {
       "name": "@ontrails/testing",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "devDependencies": {
         "@ontrails/drizzle": "workspace:^",
         "@ontrails/store": "workspace:^",
@@ -253,7 +253,7 @@
     },
     "packages/topographer": {
       "name": "@ontrails/topographer",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -261,7 +261,7 @@
     },
     "packages/tracing": {
       "name": "@ontrails/tracing",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "peerDependencies": {
         "@ontrails/core": "workspace:^",
         "zod": "catalog:",
@@ -269,7 +269,7 @@
     },
     "packages/warden": {
       "name": "@ontrails/warden",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "bin": {
         "warden": "./bin/warden.ts",
       },
@@ -293,7 +293,7 @@
     },
     "packages/wayfinder": {
       "name": "@ontrails/wayfinder",
-      "version": "1.0.0-beta.22",
+      "version": "1.0.0-beta.23",
       "dependencies": {
         "@ontrails/adapter-kit": "workspace:^",
       },

--- a/packages/adapter-kit/CHANGELOG.md
+++ b/packages/adapter-kit/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/adapter-kit
 
+## 1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ## 1.0.0-beta.21

--- a/packages/adapter-kit/package.json
+++ b/packages/adapter-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/adapter-kit",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "description": "Internal adapter authoring kit for Trails metadata, scaffolding, and checks.",
   "files": [
     "src/**/*.ts",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/cli
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/cli",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/config
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/config",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/core
 
+## 1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ## 1.0.0-beta.21

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/core",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/http/CHANGELOG.md
+++ b/packages/http/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/http
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- 9c5ecdc: Refresh HTTP docs for the stable RC pass so public package guidance uses the
+  binding vocabulary and beta install guidance avoids stale copied pin examples.
+  - @ontrails/core@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/http",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/logtape/CHANGELOG.md
+++ b/packages/logtape/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/logtape
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/observe@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/logtape/package.json
+++ b/packages/logtape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/logtape",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/mcp
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/mcp",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/observe/CHANGELOG.md
+++ b/packages/observe/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/observe
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/observe/package.json
+++ b/packages/observe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/observe",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/oxlint-plugin/CHANGELOG.md
+++ b/packages/oxlint-plugin/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @ontrails/oxlint-plugin
 
+## 1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ## 1.0.0-beta.21

--- a/packages/oxlint-plugin/package.json
+++ b/packages/oxlint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/oxlint-plugin",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/packages/permits/CHANGELOG.md
+++ b/packages/permits/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/permits
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/permits/package.json
+++ b/packages/permits/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/permits",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/pino/CHANGELOG.md
+++ b/packages/pino/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/pino
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/observe@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/pino",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/regrade/CHANGELOG.md
+++ b/packages/regrade/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ontrails/regrade
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.23
+- @ontrails/warden@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/regrade/package.json
+++ b/packages/regrade/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/regrade",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "private": true,
   "description": "Experimental Regrade tracer proving whether transform units can be literal Trails trails.",
   "type": "module",

--- a/packages/store/CHANGELOG.md
+++ b/packages/store/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/store
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/store",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/testing/CHANGELOG.md
+++ b/packages/testing/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ontrails/testing
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- Updated dependencies [9c5ecdc]
+  - @ontrails/http@1.0.0-beta.23
+  - @ontrails/cli@1.0.0-beta.23
+  - @ontrails/core@1.0.0-beta.23
+  - @ontrails/mcp@1.0.0-beta.23
+  - @ontrails/observe@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/testing",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/topographer/CHANGELOG.md
+++ b/packages/topographer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/topographer
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/topographer/package.json
+++ b/packages/topographer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/topographer",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "description": "Durable graph substrate for Trails: deterministic TopoGraphs, lockfile helpers, and semantic diffing.",
   "files": [
     "src/**/*.ts",

--- a/packages/tracing/CHANGELOG.md
+++ b/packages/tracing/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ontrails/tracing
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/core@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/tracing/package.json
+++ b/packages/tracing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/tracing",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/warden/CHANGELOG.md
+++ b/packages/warden/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @ontrails/warden
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/adapter-kit@1.0.0-beta.23
+- @ontrails/cli@1.0.0-beta.23
+- @ontrails/core@1.0.0-beta.23
+- @ontrails/permits@1.0.0-beta.23
+- @ontrails/store@1.0.0-beta.23
+- @ontrails/topographer@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/warden",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "bin": {
     "warden": "./bin/warden.ts"
   },

--- a/packages/wayfinder/CHANGELOG.md
+++ b/packages/wayfinder/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ontrails/wayfinder
 
+## 1.0.0-beta.23
+
+### Patch Changes
+
+- @ontrails/adapter-kit@1.0.0-beta.23
+- @ontrails/core@1.0.0-beta.23
+- @ontrails/topographer@1.0.0-beta.23
+
 ## 1.0.0-beta.22
 
 ### Patch Changes

--- a/packages/wayfinder/package.json
+++ b/packages/wayfinder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ontrails/wayfinder",
-  "version": "1.0.0-beta.22",
+  "version": "1.0.0-beta.23",
   "description": "Agent wayfinding query trails over saved graph and package evidence.",
   "files": [
     "src/**/*.ts",

--- a/plugin/hooks/__fixtures__/detect-trails/ontrails-dependency/package.json
+++ b/plugin/hooks/__fixtures__/detect-trails/ontrails-dependency/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trails-dependency-app",
   "dependencies": {
-    "@ontrails/core": "1.0.0-beta.22"
+    "@ontrails/core": "1.0.0-beta.23"
   }
 }

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -3,7 +3,7 @@ name: trails
 description: Build with the Trails framework — define trail contracts, open CLI/MCP surfaces, test with examples, debug errors, migrate codebases, run governance. Use when creating trails, adding surfaces, testing, debugging Trails errors, migrating to Trails, running warden, or any work involving @ontrails/* packages.
 metadata:
   trails:
-    version: 1.0.0-beta.22
+    version: 1.0.0-beta.23
 ---
 
 # Trails


### PR DESCRIPTION
## Context

Cuts the prerelease stable-RC pressure-test build as `1.0.0-beta.23`.

This intentionally stays in prerelease mode:
- no `bunx changeset pre exit`
- no stable `1.0.0`
- no `latest` dist-tag move
- publish target remains the `beta` dist-tag after this PR lands

Linear: TRL-953

## What Changed

- Ran Changesets versioning for the current prerelease train.
- Bumped publishable `@ontrails/*` workspace package versions to `1.0.0-beta.23`.
- Updated generated changelogs from the pending changesets.
- Updated prerelease metadata in `.changeset/pre.json`.
- Kept `bun.lock` workspace version metadata aligned with the package manifests so pack verification resolves `workspace:` dependencies to beta.23.
- Updated Trails plugin metadata and detect-hook fixtures to the same beta.23 version.

## Verification

Local verification before submit:

- `bun run plugin:metadata:check`
- `bun test scripts/__tests__/detect-trails-hook.test.ts scripts/__tests__/sync-plugin-metadata.test.ts`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun run changeset:check`
- `bun run format:check`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`

Graphite pre-push hook also passed ADR, dead-code, format, lint, lint-ast-grep, test, typecheck, and Warden.

## Release Notes

After merge, publish from fresh `main` with:

```bash
bun run publish:check
bun run publish:packages
bun run publish:registry-check:published
```

Expected registry result after publish:
- `beta` points at `1.0.0-beta.23`
- `latest` remains unchanged

