### PR TITLE
test(library): add compiler fixture topo

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -160,6 +160,19 @@
         "zod": "catalog:",
       },
     },
+    "packages/library": {
+      "name": "@ontrails/library",
+      "version": "1.0.0-beta.24",
+      "dependencies": {
+        "@ontrails/core": "workspace:^",
+      },
+      "devDependencies": {
+        "@ontrails/testing": "workspace:^",
+      },
+      "peerDependencies": {
+        "zod": "catalog:",
+      },
+    },
     "packages/logtape": {
       "name": "@ontrails/logtape",
       "version": "1.0.0-beta.24",
@@ -409,6 +422,8 @@
     "@ontrails/hono": ["@ontrails/hono@workspace:adapters/hono"],
 
     "@ontrails/http": ["@ontrails/http@workspace:packages/http"],
+
+    "@ontrails/library": ["@ontrails/library@workspace:packages/library"],
 
     "@ontrails/logtape": ["@ontrails/logtape@workspace:packages/logtape"],
 

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@ontrails/library",
+  "version": "1.0.0-beta.24",
+  "private": true,
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "dependencies": {
+    "@ontrails/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@ontrails/testing": "workspace:^"
+  },
+  "peerDependencies": {
+    "zod": "catalog:"
+  }
+}

--- a/packages/library/src/__tests__/fixture.test.ts
+++ b/packages/library/src/__tests__/fixture.test.ts
@@ -1,0 +1,8 @@
+/* oxlint-disable eslint-plugin-jest/require-hook -- testExamples registers tests at module scope. */
+import { testExamples } from '@ontrails/testing';
+
+import { fixtureApp } from './fixtures/app.js';
+
+testExamples(fixtureApp, {
+  ctx: { permit: { id: 'library-fixture', scopes: ['widget:write'] } },
+});

--- a/packages/library/src/__tests__/fixtures/app.ts
+++ b/packages/library/src/__tests__/fixtures/app.ts
@@ -1,0 +1,10 @@
+/**
+ * The fixture topo, assembled. Imports the trail/resource/signal namespace and
+ * registers it under one topo, mirroring the scaffold's `topo(name, ...modules)`
+ * shape. Projection and parity tests derive against `fixtureApp`.
+ */
+import { topo } from '@ontrails/core';
+
+import * as trails from './trails.js';
+
+export const fixtureApp = topo('library-fixture', trails);

