### PR TITLE
feat(library): derive library projection

### DIFF
--- a/packages/library/src/__tests__/derive.test.ts
+++ b/packages/library/src/__tests__/derive.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from 'bun:test';
+
+import { deriveLibraryApi } from '../derive.js';
+import { collisionApp } from './fixtures/collision.js';
+import { fixtureApp } from './fixtures/app.js';
+
+describe('deriveLibraryApi', () => {
+  test('projects established public current-version trails as exports', () => {
+    const projection = deriveLibraryApi(fixtureApp);
+
+    expect(projection.app).toBe('library-fixture');
+    expect(projection.exports.map((entry) => entry.exportName)).toEqual([
+      'widgetAdd',
+      'widgetCheck',
+      'widgetGet',
+      'widgetGreet',
+      'widgetPing',
+    ]);
+    expect(projection.collisions).toEqual([]);
+  });
+
+  test('excludes draft, internal, and activation trails, with the reason', () => {
+    const projection = deriveLibraryApi(fixtureApp);
+
+    const byTrail = new Map(
+      projection.excluded.map((entry) => [entry.trailId, entry.reason])
+    );
+    expect(byTrail.get('_draft.widget.experiment')).toBe('draft');
+    expect(byTrail.get('widget.diagnose')).toBe('internal');
+    expect(byTrail.get('widget.onCreated')).toBe('activation');
+    // Precedence: a draft+internal trail reports 'draft' (checked first).
+    expect(byTrail.get('_draft.widget.secret')).toBe('draft');
+
+    const exportedIds = new Set(
+      projection.exports.map((entry) => entry.trailId)
+    );
+    expect(exportedIds.has('_draft.widget.experiment')).toBe(false);
+    expect(exportedIds.has('widget.diagnose')).toBe(false);
+    expect(exportedIds.has('widget.onCreated')).toBe(false);
+  });
+
+  test('carries contract facts the emitter needs onto each export', () => {
+    const projection = deriveLibraryApi(fixtureApp);
+    const byName = new Map(
+      projection.exports.map((entry) => [entry.exportName, entry])
+    );
+
+    // Resource ids drive factory grouping; stateless trails carry none.
+    expect(byName.get('widgetGet')?.resources).toEqual(['widget.store']);
+    expect(byName.get('widgetAdd')?.resources).toEqual(['widget.store']);
+    expect(byName.get('widgetPing')?.resources).toEqual([]);
+    expect(byName.get('widgetCheck')?.resources).toEqual([]);
+
+    // Intent is carried verbatim (no fallback); write/read preserved.
+    expect(byName.get('widgetAdd')?.intent).toBe('write');
+    expect(byName.get('widgetPing')?.intent).toBe('read');
+
+    // Versioned trail reports its current version; unversioned is undefined.
+    expect(byName.get('widgetGreet')?.version).toBe(2);
+    expect(byName.get('widgetPing')?.version).toBeUndefined();
+
+    // Schema references and description are carried for signatures/JSDoc.
+    for (const entry of projection.exports) {
+      expect(entry.input).toBeDefined();
+      expect(entry.output).toBeDefined();
+      expect(typeof entry.description).toBe('string');
+      expect(entry.nameSource).toBe('derived');
+    }
+  });
+
+  test('narrows with an include selector without widening drafts or internal', () => {
+    const projection = deriveLibraryApi(fixtureApp, {
+      include: ['widget.get', 'widget.ping'],
+    });
+    expect(projection.exports.map((entry) => entry.exportName)).toEqual([
+      'widgetGet',
+      'widgetPing',
+    ]);
+  });
+
+  test('drops trails matching an exclude selector', () => {
+    const projection = deriveLibraryApi(fixtureApp, {
+      exclude: ['widget.add'],
+    });
+    const names = projection.exports.map((entry) => entry.exportName);
+    expect(names).not.toContain('widgetAdd');
+    expect(names).toContain('widgetGet');
+  });
+
+  test('applies include and exclude together', () => {
+    const projection = deriveLibraryApi(fixtureApp, {
+      exclude: ['widget.add'],
+      include: ['widget.*'],
+    });
+    expect(projection.exports.map((entry) => entry.exportName)).toEqual([
+      'widgetCheck',
+      'widgetGet',
+      'widgetGreet',
+      'widgetPing',
+    ]);
+  });
+
+  test('yields an empty projection when nothing matches', () => {
+    const projection = deriveLibraryApi(fixtureApp, {
+      include: ['nonexistent.*'],
+    });
+    expect(projection.exports).toEqual([]);
+  });
+
+  test('detects export-name collisions: first-by-id wins, both recorded', () => {
+    const projection = deriveLibraryApi(collisionApp);
+
+    const colliding = projection.exports.filter(
+      (entry) => entry.exportName === 'widgetGetThing'
+    );
+    expect(colliding).toHaveLength(1);
+
+    expect(projection.collisions).toHaveLength(1);
+    const [collision] = projection.collisions;
+    expect(collision?.exportName).toBe('widgetGetThing');
+    expect(collision?.trailIds.toSorted()).toEqual([
+      'widget.get-thing',
+      'widget.get.thing',
+    ]);
+    // The winner is the sorted-first id, and it is the one that is callable.
+    const [expectedWinner] = ['widget.get-thing', 'widget.get.thing'].toSorted(
+      (left, right) => left.localeCompare(right)
+    );
+    expect(colliding[0]?.trailId).toBe(expectedWinner);
+  });
+});

