### PR TITLE
docs: define surface accommodations doctrine

### DIFF
--- a/docs/adr/drafts/20260603-surface-facets-shape-dense-topos.md
+++ b/docs/adr/drafts/20260603-surface-facets-shape-dense-topos.md
@@ -3,7 +3,7 @@ slug: surface-facets-shape-dense-topos
 title: Surface Facets Shape Dense Topos
 status: draft
 created: 2026-06-03
-updated: 2026-06-04
+updated: 2026-06-13
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [0, 17, 27, 35, 42, 46]
 linear:
@@ -57,6 +57,8 @@ The authored information is intentionally small: a facet ID, a selector, a descr
 
 The term `facet` remains descriptive vocabulary for a projection slice. `surface facet` is the concrete pattern in this ADR. `schema facet` remains available as a related documentation and governance phrase, but it is not decided here as an API.
 
+In the broader surface-accommodation vocabulary, a surface facet is a grouped surface entry. It lives on the entry axis: one surface entry gathers multiple trails while preserving member identity. It is not an alternate approach to one trail. Aliases and input mappings converge on one trail contract; facets group several contracts without merging them.
+
 ### Selectors reuse trail surface filtering semantics
 
 Facet membership reuses the trail ID selector grammar already established for surface filtering:
@@ -83,6 +85,8 @@ In `@ontrails/mcp`, a facet projects as one MCP tool. The input discriminator is
 
 The handler dispatches to the selected constituent trail through the same surface execution path that ordinary MCP tools use. The facet does not call a blaze directly and does not create a second implementation path.
 
+This is grouped selection, not a hidden action bag. The selected trail ID is the member identity, and the selected member's input schema remains the contract for the nested `input` payload.
+
 Outputs are correlated with the same trail ID:
 
 ```ts
@@ -95,6 +99,10 @@ Outputs are correlated with the same trail ID:
 ```
 
 This envelope is required. A heterogeneous facet output must remain understandable to agents and machine readers after the call returns. The output schema therefore stays object-rooted for MCP compatibility and carries `{ trail, output }` at the top level instead of relying on branch order, implicit action names, or uncorrelated unions.
+
+### Facets do not hide trail forks
+
+A facet should not be used to launder a new operation into one surface affordance. If grouping would change intent, permit requirements, error meaning, output meaning, lifecycle, side effects, or hide which trail actually runs, the shape has found a trail fork. Author distinct trails or a composing trail first, then use a facet only if the surface still needs a grouped entry that preserves the selected member trail.
 
 ### Visibility never widens through a facet
 

--- a/docs/adr/drafts/20260613-cli-command-routes.md
+++ b/docs/adr/drafts/20260613-cli-command-routes.md
@@ -35,6 +35,8 @@ This ADR fills that gap.
 
 This ADR uses **CLI command route** to mean one concrete command path that a CLI surface accepts for a trail. It is a CLI projection term, not an HTTP route.
 
+In the cross-surface vocabulary, CLI command routes are surface accommodations. The surface entry is the command. The command path is the CLI-local realization of an approach. A CLI alias is an alternate approach to the same trail contract.
+
 CLI command routes are projection metadata, not behavior. The operational test is:
 
 > A CLI command route is valid only if it can be normalized into the same trail
@@ -187,6 +189,12 @@ surface-owned aliases when the deriving surface provides that context.
 paths.
 
 If graph visibility fails to solve a concrete drift problem, a later ADR may add an authored policy marker. It is not part of this decision.
+
+### Trail forks stay out of CLI route metadata
+
+An alternate command path becomes a trail fork when it would change intent, permit requirements, error meaning, output meaning, lifecycle, side effects, or which trail is actually running.
+
+Trail forks are not represented as CLI route metadata. They become distinct trails, composing trails, or surface facets that preserve member identity.
 
 ### Resolved CLI projections record the route story
 

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -282,7 +282,7 @@
       "status": "draft",
       "superseded_by": null,
       "title": "Surface Facets Shape Dense Topos",
