### PR TITLE
feat(core): reserve shift error category

### DIFF
--- a/.changeset/trl-956-shift-error-category.md
+++ b/.changeset/trl-956-shift-error-category.md
@@ -1,0 +1,9 @@
+---
+"@ontrails/core": patch
+"@ontrails/warden": patch
+---
+
+Reserve the `shift` error category and `WorkspaceShiftError` before the stable
+cutover so surface mappings can distinguish moved-workspace retry verdicts.
+Update Warden's error-mapping completeness examples to cover the reserved
+category.

--- a/docs/adr/0002-built-in-result-type.md
+++ b/docs/adr/0002-built-in-result-type.md
@@ -99,6 +99,7 @@ The Result type exists in tight partnership with the error taxonomy. The table b
 | `TimeoutError` | `timeout` | 504 | 5 | -32603 | Yes |
 | `RateLimitError` | `rate_limit` | 429 | 6 | -32603 | Yes |
 | `NetworkError` | `network` | 502 | 7 | -32603 | Yes |
+| `WorkspaceShiftError` | `shift` | 503 | 10 | -32603 | Yes |
 | `InternalError` | `internal` | 500 | 8 | -32603 | No |
 | `DerivationError` | `internal` | 500 | 8 | -32603 | No |
 | `RecoverableCompletionError` | `internal` | 500 | 8 | -32603 | No |

--- a/docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md
+++ b/docs/adr/0026-error-taxonomy-as-transport-independent-behavior-contract.md
@@ -63,6 +63,7 @@ Transports map these properties to their native representations. The framework p
 | `TimeoutError` | `timeout` | Yes | 504 | 5 | -32603 | nack -> retry | retry |
 | `RateLimitError` | `rate_limit` | Yes | 429 | 6 | -32603 | nack -> retry (with backoff) | retry (with backoff) |
 | `NetworkError` | `network` | Yes | 502 | 7 | -32603 | nack -> retry | retry |
+| `WorkspaceShiftError` | `shift` | Yes | 503 | 10 | -32603 | nack -> retry | retry |
 | `InternalError` | `internal` | No | 500 | 8 | -32603 | nack -> dead-letter | drop + dead-event |
 | `DerivationError` | `internal` | No | 500 | 8 | -32603 | nack -> dead-letter | drop + dead-event |
 | `RecoverableCompletionError` | `internal` | No | 500 | 8 | -32603 | nack -> dead-letter | drop + dead-event |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -309,6 +309,7 @@ The current taxonomy is generated from the `errorClasses` owner registry and cat
 | `timeout` | 5 | 504 | -32603 | Yes | `TimeoutError` |
 | `rate_limit` | 6 | 429 | -32603 | Yes | `RateLimitError` |
 | `network` | 7 | 502 | -32603 | Yes | `NetworkError` |
+| `shift` | 10 | 503 | -32603 | Yes | `WorkspaceShiftError` |
 | `internal` | 8 | 500 | -32603 | No | `AssertionError`, `InternalError`, `DerivationError`, `RecoverableCompletionError` |
 | `auth` | 9 | 401 | -32600 | No | `AuthError` |
 | `cancelled` | 130 | 499 | -32603 | No | `CancelledError` |

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -219,6 +219,7 @@ Status codes come directly from the error taxonomy -- the same mapping used acro
 | `timeout` | 504 | Yes | `TimeoutError` |
 | `rate_limit` | 429 | Yes | `RateLimitError` |
 | `network` | 502 | Yes | `NetworkError` |
+| `shift` | 503 | Yes | `WorkspaceShiftError` |
 | `internal` | 500 | No | `AssertionError`, `InternalError`, `DerivationError`, `RecoverableCompletionError` |
 | `auth` | 401 | No | `AuthError` |
 | `cancelled` | 499 | No | `CancelledError` |

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -129,6 +129,7 @@ The current taxonomy is generated from the `errorClasses` owner registry and cat
 | `timeout` | 5 | 504 | -32603 | Yes | `TimeoutError` |
 | `rate_limit` | 6 | 429 | -32603 | Yes | `RateLimitError` |
 | `network` | 7 | 502 | -32603 | Yes | `NetworkError` |
+| `shift` | 10 | 503 | -32603 | Yes | `WorkspaceShiftError` |
 | `internal` | 8 | 500 | -32603 | No | `AssertionError`, `InternalError`, `DerivationError`, `RecoverableCompletionError` |
 | `auth` | 9 | 401 | -32600 | No | `AuthError` |
 | `cancelled` | 130 | 499 | -32603 | No | `CancelledError` |

