### PR TITLE
docs: teach the create permit in front-door scaffold commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ The skill gives your agent the full Trails reference: lexicon, patterns, error t
 ### With code
 
 ```bash
-bunx @ontrails/trails create
+bunx @ontrails/trails create --permit '{"id":"local-dev","scopes":["project:write"]}'
 ```
 
-Follow the prompts — pick a name, choose a starter, select your surfaces. The scaffolder generates a working project with trails, a topo, surface wiring, and tests.
+Follow the prompts — pick a name, choose a starter, select your surfaces. The scaffolder generates a working project with trails, a topo, surface wiring, and tests. The `--permit` flag is required: `create` writes a new project, and Trails write commands always name their authority explicitly instead of assuming it.
 
 Or install manually:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,8 @@ This guide demonstrates CLI and MCP first because they are the shortest path to 
 # Requires Bun (https://bun.sh)
 
 # Recommended: scaffold a new project
-bunx @ontrails/trails create
+# (create writes a project, so it needs an explicit project:write permit)
+bunx @ontrails/trails create --permit '{"id":"local-dev","scopes":["project:write"]}'
 
 # Or install manually
 bun add @ontrails/core@beta @ontrails/cli@beta @ontrails/commander@beta zod


### PR DESCRIPTION
## What

Adds the required `--permit '{"id":"local-dev","scopes":["project:write"]}'` to the scaffold commands in README.md and docs/getting-started.md, with one sentence explaining why.

## Why

Published beta.24 `trails create` without a permit fails with `No permit provided` (exit 4) — write-permit doctrine, confirmed expected in TRL-945. PR #721 fixed the stable-cutover runbook's smoke command but the front-door docs still taught the bare command, so every cold consumer's first command fails. Found during the 2026-06-12 RC verification consumer exercise.

## Verification

- `bun run docs:snippets`, `bun run docs:links`, full `bun run check` at stack tip.
- Docs-only; no package content (release check passes without changeset).