-      "updated": "2026-06-04"
+      "updated": "2026-06-13"
     },
     {
       "created": "2026-06-08",

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,7 @@
 
 - **[CLI Surface](./surfaces/cli.md)** — Shipped today. Flag derivation, output modes, exit codes, `--dry-run`
 - **[MCP Surface](./surfaces/mcp.md)** — Shipped today. Tool naming, annotations, progress bridge
+- **[Surface Accommodations](./surfaces/surface-accommodations.md)** — How aliases, input mappings, facets, and trail forks keep surfaces honest
 - **[Surface Facets](./surfaces/surface-facets.md)** — MCP shaping for dense topos without adding a core facet primitive
 - **[HTTP Surface](./surfaces/http.md)** — Shipped today. Route derivation, Web Fetch kernel, Hono adapter, Bun-native serving, webhook activation
 - **[Surface Facet Parity](./surfaces/surface-facet-parity.md)** — Deferred CLI/HTTP parity decision after MCP proves grouped projection

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -471,9 +471,14 @@ A mechanically derived output from authored information. The topo store is a rel
 | `Result` | Ok/Err return type |
 | `error` | Error types |
 | `adapter` | Canonical public category for a package or subpath that connects Trails to a named external library, framework, tool, platform, format, or ecosystem |
+| `surface accommodation` | Projection-level fit adjustment that lets a surface feel native without changing the trail contract |
+| `surface entry` | Invocable affordance exposed by a surface: CLI command, MCP tool, HTTP route, or library export |
+| `approach` | Surface-specific way for a caller to reach a surface entry |
+| `input mapping` | Surface-shaped input normalization into the same authored trail input contract |
 | `facet` | Qualified projection-slice vocabulary; use `surface facet` or `schema facet`, not bare `facet` as a primitive |
-| `surface facet` | Surface-side projection slice over existing trails; not a graph node, package category, or core `Facet` primitive |
+| `surface facet` | Surface-side grouped entry over existing trails; not a graph node, package category, or core `Facet` primitive |
 | `schema facet` | Descriptive phrase for a schema-owned slice or view when docs need it; not a decided public API |
+| `trail fork` | Doctrine phrase for the point where a surface accommodation would change semantics or hide trail identity; author a distinct trail, composing trail, or honest facet instead |
 | `MCP resources` | MCP protocol resources used for cold context; not Trails `resource()` infrastructure declarations |
 | `integration (colloquial)` | Ordinary English for places Trails integrates with an external system; not a public taxonomy category |
 | `logger` / `logging` | Structured logging — framework provides the interface; developers bring their own |

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -39,6 +39,8 @@ The CLI model is validated before adapter wiring. Duplicate command paths are re
 
 Most trails should keep the default dotted-ID command path. Use `cli` only when the CLI surface needs a compatibility path, a shorter operator command, or a route that better matches the surface language. A CLI route must normalize into the same trail contract. It cannot change input, output, intent, permits, resources, or behavior.
 
+CLI routes are a surface accommodation. In CLI terms, the surface entry is the command, the command path is the path for an approach, and an alias is an alternate approach to the same command. See [Surface Accommodations](surface-accommodations.md) for the cross-surface vocabulary and fork test.
+
 Trail-owned routes live on the trail contract:
 
 ```typescript
@@ -69,6 +71,8 @@ await surface(app, { aliases: cliAliases });
 ```
 
 If an app writes topo artifacts with `trails compile`, export the same alias map as `cliAliases` or `trailsCliAliases` from the app module. Compile, validate, survey, Wayfinder, and schema inspection then see the same accepted command routes as the runtime CLI.
+
+If an alternate CLI shape needs to reshape input before it reaches the trail, that is richer than an alias. Treat it as an input mapping only if it normalizes honestly into the same authored trail input contract. If it changes behavior, permits, intent, errors, outputs, or side effects, it is a trail fork: author a new trail or a composing trail instead of hiding the split in CLI wiring.
 
 ## Flag Derivation
 

--- a/docs/surfaces/surface-accommodations.md
+++ b/docs/surfaces/surface-accommodations.md
@@ -1,0 +1,71 @@
+# Surface Accommodations
+
+Surface accommodations are projection-level fit adjustments. They let each surface feel natural without changing what a trail means.
+
+The core rule is simple:
+
+> Land the capability in the trail. Accommodate the surface in projection.
+
+A surface accommodation is valid only while the same authored trail contract remains true. If the surface shape would change intent, permits, errors, outputs, lifecycle, side effects, or which trail is actually running, the model has found a trail fork.
+
+## Vocabulary
+
+Use these terms when deciding whether a surface concern belongs on a trail, in a surface projection, or as a new trail.
+
+| Term | Meaning |
+| --- | --- |
+| `surface entry` | The invocable affordance a surface exposes. A CLI command, MCP tool, HTTP route, and library export are all surface entries. |
+| `approach` | A surface-specific way for a caller to reach a surface entry. |
+| `path` | The surface-local realization of an approach: a CLI command path, MCP tool name, HTTP path, or library export name. |
+| `alias` | An alternate approach to the same surface entry and the same trail contract. |
+| `input mapping` | Surface-shaped input that normalizes into the same authored trail input contract. |
+| `surface facet` | One grouped surface entry over multiple trails, with member trail identity preserved at invocation and response time. |
+| `trail fork` | The point where a proposed accommodation is no longer honest. Author a distinct trail, a composed trail, or a facet that preserves member identity. |
+
+`trail fork` is doctrine language, not a new API primitive. Do not confuse it with lifecycle/version forks in trail versioning.
+
+## The Shape
+
+There are two useful axes.
+
+The **approach axis** is N-to-1. Several approaches can reach the same trail:
+
+- an alias adds another path to the same surface entry;
+- an input mapping reshapes surface input before validating the same trail contract.
+
+The **entry axis** is 1-to-N when a surface facet is involved. One grouped surface entry can expose several trails, but it must keep the selected member trail visible.
+
+Those axes are related, but not interchangeable. An alias is not a facet. A facet is not a generic action bag. An input mapping is not alternate behavior.
+
+## Fork Test
+
+Use the fork test before adding an accommodation:
+
+> If a surface adjustment changes intent, permit requirements, error meaning, output meaning, lifecycle, side effects, or hides which trail is actually running, it is no longer an accommodation. Treat it as a trail fork.
+
+When the test fails, use one of these shapes instead:
+
+- a distinct trail for a distinct capability;
+- a composing trail when the capability truly coordinates existing trails;
+- a surface facet when the surface needs one grouped entry over existing trails and can preserve member identity.
+
+## Examples
+
+A CLI compatibility command such as `wayfind find` for `wayfind.search` is an alias when it reaches the same input, output, intent, permit, errors, and blaze.
+
+A CLI spelling that accepts a different ergonomic shape but normalizes into the same authored input is an input mapping. It must remain inspectable and cannot invent hidden behavior.
+
+An MCP `inspect` tool over several read-only topo inspection trails is a surface facet when the call includes the selected `trail` and the result returns the same selected `trail` with its output.
+
+A command like `manage users --action delete` that hides create, update, and delete behind one action field is usually a trail fork. Prefer separate trails and, if the surface needs grouping, a facet that still exposes the selected member trail.
+
+## Surface-Local Words
+
+Surface-local words stay local:
+
+- CLI has command paths and aliases.
+- MCP has tool names and resources.
+- HTTP has routes and route groups.
+- Library surfaces have export names.
+
+Do not use one surface's local word as the cross-surface umbrella. `route` is the right word for HTTP and an accepted phrase for CLI command-route projection, but it is not the generic family term. The generic family is surface accommodation.

--- a/docs/surfaces/surface-facet-parity.md
+++ b/docs/surfaces/surface-facet-parity.md
@@ -12,6 +12,8 @@ The same facet declaration may remain the conceptual source for future parity, b
 - HTTP parity should be evaluated as route-group projection or explicitly rejected as a non-fit.
 - Per-surface overrides are allowed only when the surface economics differ in a way the shared declaration cannot express honestly.
 
+Use the surface-accommodation vocabulary when evaluating parity. Facets live on the entry axis: one grouped surface entry over multiple trails. CLI aliases and future input mappings live on the approach axis: multiple ways to reach one trail. Do not use facets to solve a problem that is really an alternate approach to one trail, and do not use aliases to hide a grouped affordance.
+
 ## CLI Evaluation
 
 MCP facets group many trails into one tool because agent clients pay for every tool schema they inspect. CLI already has a hierarchical command tree from dotted trail IDs, so a raw copy of MCP grouping would be awkward:

--- a/docs/surfaces/surface-facets.md
+++ b/docs/surfaces/surface-facets.md
@@ -6,6 +6,8 @@ MCP hits this pressure first. MCP clients often load tool names, descriptions, i
 
 Surface facets are not a core `Facet` primitive. Do not look for `facet()`, do not create a shared `Facet` type, and do not add facet authoring configuration to adapter-kit.
 
+A facet is a surface accommodation on the entry axis: one grouped surface entry over several trails. It is not an alternate approach to one trail. Aliases and input mappings are N-to-1 accommodations that converge on one trail contract; facets are 1-to-N accommodations that gather several trails while preserving member identity. See [Surface Accommodations](surface-accommodations.md) for the full vocabulary.
+
 ## When To Use One
 
 Use a surface facet when:
@@ -21,6 +23,8 @@ Do not use a surface facet when:
 - grouping would hide important trail identity or output shape;
 - direct trail projection is already clear enough;
 - you need CLI or HTTP parity before MCP has proved the pattern for your app.
+
+The fork test still applies. If a grouped affordance would merge contracts, hide which trail is selected, or introduce an action vocabulary such as `{ action: "create" | "delete" }`, split the capability into distinct trails or a composing trail first. A facet may group and select; it must not merge and obscure.
 
 ## MCP Authoring Shape
 

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -156,6 +156,8 @@ await surface(graph);
 
 Use `cli` on a trail only for canonical command overrides or trail-owned aliases that still normalize into the same trail contract. String aliases are sibling leaf aliases (`find` beside `search`); string-array aliases are absolute command paths (`['wf', 'search']`). App-owned compatibility aliases belong in CLI surface options and should also be exported from the app module as `cliAliases` or `trailsCliAliases` so compile, validate, Wayfinder, and `trails schema` inspect the same routes the runtime CLI accepts.
 
+Treat aliases, future input mappings, and surface facets as **surface accommodations**: projection-level fit adjustments, not alternate behavior. The trail stays the capability. A surface entry is the invocable affordance on a surface; an approach is the way a caller reaches it. Aliases add alternate approaches to the same trail, input mappings normalize surface-shaped input into the same trail input, and surface facets group several trails into one entry while preserving the selected trail ID. If the fit would change intent, permits, errors, outputs, lifecycle, side effects, or hide which trail is running, call it a trail fork and author a distinct or composing trail instead.
+
 **MCP**: Tool names from trail IDs, JSON Schema from Zod, annotations from intent, idempotency, and description.
 
 ```typescript


### PR DESCRIPTION
## Context

This records the settled surface-accommodation doctrine from the Trails/Clark design pass. The goal is to keep aliases, input mappings, facets, and the new trail fork test from collapsing into a surface junk drawer.

## What changed

- Added `docs/surfaces/surface-accommodations.md` with the shared vocabulary: surface entry, approach, path, alias, input mapping, surface facet, and trail fork.
- Linked the doctrine from the docs index, CLI surface guide, surface facets guide, and surface facet parity note.
- Updated the lexicon, draft CLI route ADR, draft surface facets ADR, and Trails skill guidance so agents inherit the same model.

## Verification

- `bun run docs:wrap-check`
- `bun scripts/adr.ts check`
- `bun run plugin:metadata:check`
- Graphite pre-push hook passed: Warden, ADR, test, typecheck, lint, lint-ast-grep, format, and dead-code. Warden reported 0 errors and the existing Wayfinder internal-trail warnings.

## Notes

This is docs/doctrine only. No package code, release behavior, or runtime projection changed.