--- a/packages/core/src/__tests__/errors.test.ts
+++ b/packages/core/src/__tests__/errors.test.ts
@@ -8,6 +8,7 @@ import {
   TimeoutError,
   RateLimitError,
   NetworkError,
+  WorkspaceShiftError,
   InternalError,
   AuthError,
   CancelledError,
@@ -223,6 +224,11 @@ describe('codesByCategory', () => {
       http: 401,
       jsonRpc: -32_600,
     });
+    expect(codesByCategory.shift).toEqual({
+      exit: 10,
+      http: 503,
+      jsonRpc: -32_603,
+    });
     expect(codesByCategory.cancelled).toEqual({
       exit: 130,
       http: 499,
@@ -250,6 +256,7 @@ describe('exitCodeMap', () => {
     expect(exitCodeMap.network).toBe(7);
     expect(exitCodeMap.internal).toBe(8);
     expect(exitCodeMap.auth).toBe(9);
+    expect(exitCodeMap.shift).toBe(10);
     expect(exitCodeMap.cancelled).toBe(130);
   });
 });
@@ -263,6 +270,7 @@ describe('statusCodeMap', () => {
     expect(statusCodeMap.timeout).toBe(504);
     expect(statusCodeMap.rate_limit).toBe(429);
     expect(statusCodeMap.network).toBe(502);
+    expect(statusCodeMap.shift).toBe(503);
     expect(statusCodeMap.internal).toBe(500);
     expect(statusCodeMap.auth).toBe(401);
     expect(statusCodeMap.cancelled).toBe(499);
@@ -278,6 +286,7 @@ describe('jsonRpcCodeMap', () => {
     expect(jsonRpcCodeMap.timeout).toBe(-32_603);
     expect(jsonRpcCodeMap.rate_limit).toBe(-32_603);
     expect(jsonRpcCodeMap.network).toBe(-32_603);
+    expect(jsonRpcCodeMap.shift).toBe(-32_603);
     expect(jsonRpcCodeMap.internal).toBe(-32_603);
     expect(jsonRpcCodeMap.auth).toBe(-32_600);
     expect(jsonRpcCodeMap.cancelled).toBe(-32_603);
@@ -285,10 +294,11 @@ describe('jsonRpcCodeMap', () => {
 });
 
 describe('retryableMap', () => {
-  test('only timeout, rate_limit, and network are retryable', () => {
+  test('only timeout, rate_limit, network, and shift are retryable', () => {
     expect(retryableMap.timeout).toBe(true);
     expect(retryableMap.rate_limit).toBe(true);
     expect(retryableMap.network).toBe(true);
+    expect(retryableMap.shift).toBe(true);
 
     expect(retryableMap.validation).toBe(false);
     expect(retryableMap.not_found).toBe(false);
@@ -309,6 +319,7 @@ describe('isRetryable', () => {
     expect(isRetryable(new TimeoutError('timed out'))).toBe(true);
     expect(isRetryable(new RateLimitError('too fast'))).toBe(true);
     expect(isRetryable(new NetworkError('disconnected'))).toBe(true);
+    expect(isRetryable(new WorkspaceShiftError('moved'))).toBe(true);
   });
 
   test('returns false for non-retryable errors', () => {

--- a/packages/core/src/__tests__/transport-error-map.test.ts
+++ b/packages/core/src/__tests__/transport-error-map.test.ts
@@ -164,6 +164,7 @@ describe('createSurfaceErrorMapper', () => {
       not_found: 'not_found',
       permission: 'permission',
       rate_limit: 'rate_limit',
+      shift: 'shift',
       timeout: 'timeout',
       validation: 'validation',
     });

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -18,6 +18,7 @@ export const errorCategories = [
   'timeout',
   'rate_limit',
   'network',
+  'shift',
   'internal',
   'auth',
   'cancelled',
@@ -176,6 +177,22 @@ export class RateLimitError extends TrailsError {
 
 export class NetworkError extends TrailsError {
   readonly category = 'network' as const;
+  readonly retryable = true as const;
+}
+
+/**
+ * @example
+ * ```ts
+ * return Result.err(new WorkspaceShiftError('workspace changed during check'));
+ * ```
+ *
+ * Raised when the observed workspace substrate moves during one run.
+ *
+ * A shift voids the run's verdict, including passes. Callers can retry on
+ * stable ground without changing their request.
+ */
+export class WorkspaceShiftError extends TrailsError {
+  readonly category = 'shift' as const;
   readonly retryable = true as const;
 }
 
@@ -345,6 +362,12 @@ export const errorClasses = [
     retryable: true,
   },
   {
+    category: 'shift',
+    ctor: WorkspaceShiftError,
+    name: 'WorkspaceShiftError',
+    retryable: true,
+  },
+  {
     category: 'internal',
     ctor: InternalError,
     name: 'InternalError',
@@ -397,6 +420,7 @@ export const codesByCategory = {
   not_found: { exit: 2, http: 404, jsonRpc: -32_601 },
   permission: { exit: 4, http: 403, jsonRpc: -32_600 },
   rate_limit: { exit: 6, http: 429, jsonRpc: -32_603 },
+  shift: { exit: 10, http: 503, jsonRpc: -32_603 },
   timeout: { exit: 5, http: 504, jsonRpc: -32_603 },
   validation: { exit: 1, http: 400, jsonRpc: -32_602 },
 } as const satisfies Record<ErrorCategory, ErrorCategoryCodes>;
@@ -414,6 +438,7 @@ const deriveCodeMap = <TCode extends keyof ErrorCategoryCodes>(
   not_found: codesByCategory.not_found[code],
   permission: codesByCategory.permission[code],
   rate_limit: codesByCategory.rate_limit[code],
+  shift: codesByCategory.shift[code],
   timeout: codesByCategory.timeout[code],
   validation: codesByCategory.validation[code],
 });
@@ -436,6 +461,7 @@ export const retryableMap: Record<ErrorCategory, boolean> = {
   not_found: false,
   permission: false,
   rate_limit: true,
+  shift: true,
   timeout: true,
   validation: false,
 } as const;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export {
   TimeoutError,
   RateLimitError,
   NetworkError,
+  WorkspaceShiftError,
   InternalError,
   AuthError,
   CancelledError,

--- a/packages/core/src/serialization.ts
+++ b/packages/core/src/serialization.ts
@@ -18,6 +18,7 @@ import {
   RateLimitError,
   RetryExhaustedError,
   TimeoutError,
+  WorkspaceShiftError,
   errorClasses,
   isTrailsError,
 } from './errors.js';
@@ -89,6 +90,7 @@ const errorFactories: Record<ErrorCategory, ErrorFactory> = {
     }
     return new RateLimitError(msg, rlOpts);
   },
+  shift: (msg, opts) => new WorkspaceShiftError(msg, opts),
   timeout: (msg, opts) => new TimeoutError(msg, opts),
   validation: (msg, opts) => new ValidationError(msg, opts),
 };

--- a/packages/warden/src/__tests__/error-mapping-completeness.test.ts
+++ b/packages/warden/src/__tests__/error-mapping-completeness.test.ts
@@ -18,6 +18,7 @@ const cliMapper = createSurfaceErrorMapper({
   not_found: 2,
   permission: 4,
   rate_limit: 6,
+  shift: 10,
   timeout: 5,
   validation: 1,
 });

--- a/packages/warden/src/trails/error-mapping-completeness.trail.ts
+++ b/packages/warden/src/trails/error-mapping-completeness.trail.ts
@@ -18,6 +18,7 @@ const cliMapper = createSurfaceErrorMapper({
   not_found: 2,
   permission: 4,
   rate_limit: 6,
+  shift: 10,
   timeout: 5,
   validation: 1,
 });`,


### PR DESCRIPTION
## Context

TRL-956 reserves the shift error category before workspace-shift and stable-ground checks start reporting that condition. A shift means the observed workspace substrate moved during a run, so the verdict is void and callers may retry on stable ground.

## What changed

- Added shift to the core error taxonomy and transport code maps.
- Added WorkspaceShiftError with retryable semantics and a TSDoc example.
- Wired serialization, category derivation, and surface mapper coverage.
- Regenerated error taxonomy docs and ADR tables.
- Added branch-local changesets for core and warden.

## Verification

- bun test packages/core/src/__tests__/errors.test.ts packages/core/src/__tests__/serialization.test.ts packages/core/src/__tests__/transport-error-map.test.ts
- bun run --cwd packages/core typecheck
- bun run error-taxonomy:check
- bun run test
- bun run check
- bun run build
- bun run publish:check
- bun run changeset:check
- git diff --check

## Risk

Low. This reserves a new semantic category and mapper codes without changing existing category behavior.