--- a/packages/library/src/__tests__/fixtures/trails.ts
+++ b/packages/library/src/__tests__/fixtures/trails.ts
@@ -1,0 +1,201 @@
+/**
+ * Deliberate fixture topo for the library projection + materialization lanes
+ * (TRL-970). Small enough to read; rich enough that v0 cannot bake in
+ * resource-free or happy-path-only assumptions. Each trail exercises one
+ * projection path the foundation must prove.
+ */
+import { NotFoundError, Result, resource, signal, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+// --- resource with a mock factory (testAll works without configuration) ---
+
+export interface Widget {
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface WidgetStore {
+  add(widget: Widget): void;
+  get(id: string): Widget | undefined;
+  list(): Widget[];
+}
+
+const defaultWidgets: readonly Widget[] = [{ id: '1', name: 'Example' }];
+
+export const createWidgetStore = (
+  seed: readonly Widget[] = defaultWidgets
+): WidgetStore => {
+  const store = new Map(seed.map((widget) => [widget.id, widget] as const));
+  return {
+    add(widget) {
+      store.set(widget.id, widget);
+    },
+    get(id) {
+      return store.get(id);
+    },
+    list() {
+      return [...store.values()];
+    },
+  };
+};
+
+export const widgetStore = resource('widget.store', {
+  create: () => Result.ok(createWidgetStore()),
+  description: 'In-memory widget store (library fixture).',
+  mock: createWidgetStore,
+});
+
+const widgetSchema = z.object({ id: z.string(), name: z.string() });
+
+// --- stateless trail -> projects to a root named export ---
+
+export const ping = trail('widget.ping', {
+  blaze: (input) => Result.ok({ echo: input.message }),
+  description: 'Stateless echo; projects to a root named export.',
+  examples: [
+    { expected: { echo: 'hi' }, input: { message: 'hi' }, name: 'echo' },
+  ],
+  input: z.object({ message: z.string() }),
+  intent: 'read',
+  output: z.object({ echo: z.string() }),
+});
+
+// --- domain-negative output: a failing check is a RETURNED value, not a throw ---
+
+export const check = trail('widget.check', {
+  blaze: (input) =>
+    Result.ok(
+      input.name.length > 0
+        ? { issues: [] as string[], status: 'pass' as const }
+        : { issues: ['name is empty'], status: 'fail' as const }
+    ),
+  description:
+    'Check a widget name. A failing result is a normal returned value, never a thrown error.',
+  examples: [
+    {
+      expected: { issues: [], status: 'pass' },
+      input: { name: 'ok' },
+      name: 'pass',
+    },
+    {
+      expected: { issues: ['name is empty'], status: 'fail' },
+      input: { name: '' },
+      name: 'fail (returned, not thrown)',
+    },
+  ],
+  input: z.object({ name: z.string() }),
+  intent: 'read',
+  output: z.object({
+    issues: z.array(z.string()),
+    status: z.enum(['pass', 'fail']),
+  }),
+});
+
+// --- resource-bearing read + an expectErr example (maps to a root throw) ---
+
+export const get = trail('widget.get', {
+  blaze: (input, ctx) => {
+    const store = widgetStore.from(ctx);
+    const widget = store.get(input.id);
+    if (!widget) {
+      return Result.err(new NotFoundError(`Widget "${input.id}" not found`));
+    }
+    return Result.ok(widget);
+  },
+  description: 'Get a widget by id.',
+  examples: [
+    {
+      expected: { id: '1', name: 'Example' },
+      input: { id: '1' },
+      name: 'found',
+    },
+    {
+      error: 'NotFoundError',
+      input: { id: 'missing' },
+      name: 'not found -> throws at the root API',
+    },
+  ],
+  input: z.object({ id: z.string() }),
+  intent: 'read',
+  output: widgetSchema,
+  resources: [widgetStore],
+});
+
+// --- resource-bearing write + permit ---
+
+export const add = trail('widget.add', {
+  blaze: (input, ctx) => {
+    const store = widgetStore.from(ctx);
+    const widget = { id: input.id, name: input.name };
+    store.add(widget);
+    return Result.ok(widget);
+  },
+  description: 'Add a widget.',
+  examples: [
+    {
+      expected: { id: '2', name: 'New' },
+      input: { id: '2', name: 'New' },
+      name: 'add',
+    },
+  ],
+  input: z.object({ id: z.string(), name: z.string() }),
+  intent: 'write',
+  output: widgetSchema,
+  permit: { scopes: ['widget:write'] },
+  resources: [widgetStore],
+});
+
+// --- versioned trail: library projects the CURRENT version only ---
+
+export const greet = trail('widget.greet', {
+  blaze: (input) => Result.ok({ message: `Hello, ${input.name}!` }),
+  description:
+    'Versioned greeting; the library projects the current version only.',
+  examples: [
+    {
+      expected: { message: 'Hello, Ada!' },
+      input: { name: 'Ada' },
+      name: 'greet (current version)',
+    },
+  ],
+  input: z.object({ name: z.string() }),
+  intent: 'read',
+  output: z.object({ message: z.string() }),
+  version: 2,
+  versions: {
+    1: {
+      input: z.object({ name: z.string() }),
+      output: z.object({ message: z.string() }),
+      status: { state: 'archived' },
+    },
+  },
+});
+
+// --- internal visibility: MUST be excluded from the projection ---
+
+export const diagnose = trail('widget.diagnose', {
+  blaze: () => Result.ok({ ok: true }),
+  description:
+    'Internal-only diagnostic; excluded from the library projection.',
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ ok: z.boolean() }),
+  visibility: 'internal',
+});
+
+// --- draft id: MUST be excluded from the projection ---
+
+export const experiment = trail('_draft.widget.experiment', {
+  blaze: () => Result.ok({ todo: true }),
+  description: 'Draft-authored trail; excluded from the library projection.',
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ todo: z.boolean() }),
+});
+
+// --- signal: not a callable; should not appear as a library export ---
+
+export const widgetAdded = signal('widget.added', {
+  description: 'Fired when a widget is added.',
+  payload: z.object({ id: z.string() }),
+});

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -1,0 +1,15 @@
+/**
+ * `@ontrails/library` — render a Trails topo as an idiomatic TypeScript library.
+ *
+ * The library surface is a peer of CLI, MCP, and HTTP. Its public ladder:
+ *
+ * - `deriveLibraryApi(graph, options)` — pure projection → `LibraryProjection`
+ * - `surface(graph, options)` — in-memory callable client
+ * - `compile(graph, options)` — TypeScript package emitter
+ *
+ * Those land across the projection, surface, and emitter lanes (Linear project
+ * "Library surface & compiler"). This scaffold establishes the package and the
+ * runtime-kernel seam; see `./kernel` and the Library Surface and Compiler ADR.
+ */
+export { kernelRun } from './kernel.js';
+export type { Result, Topo } from './kernel.js';

