### PR TITLE
feat(trails): dogfood CLI route aliases in the operator

### DIFF
--- a/.changeset/trl-962-cli-route-dogfood.md
+++ b/.changeset/trl-962-cli-route-dogfood.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/trails": patch
+"@ontrails/topographer": patch
+"@ontrails/wayfinder": patch
+---
+
+Dogfood CLI command route aliases through the Trails operator, saved Topographer artifacts, and Wayfinder contract inspection.

--- a/apps/trails/README.md
+++ b/apps/trails/README.md
@@ -15,8 +15,8 @@ Common workflows:
 - `trails topo` inspects topo state and manages pins/history.
 - `trails compile` writes committed topo artifacts.
 - `trails validate` checks committed topo artifacts for drift.
-- `trails wayfind overview` and adjacent `trails wayfind ...` commands read
-  saved topo artifacts through Wayfinder for local graph navigation.
+- `trails wayfind overview`, `trails wayfind find`, `trails wf search`, and adjacent `trails wayfind ...` commands read saved topo artifacts through Wayfinder for local graph navigation.
+- `trails schema <command...>` shows accepted CLI routes, aliases, flags, and schemas for an operator command.
 - `trails warden` runs Trails governance checks for contract and architecture drift.
 - `trails guide` shows available trails and examples from a project.
 

--- a/apps/trails/src/__tests__/load-app.test.ts
+++ b/apps/trails/src/__tests__/load-app.test.ts
@@ -334,6 +334,79 @@ describe('loadApp', () => {
     }
   });
 
