### PR TITLE
feat(warden): coach trail forks in surface accommodations

### DIFF
--- a/.agents/skills/clark/references/warden-guide.md
+++ b/.agents/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 64
+- Rule count: 65
 
 ## Agent Instructions
 
@@ -69,6 +69,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 
 - `cli-command-route-coherence` (error, topo/topo-aware, external): CLI command routes and aliases resolve to one coherent trail contract. Guidance: Keep every CLI command route and alias normalized into one trail contract.
 - `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep surface facet maps reviewable before they reach MCP projection.
+- `trail-fork-coaching` (warn, all/source-static, advisory): Trails avoid hiding distinct capabilities behind branching action or operation inputs. Guidance: Keep surface accommodations from hiding several capabilities behind one branching trail input.
 
 ### Permits
 

--- a/.changeset/trl-978-trail-fork-coaching.md
+++ b/.changeset/trl-978-trail-fork-coaching.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/warden': patch
+---
+
+Add advisory trail-fork coaching so Warden can warn when a trail may be hiding
+several capabilities behind one branching action or operation input.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 64
+- Rule count: 65
 
 ## Agent Instructions
 
@@ -69,6 +69,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 
 - `cli-command-route-coherence` (error, topo/topo-aware, external): CLI command routes and aliases resolve to one coherent trail contract. Guidance: Keep every CLI command route and alias normalized into one trail contract.
 - `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep surface facet maps reviewable before they reach MCP projection.
+- `trail-fork-coaching` (warn, all/source-static, advisory): Trails avoid hiding distinct capabilities behind branching action or operation inputs. Guidance: Keep surface accommodations from hiding several capabilities behind one branching trail input.
 
 ### Permits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Use the project language consistently:
 This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
-- Rule count: 64
+- Rule count: 65
 
 ### Rule Index
 
