### PR TITLE
feat(cli): derive command route projections from trails

### DIFF
--- a/.changeset/trl-958-cli-command-projection.md
+++ b/.changeset/trl-958-cli-command-projection.md
@@ -1,0 +1,9 @@
+---
+"@ontrails/core": patch
+"@ontrails/cli": patch
+"@ontrails/topographer": patch
+"@ontrails/trails": patch
+---
+
+Add trail-owned CLI command projection metadata and serialize resolved command
+route facts for downstream tools.

--- a/apps/trails/src/trails/topo-output-schemas.ts
+++ b/apps/trails/src/trails/topo-output-schemas.ts
@@ -178,6 +178,17 @@ export const trailDetailOutput = z.object({
   cli: z
     .object({
       path: z.array(z.string()).readonly(),
+      routes: z
+        .array(
+          z.object({
+            kind: z.enum(['alias', 'canonical']),
+            path: z.array(z.string()).readonly(),
+            source: z.enum(['derived', 'surface', 'trail']),
+            target: z.string(),
+          })
+        )
+        .readonly()
+        .optional(),
     })
     .nullable(),
   composedLayers: z.object({

--- a/apps/trails/src/trails/topo-reports.ts
+++ b/apps/trails/src/trails/topo-reports.ts
@@ -1,6 +1,6 @@
 import {
   DETOUR_MAX_ATTEMPTS_CAP,
-  deriveCliPath,
+  deriveTrailCliCommandProjection,
   filterSurfaceTrails,
   isArchivedTrailVersionEntry,
   zodToJsonSchema,
@@ -176,6 +176,7 @@ export interface TrailDetailReport {
   readonly activationSources: readonly ActivationSourceReport[];
   readonly cli: {
     readonly path: readonly string[];
+    readonly routes?: NonNullable<TopoGraphEntry['cli']>['routes'];
   } | null;
   /**
    * Composed layer names visible at the survey boundary.
@@ -560,7 +561,8 @@ export const deriveShippedSurfaceProjectionsForTrail = (
     trail.id,
     'trail'
   );
-  const commandPath = deriveCliPath(trail.id);
+  const commandPath =
+    entry?.cli?.path ?? deriveTrailCliCommandProjection(trail).path;
   const httpMethod = deriveHttpMethod(trail.intent);
   const httpPath = deriveHttpPath(trail.id);
   const mcpToolName = deriveToolName(app.name, trail.id);

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -116,6 +116,84 @@ describe('buildCommands path derivation', () => {
     expect(commands[0]?.path).toEqual(['topo', 'pin', 'remove']);
   });
 
+  test('uses trail-owned CLI canonical path overrides', () => {
+    const search = trail('wayfind.search', {
+      blaze: () => Result.ok([]),
+      cli: 'find',
+      input: z.object({ query: z.string() }),
+    });
+    const app = makeApp(search);
+    const commands = buildCommands(app);
+
+    expect(commands[0]?.path).toEqual(['find']);
+    expect(commands[0]?.routes).toEqual([
+      {
+        kind: 'canonical',
+        path: ['find'],
+        source: 'trail',
+        target: 'wayfind.search',
+      },
+    ]);
+  });
+
+  test('projects trail-owned and surface-owned CLI aliases as routes', () => {
+    const search = trail('wayfind.search', {
+      blaze: () => Result.ok([]),
+      cli: {
+        aliases: ['find'],
+      },
+      input: z.object({ query: z.string() }),
+    });
+    const app = makeApp(search);
+    const commands = buildCommands(app, {
+      aliases: {
+        'wayfind.search': [['wf', 'search']],
+      },
+    });
+
+    expect(commands[0]?.path).toEqual(['wayfind', 'search']);
+    expect(commands[0]?.routes).toEqual([
+      {
+        kind: 'canonical',
+        path: ['wayfind', 'search'],
+        source: 'derived',
+        target: 'wayfind.search',
+      },
+      {
+        kind: 'alias',
+        path: ['wayfind', 'find'],
+        source: 'trail',
+        target: 'wayfind.search',
+      },
+      {
+        kind: 'alias',
+        path: ['wf', 'search'],
+        source: 'surface',
+        target: 'wayfind.search',
+      },
+    ]);
+  });
+
+  test('rejects surface-owned aliases for unknown trail ids', () => {
+    const search = trail('wayfind.search', {
+      blaze: () => Result.ok([]),
+      input: z.object({ query: z.string() }),
+    });
+    const result = deriveCliCommands(makeApp(search), {
+      aliases: {
+        'wayfind.serch': [['wf', 'search']],
+      },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(ValidationError);
+      expect(result.error.message).toContain(
+        'CLI command aliases target unknown trail "wayfind.serch"'
+      );
+    }
+  });
+
   test('derives flags from input schema', () => {
     const t = trail('search', {
       blaze: () => Result.ok([]),

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -5,6 +5,7 @@
 import type {
   BasePermit,
   BaseSurfaceOptions,
+  CliCommandAliasInput,
   Field,
   Layer,
   LayerInputSchema,
@@ -19,9 +20,9 @@ import {
   ValidationError,
   basePermitSchema,
   collectAttachedTypedLayers as collectTypedLayers,
-  deriveCliPath,
   deriveFields,
   deriveSurfaceTrailVersionProjections,
+  deriveTrailCliCommandProjection,
   executeTrail,
   filterSurfaceTrails,
   LAYER_FIELD_RESERVED_NAMES,
@@ -92,6 +93,9 @@ export type ResolveCliPermitFromToken = (
 
 /** Options for CLI command projection. */
 export interface DeriveCliCommandsOptions extends BaseSurfaceOptions {
+  aliases?:
+    | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+    | undefined;
   createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
@@ -134,7 +138,24 @@ const mergeStructuredInputFlags = (derived: CliFlag[]): CliFlag[] => {
 const validateCliCommandBuild = (
   graph: Topo,
   options?: DeriveCliCommandsOptions
-): Result<void, Error> => validateSurfaceTopo(graph, options);
+): Result<void, Error> => {
+  const surfaceValidation = validateSurfaceTopo(graph, options);
+  if (surfaceValidation.isErr()) {
+    return surfaceValidation;
+  }
+
+  for (const trailId of Object.keys(options?.aliases ?? {})) {
+    if (!graph.trails.has(trailId)) {
+      return Result.err(
+        new ValidationError(
+          `CLI command aliases target unknown trail "${trailId}". Surface-owned aliases must target existing trail IDs.`
+        )
+      );
+    }
+  }
+
+  return Result.ok();
+};
 
 // ---------------------------------------------------------------------------
 // deriveCliCommands
@@ -1190,6 +1211,10 @@ const toCliCommand = (
   const dateFields = detectDateFields(t.input);
   const dateFieldKinds = detectDateFieldKinds(t.input);
   const versions = deriveSurfaceTrailVersionProjections(t);
+  const cliProjection = deriveTrailCliCommandProjection(t, {
+    aliasSource: 'surface',
+    aliases: options?.aliases?.[t.id],
+  });
 
   return {
     args,
@@ -1209,7 +1234,8 @@ const toCliCommand = (
     idempotent: t.idempotent,
     intent: t.intent,
     layers: options?.layers,
-    path: deriveCliPath(t.id),
+    path: cliProjection.path,
+    routes: cliProjection.routes,
     trail: t,
     ...(versions === undefined ? {} : { versions }),
   };

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -9,6 +9,7 @@
 import type {
   Layer,
   Result,
+  CliCommandRoute,
   SurfaceTrailVersionProjection,
   Trail,
   TrailContext,
@@ -69,6 +70,7 @@ export interface CliArg {
 /** A framework-agnostic representation of a CLI command. */
 export interface CliCommand {
   readonly path: readonly string[];
+  readonly routes?: readonly CliCommandRoute[] | undefined;
   readonly description?: string | undefined;
   readonly flags: CliFlag[];
   readonly args: CliArg[];

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -6,6 +6,16 @@ const renderPath = (path: readonly string[]): string => path.join(' ');
 
 const keyPath = (path: readonly string[]): string => path.join('\0');
 
+const commandRoutes = (command: CliCommand) =>
+  command.routes ?? [
+    {
+      kind: 'canonical' as const,
+      path: command.path,
+      source: 'derived' as const,
+      target: command.trail.id,
+    },
+  ];
+
 const toOptionKey = (name: string): string =>
   name.replaceAll(/-([a-zA-Z0-9])/g, (_, ch: string) => ch.toUpperCase());
 
@@ -15,15 +25,23 @@ interface SeenOptionNames {
 }
 
 const validateCommandPath = (command: CliCommand): void => {
-  if (command.path.length === 0) {
-    throw new ValidationError('CLI command path cannot be empty');
-  }
+  for (const route of commandRoutes(command)) {
+    if (route.path.length === 0) {
+      throw new ValidationError('CLI command path cannot be empty');
+    }
 
-  for (const segment of command.path) {
-    if (segment.trim().length === 0) {
+    if (route.target !== command.trail.id) {
       throw new ValidationError(
-        'CLI command path cannot contain empty segments'
+        `CLI command route ${renderPath(route.path)} targets "${route.target}" but command belongs to "${command.trail.id}"`
       );
+    }
+
+    for (const segment of route.path) {
+      if (segment.trim().length === 0) {
+        throw new ValidationError(
+          'CLI command path cannot contain empty segments'
+        );
+      }
     }
   }
 };
@@ -32,13 +50,15 @@ const validateUniquePaths = (commands: readonly CliCommand[]): void => {
   const seen = new Set<string>();
 
   for (const command of commands) {
-    const key = keyPath(command.path);
-    if (seen.has(key)) {
-      throw new ValidationError(
-        `Duplicate CLI path: ${renderPath(command.path)}`
-      );
+    for (const route of commandRoutes(command)) {
+      const key = keyPath(route.path);
+      if (seen.has(key)) {
+        throw new ValidationError(
+          `Duplicate CLI path: ${renderPath(route.path)}`
+        );
+      }
+      seen.add(key);
     }
-    seen.add(key);
   }
 };
 

--- a/packages/core/src/__tests__/derive.test.ts
+++ b/packages/core/src/__tests__/derive.test.ts
@@ -2,7 +2,12 @@ import { describe, test, expect } from 'bun:test';
 
 import { z } from 'zod';
 
-import { deriveCliPath, deriveFields } from '../derive.js';
+import {
+  deriveCliPath,
+  deriveFields,
+  deriveTrailCliCommandProjection,
+  normalizeCliCommandPath,
+} from '../derive.js';
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -38,6 +43,81 @@ describe('derive', () => {
       expect(() => deriveCliPath('pin.')).toThrow(
         'Trail ID "pin." contains an empty segment'
       );
+    });
+  });
+
+  describe('CLI command route projection', () => {
+    test('normalizes authored canonical command paths', () => {
+      expect(normalizeCliCommandPath('wayfind search')).toEqual([
+        'wayfind',
+        'search',
+      ]);
+      expect(normalizeCliCommandPath(['wf', 'search'])).toEqual([
+        'wf',
+        'search',
+      ]);
+    });
+
+    test('derives canonical and alias routes from trail CLI metadata', () => {
+      const projection = deriveTrailCliCommandProjection({
+        cli: {
+          aliases: ['find', ['wf', 'search']],
+        },
+        id: 'wayfind.search',
+      });
+
+      expect(projection.path).toEqual(['wayfind', 'search']);
+      expect(projection.routes).toEqual([
+        {
+          kind: 'canonical',
+          path: ['wayfind', 'search'],
+          source: 'derived',
+          target: 'wayfind.search',
+        },
+        {
+          kind: 'alias',
+          path: ['wayfind', 'find'],
+          source: 'trail',
+          target: 'wayfind.search',
+        },
+        {
+          kind: 'alias',
+          path: ['wf', 'search'],
+          source: 'trail',
+          target: 'wayfind.search',
+        },
+      ]);
+    });
+
+    test('rejects multi-segment string aliases', () => {
+      expect(() =>
+        deriveTrailCliCommandProjection({
+          cli: {
+            aliases: ['wayfind find'],
+          },
+          id: 'wayfind.search',
+        })
+      ).toThrow(
+        'CLI command alias for trail "wayfind.search" must be a single command segment'
+      );
+    });
+
+    test('records surface-owned aliases separately from trail-owned aliases', () => {
+      const projection = deriveTrailCliCommandProjection(
+        {
+          cli: {
+            aliases: ['find'],
+          },
+          id: 'wayfind.search',
+        },
+        { aliases: [['wf', 'search']] }
+      );
+
+      expect(projection.routes.map((route) => route.source)).toEqual([
+        'derived',
+        'trail',
+        'surface',
+      ]);
     });
   });
 

--- a/packages/core/src/derive.ts
+++ b/packages/core/src/derive.ts
@@ -51,6 +51,57 @@ export interface FieldOverride {
 }
 
 // ---------------------------------------------------------------------------
+// CLI command route projection
+// ---------------------------------------------------------------------------
+
+/** Authored CLI command path shape. Strings are split on whitespace. */
+export type CliCommandPathInput = string | readonly string[];
+
+/**
+ * Authored CLI command alias shape.
+ *
+ * String aliases are sibling leaf aliases. Array aliases are absolute command
+ * paths.
+ */
+export type CliCommandAliasInput = string | readonly string[];
+
+/** Source that produced a resolved CLI command route. */
+export type CliCommandRouteSource = 'derived' | 'trail' | 'surface';
+
+/** Whether a resolved CLI command route is canonical or an alias. */
+export type CliCommandRouteKind = 'alias' | 'canonical';
+
+/** Trail-authored CLI projection metadata. */
+export interface TrailCliProjection {
+  readonly aliases?: readonly CliCommandAliasInput[] | undefined;
+  readonly path?: CliCommandPathInput | undefined;
+}
+
+/** A resolved command path accepted by a CLI surface for one trail. */
+export interface CliCommandRoute {
+  readonly kind: CliCommandRouteKind;
+  readonly path: readonly string[];
+  readonly source: CliCommandRouteSource;
+  readonly target: string;
+}
+
+/** Resolved CLI projection for one trail. */
+export interface TrailCliCommandProjection {
+  readonly path: readonly string[];
+  readonly routes: readonly CliCommandRoute[];
+}
+
+interface TrailCliProjectionInput {
+  readonly cli?: CliCommandPathInput | TrailCliProjection | undefined;
+  readonly id: string;
+}
+
+export interface DeriveTrailCliCommandProjectionOptions {
+  readonly aliases?: readonly CliCommandAliasInput[] | undefined;
+  readonly aliasSource?: Extract<CliCommandRouteSource, 'surface' | 'trail'>;
+}
+
+// ---------------------------------------------------------------------------
 // Zod v4 internals accessor
 // ---------------------------------------------------------------------------
 
@@ -212,6 +263,149 @@ export const deriveCliPath = (trailId: string): string[] => {
     );
   }
   return segments;
+};
+
+const hasWhitespace = (value: string): boolean => /\s/.test(value);
+
+const validateCliSegment = (segment: string, context: string): string => {
+  const normalized = segment.trim();
+  if (normalized.length === 0) {
+    throw new ValidationError(`${context} cannot contain empty segments`);
+  }
+  if (hasWhitespace(normalized)) {
+    throw new ValidationError(
+      `${context} segment "${segment}" cannot contain whitespace`
+    );
+  }
+  return normalized;
+};
+
+const splitCliPathString = (value: string, context: string): string[] => {
+  const segments = value
+    .trim()
+    .split(/\s+/)
+    .filter((segment) => segment.length > 0);
+  if (segments.length === 0) {
+    throw new ValidationError(`${context} cannot be empty`);
+  }
+  return segments.map((segment) => validateCliSegment(segment, context));
+};
+
+/** Normalize an authored CLI command path. */
+export const normalizeCliCommandPath = (
+  value: CliCommandPathInput,
+  context = 'CLI command path'
+): readonly string[] =>
+  typeof value === 'string'
+    ? splitCliPathString(value, context)
+    : value.map((segment) => validateCliSegment(segment, context));
+
+const isTrailCliProjection = (
+  value: CliCommandPathInput | TrailCliProjection
+): value is TrailCliProjection =>
+  typeof value !== 'string' &&
+  !Array.isArray(value) &&
+  value !== null &&
+  typeof value === 'object';
+
+const trailCliProjectionFor = (
+  trail: TrailCliProjectionInput
+): TrailCliProjection | undefined => {
+  if (trail.cli === undefined) {
+    return undefined;
+  }
+  return isTrailCliProjection(trail.cli) ? trail.cli : { path: trail.cli };
+};
+
+const deriveCanonicalCliRoute = (
+  trail: TrailCliProjectionInput
+): CliCommandRoute => {
+  const projection = trailCliProjectionFor(trail);
+  const path =
+    projection?.path === undefined
+      ? deriveCliPath(trail.id)
+      : normalizeCliCommandPath(
+          projection.path,
+          `CLI command path for trail "${trail.id}"`
+        );
+  return {
+    kind: 'canonical',
+    path,
+    source: projection?.path === undefined ? 'derived' : 'trail',
+    target: trail.id,
+  };
+};
+
+const normalizeCliAlias = ({
+  alias,
+  canonicalPath,
+  source,
+  target,
+}: {
+  readonly alias: CliCommandAliasInput;
+  readonly canonicalPath: readonly string[];
+  readonly source: Extract<CliCommandRouteSource, 'surface' | 'trail'>;
+  readonly target: string;
+}): CliCommandRoute => {
+  const context = `CLI command alias for trail "${target}"`;
+  if (typeof alias === 'string') {
+    const segment = alias.trim();
+    if (segment.length === 0) {
+      throw new ValidationError(`${context} cannot be empty`);
+    }
+    if (hasWhitespace(segment)) {
+      throw new ValidationError(
+        `${context} must be a single command segment; use a string array for absolute paths`
+      );
+    }
+    return {
+      kind: 'alias',
+      path: [
+        ...canonicalPath.slice(0, -1),
+        validateCliSegment(segment, context),
+      ],
+      source,
+      target,
+    };
+  }
+  return {
+    kind: 'alias',
+    path: normalizeCliCommandPath(alias, context),
+    source,
+    target,
+  };
+};
+
+/** Derive resolved CLI command routes for one trail. */
+export const deriveTrailCliCommandProjection = (
+  trail: TrailCliProjectionInput,
+  options?: DeriveTrailCliCommandProjectionOptions
+): TrailCliCommandProjection => {
+  const canonical = deriveCanonicalCliRoute(trail);
+  const projection = trailCliProjectionFor(trail);
+  const trailAliases =
+    projection?.aliases?.map((alias) =>
+      normalizeCliAlias({
+        alias,
+        canonicalPath: canonical.path,
+        source: 'trail',
+        target: trail.id,
+      })
+    ) ?? [];
+  const surfaceAliases =
+    options?.aliases?.map((alias) =>
+      normalizeCliAlias({
+        alias,
+        canonicalPath: canonical.path,
+        source: options.aliasSource ?? 'surface',
+        target: trail.id,
+      })
+    ) ?? [];
+
+  return {
+    path: canonical.path,
+    routes: [canonical, ...trailAliases, ...surfaceAliases],
+  };
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -441,8 +441,24 @@ export type {
 } from './layer-projection.js';
 
 // Derive
-export { deriveCliPath, deriveFields } from './derive.js';
-export type { Field, FieldOverride } from './derive.js';
+export {
+  deriveCliPath,
+  deriveFields,
+  deriveTrailCliCommandProjection,
+  normalizeCliCommandPath,
+} from './derive.js';
+export type {
+  CliCommandAliasInput,
+  CliCommandPathInput,
+  CliCommandRoute,
+  CliCommandRouteKind,
+  CliCommandRouteSource,
+  DeriveTrailCliCommandProjectionOptions,
+  Field,
+  FieldOverride,
+  TrailCliCommandProjection,
+  TrailCliProjection,
+} from './derive.js';
 
 // Compose schema
 export { buildComposeValidationSchema } from './compose-schema.js';

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -12,7 +12,11 @@ import {
   isActivationSource,
 } from './activation-source.js';
 import type { AnyContour } from './contour.js';
-import type { FieldOverride } from './derive.js';
+import type {
+  FieldOverride,
+  CliCommandPathInput,
+  TrailCliProjection,
+} from './derive.js';
 import type { Layer } from './layer.js';
 import type { Result } from './result.js';
 import type { AnyResource } from './resource.js';
@@ -413,6 +417,8 @@ export interface TrailSpec<
   readonly layers?: readonly Layer[] | undefined;
   /** Per-field overrides for deriveFields() (labels, hints, options) */
   readonly fields?: Readonly<Record<string, FieldOverride>> | undefined;
+  /** CLI projection metadata for canonical command path overrides and aliases. */
+  readonly cli?: CliCommandPathInput | TrailCliProjection | undefined;
   /** Contours this trail operates on. */
   readonly contours?: readonly AnyContour[] | undefined;
   /** IDs or trail objects of downstream trails this trail may invoke via ctx.compose() */

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -165,6 +165,42 @@ describe('deriveTopoGraph', () => {
       expect(entry.resources).toEqual(['db.main']);
     });
 
+    test('trail-owned CLI projection metadata is serialized with route facts', () => {
+      const t = trail('wayfind.search', {
+        blaze: noop,
+        cli: {
+          aliases: ['find', ['wf', 'search']],
+        },
+        input: z.object({ query: z.string() }),
+        output: z.array(z.string()),
+      });
+      const entry = getFirstEntry(deriveTopoGraph(topoFrom({ t })));
+
+      expect(entry.cli).toEqual({
+        path: ['wayfind', 'search'],
+        routes: [
+          {
+            kind: 'canonical',
+            path: ['wayfind', 'search'],
+            source: 'derived',
+            target: 'wayfind.search',
+          },
+          {
+            kind: 'alias',
+            path: ['wayfind', 'find'],
+            source: 'trail',
+            target: 'wayfind.search',
+          },
+          {
+            kind: 'alias',
+            path: ['wf', 'search'],
+            source: 'trail',
+            target: 'wayfind.search',
+          },
+        ],
+      });
+    });
+
     test('trail entries include topo and trail layer attachments', () => {
       const topoLayer = passThroughLayer(
         'topo.auth',

--- a/packages/topographer/src/__tests__/topo-store-read.test.ts
+++ b/packages/topographer/src/__tests__/topo-store-read.test.ts
@@ -649,42 +649,53 @@ describe('read-only topo store', () => {
     const processDetail = store.trails.get('entity.process', {
       snapshot: { snapshotId: snapshot.id },
     });
-    expect(processDetail).toEqual(
-      expect.objectContaining({
-        activationContext: expect.objectContaining({
-          edgeCount: 1,
-          sourceCount: 1,
-          sourceKeys: ['schedule:schedule.entity.audit'],
-          trailIds: ['entity.process'],
-        }),
-        activationEdges: [
+    if (!processDetail) {
+      throw new Error('Expected entity.process detail to exist');
+    }
+    expect(processDetail).toMatchObject({
+      activationContext: {
+        edgeCount: 1,
+        sourceCount: 1,
+        sourceKeys: ['schedule:schedule.entity.audit'],
+        trailIds: ['entity.process'],
+      },
+      activationEdges: [
+        {
+          hasWhere: false,
+          sourceId: 'schedule.entity.audit',
+          sourceKey: 'schedule:schedule.entity.audit',
+          sourceKind: 'schedule',
+          trailId: 'entity.process',
+        },
+      ],
+      activationSources: processEntry?.activationSources,
+      cli: {
+        path: ['entity', 'process'],
+        routes: [
           {
-            hasWhere: false,
-            sourceId: 'schedule.entity.audit',
-            sourceKey: 'schedule:schedule.entity.audit',
-            sourceKind: 'schedule',
-            trailId: 'entity.process',
+            kind: 'canonical',
+            path: ['entity', 'process'],
+            source: 'derived',
+            target: 'entity.process',
           },
         ],
-        activationSources: processEntry?.activationSources,
-        cli: { path: ['entity', 'process'] },
-        contours: ['entity'],
-        fieldOverrides: processEntry?.fieldOverrides,
-        governance: null,
-        input: processEntry?.input,
-        layers: processEntry?.layers,
-        output: expect.objectContaining({ type: 'object' }),
-        surfaceProjections: [
-          {
-            derivedName: 'entity process',
-            method: null,
-            surface: 'cli',
-            trailId: 'entity.process',
-          },
-        ],
-        surfaces: [],
-      })
-    );
+      },
+      contours: ['entity'],
+      fieldOverrides: processEntry?.fieldOverrides,
+      governance: null,
+      input: processEntry?.input,
+      layers: processEntry?.layers,
+      output: { type: 'object' },
+      surfaceProjections: [
+        {
+          derivedName: 'entity process',
+          method: null,
+          surface: 'cli',
+          trailId: 'entity.process',
+        },
+      ],
+      surfaces: [],
+    });
     expect(processDetail?.contourDetails).toEqual([
       expect.objectContaining({
         id: 'entity',

--- a/packages/topographer/src/derive.ts
+++ b/packages/topographer/src/derive.ts
@@ -5,9 +5,9 @@
 import {
   DETOUR_MAX_ATTEMPTS_CAP,
   activationSourceKey,
-  deriveCliPath,
   deriveStructuredSignalExamples,
   deriveStructuredTrailExamples,
+  deriveTrailCliCommandProjection,
   getContourReferences,
   projectActivationSourceDeclaration,
   validateEstablishedTopo,
@@ -499,7 +499,7 @@ const trailToEntry = (
   const raw = t as unknown as Record<string, unknown>;
   const surfaces = extractSurfaces(raw);
   const entry: Record<string, unknown> = {
-    cli: { path: deriveCliPath(t.id) },
+    cli: deriveTrailCliCommandProjection(t),
     exampleCount: Array.isArray(t.examples) ? t.examples.length : 0,
     id: t.id,
     kind: t.kind,

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -7,6 +7,7 @@ import {
   deriveCliPath,
   deriveStructuredSignalExamples,
   deriveStructuredTrailExamples,
+  deriveTrailCliCommandProjection,
   getContourReferences,
   projectActivationSourceDeclaration,
   signalDiagnosticDefinitions,
@@ -1055,7 +1056,7 @@ const buildTrailEntryBase = (
 } => {
   const raw = trail as unknown as Record<string, unknown>;
   const entry: Record<string, unknown> = {
-    cli: { path: deriveCliPath(trail.id) },
+    cli: deriveTrailCliCommandProjection(trail),
     exampleCount: trail.examples?.length ?? 0,
     id: trail.id,
     input: trailSchema.input,

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type {
+  CliCommandRoute,
   StructuredSignalExample,
   StructuredTrailExample,
   TrailVersionStatus,
@@ -158,6 +159,7 @@ export interface TopoGraphEntry {
   readonly cli?:
     | {
         readonly path: readonly string[];
+        readonly routes?: readonly CliCommandRoute[] | undefined;
       }
     | undefined;
   readonly input?: JsonSchema | undefined;


### PR DESCRIPTION
## Context

Adds the core command-route projection model so CLI paths are derived from trail contracts instead of being hand-wired by each surface.

## Changes

- Adds `TrailSpec.cli`, `deriveTrailCliCommandProjection`, and route normalization helpers.
- Projects canonical and alias routes through `@ontrails/cli` commands.
- Validates route grammar, duplicate paths, collisions, and unknown alias targets.
- Updates Topographer and Trails reports so authored CLI paths survive survey/detail views.

## Verification

- bun test packages/cli/src/__tests__/build.test.ts
- bun run --cwd packages/cli typecheck
- bun test apps/trails/src/__tests__/survey.test.ts apps/trails/src/__tests__/guide.test.ts
- bun run check
- Graphite pre-push stable checks

## Risk

This is the foundation branch. Route validation is intentionally strict so bad aliases fail early rather than drifting into Commander, Topographer, or Wayfinder.