### PR TITLE
fix(warden): govern CLI command route drift

### DIFF
--- a/.agents/skills/clark/references/warden-guide.md
+++ b/.agents/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 63
+- Rule count: 64
 
 ## Agent Instructions
 
@@ -67,6 +67,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 
 ### Meta
 
+- `cli-command-route-coherence` (error, topo/topo-aware, external): CLI command routes and aliases resolve to one coherent trail contract. Guidance: Keep every CLI command route and alias normalized into one trail contract.
 - `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep surface facet maps reviewable before they reach MCP projection.
 
 ### Permits

--- a/.changeset/trl-961-cli-route-warden.md
+++ b/.changeset/trl-961-cli-route-warden.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Add Warden governance for CLI command route and alias coherence.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 63
+- Rule count: 64
 
 ## Agent Instructions
 
@@ -67,6 +67,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 
 ### Meta
 
+- `cli-command-route-coherence` (error, topo/topo-aware, external): CLI command routes and aliases resolve to one coherent trail contract. Guidance: Keep every CLI command route and alias normalized into one trail contract.
 - `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep surface facet maps reviewable before they reach MCP projection.
 
 ### Permits

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Use the project language consistently:
 This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
-- Rule count: 63
+- Rule count: 64
 
 ### Rule Index
 
@@ -146,6 +146,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 
 #### Meta
 
