### PR TITLE
docs(tenets): add regression hardening pattern

### DIFF
--- a/docs/tenets.md
+++ b/docs/tenets.md
@@ -218,6 +218,14 @@ The testing and development workflow follows a progression:
 
 Repeat until the warden is quiet. One line tests every trail against every example.
 
+### Regressions harden the trail
+
+Escaped regressions are design feedback. A regression is not fully fixed until the system is harder to regress in the same way again.
+
+The first repair restores behavior. The second repair moves the guarantee closer to the contract: into types, examples, surface parity tests, Warden rules, release checks, resolved graph diffs, fresh-consumer smoke, or clearer agent guidance.
+
+Not every bug demands a new abstraction. But repeated or contract-shaped regressions are evidence that the framework is carrying too little structure. As Trails matures, important behavior should move left: from operator memory, to governance, to tests, to compile-time guarantees, and ultimately to derivation, where the information cannot drift at all.
+
 ## Posture
 
 Trails makes deliberate choices about where it is opinionated, where it defers to standards, and how it relates to the broader ecosystem.


### PR DESCRIPTION
## Context

Matt called out the lesson from the beta.23 -> beta.24 RC loop: when an escaped regression happens, the fix should not stop at restoring behavior. Trails should get structurally harder to regress in the same way again.

## What changed

- Added a `Regressions harden the trail` pattern to `docs/tenets.md`.
- Frames escaped regressions as design feedback.
- Captures the repair loop: restore behavior first, then move the guarantee closer to the contract through types, examples, surface parity tests, Warden, release checks, graph diffs, fresh-consumer smoke, or agent guidance.

## Verification

- `bun run docs:wrap-check`
- `bun run format:check`
- Graphite pre-push hook passed: ADR, dead-code, format, lint, ast-grep, test, typecheck, Warden.

## Notes

- No package behavior changed.
- No changeset needed.
- Warden still reports the known Wayfinder internal-trail warnings during pre-push; unrelated to this docs-only branch.