--- a/packages/library/src/__tests__/fixtures/collision.ts
+++ b/packages/library/src/__tests__/fixtures/collision.ts
@@ -1,0 +1,26 @@
+/**
+ * Collision fixture: two distinct trail ids that derive the same export name
+ * (`widgetGetThing`), to exercise `deriveLibraryApi`'s collision handling —
+ * first-by-sorted-id wins in `exports`, both ids recorded in `collisions`.
+ * `widget.get-thing` sorts before `widget.get.thing` ('-' < '.'), so it wins.
+ */
+import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+export const dotted = trail('widget.get.thing', {
+  blaze: () => Result.ok({ via: 'dotted' }),
+  description: 'Collides via a dotted id.',
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ via: z.string() }),
+});
+
+export const kebab = trail('widget.get-thing', {
+  blaze: () => Result.ok({ via: 'kebab' }),
+  description: 'Collides via a hyphenated tail segment.',
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ via: z.string() }),
+});
+
+export const collisionApp = topo('collision-fixture', { dotted, kebab });

--- a/packages/library/src/__tests__/fixtures/trails.ts
+++ b/packages/library/src/__tests__/fixtures/trails.ts
@@ -137,6 +137,11 @@ export const add = trail('widget.add', {
       input: { id: '2', name: 'New' },
       name: 'add',
     },
+    {
+      expectedMatch: { name: 'Matched' },
+      input: { id: '3', name: 'Matched' },
+      name: 'add (partial match)',
+    },
   ],
   input: z.object({ id: z.string(), name: z.string() }),
   intent: 'write',
@@ -198,4 +203,27 @@ export const experiment = trail('_draft.widget.experiment', {
 export const widgetAdded = signal('widget.added', {
   description: 'Fired when a widget is added.',
   payload: z.object({ id: z.string() }),
+});
+
+// --- draft AND internal: excluded, exercises reason precedence (draft wins) ---
+
+export const secret = trail('_draft.widget.secret', {
+  blaze: () => Result.ok({ secret: true }),
+  description: 'Draft and internal; excluded with primary reason "draft".',
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ secret: z.boolean() }),
+  visibility: 'internal',
+});
+
+// --- activation-driven: reacts to a signal; MUST be excluded (activation) ---
+
+export const onCreated = trail('widget.onCreated', {
+  blaze: () => Result.ok({ handled: true }),
+  description:
+    'Reacts to widget.added; excluded from the projection (activation-driven).',
+  input: z.object({ id: z.string() }),
+  intent: 'read',
+  on: ['widget.added'],
+  output: z.object({ handled: z.boolean() }),
 });

