### PR TITLE
fix(commander): render validation issues and permit scopes on CLI errors

### DIFF
--- a/.changeset/commander-error-detail-lines.md
+++ b/.changeset/commander-error-detail-lines.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/commander': patch
+---
+
+Render operator-actionable detail lines after CLI execution errors: validation failures list their topo issues (message plus trail id) and permission failures name the required permit scopes with a copyable `--permit` form. Non-internal Trails error context only, passed through the shared redactor; internal errors keep the redacted generic message.

--- a/adapters/commander/src/__tests__/to-commander.test.ts
+++ b/adapters/commander/src/__tests__/to-commander.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, mock, test } from 'bun:test';
 import {
   createTrailContext,
   NotFoundError,
+  PermitError,
   Result,
   trail,
   topo,
+  ValidationError,
 } from '@ontrails/core';
 import type { AnyTrail, CliCommand } from '@ontrails/cli';
 import { deriveCliCommands } from '@ontrails/cli';
@@ -1227,6 +1229,160 @@ describe('toCommander option wiring', () => {
       ).rejects.toThrow('EXIT 8');
       expect(process.stderr.write).toHaveBeenCalledWith(
         'Error: Internal server error\n'
+      );
+    });
+  });
+
+  test('error handling lists validation issues from error context', async () => {
+    await withMockedProcess(async () => {
+      const failTrail = trail('fail', {
+        blaze: () => Result.ok('ok'),
+        input: z.object({}),
+      });
+      const program = toCommander([
+        {
+          args: [],
+          execute: () => {
+            throw new ValidationError(
+              'Topo validation failed with 2 issue(s)',
+              {
+                context: {
+                  issues: [
+                    {
+                      message: 'Resource "note-store" is not in the topo',
+                      rule: 'resource-exists',
+                      trailId: 'notes.add',
+                    },
+                    {
+                      message: 'Resource "note-store" is not in the topo',
+                      rule: 'resource-exists',
+                      trailId: 'notes.list',
+                    },
+                  ],
+                },
+              }
+            );
+          },
+          flags: [],
+          intent: 'read' as const,
+          path: ['fail'] as const,
+          trail: failTrail,
+        },
+      ]);
+
+      await expect(
+        program.parseAsync(['node', 'test', 'fail'], { from: 'node' })
+      ).rejects.toThrow(/EXIT/);
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        'Error: Topo validation failed with 2 issue(s)\n'
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        '  - Resource "note-store" is not in the topo (notes.add)\n'
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        '  - Resource "note-store" is not in the topo (notes.list)\n'
+      );
+    });
+  });
+
+  test('error handling names required permit scopes and the --permit form', async () => {
+    await withMockedProcess(async () => {
+      const failTrail = trail('fail', {
+        blaze: () => Result.ok('ok'),
+        input: z.object({}),
+      });
+      const program = toCommander([
+        {
+          args: [],
+          execute: () => {
+            throw new PermitError('No permit provided', {
+              context: { required: ['project:write'], trailId: 'create' },
+            });
+          },
+          flags: [],
+          intent: 'read' as const,
+          path: ['fail'] as const,
+          trail: failTrail,
+        },
+      ]);
+
+      await expect(
+        program.parseAsync(['node', 'test', 'fail'], { from: 'node' })
+      ).rejects.toThrow(/EXIT/);
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        'Error: No permit provided\n'
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        '  Required scopes: project:write\n'
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        `  Grant with: --permit '{"id":"<caller-id>","scopes":["project:write"]}'\n`
+      );
+    });
+  });
+
+  test('error handling JSON-escapes permit scopes in the grant form', async () => {
+    await withMockedProcess(async () => {
+      const failTrail = trail('fail', {
+        blaze: () => Result.ok('ok'),
+        input: z.object({}),
+      });
+      const program = toCommander([
+        {
+          args: [],
+          execute: () => {
+            throw new PermitError('No permit provided', {
+              context: { required: ['weird"scope'] },
+            });
+          },
+          flags: [],
+          intent: 'read' as const,
+          path: ['fail'] as const,
+          trail: failTrail,
+        },
+      ]);
+
+      await expect(
+        program.parseAsync(['node', 'test', 'fail'], { from: 'node' })
+      ).rejects.toThrow(/EXIT/);
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        `  Grant with: --permit '{"id":"<caller-id>","scopes":["weird\\"scope"]}'\n`
+      );
+    });
+  });
+
+  test('error handling builds the permit grant from all required scopes', async () => {
+    await withMockedProcess(async () => {
+      const failTrail = trail('fail', {
+        blaze: () => Result.ok('ok'),
+        input: z.object({}),
+      });
+      const program = toCommander([
+        {
+          args: [],
+          execute: () => {
+            throw new PermitError('Missing scopes: project:write', {
+              context: {
+                missing: ['project:write'],
+                required: ['project:read', 'project:write'],
+              },
+            });
+          },
+          flags: [],
+          intent: 'read' as const,
+          path: ['fail'] as const,
+          trail: failTrail,
+        },
+      ]);
+
+      await expect(
+        program.parseAsync(['node', 'test', 'fail'], { from: 'node' })
+      ).rejects.toThrow(/EXIT/);
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        '  Required scopes: project:read, project:write\n'
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        `  Grant with: --permit '{"id":"<caller-id>","scopes":["project:read","project:write"]}'\n`
       );
     });
   });