@@ -148,6 +148,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 
 - `cli-command-route-coherence` (error, topo/topo-aware, external): CLI command routes and aliases resolve to one coherent trail contract.
 - `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors.
+- `trail-fork-coaching` (warn, all/source-static, advisory): Trails avoid hiding distinct capabilities behind branching action or operation inputs.
 
 #### Permits
 
@@ -198,6 +199,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `resource-mock-coverage`: Make each resource declare a test mock or an explicit unmockable reason.
 - `static-resource-accessor-preference`: Use statically scoped resource helpers when the resource definition is already available.
 - `surface-facet-coherence`: Keep surface facet maps reviewable before they reach MCP projection.
+- `trail-fork-coaching`: Keep surface accommodations from hiding several capabilities behind one branching trail input.
 
 <!-- warden-guide:end -->
 

--- a/docs/adr/drafts/20260613-cli-command-routes.md
+++ b/docs/adr/drafts/20260613-cli-command-routes.md
@@ -226,7 +226,7 @@ The authored API stays terse. The resolved projection carries the full command r
 
 The resolved projection is the surface truth. Commander materializes it. The graph explains it.
 
-### Conditional route recipes are deferred
+### Conditional input mappings are deferred
 
 Some command shapes are not simple aliases.
 
@@ -239,7 +239,7 @@ Both may be able to normalize into the same trail input. That idea is valid, but
 
 This is deferred because conditions such as `when: { flag: 'analysis' }` can become a miniature CLI authoring language. The release-candidate scope supports canonical overrides and aliases only.
 
-When conditional recipes return, they must satisfy the same normalization test: can this route normalize into the same trail contract without lying?
+When input mappings return, they must satisfy the same normalization test: can this shape normalize into the same trail contract without lying?
 
 If not, the alternate command must be a separate trail, usually a small composing trail.
 
@@ -274,7 +274,7 @@ This is a direct extension of "one write, many reads": the trail owns the contra
 
 ## Non-Goals
 
-- This ADR does not add conditional route recipes.
+- This ADR does not add conditional input mappings.
 - This ADR does not create a generic command DSL.
 - This ADR does not make aliases change permit, intent, output, or error
 behavior.

--- a/packages/warden/src/__tests__/trail-fork-coaching.test.ts
+++ b/packages/warden/src/__tests__/trail-fork-coaching.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'bun:test';
+
+import { trailForkCoaching } from '../rules/trail-fork-coaching.js';
+
+const check = (sourceCode: string) =>
+  trailForkCoaching.check(sourceCode, 'src/trails/users.ts');
+
+describe('trail-fork-coaching', () => {
+  test('warns when a trail branches on an action discriminator', () => {
+    const source = `
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const usersManage = trail('users.manage', {
+  input: z.object({
+    action: z.enum(['create', 'delete']),
+    id: z.string().optional(),
+  }),
+  blaze: async (input) => {
+    switch (input.action) {
+      case 'create':
+        return Result.ok({ created: true });
+      case 'delete':
+        return Result.ok({ deleted: true });
+    }
+  },
+});
+`;
+    const diagnostics = check(source);
+    const switchLine =
+      source.split('\n').findIndex((line) => line.includes('switch')) + 1;
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      line: switchLine,
+      rule: 'trail-fork-coaching',
+      severity: 'warn',
+    });
+    expect(diagnostics[0]?.message).toContain('Trail "users.manage"');
+    expect(diagnostics[0]?.message).toContain('input.action');
+    expect(diagnostics[0]?.message).toContain('trail fork');
+    expect(diagnostics[0]?.message).toContain('honest facet');
+  });
+
+  test('warns when a trail branches on an extracted input schema', () => {
+    const diagnostics = check(`
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const manageInput = z.object({
+  action: z.enum(['create', 'delete']),
+  id: z.string().optional(),
+});
+
+export const usersManage = trail('users.manage', {
+  input: manageInput,
+  blaze: async (input) => {
+    if (input.action === 'delete') {
+      return Result.ok({ deleted: true });
+    }
+    return Result.ok({ created: true });
+  },
+});
+`);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('input.action');
+  });
+
+  test('warns when a trail branches on a direct destructured input parameter', () => {
+    const diagnostics = check(`
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const usersManage = trail('users.manage', {
+  input: z.object({
+    action: z.enum(['create', 'delete']),
+    id: z.string().optional(),
+  }),
+  blaze: async ({ action }) => {
+    if (action === 'delete') {
+      return Result.ok({ deleted: true });
+    }
+    return Result.ok({ created: true });
+  },
+});
+`);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('input.action');
+  });
+
+  test('warns when a trail branches on a destructured operation discriminator', () => {
+    const diagnostics = check(`
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const migration = trail('migration.run', {
+  input: z.object({
+    operation: z.union([z.literal('apply'), z.literal('review')]),
+    root: z.string(),
+  }),
+  blaze: async (input) => {
+    const { operation: selectedOperation } = input;
+    if (selectedOperation === 'apply') {
+      return Result.ok({ applied: true });
+    }
+    return Result.ok({ reviewed: true });
+  },
+});
+`);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('input.operation');
+    expect(diagnostics[0]?.message).toContain('"apply"');
+    expect(diagnostics[0]?.message).toContain('"review"');
+  });
+
+  test('allows non-branching domain action fields', () => {
+    const diagnostics = check(`
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const notify = trail('entity.notify', {
+  input: z.object({
+    action: z.enum(['created', 'updated', 'deleted']),
+    entityId: z.string(),
+  }),
+  blaze: async (input) => Result.ok({ action: input.action }),
+});
+`);
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('allows output computations from action fields', () => {
+    const diagnostics = check(`
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const notify = trail('entity.notify', {
+  input: z.object({
+    action: z.enum(['created', 'updated', 'deleted']),
+    entityId: z.string(),
+  }),
+  blaze: async (input) => Result.ok({ isCreated: input.action === 'created' }),
+});
+`);
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('ignores signal definitions with action payloads', () => {
+    const diagnostics = check(`
+import { Result, signal } from '@ontrails/core';
+import { z } from 'zod';
+
+export const entityChanged = signal('entity.changed', {
+  input: z.object({
+    action: z.enum(['created', 'updated', 'deleted']),
+    entityId: z.string(),
+  }),
+  blaze: async (input) => Result.ok(input),
+});
+`);
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('does not flag unrelated discriminators', () => {
+    const diagnostics = check(`
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const publish = trail('release.publish', {
+  input: z.object({
+    status: z.enum(['draft', 'published']),
+  }),
+  blaze: async (input) => {
+    if (input.status === 'published') {
+      return Result.ok({ visible: true });
+    }
+    return Result.ok({ visible: false });
+  },
+});
+`);
+
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -9,8 +9,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 64 rule trails', () => {
-    expect(wardenTopo.count).toBe(64);
+  test('contains all 65 rule trails', () => {
+    expect(wardenTopo.count).toBe(65);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -218,6 +218,7 @@ export {
   signalGraphCoachingTrail,
   staticResourceAccessorPreferenceTrail,
   surfaceFacetCoherenceTrail,
+  trailForkCoachingTrail,
   unmaterializedActivationSourceTrail,
   topoAwareRuleInput,
   unreachableDetourShadowingTrail,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -48,6 +48,7 @@ import { scheduledDestroyIntent } from './scheduled-destroy-intent.js';
 import { signalGraphCoaching } from './signal-graph-coaching.js';
 import { staticResourceAccessorPreference } from './static-resource-accessor-preference.js';
 import { surfaceFacetCoherence } from './surface-facet-coherence.js';
+import { trailForkCoaching } from './trail-fork-coaching.js';
 import {
   forkWithoutPreservedBlaze,
   markerSchemaUnsupported,
@@ -152,6 +153,7 @@ export { scheduledDestroyIntent } from './scheduled-destroy-intent.js';
 export { signalGraphCoaching } from './signal-graph-coaching.js';
 export { staticResourceAccessorPreference } from './static-resource-accessor-preference.js';
 export { surfaceFacetCoherence } from './surface-facet-coherence.js';
+export { trailForkCoaching } from './trail-fork-coaching.js';
 export {
   forkWithoutPreservedBlaze,
   markerSchemaUnsupported,
@@ -205,6 +207,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [preferSchemaInference.name, preferSchemaInference],
   [staticResourceAccessorPreference.name, staticResourceAccessorPreference],
   [surfaceFacetCoherence.name, surfaceFacetCoherence],
+  [trailForkCoaching.name, trailForkCoaching],
   [validDescribeRefs.name, validDescribeRefs],
   [noDevPermitInSource.name, noDevPermitInSource],
   [noDestructuredCompose.name, noDestructuredCompose],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -107,6 +107,7 @@ const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
   'signal-graph-coaching': 'signals',
   'static-resource-accessor-preference': 'resources',
   'surface-facet-coherence': 'meta',
+  'trail-fork-coaching': 'meta',
   'unmaterialized-activation-source': 'lifecycle',
   'valid-detour-contract': 'results',
   'version-gap': 'lifecycle',
@@ -570,6 +571,29 @@ const builtinWardenRuleMetadataInput = {
     },
     invariant:
       'Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors.',
+    tier: 'source-static',
+  },
+  'trail-fork-coaching': {
+    ...durableExternal,
+    guidance: {
+      docs: [
+        {
+          label: 'Surface Accommodations',
+          path: 'docs/surfaces/surface-accommodations.md',
+        },
+      ],
+      relatedRules: ['surface-facet-coherence', 'cli-command-route-coherence'],
+      steps: [
+        'Check whether each branch still shares the same intent, permits, outputs, errors, lifecycle, side effects, and selected trail identity.',
+        'Split real capability forks into distinct trails or a composing trail.',
+        'Use a facet only when one surface entry needs to group multiple trails while preserving selected member identity.',
+      ],
+      summary:
+        'Keep surface accommodations from hiding several capabilities behind one branching trail input.',
+    },
+    invariant:
+      'Trails avoid hiding distinct capabilities behind branching action or operation inputs.',
+    scope: 'advisory',
     tier: 'source-static',
   },
   'unmaterialized-activation-source': {

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -56,6 +56,7 @@ import { scheduledDestroyIntent } from './scheduled-destroy-intent.js';
 import { signalGraphCoaching } from './signal-graph-coaching.js';
 import { staticResourceAccessorPreference } from './static-resource-accessor-preference.js';
 import { surfaceFacetCoherence } from './surface-facet-coherence.js';
+import { trailForkCoaching } from './trail-fork-coaching.js';
 import {
   forkWithoutPreservedBlaze,
   markerSchemaUnsupported,
@@ -135,6 +136,7 @@ export const registeredRuleNames: readonly string[] = [
   signalGraphCoaching.name,
   staticResourceAccessorPreference.name,
   surfaceFacetCoherence.name,
+  trailForkCoaching.name,
   unmaterializedActivationSource.name,
   unreachableDetourShadowing.name,
   validDetourContract.name,

--- a/packages/warden/src/rules/trail-fork-coaching.ts
+++ b/packages/warden/src/rules/trail-fork-coaching.ts
@@ -1,0 +1,620 @@
+import {
+  extractStringOrTemplateLiteral,
+  findBlazeBodies,
+  findConfigProperty,
+  findTrailDefinitions,
+  getPropertyName,
+  identifierName,
+  offsetToLine,
+  parse,
+  walkScope,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import type { WardenDiagnostic, WardenRule } from './types.js';
+
+const RULE_NAME = 'trail-fork-coaching';
+
+const CONTROL_FIELD_NAMES = new Set(['action', 'operation']);
+
+interface ControlField {
+  readonly name: string;
+  readonly node: AstNode;
+  readonly options: readonly string[];
+}
+
+interface SchemaBindingRecord {
+  readonly initializer: AstNode | undefined;
+  readonly scopeEnd: number;
+  readonly scopeStart: number;
+  readonly start: number;
+}
+
+type SchemaBindings = ReadonlyMap<string, readonly SchemaBindingRecord[]>;
+
+interface BlazeInputBindings {
+  readonly aliases: ReadonlyMap<string, string>;
+  readonly inputParamName: string | null;
+}
+
+const LEXICAL_SCOPE_TYPES = new Set([
+  'ArrowFunctionExpression',
+  'BlockStatement',
+  'CatchClause',
+  'ClassStaticBlock',
+  'ForInStatement',
+  'ForOfStatement',
+  'ForStatement',
+  'FunctionBody',
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'Program',
+  'StaticBlock',
+  'SwitchStatement',
+]);
+
+const unwrapExpression = (node: AstNode | undefined): AstNode | undefined => {
+  let current = node;
+  while (
+    current?.type === 'TSAsExpression' ||
+    current?.type === 'TSSatisfiesExpression'
+  ) {
+    current =
+      (current as unknown as { expression?: AstNode }).expression ??
+      (current as unknown as { argument?: AstNode }).argument;
+  }
+  return current;
+};
+
+const callArguments = (node: AstNode): readonly AstNode[] =>
+  (node as unknown as { arguments?: readonly AstNode[] }).arguments ?? [];
+
+const callName = (node: AstNode | undefined): string | null => {
+  const unwrapped = unwrapExpression(node);
+  if (unwrapped?.type !== 'CallExpression') {
+    return null;
+  }
+  const { callee } = unwrapped as unknown as { callee?: AstNode };
+  if (callee?.type !== 'MemberExpression') {
+    return identifierName(callee);
+  }
+  return getPropertyName(
+    (callee as unknown as { property?: AstNode }).property
+  );
+};
+
+const callObject = (node: AstNode): AstNode | undefined => {
+  const { callee } = node as unknown as { callee?: AstNode };
+  if (callee?.type !== 'MemberExpression') {
+    return undefined;
+  }
+  return (callee as unknown as { object?: AstNode }).object;
+};
+
+const schemaBindingInitializer = (
+  schemaBindings: SchemaBindings,
+  name: string,
+  referenceStart: number
+): AstNode | undefined => {
+  const records = schemaBindings.get(name) ?? [];
+  for (const record of records) {
+    if (
+      record.start < referenceStart &&
+      record.scopeStart <= referenceStart &&
+      referenceStart <= record.scopeEnd
+    ) {
+      return record.initializer;
+    }
+  }
+  return undefined;
+};
+
+const resolveSchemaReference = (
+  node: AstNode | undefined,
+  schemaBindings: SchemaBindings,
+  seenBindings = new Set<string>()
+): AstNode | undefined => {
+  const current = unwrapExpression(node);
+  const name = identifierName(current);
+  if (!name || seenBindings.has(name)) {
+    return current;
+  }
+
+  const initializer = schemaBindingInitializer(
+    schemaBindings,
+    name,
+    current?.start ?? 0
+  );
+  if (!initializer) {
+    return current;
+  }
+
+  seenBindings.add(name);
+  return resolveSchemaReference(initializer, schemaBindings, seenBindings);
+};
+
+const unwrapZodDecorators = (
+  node: AstNode | undefined,
+  schemaBindings: SchemaBindings
+): AstNode | undefined => {
+  let current = resolveSchemaReference(node, schemaBindings);
+  while (current?.type === 'CallExpression') {
+    const name = callName(current);
+    if (
+      name !== 'default' &&
+      name !== 'describe' &&
+      name !== 'optional' &&
+      name !== 'nullable' &&
+      name !== 'nullish' &&
+      name !== 'passthrough' &&
+      name !== 'readonly' &&
+      name !== 'strict' &&
+      name !== 'strip'
+    ) {
+      break;
+    }
+    const next = callObject(current);
+    if (!next) {
+      break;
+    }
+    current = resolveSchemaReference(next, schemaBindings);
+  }
+  return current;
+};
+
+const objectProperties = (node: AstNode): readonly AstNode[] =>
+  node.type === 'ObjectExpression' || node.type === 'ObjectPattern'
+    ? ((node as unknown as { properties?: readonly AstNode[] }).properties ??
+      [])
+    : [];
+
+const propertyValue = (property: AstNode): AstNode | undefined =>
+  property.type === 'Property'
+    ? (property as unknown as { value?: AstNode }).value
+    : undefined;
+
+const arrayElements = (node: AstNode | undefined): readonly AstNode[] => {
+  const unwrapped = unwrapExpression(node);
+  if (unwrapped?.type !== 'ArrayExpression') {
+    return [];
+  }
+  return (
+    (unwrapped as unknown as { elements?: readonly (AstNode | null)[] })
+      .elements ?? []
+  ).filter((element): element is AstNode => element !== null);
+};
+
+const literalOptionsFromEnum = (node: AstNode): readonly string[] => {
+  const [options] = callArguments(node);
+  return arrayElements(options)
+    .map((element) => extractStringOrTemplateLiteral(element))
+    .filter((value): value is string => value !== null);
+};
+
+const literalOptionFromLiteral = (node: AstNode): string | null => {
+  const [literal] = callArguments(node);
+  return extractStringOrTemplateLiteral(literal);
+};
+
+const literalOptionsFromUnion = (node: AstNode): readonly string[] => {
+  const [branches] = callArguments(node);
+  return arrayElements(branches)
+    .map((branch) => {
+      const base = unwrapZodDecorators(branch, new Map());
+      return base?.type === 'CallExpression' && callName(base) === 'literal'
+        ? literalOptionFromLiteral(base)
+        : null;
+    })
+    .filter((value): value is string => value !== null);
+};
+
+const literalOptionsForSchema = (
+  schemaNode: AstNode | undefined,
+  schemaBindings: SchemaBindings
+): readonly string[] => {
+  const base = unwrapZodDecorators(schemaNode, schemaBindings);
+  if (base?.type !== 'CallExpression') {
+    return [];
+  }
+
+  if (callName(base) === 'enum') {
+    return literalOptionsFromEnum(base);
+  }
+  if (callName(base) === 'union') {
+    return literalOptionsFromUnion(base);
+  }
+  return [];
+};
+
+const astChildNodes = (node: AstNode): readonly AstNode[] => {
+  const children: AstNode[] = [];
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      children.push(
+        ...value.filter(
+          (entry): entry is AstNode =>
+            typeof entry === 'object' &&
+            entry !== null &&
+            typeof (entry as AstNode).type === 'string'
+        )
+      );
+      continue;
+    }
+    if (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as AstNode).type === 'string'
+    ) {
+      children.push(value as AstNode);
+    }
+  }
+  return children;
+};
+
+const variableDeclaratorName = (node: AstNode): string | undefined => {
+  if (node.type !== 'VariableDeclarator') {
+    return undefined;
+  }
+  const { id } = node as unknown as { id?: AstNode };
+  return identifierName(id) ?? undefined;
+};
+
+const collectSchemaBindings = (ast: AstNode): SchemaBindings => {
+  const bindings = new Map<string, SchemaBindingRecord[]>();
+
+  const visit = (
+    node: AstNode,
+    scope: { readonly end: number; readonly start: number }
+  ): void => {
+    const nextScope = LEXICAL_SCOPE_TYPES.has(node.type)
+      ? { end: node.end, start: node.start }
+      : scope;
+    const name = variableDeclaratorName(node);
+    if (name !== undefined) {
+      const records = bindings.get(name) ?? [];
+      records.push({
+        initializer: (node as unknown as { init?: AstNode }).init ?? undefined,
+        scopeEnd: nextScope.end,
+        scopeStart: nextScope.start,
+        start: node.start,
+      });
+      bindings.set(name, records);
+    }
+
+    for (const child of astChildNodes(node)) {
+      visit(child, nextScope);
+    }
+  };
+
+  visit(ast, { end: ast.end, start: ast.start });
+  return bindings;
+};
+
+const inputShapeObject = (
+  config: AstNode,
+  schemaBindings: SchemaBindings
+): AstNode | null => {
+  const input = findConfigProperty(config, 'input');
+  const value = unwrapZodDecorators(
+    propertyValue(input ?? config),
+    schemaBindings
+  );
+  if (value?.type !== 'CallExpression' || callName(value) !== 'object') {
+    return null;
+  }
+
+  const [shape] = callArguments(value);
+  const unwrappedShape = unwrapExpression(shape);
+  return unwrappedShape?.type === 'ObjectExpression' ? unwrappedShape : null;
+};
+
+const findControlFields = (
+  config: AstNode,
+  schemaBindings: SchemaBindings
+): readonly ControlField[] => {
+  const shape = inputShapeObject(config, schemaBindings);
+  if (!shape) {
+    return [];
+  }
+
+  const fields: ControlField[] = [];
+  for (const property of objectProperties(shape)) {
+    const name = getPropertyName(
+      (property as unknown as { key?: AstNode }).key
+    );
+    if (!name || !CONTROL_FIELD_NAMES.has(name)) {
+      continue;
+    }
+
+    const options = literalOptionsForSchema(
+      propertyValue(property),
+      schemaBindings
+    );
+    if (options.length >= 2) {
+      fields.push({ name, node: property, options });
+    }
+  }
+  return fields;
+};
+
+const blazeParams = (blaze: AstNode): readonly AstNode[] =>
+  (blaze as unknown as { params?: readonly AstNode[] }).params ?? [];
+
+const memberFieldName = (
+  node: AstNode | undefined,
+  inputParamName: string | null
+): string | null => {
+  if (!inputParamName) {
+    return null;
+  }
+  const unwrapped = unwrapExpression(node);
+  if (unwrapped?.type !== 'MemberExpression') {
+    return null;
+  }
+  const { object } = unwrapped as unknown as { object?: AstNode };
+  if (identifierName(object) !== inputParamName) {
+    return null;
+  }
+  return getPropertyName(
+    (unwrapped as unknown as { property?: AstNode }).property
+  );
+};
+
+const patternAliasName = (node: AstNode | undefined): string | null => {
+  const unwrapped = unwrapExpression(node);
+  if (unwrapped?.type === 'AssignmentPattern') {
+    return identifierName((unwrapped as unknown as { left?: AstNode }).left);
+  }
+  return identifierName(unwrapped);
+};
+
+const collectDestructuredFieldAliasesFromPattern = (
+  pattern: AstNode | undefined,
+  fields: ReadonlySet<string>
+): ReadonlyMap<string, string> => {
+  const aliases = new Map<string, string>();
+  if (pattern?.type !== 'ObjectPattern') {
+    return aliases;
+  }
+
+  for (const property of objectProperties(pattern)) {
+    if (property.type === 'RestElement') {
+      continue;
+    }
+    const fieldName = getPropertyName(
+      (property as unknown as { key?: AstNode }).key
+    );
+    if (!fieldName || !fields.has(fieldName)) {
+      continue;
+    }
+    const alias = patternAliasName(propertyValue(property)) ?? fieldName;
+    aliases.set(alias, fieldName);
+  }
+  return aliases;
+};
+
+const collectDestructuredFieldAliases = (
+  blaze: AstNode,
+  inputParamName: string,
+  fields: ReadonlySet<string>
+): ReadonlyMap<string, string> => {
+  const aliases = new Map<string, string>();
+
+  walkScope(blaze, (node) => {
+    if (node.type !== 'VariableDeclarator') {
+      return;
+    }
+    const { id, init } = node as unknown as {
+      readonly id?: AstNode;
+      readonly init?: AstNode;
+    };
+    if (
+      identifierName(init) !== inputParamName ||
+      id?.type !== 'ObjectPattern'
+    ) {
+      return;
+    }
+
+    for (const [alias, fieldName] of collectDestructuredFieldAliasesFromPattern(
+      id,
+      fields
+    )) {
+      aliases.set(alias, fieldName);
+    }
+  });
+
+  return aliases;
+};
+
+const collectBlazeInputBindings = (
+  blaze: AstNode,
+  fields: ReadonlySet<string>
+): BlazeInputBindings | null => {
+  const [inputParam] = blazeParams(blaze);
+  const inputParamName = identifierName(inputParam);
+  if (inputParamName) {
+    return {
+      aliases: collectDestructuredFieldAliases(blaze, inputParamName, fields),
+      inputParamName,
+    };
+  }
+
+  if (inputParam?.type === 'ObjectPattern') {
+    return {
+      aliases: collectDestructuredFieldAliasesFromPattern(inputParam, fields),
+      inputParamName: null,
+    };
+  }
+
+  return null;
+};
+
+const branchFieldName = (
+  node: AstNode | undefined,
+  inputParamName: string | null,
+  aliases: ReadonlyMap<string, string>
+): string | null => {
+  const memberName = memberFieldName(node, inputParamName);
+  if (memberName) {
+    return memberName;
+  }
+  const identifier = identifierName(unwrapExpression(node));
+  return identifier ? (aliases.get(identifier) ?? null) : null;
+};
+
+const comparisonBranchesOnField = (
+  node: AstNode | undefined,
+  inputParamName: string | null,
+  fieldName: string,
+  aliases: ReadonlyMap<string, string>
+): AstNode | null => {
+  const unwrapped = unwrapExpression(node);
+  if (!unwrapped) {
+    return null;
+  }
+
+  if (unwrapped.type === 'LogicalExpression') {
+    const { left, right } = unwrapped as unknown as {
+      readonly left?: AstNode;
+      readonly right?: AstNode;
+    };
+    return (
+      comparisonBranchesOnField(left, inputParamName, fieldName, aliases) ??
+      comparisonBranchesOnField(right, inputParamName, fieldName, aliases)
+    );
+  }
+
+  if (unwrapped.type === 'UnaryExpression') {
+    const { argument } = unwrapped as unknown as {
+      readonly argument?: AstNode;
+    };
+    return comparisonBranchesOnField(
+      argument,
+      inputParamName,
+      fieldName,
+      aliases
+    );
+  }
+
+  if (unwrapped.type !== 'BinaryExpression') {
+    return null;
+  }
+
+  const { left, operator, right } = unwrapped as unknown as {
+    readonly left?: AstNode;
+    readonly operator?: string;
+    readonly right?: AstNode;
+  };
+  if (operator !== '===' && operator !== '!==') {
+    return null;
+  }
+
+  return branchFieldName(left, inputParamName, aliases) === fieldName ||
+    branchFieldName(right, inputParamName, aliases) === fieldName
+    ? unwrapped
+    : null;
+};
+
+const branchesOnField = (
+  blaze: AstNode,
+  inputParamName: string | null,
+  fieldName: string,
+  aliases: ReadonlyMap<string, string>
+): AstNode | null => {
+  let found: AstNode | null = null;
+  walkScope(blaze, (node) => {
+    if (found) {
+      return;
+    }
+
+    if (node.type === 'SwitchStatement') {
+      const { discriminant } = node as unknown as { discriminant?: AstNode };
+      if (
+        branchFieldName(discriminant, inputParamName, aliases) === fieldName
+      ) {
+        found = node;
+      }
+      return;
+    }
+
+    if (node.type !== 'IfStatement' && node.type !== 'ConditionalExpression') {
+      return;
+    }
+    const { test } = node as unknown as { readonly test?: AstNode };
+    found = comparisonBranchesOnField(test, inputParamName, fieldName, aliases);
+  });
+  return found;
+};
+
+const diagnosticForField = (
+  sourceCode: string,
+  filePath: string,
+  trailId: string,
+  field: ControlField,
+  branchNode: AstNode
+): WardenDiagnostic => ({
+  filePath,
+  line: offsetToLine(sourceCode, branchNode.start),
+  message: `Trail "${trailId}" branches on input.${field.name} (${field.options
+    .map((option) => `"${option}"`)
+    .join(
+      ', '
+    )}). This may be a trail fork hidden as a surface accommodation. If branches change intent, permits, errors, outputs, lifecycle, side effects, or selected trail identity, split them into distinct trails, a composing trail, or an honest facet.`,
+  rule: RULE_NAME,
+  severity: 'warn',
+});
+
+export const trailForkCoaching: WardenRule = {
+  check(sourceCode, filePath) {
+    const ast = parse(filePath, sourceCode);
+    if (!ast) {
+      return [];
+    }
+
+    const schemaBindings = collectSchemaBindings(ast);
+    const diagnostics: WardenDiagnostic[] = [];
+    for (const definition of findTrailDefinitions(ast)) {
+      if (definition.kind !== 'trail') {
+        continue;
+      }
+
+      const fields = findControlFields(definition.config, schemaBindings);
+      if (fields.length === 0) {
+        continue;
+      }
+      const fieldNames = new Set(fields.map((field) => field.name));
+
+      for (const blaze of findBlazeBodies(definition.config)) {
+        const inputBindings = collectBlazeInputBindings(blaze, fieldNames);
+        if (!inputBindings) {
+          continue;
+        }
+
+        for (const field of fields) {
+          const branchNode = branchesOnField(
+            blaze,
+            inputBindings.inputParamName,
+            field.name,
+            inputBindings.aliases
+          );
+          if (branchNode) {
+            diagnostics.push(
+              diagnosticForField(
+                sourceCode,
+                filePath,
+                definition.id,
+                field,
+                branchNode
+              )
+            );
+          }
+        }
+      }
+    }
+
+    return diagnostics;
+  },
+  description:
+    'Coach trails away from hiding several capabilities behind one branching action or operation input.',
+  name: RULE_NAME,
+  severity: 'warn',
+};

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -52,6 +52,7 @@ export { scheduledDestroyIntentTrail } from './scheduled-destroy-intent.trail.js
 export { signalGraphCoachingTrail } from './signal-graph-coaching.trail.js';
 export { staticResourceAccessorPreferenceTrail } from './static-resource-accessor-preference.trail.js';
 export { surfaceFacetCoherenceTrail } from './surface-facet-coherence.trail.js';
+export { trailForkCoachingTrail } from './trail-fork-coaching.trail.js';
 export { unmaterializedActivationSourceTrail } from './unmaterialized-activation-source.trail.js';
 export { unreachableDetourShadowingTrail } from './unreachable-detour-shadowing.trail.js';
 export { validDetourContractTrail } from './valid-detour-contract.trail.js';

--- a/packages/warden/src/trails/trail-fork-coaching.trail.ts
+++ b/packages/warden/src/trails/trail-fork-coaching.trail.ts
@@ -1,0 +1,42 @@
+import { trailForkCoaching } from '../rules/trail-fork-coaching.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const trailForkCoachingTrail = wrapRule({
+  examples: [
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: 'users.ts',
+            line: 9,
+            message:
+              'Trail "users.manage" branches on input.action ("create", "delete"). This may be a trail fork hidden as a surface accommodation. If branches change intent, permits, errors, outputs, lifecycle, side effects, or selected trail identity, split them into distinct trails, a composing trail, or an honest facet.',
+            rule: 'trail-fork-coaching',
+            severity: 'warn',
+          },
+        ],
+      },
+      input: {
+        filePath: 'users.ts',
+        sourceCode: `import { Result, trail } from "@ontrails/core";
+import { z } from "zod";
+
+export const usersManage = trail("users.manage", {
+  input: z.object({
+    action: z.enum(["create", "delete"]),
+  }),
+  blaze: async (input) => {
+    switch (input.action) {
+      case "create":
+        return Result.ok({ created: true });
+      case "delete":
+        return Result.ok({ deleted: true });
+    }
+  },
+});`,
+      },
+      name: 'Possible trail fork hidden behind action',
+    },
+  ],
+  rule: trailForkCoaching,
+});

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 64
+- Rule count: 65
 
 ## Agent Instructions
 
@@ -69,6 +69,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 
 - `cli-command-route-coherence` (error, topo/topo-aware, external): CLI command routes and aliases resolve to one coherent trail contract. Guidance: Keep every CLI command route and alias normalized into one trail contract.
 - `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep surface facet maps reviewable before they reach MCP projection.
