### PR TITLE
fix(warden): recognize conditional Result returns in blazes

### DIFF
--- a/.changeset/warden-conditional-result-recognition.md
+++ b/.changeset/warden-conditional-result-recognition.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/warden': patch
+---
+
+`implementation-returns-result` now recognizes conditional returns whose branches are all recognized Result expressions — both `return cond ? Result.err(...) : Result.ok(...)` statements (including branches that are Result helpers or Result-bound variables) and concise ternary blaze bodies. Previously the idiomatic two-branch ternary was flagged as an error.

--- a/packages/warden/src/__tests__/implementation-returns-result.test.ts
+++ b/packages/warden/src/__tests__/implementation-returns-result.test.ts
@@ -80,6 +80,108 @@ trail("entity.create", {
     expect(diagnostics.length).toBe(0);
   });
 
+  test('allows conditional returns whose branches are both Result expressions', () => {
+    const code = `
+trail("entity.show", {
+  blaze: (input, ctx) => {
+    const note = store.get(input.id);
+    return note === undefined
+      ? Result.err(new NotFoundError("missing"))
+      : Result.ok(note);
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(0);
+  });
+
+  test('allows conditional returns mixing Result literals and Result variables', () => {
+    const code = `
+trail("entity.pick", {
+  blaze: async (input, ctx) => {
+    const fallback = await ctx.compose("entity.default", {});
+    return input.id === undefined ? fallback : Result.ok({ id: input.id });
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(0);
+  });
+
+  test('allows awaited conditional returns whose branches produce Results', () => {
+    const code = `
+trail("entity.pick", {
+  blaze: async (input, ctx) => {
+    return await (input.id === undefined
+      ? ctx.compose("entity.default", {})
+      : Result.ok({ id: input.id }));
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(0);
+  });
+
+  test('flags conditional Result variables shadowed by non-Result bindings', () => {
+    const code = `
+trail("entity.pick", {
+  blaze: async (input, ctx) => {
+    const fallback = await ctx.compose("entity.default", {});
+    if (input.raw) {
+      const fallback = { id: "raw" };
+      return input.raw ? fallback : Result.ok({ id: input.id });
+    }
+    return fallback;
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.message).toContain('entity.pick');
+  });
+
+  test('allows concise ternary blaze bodies with Result branches', () => {
+    const code = `
+trail("entity.toggle", {
+  blaze: (input, ctx) => input.on ? Result.ok({ on: true }) : Result.err(new ValidationError("off"))
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(0);
+  });
+
+  test('allows awaited concise ternary blaze bodies with Result branches', () => {
+    const code = `
+trail("entity.toggle", {
+  blaze: async (input, ctx) => await (input.on
+    ? ctx.compose("entity.default", {})
+    : Result.ok({ on: false }))
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(0);
+  });
+
+  test('flags conditional returns when a branch is not a Result expression', () => {
+    const code = `
+trail("entity.show", {
+  blaze: (input, ctx) => {
+    return input.raw ? { id: "123" } : Result.ok({ id: "123" });
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.message).toContain('entity.show');
+  });
+
   test('flags concise raw blaze bodies', () => {
     const code = `
 trail("entity.create", {

--- a/packages/warden/src/rules/implementation-returns-result.ts
+++ b/packages/warden/src/rules/implementation-returns-result.ts
@@ -79,6 +79,13 @@ export type ScopedHelperMap = ReadonlyMap<
 
 export type MutableScopedHelperMap = Map<ReadonlySet<string>, Set<string>>;
 
+type ScopedResultVariableMap = ReadonlyMap<
+  ReadonlySet<string>,
+  ReadonlySet<string>
+>;
+
+type MutableScopedResultVariableMap = Map<ReadonlySet<string>, Set<string>>;
+
 export const findNearestBindingScope = (
   name: string,
   scopes: readonly ReadonlySet<string>[]
@@ -90,6 +97,15 @@ const isScopedHelperBinding = (
   scope: ReadonlySet<string>,
   scopedHelpers: ScopedHelperMap
 ): boolean => scopedHelpers.get(scope)?.has(name) ?? false;
+
+const isScopedResultVariableBinding = (
+  name: string,
+  scopes: readonly ReadonlySet<string>[],
+  resultVars: ScopedResultVariableMap
+): boolean => {
+  const bindingScope = findNearestBindingScope(name, scopes);
+  return Boolean(bindingScope && resultVars.get(bindingScope)?.has(name));
+};
 
 /**
  * Check whether a namespace-member call like `ns.helper(...)` resolves to a
@@ -171,26 +187,74 @@ const resolveIdentifierName = (node: AstNode): string | null => {
   return null;
 };
 
+const unwrapReturnExpression = (node: AstNode): AstNode => {
+  let current = node;
+  while (
+    current.type === 'AwaitExpression' ||
+    current.type === 'ParenthesizedExpression'
+  ) {
+    const next =
+      current.type === 'AwaitExpression'
+        ? (current as unknown as { argument?: AstNode }).argument
+        : (current as unknown as { expression?: AstNode }).expression;
+    if (!next) {
+      return current;
+    }
+    current = next;
+  }
+  return current;
+};
+
 /** Check if a return argument is an allowed Result value. */
 const isAllowedReturnArgument = (
   argument: AstNode,
   helperNames: ReadonlySet<string>,
-  resultVars: ReadonlySet<string>,
+  resultVars: ScopedResultVariableMap,
   namespaceHelpers: NamespaceHelperMap,
   scopes: readonly ReadonlySet<string>[] = [],
   scopedHelpers: ScopedHelperMap = new Map()
 ): boolean => {
-  if (isResultExpression(argument)) {
+  const target = unwrapReturnExpression(argument);
+  if (target.type === 'ConditionalExpression') {
+    const { alternate, consequent } = target as unknown as {
+      alternate?: AstNode;
+      consequent?: AstNode;
+    };
+    return (
+      consequent !== undefined &&
+      alternate !== undefined &&
+      isAllowedReturnArgument(
+        consequent,
+        helperNames,
+        resultVars,
+        namespaceHelpers,
+        scopes,
+        scopedHelpers
+      ) &&
+      isAllowedReturnArgument(
+        alternate,
+        helperNames,
+        resultVars,
+        namespaceHelpers,
+        scopes,
+        scopedHelpers
+      )
+    );
+  }
+  if (isResultExpression(target)) {
     return true;
   }
   if (
-    isHelperCall(argument, helperNames, namespaceHelpers, scopes, scopedHelpers)
+    isHelperCall(target, helperNames, namespaceHelpers, scopes, scopedHelpers)
   ) {
     return true;
   }
 
-  const varName = resolveIdentifierName(argument);
-  return varName !== null && resultVars.has(varName);
+  const varName = resolveIdentifierName(target);
+  return (
+    varName !== null &&
+    isScopedResultVariableBinding(varName, scopes, resultVars)
+  );
 };
 
 // ---------------------------------------------------------------------------
@@ -284,6 +348,19 @@ const addScopedHelper = (
   scopedHelpers.set(scope, new Set([name]));
 };
 
+const addScopedResultVariable = (
+  resultVars: MutableScopedResultVariableMap,
+  scope: ReadonlySet<string>,
+  name: string
+): void => {
+  const existing = resultVars.get(scope);
+  if (existing) {
+    existing.add(name);
+    return;
+  }
+  resultVars.set(scope, new Set([name]));
+};
+
 /** Record `const helper = (): Result<...> => ...` declarations for the current lexical scope. */
 export const trackScopedResultHelperDeclaration = (
   node: AstNode,
@@ -316,7 +393,7 @@ export const trackScopedResultHelperDeclaration = (
 /** Track a VariableDeclarator, adding to resultVars if it produces a Result. */
 const trackResultVariable = (
   node: AstNode,
-  resultVars: Set<string>,
+  resultVars: MutableScopedResultVariableMap,
   helperNames: ReadonlySet<string>,
   namespaceHelpers: NamespaceHelperMap,
   scopes: readonly ReadonlySet<string>[],
@@ -330,7 +407,10 @@ const trackResultVariable = (
       isResultExpression(init) ||
       isHelperCall(init, helperNames, namespaceHelpers, scopes, scopedHelpers)
     ) {
-      resultVars.add(name);
+      const bindingScope = findNearestBindingScope(name, scopes);
+      if (bindingScope) {
+        addScopedResultVariable(resultVars, bindingScope, name);
+      }
     }
   }
 };
@@ -351,7 +431,7 @@ const checkReturnStatements = (
   diagnostics: WardenDiagnostic[],
   implScope: ReadonlySet<string> = new Set<string>()
 ): void => {
-  const resultVars = new Set<string>();
+  const resultVars: MutableScopedResultVariableMap = new Map();
   const scopedHelpers: MutableScopedHelperMap = new Map();
   const initialScopes = implScope.size > 0 ? [implScope] : [];
 
@@ -1443,10 +1523,26 @@ const checkImplementation = (
 
   const conciseScopes: readonly ReadonlySet<string>[] =
     implScope.size > 0 ? [implScope] : [];
-  if (
-    !isResultExpression(fnBody) &&
-    !isHelperCall(fnBody, helperNames, namespaceHelpers, conciseScopes)
-  ) {
+  const isConciseResultBody = (node: AstNode): boolean => {
+    const target = unwrapReturnExpression(node);
+    if (target.type === 'ConditionalExpression') {
+      const { alternate, consequent } = target as unknown as {
+        alternate?: AstNode;
+        consequent?: AstNode;
+      };
+      return (
+        consequent !== undefined &&
+        alternate !== undefined &&
+        isConciseResultBody(consequent) &&
+        isConciseResultBody(alternate)
+      );
+    }
+    return (
+      isResultExpression(target) ||
+      isHelperCall(target, helperNames, namespaceHelpers, conciseScopes)
+    );
+  };
+  if (!isConciseResultBody(fnBody)) {
     diagnostics.push({
       filePath,
       line: offsetToLine(sourceCode, implValue.start),


### PR DESCRIPTION
## What

`implementation-returns-result` recognizes conditional returns whose branches are all recognized Result expressions: `return cond ? Result.err(...) : Result.ok(...)` statements (branches may also be Result helpers or Result-bound variables) and concise ternary blaze bodies.

## Why

The most idiomatic consumer error-path shape — a two-branch ternary of `Result.err`/`Result.ok` — was flagged as a blocking governance **error**. Hit organically while writing a fresh consumer app during RC verification (adjacent to the known recognition limitations tracked in TRL-785/786/787, but this two-literal case is unambiguous).

## Verification

- Four new rule tests: return-statement ternary, mixed literal/Result-variable branches, concise ternary body, and a negative case (one raw branch still flags). Full warden suite 1086/1086.
- Changeset: patch `@ontrails/warden`.