### PR TITLE
feat(cli): expose command route schemas

### DIFF
--- a/.changeset/trl-960-cli-route-inspection.md
+++ b/.changeset/trl-960-cli-route-inspection.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/cli": patch
+"@ontrails/trails": patch
+"@ontrails/wayfinder": patch
+---
+
+Expose resolved CLI command routes through schema helpers, the Trails operator
+schema command, and Wayfinder trail contract output.

--- a/apps/trails/src/__tests__/schema-cli.test.ts
+++ b/apps/trails/src/__tests__/schema-cli.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+import { deriveCliCommands } from '@ontrails/cli';
+import { Result, trail, topo } from '@ontrails/core';
+import { Command } from 'commander';
+import { z } from 'zod';
+
+import { attachSchemaCommand } from '../run-schema.js';
+
+const buildProgram = () => {
+  const search = trail('wayfind.search', {
+    blaze: (input: { query: string }) => Result.ok(input.query),
+    input: z.object({ query: z.string() }),
+    output: z.string(),
+  });
+  const commands = deriveCliCommands(
+    topo('schema-cli', { [search.id]: search }),
+    {
+      aliases: {
+        'wayfind.search': [['wf', 'search']],
+      },
+    }
+  );
+  if (commands.isErr()) {
+    throw commands.error;
+  }
+  const program = new Command('trails');
+  program.exitOverride();
+  attachSchemaCommand(program, commands.value);
+  return program;
+};
+
+const withStdout = async (
+  invoke: () => Promise<void> | void
+): Promise<string> => {
+  const originalWrite = process.stdout.write;
+  const chunks: string[] = [];
+  process.stdout.write = mock((chunk: string | Uint8Array) => {
+    chunks.push(String(chunk));
+    return true;
+  }) as unknown as typeof process.stdout.write;
+  try {
+    await invoke();
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+  return chunks.join('');
+};
+
+describe('attachSchemaCommand', () => {
+  test('prints the full CLI schema index as JSON', async () => {
+    const program = buildProgram();
+    const output = await withStdout(() =>
+      program.parseAsync(['node', 'trails', 'schema'])
+    );
+    const parsed = JSON.parse(output);
+
+    expect(parsed.commands[0]).toMatchObject({
+      commandPath: ['wayfind', 'search'],
+      trailId: 'wayfind.search',
+    });
+  });
+
+  test('finds a command by alias path', async () => {
+    const program = buildProgram();
+    const output = await withStdout(() =>
+      program.parseAsync(['node', 'trails', 'schema', 'wf', 'search'])
+    );
+    const parsed = JSON.parse(output);
+
+    expect(parsed.command).toMatchObject({
+      commandPath: ['wayfind', 'search'],
+      trailId: 'wayfind.search',
+    });
+  });
+});

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -5,6 +5,7 @@ import { isAbsolute, join, resolve } from 'node:path';
 import {
   defaultOnResult,
   devPermitPreset,
+  deriveCliCommands,
   outputModePreset,
   permitPreset,
   tokenPreset,
@@ -16,6 +17,7 @@ import type {
   ResolveCliPermitFromToken,
 } from '@ontrails/cli';
 import { createProgram } from '@ontrails/commander';
+import type { CreateProgramOptions } from '@ontrails/commander';
 import { resolvePermitFromBearerToken } from '@ontrails/permits';
 import { deriveTopoGraph } from '@ontrails/topographer';
 
@@ -23,6 +25,7 @@ import { app, trailsCliIncludedTrails } from './app.js';
 import { resolveInputWithClack } from './clack.js';
 import { getRetiredTopoCommandDiagnostic } from './retired-topo-command.js';
 import { attachCompletionsInstallCommand } from './run-completions-install.js';
+import { attachSchemaCommand } from './run-schema.js';
 import {
   applyAdapterCheckExitCode,
   tryAdapterCheckOutput,
@@ -293,7 +296,7 @@ const runSurfaceOnce = async (): Promise<void> => {
 
   const session = maybeInstallTraceSession();
   try {
-    const program = createProgram(app, {
+    const surfaceOptions = {
       description: 'Agent-native, contract-first TypeScript framework',
       include: trailsCliIncludedTrails,
       name: 'trails',
@@ -309,7 +312,13 @@ const runSurfaceOnce = async (): Promise<void> => {
       resolveInput: resolveInputWithClack,
       resolvePermitFromToken: resolveCliPermitFromToken,
       version: trailsPackageVersion,
-    });
+    } satisfies CreateProgramOptions;
+    const program = createProgram(app, surfaceOptions);
+    const schemaCommands = deriveCliCommands(app, surfaceOptions);
+    if (schemaCommands.isErr()) {
+      throw schemaCommands.error;
+    }
+    attachSchemaCommand(program, schemaCommands.value);
     attachCompletionsInstallCommand(program);
     await program.parseAsync(normalizeWardenArgv(process.argv));
   } finally {

--- a/apps/trails/src/run-schema.ts
+++ b/apps/trails/src/run-schema.ts
@@ -1,0 +1,41 @@
+import type { CliCommand } from '@ontrails/cli';
+import { deriveCliSchema, findCliSchemaCommand } from '@ontrails/cli';
+import type { Command } from 'commander';
+
+const normalizeCommandPath = (path: readonly string[] | undefined): string[] =>
+  (path ?? []).flatMap((segment) =>
+    segment
+      .trim()
+      .split(/\s+/)
+      .filter((part) => part.length > 0)
+  );
+
+const writeJson = (value: unknown): void => {
+  process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
+};
+
+export const attachSchemaCommand = (
+  program: Command,
+  commands: readonly CliCommand[]
+): void => {
+  const schema = deriveCliSchema(commands);
+  program
+    .command('schema [command...]')
+    .description('Inspect accepted CLI command contracts as JSON')
+    .action((commandPath: string[] | undefined) => {
+      const path = normalizeCommandPath(commandPath);
+      if (path.length === 0) {
+        writeJson(schema);
+        return;
+      }
+
+      const command = findCliSchemaCommand(schema, path);
+      if (command === undefined) {
+        process.stderr.write(`Unknown CLI command: ${path.join(' ')}\n`);
+        process.exitCode = 1;
+        return;
+      }
+
+      writeJson({ command });
+    });
+};

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -276,18 +276,16 @@ await surface(graph);
 
 To use a different CLI framework (yargs, oclif, etc.), consume the successful `CliCommand[]` result directly and write your own adapter. The model carries everything needed: a full ordered command path, flags, args, and an `execute()` function.
 
-## Planned Schema Command
+## Schema Command
 
-Trails CLI apps should eventually expose command schemas for free. The planned shape is a default-on `schema` command derived from the same topo and framework-agnostic CLI command model as the derived commands.
+Trails CLI apps can expose command schemas from the same topo and framework-agnostic CLI command model as the derived commands. The Trails operator CLI dogfoods this as `trails schema`.
 
 ```bash
-myapp schema
-myapp schema entity.update
-myapp schema entity update --json
+trails schema
+trails schema wayfind search
+trails schema wf search
 ```
 
-The no-arg form should return a compact index of available command contracts. Targeted schema lookup should return the full Trails command-contract envelope: command path, trail id, args, flags, aliases, input schema, output schema, output formats, examples, and deprecation metadata when derivable.
+The no-arg form returns a command contract index. Targeted schema lookup accepts any canonical or alias command path and returns the full command-contract envelope: command path, trail id, args, flags, routes, aliases, input schema, output schema, examples, and version metadata when derivable.
 
-Schema visibility should describe the surface-bound CLI commands by default. Apps may configure broader schema visibility for dev or agent environments, but runtime flags should not reveal hidden/internal schemas that the app author did not choose to expose.
-
-This schema command is planned future work in `@ontrails/cli`; it is not part of beta 15.
+Schema visibility describes the surface-bound CLI commands. Apps may configure broader schema visibility for dev or agent environments, but runtime schema output must not reveal hidden/internal schemas that the app author did not choose to expose.

--- a/packages/cli/src/__tests__/schema.test.ts
+++ b/packages/cli/src/__tests__/schema.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Result, trail, topo } from '@ontrails/core';
+import { z } from 'zod';
+
+import { deriveCliCommands } from '../build.js';
+import { deriveCliSchema, findCliSchemaCommand } from '../schema.js';
+
+const buildSchema = () => {
+  const search = trail('wayfind.search', {
+    blaze: (input: { query: string }) => Result.ok(input.query),
+    cli: {
+      aliases: ['find'],
+    },
+    description: 'Search the graph',
+    examples: [{ input: { query: 'trail' }, name: 'Search trails' }],
+    input: z.object({ query: z.string() }),
+    output: z.string(),
+  });
+  const result = deriveCliCommands(
+    topo('schema-test', { [search.id]: search }),
+    {
+      aliases: {
+        'wayfind.search': [['wf', 'search']],
+      },
+    }
+  );
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return deriveCliSchema(result.value);
+};
+
+describe('deriveCliSchema', () => {
+  test('projects command routes and contracts into a schema index', () => {
+    const schema = buildSchema();
+    const [command] = schema.commands;
+
+    expect(command).toMatchObject({
+      aliases: [
+        {
+          kind: 'alias',
+          path: ['wayfind', 'find'],
+          source: 'trail',
+          target: 'wayfind.search',
+        },
+        {
+          kind: 'alias',
+          path: ['wf', 'search'],
+          source: 'surface',
+          target: 'wayfind.search',
+        },
+      ],
+      commandPath: ['wayfind', 'search'],
+      description: 'Search the graph',
+      intent: 'write',
+      trailId: 'wayfind.search',
+    });
+    expect(command?.input).toMatchObject({
+      properties: {
+        query: { type: 'string' },
+      },
+      type: 'object',
+    });
+    expect(command?.output).toEqual({ type: 'string' });
+  });
+
+  test('finds commands by canonical and alias paths', () => {
+    const schema = buildSchema();
+
+    expect(findCliSchemaCommand(schema, ['wayfind', 'search'])?.trailId).toBe(
+      'wayfind.search'
+    );
+    expect(findCliSchemaCommand(schema, ['wayfind', 'find'])?.trailId).toBe(
+      'wayfind.search'
+    );
+    expect(findCliSchemaCommand(schema, ['wf', 'search'])?.trailId).toBe(
+      'wayfind.search'
+    );
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,12 @@ export type {
   ResolveCliPermitFromTokenInput,
 } from './build.js';
 export { validateCliCommands } from './validate.js';
+export { deriveCliSchema, findCliSchemaCommand } from './schema.js';
+export type {
+  CliCommandSchemaEntry,
+  CliCommandSchemaRoute,
+  CliSchemaIndex,
+} from './schema.js';
 
 // Flags
 export {

--- a/packages/cli/src/schema.ts
+++ b/packages/cli/src/schema.ts
@@ -1,0 +1,113 @@
+import type { CliCommand } from './command.js';
+import { zodToJsonSchema } from '@ontrails/core';
+
+export interface CliCommandSchemaRoute {
+  readonly kind: 'alias' | 'canonical';
+  readonly path: readonly string[];
+  readonly source: 'derived' | 'surface' | 'trail';
+  readonly target: string;
+}
+
+export interface CliCommandSchemaEntry {
+  readonly aliases: readonly CliCommandSchemaRoute[];
+  readonly args: CliCommand['args'];
+  readonly commandPath: readonly string[];
+  readonly description?: string | undefined;
+  readonly examples: readonly unknown[];
+  readonly flags: CliCommand['flags'];
+  readonly idempotent?: boolean | undefined;
+  readonly input: Readonly<Record<string, unknown>>;
+  readonly intent: CliCommand['intent'];
+  readonly output: Readonly<Record<string, unknown>> | null;
+  readonly routes: readonly CliCommandSchemaRoute[];
+  readonly trailId: string;
+  readonly versions?: CliCommand['versions'];
+}
+
+export interface CliSchemaIndex {
+  readonly commands: readonly CliCommandSchemaEntry[];
+}
+
+const routePathKey = (path: readonly string[]) => path.join('\0');
+
+const commandRoutes = (command: CliCommand): readonly CliCommandSchemaRoute[] =>
+  command.routes ?? [
+    {
+      kind: 'canonical',
+      path: command.path,
+      source: 'derived',
+      target: command.trail.id,
+    },
+  ];
+
+const commandSchemaEntry = (command: CliCommand): CliCommandSchemaEntry => {
+  const routes = commandRoutes(command);
+  const aliases = routes.filter((route) => route.kind === 'alias');
+  return {
+    aliases,
+    args: command.args,
+    commandPath: command.path,
+    description: command.description,
+    examples: command.trail.examples ?? [],
+    flags: command.flags,
+    idempotent: command.idempotent,
+    input: zodToJsonSchema(command.trail.input) as Readonly<
+      Record<string, unknown>
+    >,
+    intent: command.intent,
+    output:
+      command.trail.output === undefined
+        ? null
+        : (zodToJsonSchema(command.trail.output) as Readonly<
+            Record<string, unknown>
+          >),
+    routes,
+    trailId: command.trail.id,
+    versions: command.versions,
+  };
+};
+
+/**
+ * Derive a JSON-friendly schema index from framework-agnostic CLI commands.
+ *
+ * @example
+ * ```ts
+ * import { deriveCliCommands, deriveCliSchema } from '@ontrails/cli';
+ *
+ * const commands = deriveCliCommands(graph);
+ * if (commands.isErr()) throw commands.error;
+ *
+ * const schema = deriveCliSchema(commands.value);
+ * console.log(schema.commands.map((command) => command.commandPath));
+ * ```
+ */
+export const deriveCliSchema = (
+  commands: readonly CliCommand[]
+): CliSchemaIndex => ({
+  commands: commands
+    .map(commandSchemaEntry)
+    .toSorted((a, b) =>
+      a.commandPath.join(' ').localeCompare(b.commandPath.join(' '))
+    ),
+});
+
+/**
+ * Find the command schema entry addressed by a canonical path or alias path.
+ *
+ * @example
+ * ```ts
+ * import { findCliSchemaCommand } from '@ontrails/cli';
+ *
+ * const command = findCliSchemaCommand(schema, ['wayfind', 'find']);
+ * console.log(command?.trailId);
+ * ```
+ */
+export const findCliSchemaCommand = (
+  schema: CliSchemaIndex,
+  path: readonly string[]
+): CliCommandSchemaEntry | undefined => {
+  const key = routePathKey(path);
+  return schema.commands.find((command) =>
+    command.routes.some((route) => routePathKey(route.path) === key)
+  );
+};

--- a/packages/wayfinder/src/__tests__/queries.test.ts
+++ b/packages/wayfinder/src/__tests__/queries.test.ts
@@ -66,6 +66,9 @@ const userShow = trail('user.show', {
 
 const userCreate = trail('user.create', {
   blaze: () => Result.ok({ id: 'u1' }),
+  cli: {
+    aliases: ['add'],
+  },
   fires: [userCreated],
   input: z.object({ name: z.string() }),
   intent: 'write',
@@ -541,6 +544,23 @@ describe('wayfinder graph-read query trails', () => {
       'user.create',
       'user.show',
     ]);
+    expect(trails.trails[0]?.cli).toMatchObject({
+      path: ['user', 'create'],
+      routes: [
+        {
+          kind: 'canonical',
+          path: ['user', 'create'],
+          source: 'derived',
+          target: 'user.create',
+        },
+        {
+          kind: 'alias',
+          path: ['user', 'add'],
+          source: 'trail',
+          target: 'user.create',
+        },
+      ],
+    });
     expect(surfaces.surfaces).toEqual([
       { facets: [], id: 'cli', trails: ['user.create'] },
       { facets: ['users'], id: 'mcp', trails: ['user.create', 'user.show'] },
@@ -884,7 +904,7 @@ describe('wayfinder graph-read query trails', () => {
 
   test('returns contract details for current and historical trail versions', async () => {
     const current = await expectOk(
-      wayfindContractTrail.blaze({ id: 'user.show', rootDir: tempDir }, ctx())
+      wayfindContractTrail.blaze({ id: 'user.create', rootDir: tempDir }, ctx())
     );
     const historical = await expectOk(
       wayfindContractTrail.blaze(
@@ -894,7 +914,24 @@ describe('wayfinder graph-read query trails', () => {
     );
 
     expect(current.contract).toMatchObject({
-      id: 'user.show',
+      cli: {
+        path: ['user', 'create'],
+        routes: [
+          {
+            kind: 'canonical',
+            path: ['user', 'create'],
+            source: 'derived',
+            target: 'user.create',
+          },
+          {
+            kind: 'alias',
+            path: ['user', 'add'],
+            source: 'trail',
+            target: 'user.create',
+          },
+        ],
+      },
+      id: 'user.create',
       kind: 'trail',
       resources: ['db.main'],
     });

--- a/packages/wayfinder/src/queries.ts
+++ b/packages/wayfinder/src/queries.ts
@@ -187,7 +187,22 @@ const entrySummarySchema = z.object({
   surfaces: z.array(z.string()).readonly(),
 });
 
+const cliRouteSchema = z.object({
+  kind: z.enum(['alias', 'canonical']),
+  path: z.array(z.string()).readonly(),
+  source: z.enum(['derived', 'surface', 'trail']),
+  target: z.string(),
+});
+
+const cliProjectionSchema = z
+  .object({
+    path: z.array(z.string()).readonly(),
+    routes: z.array(cliRouteSchema).readonly().optional(),
+  })
+  .nullable();
+
 const trailSummarySchema = entrySummarySchema.extend({
+  cli: cliProjectionSchema,
   composes: z.array(z.string()).readonly(),
   intent: z.enum(['destroy', 'read', 'write']),
   kind: z.literal('trail'),
@@ -607,6 +622,7 @@ const trailSummaries = (graph: TopoGraph) =>
   graph.entries
     .filter((entry) => entry.kind === 'trail')
     .map((entry) => ({
+      cli: entry.cli ?? null,
       composes: entry.composes ?? [],
       exampleCount: entry.exampleCount,
       id: entry.id,
@@ -1010,6 +1026,7 @@ const contractEntryKind = (
 const contractEntry = (
   entry: TopoGraphEntry
 ): Readonly<Record<string, unknown>> => ({
+  cli: entry.cli ?? null,
   id: entry.id,
   input: entry.input ?? null,
   kind: entry.kind,


### PR DESCRIPTION
## Context

Gives agents and users an inspection surface for CLI routes, including aliases, so they can discover command shape before invoking it.

## Changes

- Adds CLI schema derivation and lookup by canonical or alias path.
- Adds the `trails schema [command...]` command.
- Projects CLI route facts into Wayfinder summaries and contracts.
- Adds a trail-owned `wayfind find` sibling alias for `wayfind.search`.

## Verification

- bun test apps/trails/src/__tests__/schema-cli.test.ts apps/trails/src/__tests__/wayfind-cli.test.ts
- Manual smoke: `trails schema wf search` resolves `wayfind.search` and lists all routes.
- bun run check
- Graphite pre-push stable checks

## Risk

Schema output is inspect-only, but it is now part of the agent-facing contract and should stay stable enough for tooling.