### PR TITLE
feat(commander): materialize CLI command aliases

### DIFF
--- a/.changeset/trl-959-cli-command-aliases.md
+++ b/.changeset/trl-959-cli-command-aliases.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/commander": patch
+---
+
+Materialize resolved CLI command aliases through the Commander surface while
+preserving the same trail contract and execution path.

--- a/adapters/commander/src/__tests__/surface.test.ts
+++ b/adapters/commander/src/__tests__/surface.test.ts
@@ -78,6 +78,23 @@ describe('surface', () => {
     expect(program.commands[0]?.name()).toBe('greet');
   });
 
+  test('createProgram forwards surface-owned command aliases', () => {
+    const t = trail('wayfind.search', {
+      blaze: (input: { query: string }) => Result.ok(input.query),
+      input: z.object({ query: z.string() }),
+    });
+    const app = topo('surface-aliases', { [t.id]: t });
+    const program = createProgram(app, {
+      aliases: {
+        'wayfind.search': [['wf', 'search']],
+      },
+      description: 'Surface alias smoke',
+    });
+
+    const wf = program.commands.find((command) => command.name() === 'wf');
+    expect(wf?.commands[0]?.name()).toBe('search');
+  });
+
   test('surface throws on invalid topo', async () => {
     const t = trail('broken', {
       blaze: () => Result.ok({}),

--- a/adapters/commander/src/__tests__/to-commander.test.ts
+++ b/adapters/commander/src/__tests__/to-commander.test.ts
@@ -210,6 +210,57 @@ describe('toCommander command trees', () => {
     expect(removeCmd.name()).toBe('remove');
   });
 
+  test('materializes trail-owned aliases that execute the same command', async () => {
+    const calls: string[] = [];
+    const search = trail('wayfind.search', {
+      blaze: (input: { query: string }) => {
+        calls.push(input.query);
+        return Result.ok(input.query);
+      },
+      cli: {
+        aliases: ['find'],
+      },
+      input: z.object({ query: z.string() }),
+    });
+    const app = makeApp(search);
+    const commands = buildCommands(app, { onResult: noopResult });
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+
+    expect(requireNestedCommand(program, ['wayfind', 'search'])).toBeDefined();
+    expect(requireNestedCommand(program, ['wayfind', 'find'])).toBeDefined();
+
+    await program.parseAsync(['node', 'test', 'wayfind', 'find', 'trails']);
+
+    expect(calls).toEqual(['trails']);
+  });
+
+  test('materializes surface-owned aliases that execute the same command', async () => {
+    const calls: string[] = [];
+    const search = trail('wayfind.search', {
+      blaze: (input: { query: string }) => {
+        calls.push(input.query);
+        return Result.ok(input.query);
+      },
+      input: z.object({ query: z.string() }),
+    });
+    const app = makeApp(search);
+    const commands = buildCommands(app, {
+      aliases: {
+        'wayfind.search': [['wf', 'search']],
+      },
+      onResult: noopResult,
+    });
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+
+    expect(requireNestedCommand(program, ['wf', 'search'])).toBeDefined();
+
+    await program.parseAsync(['node', 'test', 'wf', 'search', 'trails']);
+
+    expect(calls).toEqual(['trails']);
+  });
+
   test('supports executable parents alongside child commands', async () => {
     const calls: string[] = [];
     const program = buildExecutableParentProgram(calls);

--- a/adapters/commander/src/surface.ts
+++ b/adapters/commander/src/surface.ts
@@ -4,6 +4,7 @@
 
 import type {
   BaseSurfaceOptions,
+  CliCommandAliasInput,
   Layer,
   ResourceOverrideMap,
   Topo,
@@ -27,6 +28,9 @@ import { toCommander } from './to-commander.js';
  * Options for creating Commander CLI surfaces from a Trails topo.
  */
 export interface CreateProgramOptions extends BaseSurfaceOptions {
+  readonly aliases?:
+    | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+    | undefined;
   readonly createContext?:
     | (() => TrailContextInit | Promise<TrailContextInit>)
     | undefined;
@@ -88,6 +92,7 @@ export const createProgram = (
   options: CreateProgramOptions = {}
 ) => {
   const commandsResult = deriveCliCommands(graph, {
+    aliases: options.aliases,
     configValues: options.configValues,
     createContext: options.createContext,
     exclude: options.exclude,

--- a/adapters/commander/src/to-commander.ts
+++ b/adapters/commander/src/to-commander.ts
@@ -458,15 +458,16 @@ const ensureCommandNode = (
 
 const createBareChildFallback = (
   cmd: CliCommand,
+  path: readonly string[],
   parentState?: CommandNodeState | undefined
 ): BareChildFallback | undefined => {
-  if (!parentState?.cliCommand || cmd.path.length < 2) {
+  if (!parentState?.cliCommand || path.length < 2) {
     return undefined;
   }
 
   const [parentArg] = parentState.cliCommand.args;
   const [childArg] = cmd.args;
-  const childSegment = cmd.path.at(-1);
+  const childSegment = path.at(-1);
   if (
     parentArg === undefined ||
     childArg === undefined ||
@@ -490,10 +491,11 @@ const createBareChildFallback = (
 const applyCliCommand = (
   state: CommandNodeState,
   cmd: CliCommand,
+  path: readonly string[],
   fallback?: BareChildFallback | undefined
 ): void => {
   if (state.executable) {
-    throw new Error(`Duplicate CLI path: ${cmd.path.join(' ')}`);
+    throw new Error(`Duplicate CLI path: ${path.join(' ')}`);
   }
 
   if (cmd.description) {
@@ -511,6 +513,21 @@ const applyCliCommand = (
   state.cliCommand = cmd;
   state.executable = true;
 };
+
+const commandRoutes = (cmd: CliCommand) =>
+  cmd.routes ?? [
+    {
+      kind: 'canonical' as const,
+      path: cmd.path,
+      source: 'derived' as const,
+      target: cmd.trail.id,
+    },
+  ];
+
+const commandRouteEntries = (commands: readonly CliCommand[]) =>
+  commands.flatMap((cmd) =>
+    commandRoutes(cmd).map((route) => ({ cmd, path: route.path }))
+  );
 
 /**
  * Convert framework-agnostic CLI commands into a Commander program.
@@ -535,15 +552,15 @@ export const toCommander = (
   applyOptions(program, options);
   const nodes = new Map<string, CommandNodeState>();
 
-  for (const cmd of commands.toSorted((a, b) =>
+  for (const { cmd, path } of commandRouteEntries(commands).toSorted((a, b) =>
     a.path.length === b.path.length
       ? a.path.join('.').localeCompare(b.path.join('.'))
       : a.path.length - b.path.length
   )) {
-    const state = ensureCommandNode(cmd.path, program, nodes);
-    const parentKey = pathKey(cmd.path.slice(0, -1));
-    const fallback = createBareChildFallback(cmd, nodes.get(parentKey));
-    applyCliCommand(state, cmd, fallback);
+    const state = ensureCommandNode(path, program, nodes);
+    const parentKey = pathKey(path.slice(0, -1));
+    const fallback = createBareChildFallback(cmd, path, nodes.get(parentKey));
+    applyCliCommand(state, cmd, path, fallback);
   }
 
   return program;


### PR DESCRIPTION
## Context

Lets the Commander surface consume the same CLI command routes derived from trails, including alias routes.

## Changes

- Adds Commander surface alias support.
- Materializes all route paths for a command while preserving one trail contract.
- Keeps duplicate route diagnostics near the surface adapter.
- Adds a changeset for the published Commander-facing behavior.

## Verification

- bun run check
- bun run test
- bun run build
- bun run publish:check
- Graphite pre-push stable checks

## Risk

Aliases are extra entry paths only. They do not carry separate input, output, permit, intent, or behavior.