+  test('loads optional CLI alias exports from the app module', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-cli-aliases-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      writeFileSync(
+        resolve(cwd, 'src/app.ts'),
+        `export const app = {
+  name: 'aliases',
+  trails: new Map(),
+  signals: new Map(),
+  resources: new Map()
+};
+
+export const trailsCliAliases = {
+  'wayfind.search': [['wf', 'search'], 'find']
+};`
+      );
+
+      const lease = await loadFreshAppLease('./src/app.ts', cwd);
+      try {
+        expect(lease.cliAliases).toEqual({
+          'wayfind.search': [['wf', 'search'], 'find'],
+        });
+      } finally {
+        lease.release();
+      }
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects malformed CLI alias exports from the app module', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-bad-cli-aliases-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      writeFileSync(
+        resolve(cwd, 'src/app.ts'),
+        `export const app = {
+  name: 'bad-aliases',
+  trails: new Map(),
+  signals: new Map(),
+  resources: new Map()
+};
+
+export const cliAliases = {
+  'wayfind.search': [42]
+};`
+      );
+
+      const result = await tryLoadFreshAppLease('./src/app.ts', cwd);
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain(
+          'must contain string aliases or string-array paths'
+        );
+      }
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
   test('rejects app module paths outside the default trust boundary', async () => {
     const root = resolve(
       tmpdir(),

--- a/apps/trails/src/__tests__/wayfind-cli.test.ts
+++ b/apps/trails/src/__tests__/wayfind-cli.test.ts
@@ -1,10 +1,18 @@
 import { deriveCliCommands } from '@ontrails/cli';
 import { describe, expect, test } from 'bun:test';
 
-import { app, operatorApp, trailsCliIncludedTrails } from '../app.js';
+import {
+  app,
+  operatorApp,
+  trailsCliAliases,
+  trailsCliIncludedTrails,
+} from '../app.js';
 
 const unwrapCommands = () => {
-  const result = deriveCliCommands(app, { include: trailsCliIncludedTrails });
+  const result = deriveCliCommands(app, {
+    aliases: trailsCliAliases,
+    include: trailsCliIncludedTrails,
+  });
   if (result.isErr()) {
     throw result.error;
   }
@@ -38,6 +46,30 @@ describe('Trails Wayfinder CLI surface', () => {
     expect(trailIds).toContain('wayfind.nearby');
     expect(trailIds).toContain('wayfind.impact');
     expect(trailIds).toContain('wayfind.examples');
+
+    const search = commands.find(
+      (command) => command.trail.id === 'wayfind.search'
+    );
+    expect(search?.routes).toEqual([
+      {
+        kind: 'canonical',
+        path: ['wayfind', 'search'],
+        source: 'derived',
+        target: 'wayfind.search',
+      },
+      {
+        kind: 'alias',
+        path: ['wayfind', 'find'],
+        source: 'trail',
+        target: 'wayfind.search',
+      },
+      {
+        kind: 'alias',
+        path: ['wf', 'search'],
+        source: 'surface',
+        target: 'wayfind.search',
+      },
+    ]);
   });
 
   test('does not expose deferred Wayfinder queries on the CLI', () => {

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -103,4 +103,8 @@ export const trailsCliIncludedTrails = [
   ...Object.values(cliWayfinderTrails).map((trailItem) => trailItem.id),
 ];
 
+export const trailsCliAliases = {
+  'wayfind.search': [['wf', 'search']],
+} as const;
+
 export const app = topo('trails', operatorTrails, cliWayfinderTrails);

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -21,7 +21,7 @@ import type { CreateProgramOptions } from '@ontrails/commander';
 import { resolvePermitFromBearerToken } from '@ontrails/permits';
 import { deriveTopoGraph } from '@ontrails/topographer';
 
-import { app, trailsCliIncludedTrails } from './app.js';
+import { app, trailsCliAliases, trailsCliIncludedTrails } from './app.js';
 import { resolveInputWithClack } from './clack.js';
 import { getRetiredTopoCommandDiagnostic } from './retired-topo-command.js';
 import { attachCompletionsInstallCommand } from './run-completions-install.js';
@@ -297,6 +297,7 @@ const runSurfaceOnce = async (): Promise<void> => {
   const session = maybeInstallTraceSession();
   try {
     const surfaceOptions = {
+      aliases: trailsCliAliases,
       description: 'Agent-native, contract-first TypeScript framework',
       include: trailsCliIncludedTrails,
       name: 'trails',

--- a/apps/trails/src/release/wayfinder-dogfood-smoke.ts
+++ b/apps/trails/src/release/wayfinder-dogfood-smoke.ts
@@ -1,6 +1,7 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const repoRoot = resolve(process.cwd());
 const trailsBin = join(repoRoot, 'apps/trails/bin/trails.ts');
@@ -40,18 +41,9 @@ const parseJson = (stdout: string, label: string): JsonObject => {
   }
 };
 
-const runWayfind = (tempRoot: string, args: readonly string[]): JsonObject => {
-  const command = [
-    process.execPath,
-    trailsBin,
-    'wayfind',
-    ...args,
-    '--root-dir',
-    tempRoot,
-    '--json',
-  ];
+const runCommand = (command: readonly string[], label: string): JsonObject => {
   const result = Bun.spawnSync({
-    cmd: command,
+    cmd: [...command],
     cwd: repoRoot,
     env: { ...process.env, NO_COLOR: '1' } as Record<
       string,
@@ -72,7 +64,35 @@ const runWayfind = (tempRoot: string, args: readonly string[]): JsonObject => {
       ].join('\n')
     );
   }
-  return parseJson(stdout, `trails ${args.join(' ')}`);
+  return parseJson(stdout, label);
+};
+
+const runTrails = (tempRoot: string, args: readonly string[]): JsonObject => {
+  const command = [
+    process.execPath,
+    trailsBin,
+    ...args,
+    '--root-dir',
+    tempRoot,
+    '--json',
+  ];
+  return runCommand(command, `trails ${args.join(' ')}`);
+};
+
+const runWayfind = (tempRoot: string, args: readonly string[]): JsonObject =>
+  runTrails(tempRoot, ['wayfind', ...args]);
+
+const runSchema = (args: readonly string[]): JsonObject =>
+  runCommand([process.execPath, trailsBin, 'schema', ...args], 'trails schema');
+
+const writeOperatorAppWrapper = async (tempRoot: string): Promise<void> => {
+  const srcDir = join(tempRoot, 'src');
+  await mkdir(srcDir, { recursive: true });
+  const appModuleUrl = pathToFileURL(join(repoRoot, 'apps/trails/src/app.ts'));
+  await writeFile(
+    join(srcDir, 'app.ts'),
+    `export { app, trailsCliAliases } from ${JSON.stringify(appModuleUrl.href)};\n`
+  );
 };
 
 const assertSearchFindsWayfinder = (search: JsonObject): void => {
@@ -86,6 +106,35 @@ const assertSearchFindsWayfinder = (search: JsonObject): void => {
   if (!ids.includes('wayfind.search')) {
     throw new Error('wayfind search did not find wayfind.search');
   }
+};
+
+const assertRoutePathsForSearch = (routes: unknown, label: string): void => {
+  if (!Array.isArray(routes)) {
+    throw new TypeError(`${label} did not return command routes`);
+  }
+  const routePaths = new Set(
+    routes
+      .map((route) => assertObject(route, `${label} route`)['path'])
+      .filter(
+        (path): path is string[] =>
+          Array.isArray(path) &&
+          path.every((segment) => typeof segment === 'string')
+      )
+      .map((path) => path.join(' '))
+  );
+  for (const expected of ['wayfind search', 'wayfind find', 'wf search']) {
+    if (!routePaths.has(expected)) {
+      throw new Error(`${label} did not include ${expected}`);
+    }
+  }
+};
+
+const assertSchemaForSearch = (schema: JsonObject): void => {
+  const command = assertObject(schema['command'], 'schema command');
+  if (command['trailId'] !== 'wayfind.search') {
+    throw new Error('schema did not inspect wayfind.search');
+  }
+  assertRoutePathsForSearch(command['routes'], 'schema');
 };
 
 const assertErrorsFindWayfinder = (errorsResult: JsonObject): void => {
@@ -142,6 +191,8 @@ const assertContractForSearch = (contractResult: JsonObject): void => {
   if (contract['id'] !== 'wayfind.search') {
     throw new Error('wayfind contract did not inspect wayfind.search');
   }
+  const cli = assertObject(contract['cli'], 'contract.cli');
+  assertRoutePathsForSearch(cli['routes'], 'contract');
 };
 
 const assertResolvedTarget = (value: JsonObject, label: string): void => {
@@ -156,16 +207,14 @@ export const runWayfinderDogfoodSmoke =
     const tempRoot = await mkdtemp(join(tmpdir(), 'trails-wayfinder-dogfood-'));
 
     try {
-      const [{ trailsMcpApp }, { exportCurrentTopo }] = await Promise.all([
-        import('../mcp-app.js'),
-        import('../trails/topo-store-support.js'),
+      await writeOperatorAppWrapper(tempRoot);
+      runTrails(tempRoot, [
+        'compile',
+        '--module',
+        './src/app.ts',
+        '--permit',
+        '{"id":"wayfinder-dogfood","scopes":["topo:write"]}',
       ]);
-      const exported = await exportCurrentTopo(trailsMcpApp, {
-        rootDir: tempRoot,
-      });
-      if (exported.isErr()) {
-        throw exported.error;
-      }
 
       const overview = runWayfind(tempRoot, ['overview']);
       assertFreshSource(overview, 'wayfind overview');
@@ -185,6 +234,25 @@ export const runWayfinderDogfoodSmoke =
       ]);
       assertFreshSource(search, 'wayfind search');
       assertSearchFindsWayfinder(search);
+
+      const findAlias = runWayfind(tempRoot, [
+        'find',
+        '--input-json',
+        '{"filters":{"kind":"trail","idPrefix":"wayfind."}}',
+      ]);
+      assertFreshSource(findAlias, 'wayfind find');
+      assertSearchFindsWayfinder(findAlias);
+
+      const shortAlias = runTrails(tempRoot, [
+        'wf',
+        'search',
+        '--input-json',
+        '{"filters":{"kind":"trail","idPrefix":"wayfind."}}',
+      ]);
+      assertFreshSource(shortAlias, 'wf search');
+      assertSearchFindsWayfinder(shortAlias);
+
+      assertSchemaForSearch(runSchema(['wf', 'search']));
 
       const errors = runWayfind(tempRoot, [
         'errors',

--- a/apps/trails/src/trails/compile.ts
+++ b/apps/trails/src/trails/compile.ts
@@ -1,5 +1,5 @@
 import { trail } from '@ontrails/core';
-import type { Result, Topo } from '@ontrails/core';
+import type { CliCommandAliasInput, Result, Topo } from '@ontrails/core';
 import { z } from 'zod';
 
 import { tryLoadFreshAppLease } from './load-app.js';
@@ -13,7 +13,13 @@ import {
 
 export const compileCurrentTopo = async (
   app: Topo,
-  options?: { readonly force?: boolean | undefined; readonly rootDir?: string }
+  options?: {
+    readonly cliAliases?:
+      | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+      | undefined;
+    readonly force?: boolean | undefined;
+    readonly rootDir?: string;
+  }
 ): Promise<Result<TopoExportReport, Error>> => exportCurrentTopo(app, options);
 
 const compileTrailInputSchema = z.object({
@@ -41,6 +47,7 @@ export const compileTrail = trail('compile', {
     const lease = leaseResult.value;
     try {
       return await compileCurrentTopo(lease.app, {
+        cliAliases: lease.cliAliases,
         force: input.force,
         rootDir,
       });

--- a/apps/trails/src/trails/guide.ts
+++ b/apps/trails/src/trails/guide.ts
@@ -56,6 +56,7 @@ export const guideTrail = trail('guide', {
     try {
       if (input.trailId) {
         const detail = buildCurrentTopoDetail(lease.app, input.trailId, {
+          cliAliases: lease.cliAliases,
           rootDir,
           surfaceLayerNames: readSurfaceLayerNamesFromContext(ctx),
         });

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -23,7 +23,7 @@ import {
   Result,
   ValidationError,
 } from '@ontrails/core';
-import type { Topo } from '@ontrails/core';
+import type { CliCommandAliasInput, Topo } from '@ontrails/core';
 import { findAppModule } from '@ontrails/cli';
 
 import {
@@ -1054,8 +1054,52 @@ const resolveLoadedTopo = (
   return app;
 };
 
+type LoadedCliAliases = Readonly<
+  Record<string, readonly CliCommandAliasInput[]>
+>;
+
+const isStringArray = (value: unknown): value is readonly string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === 'string');
+
+const isCliAliasInput = (value: unknown): value is CliCommandAliasInput =>
+  typeof value === 'string' || isStringArray(value);
+
+const resolveLoadedCliAliases = (
+  effectivePath: string,
+  mod: Record<string, unknown>
+): LoadedCliAliases | undefined => {
+  const value = mod['trailsCliAliases'] ?? mod['cliAliases'];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new ValidationError(
+      `CLI alias export in "${effectivePath}" must be a record from trail ID to alias list.`
+    );
+  }
+
+  const aliases = value as Record<string, unknown>;
+  for (const [trailId, trailAliases] of Object.entries(aliases)) {
+    if (!Array.isArray(trailAliases)) {
+      throw new ValidationError(
+        `CLI alias export for trail "${trailId}" in "${effectivePath}" must be an array.`
+      );
+    }
+    for (const alias of trailAliases) {
+      if (!isCliAliasInput(alias)) {
+        throw new ValidationError(
+          `CLI alias export for trail "${trailId}" in "${effectivePath}" must contain string aliases or string-array paths.`
+        );
+      }
+    }
+  }
+
+  return aliases as LoadedCliAliases;
+};
+
 export interface FreshAppLease {
   readonly app: Topo;
+  readonly cliAliases?: LoadedCliAliases | undefined;
   readonly mirrorRoot: string;
   readonly release: () => void;
 }
@@ -1071,14 +1115,18 @@ const noopRelease = (): void => undefined;
 const createUrlSchemeLease = async (
   absolutePath: string,
   effectivePath: string
-): Promise<FreshAppLease> => ({
-  app: resolveLoadedTopo(
-    effectivePath,
-    await importWithCacheBust(absolutePath)
-  ),
-  mirrorRoot: absolutePath,
-  release: noopRelease,
-});
+): Promise<FreshAppLease> => {
+  const mod = (await importWithCacheBust(absolutePath)) as Record<
+    string,
+    unknown
+  >;
+  return {
+    app: resolveLoadedTopo(effectivePath, mod),
+    cliAliases: resolveLoadedCliAliases(effectivePath, mod),
+    mirrorRoot: absolutePath,
+    release: noopRelease,
+  };
+};
 
 const createFilesystemLease = async (
   absolutePath: string,
@@ -1096,6 +1144,7 @@ const createFilesystemLease = async (
 
     return {
       app: resolveLoadedTopo(effectivePath, mod),
+      cliAliases: resolveLoadedCliAliases(effectivePath, mod),
       mirrorRoot,
       release,
     };

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -7,7 +7,7 @@
 
 import { basename, extname, join } from 'node:path';
 
-import type { Topo } from '@ontrails/core';
+import type { CliCommandAliasInput, Topo } from '@ontrails/core';
 import {
   deriveSafePath,
   NotFoundError,
@@ -505,9 +505,13 @@ const buildSurveyLookup = (
   app: Topo,
   entityId: string,
   rootDir: string,
+  cliAliases:
+    | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+    | undefined,
   surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ): Result<object, Error> => {
   const matches = buildCurrentTopoMatches(app, entityId, {
+    cliAliases,
     rootDir,
     surfaceLayerNames,
   });
@@ -518,9 +522,13 @@ const buildSurveyTrailDetail = (
   app: Topo,
   id: string,
   rootDir: string,
+  cliAliases:
+    | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+    | undefined,
   surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ): Result<object, Error> => {
   const detail = buildCurrentTrailDetail(app, id, {
+    cliAliases,
     rootDir,
     surfaceLayerNames,
   });
@@ -572,15 +580,24 @@ type SurveyHandler = (
   app: Topo,
   input: SurveyInput,
   rootDir: string,
+  cliAliases:
+    | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+    | undefined,
   surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ) => Result<object, Error> | Promise<Result<object, Error>>;
 
 /** Handlers keyed by survey mode. */
 const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
-  lookup: (app, input, rootDir, surfaceLayerNames) =>
+  lookup: (app, input, rootDir, cliAliases, surfaceLayerNames) =>
     input.id === undefined || input.id === ''
       ? Result.err(new ValidationError('Survey lookup requires an id'))
-      : buildSurveyLookup(app, input.id, rootDir, surfaceLayerNames),
+      : buildSurveyLookup(
+          app,
+          input.id,
+          rootDir,
+          cliAliases,
+          surfaceLayerNames
+        ),
   overview: (app, _input, rootDir) =>
     Result.ok(buildCurrentTopoList(app, { rootDir })),
 };
@@ -595,11 +612,20 @@ const dispatchSurvey = async (
   app: Topo,
   input: SurveyInput,
   rootDir: string,
+  cliAliases:
+    | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+    | undefined,
   surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ): Promise<Result<SurveyEnvelope, Error>> => {
   const mode = deriveSurveyMode(input);
   const handler = surveyHandlers[mode];
-  const result = await handler(app, input, rootDir, surfaceLayerNames);
+  const result = await handler(
+    app,
+    input,
+    rootDir,
+    cliAliases,
+    surfaceLayerNames
+  );
   if (result.isErr()) {
     return result;
   }
@@ -615,7 +641,12 @@ const detailInputSchema = z.object({
 const withFreshSurveyApp = async <T>(
   input: { readonly module?: string | undefined },
   rootDir: string,
-  consume: (app: Topo) => Promise<Result<T, Error>> | Result<T, Error>
+  consume: (
+    app: Topo,
+    cliAliases:
+      | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+      | undefined
+  ) => Promise<Result<T, Error>> | Result<T, Error>
 ): Promise<Result<T, Error>> => {
   const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
   if (leaseResult.isErr()) {
@@ -623,7 +654,7 @@ const withFreshSurveyApp = async <T>(
   }
   const lease = leaseResult.value;
   try {
-    return await consume(lease.app);
+    return await consume(lease.app, lease.cliAliases);
   } finally {
     lease.release();
   }
@@ -637,7 +668,10 @@ const withResolvedSurveyApp = async <T>(
   cwd: string | undefined,
   consume: (
     app: Topo,
-    rootDir: string
+    rootDir: string,
+    cliAliases:
+      | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+      | undefined
   ) => Promise<Result<T, Error>> | Result<T, Error>
 ): Promise<Result<T, Error>> => {
   const rootDirResult = resolveTrailRootDir(input.rootDir, cwd);
@@ -645,7 +679,9 @@ const withResolvedSurveyApp = async <T>(
     return Result.err(rootDirResult.error);
   }
   const rootDir = rootDirResult.value;
-  return withFreshSurveyApp(input, rootDir, (app) => consume(app, rootDir));
+  return withFreshSurveyApp(input, rootDir, (app, cliAliases) =>
+    consume(app, rootDir, cliAliases)
+  );
 };
 
 const moduleInputSchema = z.object({
@@ -718,8 +754,14 @@ const surveyMatchOutput = z.discriminatedUnion('kind', [
 export const surveyTrail = trail('survey', {
   args: ['id'],
   blaze: async (input, ctx) =>
-    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
-      dispatchSurvey(app, input, rootDir, readSurfaceLayerNamesFromContext(ctx))
+    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir, cliAliases) =>
+      dispatchSurvey(
+        app,
+        input,
+        rootDir,
+        cliAliases,
+        readSurfaceLayerNamesFromContext(ctx)
+      )
     ),
   description: 'Full topo introspection',
   examples: [
@@ -891,11 +933,12 @@ export const diffTrail = trail('diff', {
 export const surveyTrailDetailTrail = trail('survey.trail', {
   args: ['id'],
   blaze: async (input, ctx) =>
-    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
+    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir, cliAliases) =>
       buildSurveyTrailDetail(
         app,
         input.id,
         rootDir,
+        cliAliases,
         readSurfaceLayerNamesFromContext(ctx)
       )
     ),

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -8,7 +8,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import type { Topo, TrailContext } from '@ontrails/core';
+import type { CliCommandAliasInput, Topo, TrailContext } from '@ontrails/core';
 import {
   ConflictError,
   deriveTrailsDbPath,
@@ -71,6 +71,9 @@ export interface CurrentTopoMatch {
 }
 
 export interface CurrentTopoReadOptions {
+  readonly cliAliases?:
+    | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+    | undefined;
   readonly rootDir?: string | undefined;
   readonly surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined;
 }
@@ -154,6 +157,7 @@ export const buildCurrentTrailDetail = (
     ? undefined
     : deriveTrailDetail(trail, app, undefined, {
         surfaceLayerNames: options?.surfaceLayerNames,
+        topoGraph: deriveTopoGraph(app, { cliAliases: options?.cliAliases }),
       });
 };
 
@@ -192,7 +196,7 @@ export const buildCurrentTopoMatches = (
     (activationGraph ??= deriveActivationGraph(app));
   let topoGraph: ReturnType<typeof deriveTopoGraph> | undefined;
   const getTopoGraph = (): ReturnType<typeof deriveTopoGraph> =>
-    (topoGraph ??= deriveTopoGraph(app));
+    (topoGraph ??= deriveTopoGraph(app, { cliAliases: options?.cliAliases }));
 
   const trail = app.get(id);
   if (trail !== undefined) {
@@ -220,7 +224,12 @@ export const buildCurrentTopoMatches = (
 
 export const validateCurrentTopo = async (
   app: Topo,
-  options?: { readonly rootDir?: string }
+  options?: {
+    readonly cliAliases?:
+      | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+      | undefined;
+    readonly rootDir?: string;
+  }
 ): Promise<Result<TopoValidateReport, Error>> => {
   const rootDir = deriveRootDir(options?.rootDir);
   let lockManifest: Awaited<ReturnType<typeof readLockManifest>>;
@@ -248,7 +257,10 @@ export const validateCurrentTopo = async (
     );
   }
 
-  const currentExport = deriveCurrentTopoExport(app, { rootDir });
+  const currentExport = deriveCurrentTopoExport(app, {
+    cliAliases: options?.cliAliases,
+    rootDir,
+  });
   if (currentExport.isErr()) {
     return currentExport;
   }

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -7,7 +7,7 @@
 
 import { Database } from 'bun:sqlite';
 
-import type { Topo } from '@ontrails/core';
+import type { CliCommandAliasInput, Topo } from '@ontrails/core';
 import {
   ConflictError,
   deriveTrailsDir,
@@ -42,15 +42,21 @@ import {
   readGitState,
 } from './topo-support.js';
 
+type CliAliasesOption = Readonly<
+  Record<string, readonly CliCommandAliasInput[]>
+>;
+
 const persistAndReadStoredExport = (
   app: Topo,
   db: ReturnType<typeof openWriteTrailsDb>,
-  rootDir: string
+  rootDir: string,
+  options?: { readonly cliAliases?: CliAliasesOption | undefined } | undefined
 ): Result<
   { snapshot: TopoSnapshot; storedExport: StoredTopoExport },
   Error
 > => {
   const snapshotResult = createStoredTopoSnapshot(db, app, {
+    cliAliases: options?.cliAliases,
     ...readGitState(rootDir),
     ...deriveTopoCounts(app),
   });
@@ -77,13 +83,18 @@ const persistAndReadStoredExport = (
 
 export const deriveCurrentTopoExport = (
   app: Topo,
-  options?: { readonly rootDir?: string }
+  options?: {
+    readonly cliAliases?: CliAliasesOption | undefined;
+    readonly rootDir?: string;
+  }
 ): Result<StoredTopoExport, Error> => {
   const rootDir = deriveRootDir(options?.rootDir);
   const db = new Database(':memory:');
 
   try {
-    const projected = persistAndReadStoredExport(app, db, rootDir);
+    const projected = persistAndReadStoredExport(app, db, rootDir, {
+      cliAliases: options?.cliAliases,
+    });
     return projected.isErr()
       ? projected
       : Result.ok(projected.value.storedExport);
@@ -141,13 +152,19 @@ const writeStoredExportArtifacts = async (
 
 export const exportCurrentTopo = async (
   app: Topo,
-  options?: { readonly force?: boolean | undefined; readonly rootDir?: string }
+  options?: {
+    readonly cliAliases?: CliAliasesOption | undefined;
+    readonly force?: boolean | undefined;
+    readonly rootDir?: string;
+  }
 ): Promise<Result<TopoExportReport, Error>> => {
   const rootDir = deriveRootDir(options?.rootDir);
   const db = openWriteTrailsDb({ rootDir });
 
   try {
-    const persisted = persistAndReadStoredExport(app, db, rootDir);
+    const persisted = persistAndReadStoredExport(app, db, rootDir, {
+      cliAliases: options?.cliAliases,
+    });
     if (persisted.isErr()) {
       return persisted;
     }

--- a/apps/trails/src/trails/validate.ts
+++ b/apps/trails/src/trails/validate.ts
@@ -18,7 +18,10 @@ export const validateTrail = trail('validate', {
     }
     const lease = leaseResult.value;
     try {
-      return await validateCurrentTopo(lease.app, { rootDir });
+      return await validateCurrentTopo(lease.app, {
+        cliAliases: lease.cliAliases,
+        rootDir,
+      });
     } finally {
       lease.release();
     }

--- a/docs/adr/drafts/20260613-cli-command-routes.md
+++ b/docs/adr/drafts/20260613-cli-command-routes.md
@@ -181,7 +181,8 @@ The framework solves author awareness through inspection:
 
 - Wayfinder shows all command paths for a trail.
 - Schema output shows canonical path, aliases, source, and target.
-- Topographer serializes trail-owned CLI projection facts.
+- Topographer serializes trail-owned CLI projection facts, and may include
+surface-owned aliases when the deriving surface provides that context.
 - Warden validates alias target existence, collisions, and stale migration
 paths.
 

--- a/docs/contributing/codebase-navigation.md
+++ b/docs/contributing/codebase-navigation.md
@@ -18,12 +18,17 @@ Then narrow the graph read with the selected local CLI surface:
 
 ```bash
 bun apps/trails/bin/trails.ts wayfind search --root-dir . --input-json '{"filters":{"kind":"trail","idPrefix":"wayfind."}}' --json
+bun apps/trails/bin/trails.ts wayfind find --root-dir . --input-json '{"filters":{"kind":"trail","idPrefix":"wayfind."}}' --json
+bun apps/trails/bin/trails.ts wf search --root-dir . --input-json '{"filters":{"kind":"trail","idPrefix":"wayfind."}}' --json
 bun apps/trails/bin/trails.ts wayfind contract wayfind.search --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind errors --root-dir . --input-json '{"filters":{"kind":"trail","idPrefix":"wayfind."}}' --json
 bun apps/trails/bin/trails.ts wayfind adapters --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind nearby wayfind.search --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind impact wayfind.search --root-dir . --json
+bun apps/trails/bin/trails.ts schema wf search
 ```
+
+Use `trails schema <command...>` when you need the accepted CLI routes, aliases, flags, and schemas for an operator command before invoking it from a shell.
 
 Use source search, qmd, or symbol tools when Wayfinder reports missing or stale artifacts, when the task needs implementation text that Topographer does not project, or when the current authority does not allow generating fresh artifacts. If you compile to refresh artifacts, treat the generated `.trails` files as evidence and clean them up unless the branch intentionally owns them.
 

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -35,6 +35,41 @@ Each dot becomes another command-path segment. A path node may be both executabl
 
 The CLI model is validated before adapter wiring. Duplicate command paths are rejected, and executable parents cannot also declare positional args if child commands exist beneath that path.
 
+## Command Routes and Aliases
+
+Most trails should keep the default dotted-ID command path. Use `cli` only when the CLI surface needs a compatibility path, a shorter operator command, or a route that better matches the surface language. A CLI route must normalize into the same trail contract. It cannot change input, output, intent, permits, resources, or behavior.
+
+Trail-owned routes live on the trail contract:
+
+```typescript
+const search = trail('wayfind.search', {
+  cli: {
+    aliases: ['find', ['wf', 'search']],
+  },
+  input: z.object({
+    query: z.string().describe('Search query'),
+  }),
+  output: z.array(z.string()),
+  // ...
+});
+```
+
+String aliases are sibling leaf aliases. For `wayfind.search`, `find` accepts `wayfind find`. Array aliases are absolute command paths, so `['wf', 'search']` accepts `wf search`.
+
+Use `cli: 'find'` or `cli: { path: ['wayfind', 'search'] }` only when the canonical command path itself should change. Prefer aliases for compatibility and migration paths.
+
+App-owned aliases live on the CLI surface, alongside the app that consumes them:
+
+```typescript
+export const cliAliases = {
+  'wayfind.search': [['wf', 'search']],
+} as const;
+
+await surface(app, { aliases: cliAliases });
+```
+
+If an app writes topo artifacts with `trails compile`, export the same alias map as `cliAliases` or `trailsCliAliases` from the app module. Compile, validate, survey, Wayfinder, and schema inspection then see the same accepted command routes as the runtime CLI.
+
 ## Flag Derivation
 
 Flags are derived from the trail's Zod input schema when the shape can be represented truthfully on the command line. No manual flag configuration needed.

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -201,6 +201,61 @@ describe('deriveTopoGraph', () => {
       });
     });
 
+    test('surface-owned CLI aliases are serialized when derivation receives surface context', () => {
+      const t = trail('wayfind.search', {
+        blaze: noop,
+        cli: {
+          aliases: ['find'],
+        },
+        input: z.object({ query: z.string() }),
+        output: z.array(z.string()),
+      });
+      const entry = getFirstEntry(
+        deriveTopoGraph(topoFrom({ t }), {
+          cliAliases: {
+            'wayfind.search': [['wf', 'search']],
+          },
+        })
+      );
+
+      expect(entry.cli?.routes).toEqual([
+        {
+          kind: 'canonical',
+          path: ['wayfind', 'search'],
+          source: 'derived',
+          target: 'wayfind.search',
+        },
+        {
+          kind: 'alias',
+          path: ['wayfind', 'find'],
+          source: 'trail',
+          target: 'wayfind.search',
+        },
+        {
+          kind: 'alias',
+          path: ['wf', 'search'],
+          source: 'surface',
+          target: 'wayfind.search',
+        },
+      ]);
+    });
+
+    test('rejects surface-owned CLI aliases for unknown trails', () => {
+      const t = trail('wayfind.search', {
+        blaze: noop,
+        input: z.object({ query: z.string() }),
+        output: z.array(z.string()),
+      });
+
+      expect(() =>
+        deriveTopoGraph(topoFrom({ t }), {
+          cliAliases: {
+            'wayfind.serch': [['wf', 'search']],
+          },
+        })
+      ).toThrow(ValidationError);
+    });
+
     test('trail entries include topo and trail layer attachments', () => {
       const topoLayer = passThroughLayer(
         'topo.auth',

--- a/packages/topographer/src/__tests__/topo-store.test.ts
+++ b/packages/topographer/src/__tests__/topo-store.test.ts
@@ -9,6 +9,7 @@ import {
   NotFoundError,
   contour,
   Result,
+  ValidationError,
   resource,
   schedule,
   signal,
@@ -823,6 +824,92 @@ describe('topo store projection', () => {
         summary: { contours: 0, resources: 0, signals: 2, trails: 1 },
         version: 3,
       });
+    });
+  });
+
+  test('stored TopoGraph includes surface-owned CLI alias route facts', () => {
+    withProjectionDb((db) => {
+      const search = trail('wayfind.search', {
+        blaze: noop,
+        cli: {
+          aliases: ['find'],
+        },
+        input: z.object({ query: z.string() }),
+        output: z.object({ ok: z.boolean() }),
+      });
+
+      const snapshot = unwrap(
+        createTopoSnapshot(db, topo('contract-export-app', { search }), {
+          cliAliases: {
+            'wayfind.search': [['wf', 'search']],
+          },
+          createdAt: '2026-04-03T12:00:00.000Z',
+        })
+      );
+
+      const stored = requireStoredExport(db, snapshot.id);
+      const topoGraph = JSON.parse(stored.topoGraphJson) as {
+        entries: readonly unknown[];
+      };
+      const entry = topoGraph.entries.find(
+        (candidate) =>
+          typeof candidate === 'object' &&
+          candidate !== null &&
+          (candidate as { id?: unknown }).id === 'wayfind.search'
+      ) as
+        | {
+            cli?: {
+              readonly routes?: readonly {
+                readonly path?: readonly string[];
+                readonly source?: string;
+              }[];
+            };
+          }
+        | undefined;
+
+      expect(entry?.cli?.routes).toEqual([
+        expect.objectContaining({
+          path: ['wayfind', 'search'],
+          source: 'derived',
+        }),
+        expect.objectContaining({
+          path: ['wayfind', 'find'],
+          source: 'trail',
+        }),
+        expect.objectContaining({
+          path: ['wf', 'search'],
+          source: 'surface',
+        }),
+      ]);
+    });
+  });
+
+  test('stored TopoGraph rejects surface-owned CLI aliases for unknown trails', () => {
+    withProjectionDb((db) => {
+      const search = trail('wayfind.search', {
+        blaze: noop,
+        input: z.object({ query: z.string() }),
+        output: z.object({ ok: z.boolean() }),
+      });
+
+      const snapshot = createTopoSnapshot(
+        db,
+        topo('contract-export-app', { search }),
+        {
+          cliAliases: {
+            'wayfind.serch': [['wf', 'search']],
+          },
+          createdAt: '2026-04-03T12:00:00.000Z',
+        }
+      );
+
+      expect(snapshot.isErr()).toBe(true);
+      if (snapshot.isErr()) {
+        expect(snapshot.error).toBeInstanceOf(ValidationError);
+        expect(snapshot.error.message).toContain(
+          'CLI command aliases target unknown trail "wayfind.serch"'
+        );
+      }
     });
   });
 

--- a/packages/topographer/src/derive.ts
+++ b/packages/topographer/src/derive.ts
@@ -10,6 +10,7 @@ import {
   deriveTrailCliCommandProjection,
   getContourReferences,
   projectActivationSourceDeclaration,
+  ValidationError,
   validateEstablishedTopo,
   matchesTrailPattern,
   signalDiagnosticDefinitions,
@@ -494,12 +495,16 @@ const addVersioning = (
 
 const trailToEntry = (
   t: Trail<unknown, unknown, unknown>,
-  topoLayers: readonly Layer[]
+  topoLayers: readonly Layer[],
+  options?: Pick<DeriveTopoGraphOptions, 'cliAliases'> | undefined
 ): TopoGraphEntry => {
   const raw = t as unknown as Record<string, unknown>;
   const surfaces = extractSurfaces(raw);
   const entry: Record<string, unknown> = {
-    cli: deriveTrailCliCommandProjection(t),
+    cli: deriveTrailCliCommandProjection(t, {
+      aliasSource: 'surface',
+      aliases: options?.cliAliases?.[t.id],
+    }),
     exampleCount: Array.isArray(t.examples) ? t.examples.length : 0,
     id: t.id,
     kind: t.kind,
@@ -615,12 +620,32 @@ const assertEstablishedTopo = (topo: Topo): void => {
   }
 };
 
-const collectEntries = (topo: Topo): TopoGraphEntry[] => {
+const assertCliAliasTargetsExist = (
+  topo: Topo,
+  options?: Pick<DeriveTopoGraphOptions, 'cliAliases'> | undefined
+): void => {
+  for (const trailId of Object.keys(options?.cliAliases ?? {})) {
+    if (!topo.trails.has(trailId)) {
+      throw new ValidationError(
+        `CLI command aliases target unknown trail "${trailId}". Surface-owned aliases must target existing trail IDs.`
+      );
+    }
+  }
+};
+
+const collectEntries = (
+  topo: Topo,
+  options?: Pick<DeriveTopoGraphOptions, 'cliAliases'> | undefined
+): TopoGraphEntry[] => {
   const signalRelations = collectSignalGraphRelations(topo);
   return [
     ...[...topo.contours.values()].map((contour) => contourToEntry(contour)),
     ...[...topo.trails.values()].map((trail) =>
-      trailToEntry(trail as Trail<unknown, unknown, unknown>, topo.layers)
+      trailToEntry(
+        trail as Trail<unknown, unknown, unknown>,
+        topo.layers,
+        options
+      )
     ),
     ...[...topo.signals.values()].map((signal) =>
       signalToEntry(
@@ -705,7 +730,8 @@ export const deriveTopoGraph = (
   options?: DeriveTopoGraphOptions
 ): TopoGraph => {
   assertEstablishedTopo(topo);
-  const sorted = collectEntries(topo).toSorted((a, b) =>
+  assertCliAliasTargetsExist(topo, options);
+  const sorted = collectEntries(topo, options).toSorted((a, b) =>
     a.id.localeCompare(b.id)
   );
   const activationSources = collectActivationSourceCatalog(topo);

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -74,6 +74,7 @@ export type {
   TopoGraphFieldOverride,
   TopoGraphFieldOverrideKey,
   TopoGraphLayerReference,
+  DeriveTopoGraphOptions,
   TopoGraphVersionDetour,
   TopoGraphVersionEntry,
   LockManifest,

--- a/packages/topographer/src/internal/topo-snapshots.ts
+++ b/packages/topographer/src/internal/topo-snapshots.ts
@@ -1,6 +1,7 @@
 import type { Database, SQLQueryBindings } from 'bun:sqlite';
 
 import { ensureSubsystemSchema } from '@ontrails/core';
+import type { CliCommandAliasInput } from '@ontrails/core';
 
 const TOPO_SUBSYSTEM = 'topo';
 const TOPO_TABLE_STATEMENTS = [
@@ -194,6 +195,9 @@ export interface TopoSnapshot {
 
 export interface CreateTopoSnapshotInput {
   readonly appName?: string;
+  readonly cliAliases?:
+    | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+    | undefined;
   readonly createdAt?: string;
   readonly gitDirty?: boolean;
   readonly gitSha?: string;

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -3,6 +3,7 @@ import type { Database, SQLQueryBindings } from 'bun:sqlite';
 import {
   DETOUR_MAX_ATTEMPTS_CAP,
   Result,
+  ValidationError,
   activationSourceKey,
   deriveCliPath,
   deriveStructuredSignalExamples,
@@ -1049,14 +1050,18 @@ const buildTrailEntryBase = (
   trailSchema: Readonly<{
     readonly input: JsonRecord;
     readonly output?: JsonRecord;
-  }>
+  }>,
+  options?: Pick<CreateTopoSnapshotInput, 'cliAliases'> | undefined
 ): {
   readonly entry: Record<string, unknown>;
   readonly raw: Record<string, unknown>;
 } => {
   const raw = trail as unknown as Record<string, unknown>;
   const entry: Record<string, unknown> = {
-    cli: deriveTrailCliCommandProjection(trail),
+    cli: deriveTrailCliCommandProjection(trail, {
+      aliasSource: 'surface',
+      aliases: options?.cliAliases?.[trail.id],
+    }),
     exampleCount: trail.examples?.length ?? 0,
     id: trail.id,
     input: trailSchema.input,
@@ -1116,9 +1121,10 @@ const trailToEntryRecord = (
   trailSchema: Readonly<{
     readonly input: JsonRecord;
     readonly output?: JsonRecord;
-  }>
+  }>,
+  options?: Pick<CreateTopoSnapshotInput, 'cliAliases'> | undefined
 ): TopoGraphEntryRecord => {
-  const { entry, raw } = buildTrailEntryBase(trail, trailSchema);
+  const { entry, raw } = buildTrailEntryBase(trail, trailSchema, options);
   addSafetyMarkers(entry, trail);
   addPermitRequirement(entry, trail);
   addExtendedMetadata(entry, raw, trail);
@@ -1284,7 +1290,8 @@ const buildTopoGraph = (
       readonly output?: JsonRecord;
     }>
   >,
-  trails: readonly AnyTrail[]
+  trails: readonly AnyTrail[],
+  options?: Pick<CreateTopoSnapshotInput, 'cliAliases'> | undefined
 ): TopoGraphRecord => {
   const signalRelations = collectSignalGraphRelations(signals, trails);
   const activationSources = collectActivationSourceCatalog(trails);
@@ -1295,7 +1302,8 @@ const buildTopoGraph = (
       trailToEntryRecord(
         trail,
         topoLayers,
-        requireTrailSchema(trailSchemas, trail.id)
+        requireTrailSchema(trailSchemas, trail.id),
+        options
       )
     ),
     ...signals.map((signal) =>
@@ -1352,7 +1360,8 @@ const buildLockManifest = (
 const buildStoredTopoExport = (
   db: Database,
   snapshot: TopoSnapshot,
-  topo: Topo
+  topo: Topo,
+  options?: Pick<CreateTopoSnapshotInput, 'cliAliases'> | undefined
 ): MaterializedTopoArtifacts => {
   const contours = topo
     .listContours()
@@ -1373,7 +1382,8 @@ const buildStoredTopoExport = (
     signals,
     topo.layers,
     schemas.trailSchemas,
-    trails
+    trails,
+    options
   );
   const topoGraphHash = hashTopoGraphRecord(topoGraph);
   const lockManifest = `${JSON.stringify(
@@ -1600,6 +1610,22 @@ export const getStoredTopoExport = (
   };
 };
 
+const validateCliAliasTargets = (
+  topo: Topo,
+  input?: Pick<CreateTopoSnapshotInput, 'cliAliases'> | undefined
+): Result<void, Error> => {
+  for (const trailId of Object.keys(input?.cliAliases ?? {})) {
+    if (!topo.trails.has(trailId)) {
+      return Result.err(
+        new ValidationError(
+          `CLI command aliases target unknown trail "${trailId}". Surface-owned aliases must target existing trail IDs.`
+        )
+      );
+    }
+  }
+  return Result.ok();
+};
+
 export const createTopoSnapshot = (
   db: Database,
   topo: Topo,
@@ -1608,6 +1634,10 @@ export const createTopoSnapshot = (
   const validated = validateEstablishedTopo(topo);
   if (validated.isErr()) {
     return Result.err(validated.error);
+  }
+  const cliAliasTargets = validateCliAliasTargets(topo, input);
+  if (cliAliasTargets.isErr()) {
+    return cliAliasTargets;
   }
 
   ensureTopoSnapshotSchema(db);
@@ -1621,7 +1651,7 @@ export const createTopoSnapshot = (
 
   const snapshot = db.transaction(() => {
     const record = insertTopoSnapshotRecord(db, snapshotInput);
-    const artifacts = buildStoredTopoExport(db, record, topo);
+    const artifacts = buildStoredTopoExport(db, record, topo, snapshotInput);
     insertProjectedRows(db, normalizeTopoProjection(topo, record.id));
     insertSchemaRows(db, artifacts.schemaRows);
     insertStoredExport(db, artifacts.exportRow);

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -3,6 +3,7 @@
  */
 
 import type {
+  CliCommandAliasInput,
   CliCommandRoute,
   StructuredSignalExample,
   StructuredTrailExample,
@@ -219,6 +220,9 @@ export interface TopoGraph {
 }
 
 export interface DeriveTopoGraphOptions {
+  readonly cliAliases?:
+    | Readonly<Record<string, readonly CliCommandAliasInput[]>>
+    | undefined;
   readonly facets?: readonly TopoGraphFacetDeclaration[] | undefined;
 }
 

--- a/packages/wayfinder/src/__tests__/queries.test.ts
+++ b/packages/wayfinder/src/__tests__/queries.test.ts
@@ -171,6 +171,9 @@ const writeArtifactsAt = async (
 ): Promise<TopoGraph> => {
   const baseTopoGraph = withSurfaces(
     deriveTopoGraph(app(), {
+      cliAliases: {
+        'user.create': [['u', 'create']],
+      },
       facets: [
         {
           description: 'User operations.',
@@ -559,6 +562,12 @@ describe('wayfinder graph-read query trails', () => {
           source: 'trail',
           target: 'user.create',
         },
+        {
+          kind: 'alias',
+          path: ['u', 'create'],
+          source: 'surface',
+          target: 'user.create',
+        },
       ],
     });
     expect(surfaces.surfaces).toEqual([
@@ -927,6 +936,12 @@ describe('wayfinder graph-read query trails', () => {
             kind: 'alias',
             path: ['user', 'add'],
             source: 'trail',
+            target: 'user.create',
+          },
+          {
+            kind: 'alias',
+            path: ['u', 'create'],
+            source: 'surface',
             target: 'user.create',
           },
         ],

--- a/packages/wayfinder/src/queries.ts
+++ b/packages/wayfinder/src/queries.ts
@@ -1186,6 +1186,9 @@ export const wayfindSearchTrail = trail('wayfind.search', {
         .slice(0, input.limit)
         .map(refSummary),
     })),
+  cli: {
+    aliases: ['find'],
+  },
   description: 'Find topo graph entities with typed filters',
   examples: [{ input: { filters: { kind: 'trail' } }, name: 'Find trails' }],
   input: filteredInputSchema,

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -83,11 +83,15 @@ When saved Topographer artifacts can answer a graph question, use Wayfinder befo
 ```bash
 trails wayfind overview --root-dir . --json
 trails wayfind search --root-dir . --input-json '{"filters":{"kind":"trail"}}' --json
+trails wayfind find --root-dir . --input-json '{"filters":{"kind":"trail"}}' --json
+trails wf search --root-dir . --input-json '{"filters":{"kind":"trail"}}' --json
+trails schema wf search
 trails wayfind contract <trail-id> --root-dir . --json
 ```
 
 - Start with `wayfind.overview` to learn artifact source, freshness, and graph counts.
 - Use `wayfind.search` or typed list trails (`wayfind.trails`, `wayfind.resources`, `wayfind.signals`, `wayfind.surfaces`, `wayfind.facets`, `wayfind.versions`, `wayfind.examples`, `wayfind.errors`, `wayfind.adapters`) for filtered discovery.
+- Use `trails schema <command...>` when you need accepted CLI routes, aliases, flags, and schemas before constructing shell calls.
 - Use `wayfind.describe` for a full saved entity record and `wayfind.contract` for a trail or version input/output/intent summary.
 - Use `wayfind.nearby`, `wayfind.impact`, and `wayfind.diff` for relation context, blast-radius reads, and explicit saved-baseline comparison.
 - Treat Wayfinder as graph-read only. Do not assume generic `wayfind.query`, semantic search, signposts, or implications exist in v0.
@@ -149,6 +153,8 @@ Adding a surface is a `surface()` call, not an architecture change. The framewor
 import { surface } from '@ontrails/commander';
 await surface(graph);
 ```
+
+Use `cli` on a trail only for canonical command overrides or trail-owned aliases that still normalize into the same trail contract. String aliases are sibling leaf aliases (`find` beside `search`); string-array aliases are absolute command paths (`['wf', 'search']`). App-owned compatibility aliases belong in CLI surface options and should also be exported from the app module as `cliAliases` or `trailsCliAliases` so compile, validate, Wayfinder, and `trails schema` inspect the same routes the runtime CLI accepts.
 
 **MCP**: Tool names from trail IDs, JSON Schema from Zod, annotations from intent, idempotency, and description.
 

--- a/plugin/skills/trails/references/architecture.md
+++ b/plugin/skills/trails/references/architecture.md
@@ -79,7 +79,7 @@ Every piece of information has a clear ownership model.
 
 Warden uses inference to verify declarations match actual code. Topographer captures the resolved `TopoGraph`, semantic diff, lock manifest, and `topo.lock` artifacts for CI governance. Consumer artifact workflow uses the top-level CLI commands `trails compile`, `trails validate`, and `trails diff`; `trails topo` is for topo-store history and pin management.
 
-Wayfinder is the first agent navigation move over those saved artifacts. For graph questions, start with `trails wayfind overview --root-dir . --json`, then use search, contract, describe, nearby, impact, examples, or diff queries before reconstructing topo facts with raw source search. Source reads remain the right fallback for stale or missing artifacts and implementation details Topographer does not project.
+Wayfinder is the first agent navigation move over those saved artifacts. For graph questions, start with `trails wayfind overview --root-dir . --json`, then use search, contract, describe, nearby, impact, examples, or diff queries before reconstructing topo facts with raw source search. Use `trails schema <command...>` when you need accepted CLI routes, aliases, flags, and schemas for an operator command. Source reads remain the right fallback for stale or missing artifacts and implementation details Topographer does not project.
 
 ## Package Layout
 

--- a/scripts/vocab-cutover-map.ts
+++ b/scripts/vocab-cutover-map.ts
@@ -123,6 +123,10 @@ const surfaceTermAllowedMatches = [
     line: 278,
     path: 'docs/adr/drafts/20260613-cli-command-routes.md',
   },
+  {
+    line: 279,
+    path: 'docs/adr/drafts/20260613-cli-command-routes.md',
+  },
 ] as const;
 
 const reviewedRetiredTaxonomyMentionPaths = [
@@ -180,27 +184,27 @@ const topographArtifactFamilyRetiredMatches = [
   { line: 270, path: 'apps/trails/src/trails/dev-support.ts' },
   // The topo-store migration and fixture must name pre-v12 columns exactly.
   {
-    line: 341,
+    line: 345,
     path: 'packages/topographer/src/internal/topo-snapshots.ts',
   },
   {
-    line: 351,
+    line: 355,
     path: 'packages/topographer/src/internal/topo-snapshots.ts',
   },
   {
-    line: 1336,
+    line: 1423,
     path: 'packages/topographer/src/__tests__/topo-store.test.ts',
   },
   {
-    line: 1338,
+    line: 1425,
     path: 'packages/topographer/src/__tests__/topo-store.test.ts',
   },
   {
-    line: 1352,
+    line: 1439,
     path: 'packages/topographer/src/__tests__/topo-store.test.ts',
   },
   {
-    line: 1354,
+    line: 1441,
     path: 'packages/topographer/src/__tests__/topo-store.test.ts',
   },
 ] as const;


### PR DESCRIPTION
## Context

Dogfoods the route projection through the Trails operator itself, including normal compile/validate/survey/Wayfinder paths.

## Changes

- Adds operator-owned `wf search` alias for `wayfind.search` alongside trail-owned `wayfind find`.
- Loads optional app `cliAliases` or `trailsCliAliases` exports during fresh app loading.
- Persists alias routes through compile and reads them back through Wayfinder, guide, survey, contract, and schema paths.
- Adds docs and agent guidance for CLI command routes and aliases.
- Updates Wayfinder dogfood smoke to use a real `trails compile` wrapper instead of bypassing the CLI compile path.

## Verification

- bun run wayfinder:dogfood
- Manual smoke: compile temp app, run `wayfind find`, `wf search`, `wayfind contract wayfind.search`, and `schema wf search`.
- bun run check
- bun run test
- bun run build
- bun run publish:check
- Graphite pre-push stable checks

## Risk

The only known residual is existing `dead-internal-trail` Wayfinder Warden warnings. The stack keeps aliases as route facts only, not alternate behavior.