--- a/packages/library/src/derive.ts
+++ b/packages/library/src/derive.ts
@@ -1,0 +1,198 @@
+/**
+ * `deriveLibraryApi` — the pure projection from a topo to a `LibraryProjection`.
+ *
+ * This is the single semantic authority for the library surface: trail
+ * selection, export naming, collision resolution, and the per-export contract
+ * data the emitter renders all live here. The in-memory surface and the package
+ * emitter both consume the projection; neither re-reads the topo nor reinvents
+ * selection. Pure — no fs/network/db reads (derive* purity contract).
+ */
+import { filterSurfaceTrails, isDraftId } from '@ontrails/core';
+import type { Topo, Trail } from '@ontrails/core';
+import type { ZodType } from 'zod';
+
+type AnyTrail = Trail<unknown, unknown, unknown>;
+
+/** Where a projected export name came from. */
+export type LibraryExportSource = 'derived' | 'trail-hint' | 'package-config';
+
+/** A single projected export: one trail rendered as a library entrypoint. */
+export interface LibraryExport {
+  /** Consumer-native export name (camelCased trail id by default). */
+  readonly exportName: string;
+  /** The trail id this export projects (the source of truth). */
+  readonly trailId: string;
+  /** How `exportName` was chosen. v0 derives; hints/config override later. */
+  readonly nameSource: LibraryExportSource;
+  /**
+   * Authored intent, carried for safety presets and docs. Always present —
+   * core resolves an unset intent to `'write'`, so there is no fallback here.
+   */
+  readonly intent: 'read' | 'write' | 'destroy';
+  /** Current version for versioned trails; undefined when unversioned. */
+  readonly version: number | undefined;
+  /** Trail description — the JSDoc source the emitter carries forward. */
+  readonly description: string | undefined;
+  /**
+   * Input schema reference: the emitter's method-signature and `/schemas`
+   * source. An in-memory Zod reference here; it serializes to JSON Schema when
+   * the projection is persisted to the artifact family.
+   */
+  readonly input: ZodType;
+  /** Output schema reference, when the trail declares one. */
+  readonly output: ZodType | undefined;
+  /**
+   * Resource ids this export depends on. Empty means a stateless function
+   * export; non-empty means the emitter projects the export behind a
+   * `createX()` factory/client, grouped by shared resources. Carrying ids (not
+   * just a boolean) keeps the factory-grouping decision in this authority.
+   */
+  readonly resources: readonly string[];
+}
+
+/** Why a trail did not project into the library (doctrinally-meaningful only). */
+export type LibraryExclusionReason = 'internal' | 'draft' | 'activation';
+
+/**
+ * A trail deliberately excluded from the projection, recorded for legibility.
+ * `reason` is the primary (first-matched) reason in precedence order
+ * draft > activation > internal; a trail may technically satisfy more than one.
+ */
+export interface LibraryExclusion {
+  readonly trailId: string;
+  readonly reason: LibraryExclusionReason;
+}
+
+/** Two or more trails deriving the same export name. */
+export interface LibraryCollision {
+  readonly exportName: string;
+  readonly trailIds: readonly string[];
+}
+
+/** The resolved library projection — the story of a topo as a TypeScript library. */
+export interface LibraryProjection {
+  /** The topo name. */
+  readonly app: string;
+  /** Projected exports, in stable (trail-id-sorted) order. */
+  readonly exports: readonly LibraryExport[];
+  /** Trails excluded by visibility, draft state, or activation. */
+  readonly excluded: readonly LibraryExclusion[];
+  /** Export-name collisions; first-by-id wins in `exports`, all recorded here. */
+  readonly collisions: readonly LibraryCollision[];
+}
+
+/**
+ * Options for narrowing the projection. Selectors reuse the trail-filter
+ * grammar (exact ids, `*`, `**`). v0 exposes include/exclude only; intent-based
+ * filtering is deferred (the packet promises the filter grammar, not intent
+ * narrowing, for the library surface).
+ */
+export interface DeriveLibraryApiOptions {
+  /** Narrowing include patterns. Never widens drafts/internal. */
+  readonly include?: readonly string[];
+  /** Exclude patterns. */
+  readonly exclude?: readonly string[];
+}
+
+/**
+ * Derive a consumer-native export name from a trail id: camelCase across `.`
+ * and `-` segments, preserving the full path so distinct trails stay distinct.
+ * `widget.get` -> `widgetGet`, `entity.list-all` -> `entityListAll`.
+ */
+const deriveExportName = (trailId: string): string => {
+  const words = trailId.split(/[.-]/u).filter((word) => word.length > 0);
+  return words
+    .map((word, index) =>
+      index === 0 ? word : word.charAt(0).toUpperCase() + word.slice(1)
+    )
+    .join('');
+};
+
+/**
+ * Whether a trail is surface-internal. Mirrors `effectiveVisibility` in
+ * `@ontrails/core` `surface-filter.ts`, which is not exported — so this is a
+ * deliberate local copy. Selection still routes through `filterSurfaceTrails`
+ * (authoritative); this duplication only labels exclusion reasons. If core's
+ * visibility rule gains a case, update this in lockstep.
+ */
+const isInternal = (trail: AnyTrail): boolean =>
+  trail.visibility === 'internal' || trail.meta?.['internal'] === true;
+
+/**
+ * Project a topo into a `LibraryProjection`. Selection composes
+ * `filterSurfaceTrails` (visibility, activation, intent, include/exclude) and
+ * adds draft exclusion. Established public, current-version trails become
+ * exports; drafts, internal, and activation-driven trails are excluded.
+ *
+ * @example
+ * const projection = deriveLibraryApi(app);
+ * for (const entry of projection.exports) {
+ *   console.log(entry.exportName, '->', entry.trailId);
+ * }
+ */
+export const deriveLibraryApi = (
+  graph: Topo,
+  options: DeriveLibraryApiOptions = {}
+): LibraryProjection => {
+  const all = graph.list();
+
+  const selected = filterSurfaceTrails(all, {
+    exclude: options.exclude,
+    include: options.include,
+  }).filter((trail) => !isDraftId(trail.id));
+  const selectedIds = new Set(selected.map((trail) => trail.id));
+
+  const excluded: LibraryExclusion[] = [];
+  for (const trail of all) {
+    if (selectedIds.has(trail.id)) {
+      continue;
+    }
+    // Precedence: draft > activation > internal. A trail may satisfy more than
+    // one; the first match is recorded as the primary reason.
+    if (isDraftId(trail.id)) {
+      excluded.push({ reason: 'draft', trailId: trail.id });
+    } else if (trail.activationSources.length > 0) {
+      excluded.push({ reason: 'activation', trailId: trail.id });
+    } else if (isInternal(trail)) {
+      excluded.push({ reason: 'internal', trailId: trail.id });
+    }
+    // Trails dropped purely by an explicit include/exclude filter are not
+    // surprising exclusions and are not recorded.
+  }
+
+  const sorted = selected.toSorted((left, right) =>
+    left.id.localeCompare(right.id)
+  );
+  const namesToTrailIds = new Map<string, string[]>();
+  const collisionNames = new Set<string>();
+  const exports: LibraryExport[] = [];
+
+  for (const trail of sorted) {
+    const exportName = deriveExportName(trail.id);
+    const existing = namesToTrailIds.get(exportName);
+    if (existing) {
+      existing.push(trail.id);
+      collisionNames.add(exportName);
+      continue;
+    }
+    namesToTrailIds.set(exportName, [trail.id]);
+    exports.push({
+      description: trail.description,
+      exportName,
+      input: trail.input,
+      intent: trail.intent,
+      nameSource: 'derived',
+      output: trail.output,
+      resources: trail.resources.map((resource) => resource.id),
+      trailId: trail.id,
+      version: trail.version,
+    });
+  }
+
+  const collisions: LibraryCollision[] = [...collisionNames].map((name) => ({
+    exportName: name,
+    trailIds: namesToTrailIds.get(name) ?? [],
+  }));
+
+  return { app: graph.name, collisions, excluded, exports };
+};

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -11,5 +11,15 @@
  * "Library surface & compiler"). This scaffold establishes the package and the
  * runtime-kernel seam; see `./kernel` and the Library Surface and Compiler ADR.
  */
+export { deriveLibraryApi } from './derive.js';
+export type {
+  DeriveLibraryApiOptions,
+  LibraryCollision,
+  LibraryExclusion,
+  LibraryExclusionReason,
+  LibraryExport,
+  LibraryExportSource,
+  LibraryProjection,
+} from './derive.js';
 export { kernelRun } from './kernel.js';
 export type { Result, Topo } from './kernel.js';


### PR DESCRIPTION
## Context

Introduces the pure projection model that turns a topo graph into a library API plan without performing file I/O or runtime execution.

## What Changed

- Added `deriveLibraryApi(graph, options)`.
- Filters to established public current-version trails by default.
- Excludes draft, internal, and activation trails with recorded reasons.
- Added include/exclude selectors and deterministic export-name collision reporting.

## Verification

- `bun run --cwd packages/library test`
- `bun run --cwd packages/library typecheck`
- `bun run --cwd packages/library lint`
- Full stack pre-push checks via Graphite submit.

## Notes

The projection keeps contract fidelity in the model so later emitters and surfaces share one derivation path.