--- a/adapters/commander/src/to-commander.ts
+++ b/adapters/commander/src/to-commander.ts
@@ -2,7 +2,11 @@
  * Adapt framework-agnostic CliCommand[] to a Commander program.
  */
 
-import { projectPublicSurfaceError } from '@ontrails/core';
+import {
+  isTrailsError,
+  projectPublicSurfaceError,
+  redactErrorString,
+} from '@ontrails/core';
 import type { CliCommand, CliFlag } from '@ontrails/cli';
 import { applyCliFlagValueAliases, validateCliCommands } from '@ontrails/cli';
 import { Command, InvalidArgumentError, Option } from 'commander';
@@ -220,11 +224,78 @@ const getFallbackUserSuppliedFlagKeys = (
   return userSupplied;
 };
 
+const collectValidationIssueLines = (
+  context: Readonly<Record<string, unknown>>
+): readonly string[] => {
+  const { issues } = context;
+  if (!Array.isArray(issues)) {
+    return [];
+  }
+  return issues.flatMap((issue) => {
+    if (typeof issue !== 'object' || issue === null) {
+      return [];
+    }
+    const { message, trailId } = issue as {
+      message?: unknown;
+      trailId?: unknown;
+    };
+    if (typeof message !== 'string') {
+      return [];
+    }
+    const suffix = typeof trailId === 'string' ? ` (${trailId})` : '';
+    return [`- ${redactErrorString(message)}${suffix}`];
+  });
+};
+
+const collectPermitScopeLines = (
+  context: Readonly<Record<string, unknown>>
+): readonly string[] => {
+  const candidate = [context['required'], context['missing']].find((value) =>
+    Array.isArray(value)
+  );
+  const scopes = (Array.isArray(candidate) ? candidate : [])
+    .filter((scope): scope is string => typeof scope === 'string')
+    .map((scope) => redactErrorString(scope));
+  if (scopes.length === 0) {
+    return [];
+  }
+  const scopeJson = scopes.map((scope) => JSON.stringify(scope)).join(',');
+  return [
+    `Required scopes: ${scopes.join(', ')}`,
+    `Grant with: --permit '{"id":"<caller-id>","scopes":[${scopeJson}]}'`,
+  ];
+};
+
+/**
+ * Collect operator-facing detail lines for an execution error.
+ *
+ * The public surface projection intentionally drops structured context, but
+ * the CLI is an operator surface: validation issues and permit scope
+ * requirements are what the operator needs to act, so they are re-rendered
+ * here (through the shared redactor) for non-internal Trails errors.
+ */
+const collectErrorDetailLines = (error: Error): readonly string[] => {
+  if (!isTrailsError(error) || error.category === 'internal') {
+    return [];
+  }
+  const context = error.context ?? {};
+  if (error.category === 'validation') {
+    return collectValidationIssueLines(context);
+  }
+  if (error.category === 'permission') {
+    return collectPermitScopeLines(context);
+  }
+  return [];
+};
+
 /** Handle execution errors with appropriate exit codes. */
 const handleError = (error: unknown): void => {
   const err = error instanceof Error ? error : new Error(String(error));
   const projection = projectPublicSurfaceError('cli', err);
   process.stderr.write(`Error: ${projection.message}\n`);
+  for (const line of collectErrorDetailLines(err)) {
+    process.stderr.write(`  ${line}\n`);
+  }
   process.exit(projection.code);
 };
 


### PR DESCRIPTION
## What

CLI execution errors now render operator-actionable detail lines after the message, for non-internal Trails errors only:

- validation errors list their topo issues (message + trail id) from `error.context.issues`
- permission errors name the required permit scopes and a copyable `--permit '{"id":"<caller-id>","scopes":[...]}'` form

Detail strings pass through the shared redactor; internal errors keep the redacted generic message.

## Why

During RC consumer verification, `trails compile` failed with "Topo validation failed with 3 issue(s)" while showing zero issues (they were in the dropped error context), and a permitless `trails create` said only "No permit provided" with no hint of the fix. The public surface projection intentionally drops context; the CLI is an operator surface and needs the issues/scopes to act.

## Verification

- New tests: validation issue listing, permit scope + grant-form rendering (`adapters/commander`, 36/36).
- E2E against a broken consumer app: doctor/compile now list all three resource-exists issues; permitless create names `project:write` and the grant form.
- Changeset: patch `@ontrails/commander`.