### PR TITLE
fix(trails): return validation errors from doctor instead of internal crash

### DIFF
--- a/.changeset/doctor-validation-result.md
+++ b/.changeset/doctor-validation-result.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': patch
+---
+
+`trails doctor` now returns the underlying validation error when the app topo is invalid, instead of crashing with a redacted "Internal server error". The diagnostic command reports the diagnosis: validation failures surface with their category, message, and (with the commander detail rendering) the issue list.

--- a/apps/trails/src/__tests__/version-lifecycle.test.ts
+++ b/apps/trails/src/__tests__/version-lifecycle.test.ts
@@ -9,7 +9,7 @@ import {
 import { join, resolve } from 'node:path';
 
 import { deriveCliCommands } from '@ontrails/cli';
-import { Result, topo, trail } from '@ontrails/core';
+import { isTrailsError, Result, topo, trail } from '@ontrails/core';
 import { TOPO_GRAPH_SCHEMA_VERSION } from '@ontrails/topographer';
 import type { TopoGraph } from '@ontrails/topographer';
 import { z } from 'zod';
@@ -616,6 +616,86 @@ import { topo, trail } from '@ontrails/core';`,
         trails: 1,
         versioned: 1,
       });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('doctor returns the validation error for an invalid topo', async () => {
+    const dir = repoTempDir();
+    try {
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(
+        join(dir, 'src', 'app.ts'),
+        `import { Result, resource, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const store = resource<{ ping: () => string }>('orphan-store', {
+  create: () => Result.ok({ ping: () => 'pong' }),
+  mock: () => ({ ping: () => 'pong' }),
+});
+
+const ping = trail('ping', {
+  blaze: (_input, ctx) => Result.ok({ message: store.from(ctx).ping() }),
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ message: z.string() }),
+  resources: [store],
+});
+
+// The store module is deliberately omitted from topo() so validation fails.
+export const app = topo('doctor-invalid', { ping });
+`
+      );
+
+      const doctor = await doctorTrail.blaze({ module: './src/app.ts' }, {
+        cwd: dir,
+      } as never);
+
+      expect(doctor.isErr()).toBe(true);
+      if (doctor.isOk()) {
+        throw new Error('expected doctor to fail on an invalid topo');
+      }
+      expect(isTrailsError(doctor.error)).toBe(true);
+      expect(
+        isTrailsError(doctor.error) ? doctor.error.category : 'unknown'
+      ).toBe('validation');
+      expect(doctor.error.message).toContain('Topo validation failed');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('doctor returns an internal error for unexpected summary failures', async () => {
+    const dir = repoTempDir();
+    try {
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      writeFileSync(
+        join(dir, 'src', 'app.ts'),
+        `export const app = {
+  name: 'doctor-broken',
+  trails: { broken: true },
+  contours: new Map(),
+  signals: new Map(),
+  resources: new Map(),
+  layers: [],
+};
+`
+      );
+
+      const doctor = await doctorTrail.blaze({ module: './src/app.ts' }, {
+        cwd: dir,
+      } as never);
+
+      expect(doctor.isErr()).toBe(true);
+      if (doctor.isOk()) {
+        throw new Error('expected doctor to fail on a malformed topo');
+      }
+      expect(isTrailsError(doctor.error)).toBe(true);
+      expect(
+        isTrailsError(doctor.error) ? doctor.error.category : 'unknown'
+      ).toBe('internal');
+      expect(doctor.error.message).toContain('Unable to derive doctor summary');
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/apps/trails/src/trails/doctor.ts
+++ b/apps/trails/src/trails/doctor.ts
@@ -1,4 +1,10 @@
-import { deriveTrailsDir, Result, trail } from '@ontrails/core';
+import {
+  deriveTrailsDir,
+  InternalError,
+  isTrailsError,
+  Result,
+  trail,
+} from '@ontrails/core';
 import { readTopoGraph } from '@ontrails/topographer';
 import { z } from 'zod';
 
@@ -18,11 +24,26 @@ const readDoctorForceGraph = async (
   }
 };
 
+const toDoctorSummaryError = (error: unknown): InternalError =>
+  error instanceof Error
+    ? new InternalError('Unable to derive doctor summary', { cause: error })
+    : new InternalError(`Unable to derive doctor summary: ${String(error)}`);
+
 export const doctorTrail = trail('doctor', {
   blaze: async (input, ctx) =>
     withLifecycleApp(input, ctx.cwd, async (app, rootDir) => {
       const forceGraph = await readDoctorForceGraph(rootDir);
-      return Result.ok(deriveDoctorSummary(app, { forceGraph }));
+      try {
+        return Result.ok(deriveDoctorSummary(app, { forceGraph }));
+      } catch (error) {
+        // deriveTopoGraph throws ValidationError on invalid topos; doctor must
+        // report that diagnosis instead of letting the pipeline redact it to a
+        // generic internal error.
+        if (isTrailsError(error)) {
+          return Result.err(error);
+        }
+        return Result.err(toDoctorSummaryError(error));
+      }
     }),
   description: 'Diagnose trail versioning lifecycle state',
   input: z.object({


### PR DESCRIPTION
## What

`trails doctor` returns the underlying validation error (`Result.err`) when the app topo is invalid, instead of crashing with a redacted "Internal server error" (exit 8).

## Why

`deriveDoctorSummary` → `deriveTopoGraph` throws `ValidationError` on invalid topos, and the execute pipeline (correctly) converts thrown errors to `InternalError`. Net effect: the diagnostic command produced an opaque internal crash on exactly the apps that need diagnosis. With #730, doctor on a broken app now prints the validation message plus the issue list.

## Verification

- New regression test: doctor on an invalid-topo fixture returns category `validation` with the issue message (17/17 lifecycle tests).
- E2E reproduced before/after against the RC consumer app.
- Changeset: patch `@ontrails/trails`.