--- a/packages/library/src/kernel.ts
+++ b/packages/library/src/kernel.ts
@@ -1,0 +1,41 @@
+/**
+ * The runtime kernel: the minimal, single-sourced surface through which the
+ * library surface (and, later, emitted packages) reach Trails execution.
+ *
+ * **This is the only module in `@ontrails/library` that imports execution
+ * primitives from `@ontrails/core`.** Everything else — the in-memory surface,
+ * the emitter's generated runtime — routes through here.
+ *
+ * Why this exists: standalone output (a generated package with no `@ontrails/*`
+ * runtime dependency) must be reachable as a *vendoring step*, not a rewrite.
+ * Confining the framework-runtime dependency to this one seam means "go
+ * standalone" reduces to "vendor this module's imports," with consumer code and
+ * package derivation unchanged. See the runtime-kernel section of the Library
+ * Surface and Compiler ADR.
+ *
+ * The kernel grows only as materialization demands: today it wraps execution;
+ * error projection and the context/compose shim join it as the surface and
+ * emitter lanes land. Keep it minimal and dependency-light on purpose.
+ */
+import { run } from '@ontrails/core';
+import type { Result, Topo } from '@ontrails/core';
+
+export type { Result, Topo };
+
+/**
+ * Execute a trail by id through the shared Trails pipeline. Never throws —
+ * resolves to `Result.ok` on success or `Result.err(TrailsError)` on failure,
+ * exactly as `run()` does. The library surface unwraps this into return/throw
+ * (root API) or returns it directly (`/result`).
+ *
+ * @example
+ * const result = await kernelRun(topo, 'thing.check', { root: '.' });
+ * if (result.isOk()) {
+ *   // result.value is the trail output
+ * }
+ */
+export const kernelRun = (
+  topo: Topo,
+  id: string,
+  input: unknown
+): Promise<Result<unknown, Error>> => run(topo, id, input);

--- a/packages/library/tsconfig.json
+++ b/packages/library/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/packages/library/tsconfig.tests.json
+++ b/packages/library/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/__tests__/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Context

Adds the private `@ontrails/library` workspace and fixture topo used by the library compiler and surface parity tests.

## What Changed

- Added the private `packages/library` workspace scaffold.
- Added fixture trails covering stateless calls, resource-backed calls, permit/write behavior, versioned trails, internal/draft exclusions, activation, examples, and domain-negative output.
- Added fixture tests that prove the authored examples execute against the fixture topo.

## Verification

- `bun run --cwd packages/library test`
- `bun run --cwd packages/library typecheck`
- `bun run --cwd packages/library lint`
- Full stack pre-push checks via Graphite submit.

## Release Notes

`@ontrails/library` is private in this foundation slice, so `publish:check` skips it.
