### PR TITLE
fix(trails): restore direct run input

### DIFF
--- a/.changeset/trl-954-run-direct-input.md
+++ b/.changeset/trl-954-run-direct-input.md
@@ -1,0 +1,7 @@
+---
+'@ontrails/trails': patch
+---
+
+Restore caller-facing direct input for `trails run` so positional JSON,
+`--input-json`, and `--input` payloads map to the target trail input unless
+callers explicitly use the `input` wrapper for control-field collisions.

--- a/apps/trails/src/__tests__/run-input-sources.test.ts
+++ b/apps/trails/src/__tests__/run-input-sources.test.ts
@@ -1,13 +1,14 @@
 /**
  * End-to-end coverage for `trails run` structured input.
  *
- * Structured input merges into the `run` trail's typed input object. The
- * inner trail payload therefore lives under the `input` field in the supplied
- * JSON object, without any per-trail CLI mapping table.
+ * Structured input maps to the inner trail payload. Direct JSON objects are
+ * treated as the resolved trail's input, while the explicit `input` wrapper
+ * remains available for callers that need to pass fields that collide with
+ * `run` control fields.
  *
  * The inner `run()` invocation then fails (the workspace fixture has no
  * matching trail), but that is by design — what matters here is that
- * structured-input payloads were assigned to `input.input` before execution.
+ * structured-input payloads reach the `run` trail before execution.
  */
 /* oxlint-disable-next-line eslint-plugin-jest/no-conditional-expect -- Result-shape assertions branch on isOk/isErr */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -82,7 +83,7 @@ describe('trails run structured-input mapping', () => {
     await cmd.execute(
       { id: 'never.exists' },
       {
-        inputJson: '{"input":{"name":"Alpha"}}',
+        inputJson: '{"name":"Alpha"}',
         rootDir: workspaceRoot,
       }
     );
@@ -91,7 +92,28 @@ describe('trails run structured-input mapping', () => {
     expect(isInputRecord(captured.input)).toBe(true);
     if (isInputRecord(captured.input)) {
       expect(captured.input['id']).toBe('never.exists');
-      expect(captured.input['input']).toEqual({ name: 'Alpha' });
+      expect(captured.input['name']).toBe('Alpha');
+      expect(captured.input['input']).toBeUndefined();
+    }
+  });
+
+  test('preserves the explicit input wrapper for control-field collisions', async () => {
+    const captured: CapturedInvocation = {};
+    const cmd = buildRunCommand(captured);
+
+    await cmd.execute(
+      { id: 'never.exists' },
+      {
+        inputJson: '{"input":{"module":"inner-value"}}',
+        rootDir: workspaceRoot,
+      }
+    );
+
+    expect(captured.trailId).toBe('run');
+    expect(isInputRecord(captured.input)).toBe(true);
+    if (isInputRecord(captured.input)) {
+      expect(captured.input['id']).toBe('never.exists');
+      expect(captured.input['input']).toEqual({ module: 'inner-value' });
     }
   });
 
@@ -102,7 +124,7 @@ describe('trails run structured-input mapping', () => {
     await cmd.execute(
       {
         id: 'never.exists',
-        'inline-json': '{"input":{"name":"Echo"}}',
+        'inline-json': '{"name":"Echo"}',
       },
       {
         rootDir: workspaceRoot,
@@ -113,7 +135,8 @@ describe('trails run structured-input mapping', () => {
     expect(isInputRecord(captured.input)).toBe(true);
     if (isInputRecord(captured.input)) {
       expect(captured.input['id']).toBe('never.exists');
-      expect(captured.input['input']).toEqual({ name: 'Echo' });
+      expect(captured.input['name']).toBe('Echo');
+      expect(captured.input['input']).toBeUndefined();
     }
   });
 
@@ -144,7 +167,7 @@ describe('trails run structured-input mapping', () => {
     const cmd = buildRunCommand(captured);
 
     const inputPath = join(workspaceRoot, 'payload.json');
-    writeFileSync(inputPath, '{"input":{"name":"Bravo"}}');
+    writeFileSync(inputPath, '{"name":"Bravo"}');
 
     await cmd.execute(
       { id: 'never.exists' },
@@ -156,7 +179,8 @@ describe('trails run structured-input mapping', () => {
 
     expect(isInputRecord(captured.input)).toBe(true);
     if (isInputRecord(captured.input)) {
-      expect(captured.input['input']).toEqual({ name: 'Bravo' });
+      expect(captured.input['name']).toBe('Bravo');
+      expect(captured.input['input']).toBeUndefined();
     }
   });
 
@@ -201,7 +225,7 @@ describe('trails run structured-input mapping', () => {
             yielded = true;
             return Promise.resolve({
               done: false,
-              value: Buffer.from('{"input":{"name":"Delta"}}', 'utf8'),
+              value: Buffer.from('{"name":"Delta"}', 'utf8'),
             });
           },
           [Symbol.asyncIterator]() {
@@ -233,7 +257,8 @@ describe('trails run structured-input mapping', () => {
 
     expect(isInputRecord(captured.input)).toBe(true);
     if (isInputRecord(captured.input)) {
-      expect(captured.input['input']).toEqual({ name: 'Delta' });
+      expect(captured.input['name']).toBe('Delta');
+      expect(captured.input['input']).toBeUndefined();
     }
   });
 });

--- a/apps/trails/src/__tests__/run.test.ts
+++ b/apps/trails/src/__tests__/run.test.ts
@@ -3,7 +3,12 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { AmbiguousError, NotFoundError, executeTrail } from '@ontrails/core';
+import {
+  AmbiguousError,
+  NotFoundError,
+  ValidationError,
+  executeTrail,
+} from '@ontrails/core';
 import type { Result } from '@ontrails/core';
 
 import { resolveRunModulePath, runTrail } from '../trails/run.js';
@@ -311,5 +316,49 @@ describe('runTrail collision resolution', () => {
         value: { name: 'Alpha' },
       });
     }
+  });
+
+  test('maps direct input fields to the target trail payload', async () => {
+    writeExecutableWorkspace(workspaceRoot);
+
+    const result = await executeRunTrail(
+      {
+        id: 'entity.add',
+        module: 'apps/app-a/src/app.ts',
+        name: 'Alpha',
+        rootDir: workspaceRoot,
+      },
+      ['trails:run', 'entity:write']
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({
+        kind: 'inner-trail-result',
+        trailId: 'entity.add',
+        value: { name: 'Alpha' },
+      });
+    }
+  });
+
+  test('rejects mixed direct input fields and explicit input wrapper', async () => {
+    writeExecutableWorkspace(workspaceRoot);
+
+    const result = await executeRunTrail(
+      {
+        id: 'entity.add',
+        input: { name: 'Alpha' },
+        module: 'apps/app-a/src/app.ts',
+        name: 'Bravo',
+        rootDir: workspaceRoot,
+      },
+      ['trails:run', 'entity:write']
+    );
+
+    const error = expectErr(result);
+    expect(error).toBeInstanceOf(ValidationError);
+    expect(error.message).toContain(
+      'both direct input fields and an explicit input wrapper'
+    );
   });
 });

--- a/apps/trails/src/trails/run.ts
+++ b/apps/trails/src/trails/run.ts
@@ -33,6 +33,7 @@ import {
   AmbiguousError,
   NotFoundError,
   Result,
+  ValidationError,
   run,
   trail,
 } from '@ontrails/core';
@@ -313,25 +314,57 @@ const buildAmbiguousExampleInput = (): {
   return { id: 'shared.id', rootDir: root };
 };
 
-const runTrailInputSchema = z.object({
-  app: z
-    .string()
-    .optional()
-    .describe(
-      'Workspace app to resolve the trail ID against; required when the ID is exposed by more than one app'
-    ),
-  id: z.string().describe('Trail ID to invoke'),
-  input: z
-    .unknown()
-    .optional()
-    .describe(
-      'Parsed input for the resolved trail; the CLI surface JSON.parses the inline argument before passing it through'
-    ),
-  module: z.string().optional().describe('Path to the app module'),
-  rootDir: z.string().optional().describe('Workspace root directory'),
-});
+const runTrailInputSchema = z
+  .object({
+    app: z
+      .string()
+      .optional()
+      .describe(
+        'Workspace app to resolve the trail ID against; required when the ID is exposed by more than one app'
+      ),
+    id: z.string().describe('Trail ID to invoke'),
+    input: z
+      .unknown()
+      .optional()
+      .describe(
+        'Parsed input for the resolved trail; the CLI surface JSON.parses the inline argument before passing it through'
+      ),
+    module: z.string().optional().describe('Path to the app module'),
+    rootDir: z.string().optional().describe('Workspace root directory'),
+  })
+  .catchall(z.unknown());
 
 type RunTrailInput = z.output<typeof runTrailInputSchema>;
+
+const RUN_TRAIL_CONTROL_KEYS = new Set([
+  'app',
+  'id',
+  'input',
+  'module',
+  'rootDir',
+]);
+
+const directInputEntries = (
+  input: RunTrailInput
+): readonly (readonly [string, unknown])[] =>
+  Object.entries(input).filter(([key]) => !RUN_TRAIL_CONTROL_KEYS.has(key));
+
+const resolveInnerTrailInput = (
+  input: RunTrailInput
+): Result<unknown, ValidationError> => {
+  const entries = directInputEntries(input);
+  if (entries.length === 0) {
+    return Result.ok(input.input);
+  }
+  if (Object.hasOwn(input, 'input')) {
+    return Result.err(
+      new ValidationError(
+        'trails run received both direct input fields and an explicit input wrapper. Use one shape: either {"name":"Alpha"} or {"input":{"name":"Alpha"}}.'
+      )
+    );
+  }
+  return Result.ok(Object.fromEntries(entries));
+};
 
 // ---------------------------------------------------------------------------
 // Trail definition
@@ -345,6 +378,10 @@ export const runTrail = trail('run', {
       return rootDirResult;
     }
     const rootDir = rootDirResult.value;
+    const innerInput = resolveInnerTrailInput(input);
+    if (innerInput.isErr()) {
+      return innerInput;
+    }
 
     // Single-app back-compat: if the caller provided `module`, trust it.
     const moduleResolution = await resolveRunModulePath(
@@ -365,7 +402,7 @@ export const runTrail = trail('run', {
     const lease = leaseResult.value;
 
     try {
-      const result = await run(lease.app, input.id, input.input, {
+      const result = await run(lease.app, input.id, innerInput.value, {
         ctx: ctx.permit === undefined ? {} : { permit: ctx.permit },
       });
       if (result.isErr()) {


### PR DESCRIPTION
## Context

The beta.23 RC pressure smoke found that `trails run` no longer accepted the caller-facing direct input shape promised by TRL-399. A generated app worked with the explicit wrapper shape:

```bash
trails run --id hello --input-json '{"input":{"name":"RC"}}'
```

but failed with the direct shape users actually reach for:

```bash
trails run --id hello --input-json '{"name":"RC"}'
```

## What Changed

- Preserve unknown direct fields on the `run` trail input instead of stripping them during input validation.
- Map direct JSON object fields to the target trail payload.
- Keep the explicit `input` wrapper as the escape hatch for target inputs that collide with `run` control fields like `module` or `app`.
- Reject mixed direct fields plus explicit `input` wrapper so the command fails loudly instead of guessing.
- Add a branch-local changeset for `@ontrails/trails`.

## Verification

Local:

```bash
bun test apps/trails/src/__tests__/run-input-sources.test.ts apps/trails/src/__tests__/run.test.ts
bun run wayfinder:dogfood
git diff --check
gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
```

Pre-push during Graphite submit:

```bash
bun scripts/adr.ts check
knip --no-progress
bunx ultracite check .
turbo run lint
ast-grep scan --config .ast-grep/sgconfig.yml
turbo run test
turbo run typecheck
bun apps/trails/bin/trails.ts warden --pre-push
```

## RC Note

This repairs the beta.23 RC smoke failure. After merge, beta.24 should be cut and pressure-smoked from a fresh external generated consumer before we call it the stable RC.
