### PR TITLE
fix(trails): say cross-cutting in scaffolded layer guidance

### DIFF
--- a/.changeset/scaffold-cross-cutting-wording.md
+++ b/.changeset/scaffold-cross-cutting-wording.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': patch
+---
+
+Fix the scaffolded AGENTS.md layer guidance to say "cross-cutting trail wrapping" — the cross→compose vocabulary cutover had renamed the standard English collocation, so every generated app shipped the nonsense phrase "compose-cutting".

--- a/apps/trails/src/__tests__/create.test.ts
+++ b/apps/trails/src/__tests__/create.test.ts
@@ -247,7 +247,7 @@ const assertAgentGuidance = (dir: string): void => {
     '`compose`, not follow',
     '`surface`, not transport',
     '`resource`, not service or dependency',
-    '`layer`, for compose-cutting trail wrapping',
+    '`layer`, for cross-cutting trail wrapping',
     'Blazes return `Result`; never throw',
     '`Result.ok()` and `Result.err()`',
     '`ctx.compose(...)`',

--- a/apps/trails/src/trails/create-scaffold.ts
+++ b/apps/trails/src/trails/create-scaffold.ts
@@ -168,7 +168,7 @@ bun run guide
 - \`compose\`, not follow
 - \`surface\`, not transport
 - \`resource\`, not service or dependency
-- \`layer\`, for compose-cutting trail wrapping
+- \`layer\`, for cross-cutting trail wrapping
 
 ## Trail Rules
 


### PR DESCRIPTION
## What

Scaffolded AGENTS.md now says "cross-cutting trail wrapping" instead of "compose-cutting trail wrapping" (create-scaffold.ts + content test).

## Why

The cross→compose vocabulary cutover renamed the standard English collocation "cross-cutting" inside the scaffold template, so every generated app ships a nonsense phrase. Found in the RC verification scaffold inspection (generated AGENTS.md line 29 from published beta.24).

## Verification

- `bun test apps/trails/src/__tests__/create.test.ts` (19/19).
- Changeset: patch `@ontrails/trails`.