+- `cli-command-route-coherence` (error, topo/topo-aware, external): CLI command routes and aliases resolve to one coherent trail contract.
 - `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors.
 
 #### Permits
@@ -185,6 +186,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 
 ### Structured Guidance Summaries
 
+- `cli-command-route-coherence`: Keep every CLI command route and alias normalized into one trail contract.
 - `example-valid`: Keep trail examples synchronized with their authored schemas.
 - `no-throw-in-implementation`: Convert thrown failures in blazes into explicit Result.err() outcomes.
 - `no-top-level-surface`: Keep topo entry modules side-effect-free for survey, guide, compile, and lock generation.

--- a/packages/warden/src/__tests__/cli-command-route-coherence.test.ts
+++ b/packages/warden/src/__tests__/cli-command-route-coherence.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'bun:test';
+
+import { Result, topo, trail } from '@ontrails/core';
+import { deriveTopoGraph } from '@ontrails/topographer';
+import { z } from 'zod';
+
+import { runWarden } from '../cli.js';
+import { cliCommandRouteCoherence } from '../rules/cli-command-route-coherence.js';
+
+const searchTrail = trail('wayfind.search', {
+  blaze: () => Result.ok([]),
+  cli: {
+    aliases: ['find'],
+  },
+  input: z.object({ query: z.string() }),
+  output: z.array(z.string()),
+});
+
+describe('cli-command-route-coherence', () => {
+  test('stays quiet when aliases resolve to distinct command paths', async () => {
+    const diagnostics = await cliCommandRouteCoherence.checkTopo(
+      topo('cli-routes-clean', { searchTrail })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('errors when an alias collides with another command route', async () => {
+    const collidingTrail = trail('wayfind.find', {
+      blaze: () => Result.ok([]),
+      input: z.object({ query: z.string() }),
+      output: z.array(z.string()),
+    });
+
+    const diagnostics = await cliCommandRouteCoherence.checkTopo(
+      topo('cli-routes-collide', { collidingTrail, searchTrail })
+    );
+
+    expect(diagnostics).toEqual([
+      {
+        filePath: '<topo>',
+        line: 1,
+        message:
+          'CLI command route collision on "wayfind find": canonical route for trail "wayfind.find" (derived), alias route for trail "wayfind.search" (trail). Rename or remove one CLI alias so every accepted command path normalizes into exactly one trail contract.',
+        rule: 'cli-command-route-coherence',
+        severity: 'error',
+      },
+    ]);
+  });
+
+  test('errors when a string alias is more than one segment', async () => {
+    const invalid = trail('wayfind.search', {
+      blaze: () => Result.ok([]),
+      cli: {
+        aliases: ['wayfind find'],
+      },
+      input: z.object({ query: z.string() }),
+      output: z.array(z.string()),
+    });
+
+    const diagnostics = await cliCommandRouteCoherence.checkTopo(
+      topo('cli-routes-invalid', { invalid })
+    );
+
+    expect(diagnostics[0]).toMatchObject({
+      filePath: '<topo>',
+      line: 1,
+      rule: 'cli-command-route-coherence',
+      severity: 'error',
+    });
+    expect(diagnostics[0]?.message).toContain(
+      'must be a single command segment'
+    );
+  });
+
+  test('errors when serialized graph route facts target a missing trail', async () => {
+    const app = topo('cli-routes-graph-target', { searchTrail });
+    const graph = deriveTopoGraph(app);
+    const corruptedGraph = {
+      ...graph,
+      entries: graph.entries.map((entry) =>
+        entry.id === 'wayfind.search'
+          ? {
+              ...entry,
+              cli: {
+                path: ['wayfind', 'search'],
+                routes: [
+                  {
+                    kind: 'alias' as const,
+                    path: ['wf', 'search'],
+                    source: 'surface' as const,
+                    target: 'missing.trail',
+                  },
+                ],
+              },
+            }
+          : entry
+      ),
+    };
+
+    const diagnostics = await cliCommandRouteCoherence.checkTopo(app, {
+      graph: corruptedGraph,
+    });
+
+    expect(diagnostics).toEqual([
+      {
+        filePath: '<topo>',
+        line: 1,
+        message:
+          'Serialized CLI command route "wf search" targets unknown trail "missing.trail". Surface-owned aliases must target existing trail IDs.',
+        rule: 'cli-command-route-coherence',
+        severity: 'error',
+      },
+    ]);
+  });
+
+  test('errors when serialized surface-owned aliases collide', async () => {
+    const search = trail('wayfind.search', {
+      blaze: () => Result.ok([]),
+      input: z.object({ query: z.string() }),
+      output: z.array(z.string()),
+    });
+    const collidingTrail = trail('wayfind.find', {
+      blaze: () => Result.ok([]),
+      input: z.object({ query: z.string() }),
+      output: z.array(z.string()),
+    });
+    const app = topo('cli-routes-surface-collide', {
+      collidingTrail,
+      search,
+    });
+    const graph = deriveTopoGraph(app);
+    const corruptedGraph = {
+      ...graph,
+      entries: graph.entries.map((entry) =>
+        entry.id === 'wayfind.search'
+          ? {
+              ...entry,
+              cli: {
+                ...entry.cli,
+                routes: [
+                  ...(entry.cli?.routes ?? []),
+                  {
+                    kind: 'alias' as const,
+                    path: ['wayfind', 'find'],
+                    source: 'surface' as const,
+                    target: 'wayfind.search',
+                  },
+                ],
+              },
+            }
+          : entry
+      ),
+    };
+
+    const diagnostics = await cliCommandRouteCoherence.checkTopo(app, {
+      graph: corruptedGraph,
+    });
+
+    expect(diagnostics).toEqual([
+      {
+        filePath: '<topo>',
+        line: 1,
+        message:
+          'CLI command route collision on "wayfind find": canonical route for trail "wayfind.find" (derived), alias route for trail "wayfind.search" (surface). Rename or remove one CLI alias so every accepted command path normalizes into exactly one trail contract.',
+        rule: 'cli-command-route-coherence',
+        severity: 'error',
+      },
+    ]);
+  });
+
+  test('runWarden dispatches the rule from wardenTopoRules', async () => {
+    const collidingTrail = trail('wayfind.find', {
+      blaze: () => Result.ok([]),
+      input: z.object({ query: z.string() }),
+      output: z.array(z.string()),
+    });
+
+    const result = await runWarden({
+      mode: 'check',
+      topo: topo('cli-routes-run', { collidingTrail, searchTrail }),
+    });
+
+    expect(
+      result.diagnostics.some(
+        (diagnostic) => diagnostic.rule === 'cli-command-route-coherence'
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -9,8 +9,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 63 rule trails', () => {
-    expect(wardenTopo.count).toBe(63);
+  test('contains all 64 rule trails', () => {
+    expect(wardenTopo.count).toBe(64);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -161,6 +161,7 @@ export { wardenTopo } from './trails/topo.js';
 export { runTopoAwareWardenTrails, runWardenTrails } from './trails/run.js';
 export {
   activationOrphanTrail,
+  cliCommandRouteCoherenceTrail,
   circularRefsTrail,
   contourExistsTrail,
   contextNoSurfaceTypesTrail,

--- a/packages/warden/src/rules/cli-command-route-coherence.ts
+++ b/packages/warden/src/rules/cli-command-route-coherence.ts
@@ -1,0 +1,177 @@
+import { deriveTrailCliCommandProjection } from '@ontrails/core';
+import type { CliCommandRoute, Topo } from '@ontrails/core';
+import type { TopoGraph } from '@ontrails/topographer';
+
+import type { TopoAwareWardenRule, WardenDiagnostic } from './types.js';
+
+const RULE_NAME = 'cli-command-route-coherence';
+const TOPO_FILE = '<topo>';
+
+interface RouteClaim {
+  readonly kind: CliCommandRoute['kind'];
+  readonly path: readonly string[];
+  readonly source: CliCommandRoute['source'];
+  readonly trailId: string;
+}
+
+const routeKey = (path: readonly string[]): string => path.join('\0');
+
+const renderPath = (path: readonly string[]): string => path.join(' ');
+
+const claimLabel = (claim: RouteClaim): string =>
+  `${claim.kind} route for trail "${claim.trailId}" (${claim.source})`;
+
+const buildProjectionDiagnostic = (
+  trailId: string,
+  error: unknown
+): WardenDiagnostic => ({
+  filePath: TOPO_FILE,
+  line: 1,
+  message: `CLI command route projection for trail "${trailId}" is invalid: ${
+    error instanceof Error ? error.message : String(error)
+  }`,
+  rule: RULE_NAME,
+  severity: 'error',
+});
+
+const buildCollisionDiagnostic = (
+  path: readonly string[],
+  claims: readonly RouteClaim[]
+): WardenDiagnostic => ({
+  filePath: TOPO_FILE,
+  line: 1,
+  message: `CLI command route collision on "${renderPath(path)}": ${claims
+    .toSorted((a, b) => a.trailId.localeCompare(b.trailId))
+    .map(claimLabel)
+    .join(
+      ', '
+    )}. Rename or remove one CLI alias so every accepted command path normalizes into exactly one trail contract.`,
+  rule: RULE_NAME,
+  severity: 'error',
+});
+
+const buildGraphTargetDiagnostic = (
+  entryId: string,
+  route: CliCommandRoute,
+  knownTrailIds: ReadonlySet<string>
+): WardenDiagnostic => ({
+  filePath: TOPO_FILE,
+  line: 1,
+  message: knownTrailIds.has(route.target)
+    ? `Serialized CLI command route "${renderPath(route.path)}" is stored under trail "${entryId}" but targets "${route.target}". Route facts must stay attached to their owning trail.`
+    : `Serialized CLI command route "${renderPath(route.path)}" targets unknown trail "${route.target}". Surface-owned aliases must target existing trail IDs.`,
+  rule: RULE_NAME,
+  severity: 'error',
+});
+
+const collectTopoClaims = (
+  topo: Topo
+): {
+  readonly claims: readonly RouteClaim[];
+  readonly diagnostics: readonly WardenDiagnostic[];
+} => {
+  const claims: RouteClaim[] = [];
+  const diagnostics: WardenDiagnostic[] = [];
+
+  for (const trail of topo.list()) {
+    try {
+      const projection = deriveTrailCliCommandProjection(trail);
+      for (const route of projection.routes) {
+        claims.push({
+          kind: route.kind,
+          path: route.path,
+          source: route.source,
+          trailId: trail.id,
+        });
+      }
+    } catch (error: unknown) {
+      diagnostics.push(buildProjectionDiagnostic(trail.id, error));
+    }
+  }
+
+  return { claims, diagnostics };
+};
+
+const collectGraphClaims = (
+  graph: TopoGraph | undefined
+): readonly RouteClaim[] => {
+  if (graph === undefined) {
+    return [];
+  }
+
+  const claims: RouteClaim[] = [];
+  for (const entry of graph.entries) {
+    if (entry.kind !== 'trail') {
+      continue;
+    }
+    for (const route of entry.cli?.routes ?? []) {
+      claims.push({
+        kind: route.kind,
+        path: route.path,
+        source: route.source,
+        trailId: entry.id,
+      });
+    }
+  }
+  return claims;
+};
+
+const collectCollisionDiagnostics = (
+  claims: readonly RouteClaim[]
+): readonly WardenDiagnostic[] => {
+  const claimsByRoute = new Map<string, RouteClaim[]>();
+  for (const claim of claims) {
+    const key = routeKey(claim.path);
+    const current = claimsByRoute.get(key) ?? [];
+    current.push(claim);
+    claimsByRoute.set(key, current);
+  }
+
+  return [...claimsByRoute.values()]
+    .filter((grouped) => grouped.length > 1)
+    .map((grouped) =>
+      buildCollisionDiagnostic(grouped[0]?.path ?? [], grouped)
+    );
+};
+
+const collectGraphTargetDiagnostics = (
+  graph: TopoGraph | undefined,
+  knownTrailIds: ReadonlySet<string>
+): readonly WardenDiagnostic[] => {
+  if (graph === undefined) {
+    return [];
+  }
+
+  const diagnostics: WardenDiagnostic[] = [];
+  for (const entry of graph.entries) {
+    if (entry.kind !== 'trail') {
+      continue;
+    }
+    for (const route of entry.cli?.routes ?? []) {
+      if (route.target !== entry.id || !knownTrailIds.has(route.target)) {
+        diagnostics.push(
+          buildGraphTargetDiagnostic(entry.id, route, knownTrailIds)
+        );
+      }
+    }
+  }
+  return diagnostics;
+};
+
+export const cliCommandRouteCoherence: TopoAwareWardenRule = {
+  checkTopo(topo, context) {
+    const { claims, diagnostics } = collectTopoClaims(topo);
+    const knownTrailIds = new Set(topo.trails.keys());
+    const routeClaims =
+      context?.graph === undefined ? claims : collectGraphClaims(context.graph);
+    return [
+      ...diagnostics,
+      ...collectCollisionDiagnostics(routeClaims),
+      ...collectGraphTargetDiagnostics(context?.graph, knownTrailIds),
+    ];
+  },
+  description:
+    'Ensure CLI command routes and aliases resolve to one coherent trail contract.',
+  name: RULE_NAME,
+  severity: 'error',
+};

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -1,4 +1,5 @@
 import { activationOrphan } from './activation-orphan.js';
+import { cliCommandRouteCoherence } from './cli-command-route-coherence.js';
 import { circularRefs } from './circular-refs.js';
 import { contourExists } from './contour-exists.js';
 import { contextNoSurfaceTypes } from './context-no-surface-types.js';
@@ -103,6 +104,7 @@ export {
 export type { BuiltinWardenRuleName } from './metadata.js';
 
 export { activationOrphan } from './activation-orphan.js';
+export { cliCommandRouteCoherence } from './cli-command-route-coherence.js';
 export { noThrowInImplementation } from './no-throw-in-implementation.js';
 export { circularRefs } from './circular-refs.js';
 export { contourExists } from './contour-exists.js';
@@ -239,6 +241,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
 export const wardenTopoRules: ReadonlyMap<string, TopoAwareWardenRule> =
   new Map<string, TopoAwareWardenRule>([
     [activationOrphan.name, activationOrphan],
+    [cliCommandRouteCoherence.name, cliCommandRouteCoherence],
     [incompleteAccessorForStandardOp.name, incompleteAccessorForStandardOp],
     [permitGovernance.name, permitGovernance],
     [publicOutputSchema.name, publicOutputSchema],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -68,6 +68,7 @@ const depthByTier = {
 
 const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
   'activation-orphan': 'signals',
+  'cli-command-route-coherence': 'meta',
   'composes-declarations': 'composition',
   'context-no-surface-types': 'composition',
   'dead-internal-trail': 'composition',
@@ -150,6 +151,23 @@ const builtinWardenRuleMetadataInput = {
     ...durableExternal,
     invariant: 'Contour reference graphs must be acyclic.',
     tier: 'project-static',
+  },
+  'cli-command-route-coherence': {
+    ...durableExternal,
+    guidance: {
+      docs: [
+        {
+          label: 'CLI command routes ADR',
+          path: 'docs/adr/drafts/20260613-cli-command-routes.md',
+        },
+      ],
+      relatedRules: ['webhook-route-collision'],
+      summary:
+        'Keep every CLI command route and alias normalized into one trail contract.',
+    },
+    invariant:
+      'CLI command routes and aliases resolve to one coherent trail contract.',
+    tier: 'topo-aware',
   },
   'composes-declarations': {
     ...durableExternal,

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -7,6 +7,7 @@
  * the `warden-export-symmetry` rule will fail the build if they drift.
  */
 import { activationOrphan } from './activation-orphan.js';
+import { cliCommandRouteCoherence } from './cli-command-route-coherence.js';
 import { circularRefs } from './circular-refs.js';
 import { contourExists } from './contour-exists.js';
 import { contextNoSurfaceTypes } from './context-no-surface-types.js';
@@ -81,6 +82,7 @@ import { webhookRouteCollision } from './webhook-route-collision.js';
  */
 export const registeredRuleNames: readonly string[] = [
   activationOrphan.name,
+  cliCommandRouteCoherence.name,
   circularRefs.name,
   contextNoSurfaceTypes.name,
   contourExists.name,

--- a/packages/warden/src/trails/cli-command-route-coherence.trail.ts
+++ b/packages/warden/src/trails/cli-command-route-coherence.trail.ts
@@ -1,0 +1,47 @@
+import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { cliCommandRouteCoherence } from '../rules/cli-command-route-coherence.js';
+import { wrapTopoRule } from './wrap-rule.js';
+
+const searchTrail = trail('wayfind.search', {
+  blaze: () => Result.ok([]),
+  cli: {
+    aliases: ['find'],
+  },
+  input: z.object({ query: z.string() }),
+  output: z.array(z.string()),
+});
+
+const collidingTrail = trail('wayfind.find', {
+  blaze: () => Result.ok([]),
+  input: z.object({ query: z.string() }),
+  output: z.array(z.string()),
+});
+
+export const cliCommandRouteCoherenceTrail = wrapTopoRule({
+  examples: [
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: '<topo>',
+            line: 1,
+            message:
+              'CLI command route collision on "wayfind find": canonical route for trail "wayfind.find" (derived), alias route for trail "wayfind.search" (trail). Rename or remove one CLI alias so every accepted command path normalizes into exactly one trail contract.',
+            rule: 'cli-command-route-coherence',
+            severity: 'error',
+          },
+        ],
+      },
+      input: {
+        topo: topo('cli-command-route-coherence', {
+          collidingTrail,
+          searchTrail,
+        }),
+      },
+      name: 'CLI alias colliding with another command route',
+    },
+  ],
+  rule: cliCommandRouteCoherence,
+});

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -1,4 +1,5 @@
 export { activationOrphanTrail } from './activation-orphan.trail.js';
+export { cliCommandRouteCoherenceTrail } from './cli-command-route-coherence.trail.js';
 export { circularRefsTrail } from './circular-refs.trail.js';
 export { contourExistsTrail } from './contour-exists.trail.js';
 export { contextNoSurfaceTypesTrail } from './context-no-surface-types.trail.js';

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 63
+- Rule count: 64
 
 ## Agent Instructions
 
@@ -67,6 +67,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 
 ### Meta
 
+- `cli-command-route-coherence` (error, topo/topo-aware, external): CLI command routes and aliases resolve to one coherent trail contract. Guidance: Keep every CLI command route and alias normalized into one trail contract.
 - `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep surface facet maps reviewable before they reach MCP projection.
 
 ### Permits


### PR DESCRIPTION
## Context

Adds governance for the new CLI route projection so aliases stay deterministic and cannot silently collide.

## Changes

- Adds the `cli-command-route-coherence` Warden rule and trail wrapper.
- Checks single-segment string aliases, absolute path aliases, duplicate routes, target existence, and collisions.
- Uses serialized graph route claims when topo context is available so surface-owned aliases are governed too.
- Updates generated Warden guide output.

## Verification

- bun test packages/warden/src/__tests__/cli-command-route-coherence.test.ts
- bun run --cwd packages/warden typecheck
- bun run check
- Graphite pre-push stable checks

## Risk

This may introduce new warnings or errors for apps that have ambiguous CLI alias plans. That is intentional guardrail behavior.