+- `trail-fork-coaching` (warn, all/source-static, advisory): Trails avoid hiding distinct capabilities behind branching action or operation inputs. Guidance: Keep surface accommodations from hiding several capabilities behind one branching trail input.
 
 ### Permits
 

--- a/scripts/vocab-cutover-map.ts
+++ b/scripts/vocab-cutover-map.ts
@@ -127,6 +127,10 @@ const surfaceTermAllowedMatches = [
     line: 279,
     path: 'docs/adr/drafts/20260613-cli-command-routes.md',
   },
+  {
+    line: 287,
+    path: 'docs/adr/drafts/20260613-cli-command-routes.md',
+  },
 ] as const;
 
 const reviewedRetiredTaxonomyMentionPaths = [


### PR DESCRIPTION
## Context

TRL-978 follows the surface accommodations doctrine in #742. It adds Warden
coaching for the line between a surface accommodation and a real trail fork.

## What Changed

- Added advisory `trail-fork-coaching` as a source-static Warden rule.
- Warns when a `trail(...)` defines an `action` or `operation` literal input and
  the blaze uses that field in control-flow branching.
- Leaves signals, non-branching domain fields, unrelated discriminators, and
  output-only computations alone so the rule stays coaching rather than a noisy
  policy hammer.
- Wrapped the rule as a Warden trail, registered metadata/guidance, updated the
  public barrel export, and regenerated agent/skill Warden guides.
- Added a branch-local changeset for `@ontrails/warden`.
- Tightened the CLI command route ADR draft wording from deferred "route recipes"
  to deferred "input mappings."

## Verification

- `bun test packages/warden/src/__tests__/trail-fork-coaching.test.ts packages/warden/src/__tests__/warden-rule-metadata.test.ts packages/warden/src/__tests__/trails.test.ts packages/warden/src/__tests__/public-api.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run format:check`
- `git diff --check`
- `bun run trails:check`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun run changeset:check -- --changed-files /tmp/trl-978-files-postcommit`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`
- Real `gt submit --stack --draft --restack --no-edit --no-interactive` pre-push
  hook passed.

## Notes

Warden remains clean with 0 errors. The warnings observed locally are the
pre-existing Wayfinder internal reachability warnings and demo signal coaching;
the new `trail-fork-coaching` rule did not introduce repo-local warnings.
