### PR TITLE
feat(library): add in-memory surface client

### DIFF
--- a/packages/library/src/__tests__/surface.test.ts
+++ b/packages/library/src/__tests__/surface.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from 'bun:test';
+
+import { surface } from '../surface.js';
+import type {
+  LibraryClient,
+  LibraryMethod,
+  LibraryResultMethod,
+} from '../surface.js';
+import { fixtureApp } from './fixtures/app.js';
+
+// The fixture's write trail declares a permit; the in-memory surface owns the
+// runtime context, so parity runs with a permit covering the fixture's scopes.
+const surfaceOptions = {
+  ctx: { permit: { id: 'test-permit', scopes: ['widget:write'] } },
+};
+
+const requireMethod = (lib: LibraryClient, name: string): LibraryMethod => {
+  const method = lib.call[name];
+  if (!method) {
+    throw new Error(`expected library export "${name}"`);
+  }
+  return method;
+};
+
+const requireResultMethod = (
+  lib: LibraryClient,
+  name: string
+): LibraryResultMethod => {
+  const method = lib.result[name];
+  if (!method) {
+    throw new Error(`expected library result export "${name}"`);
+  }
+  return method;
+};
+
+describe('library surface', () => {
+  test('exposes one callable method per projected export', async () => {
+    const lib = await surface(fixtureApp, surfaceOptions);
+    expect(Object.keys(lib.call).toSorted()).toEqual([
+      'widgetAdd',
+      'widgetCheck',
+      'widgetGet',
+      'widgetGreet',
+      'widgetPing',
+    ]);
+    expect(Object.keys(lib.result).toSorted()).toEqual(
+      Object.keys(lib.call).toSorted()
+    );
+  });
+
+  test('the client call maps are frozen', async () => {
+    const lib = await surface(fixtureApp, surfaceOptions);
+    expect(Object.isFrozen(lib.call)).toBe(true);
+    expect(Object.isFrozen(lib.result)).toBe(true);
+  });
+
+  test('unwraps Result.ok to a return value', async () => {
+    const lib = await surface(fixtureApp, surfaceOptions);
+    expect(await requireMethod(lib, 'widgetPing')({ message: 'hi' })).toEqual({
+      echo: 'hi',
+    });
+    expect(await requireMethod(lib, 'widgetGet')({ id: '1' })).toEqual({
+      id: '1',
+      name: 'Example',
+    });
+  });
+
+  test('throws the typed error on Result.err (root API mapping)', async () => {
+    const lib = await surface(fixtureApp, surfaceOptions);
+    await expect(
+      requireMethod(lib, 'widgetGet')({ id: 'missing' })
+    ).rejects.toThrow('not found');
+  });
+
+  test('exposes a no-throw result lane', async () => {
+    const lib = await surface(fixtureApp, surfaceOptions);
+
+    const ok = await requireResultMethod(lib, 'widgetPing')({ message: 'hi' });
+    expect(ok.isOk()).toBe(true);
+    expect(ok.value).toEqual({ echo: 'hi' });
+
+    const err = await requireResultMethod(lib, 'widgetGet')({ id: 'missing' });
+    expect(err.isErr()).toBe(true);
+    expect(err.error.name).toBe('NotFoundError');
+  });
+
+  test('domain-negative output is a returned value, not a throw', async () => {
+    const lib = await surface(fixtureApp, surfaceOptions);
+    expect(await requireMethod(lib, 'widgetCheck')({ name: '' })).toEqual({
+      issues: ['name is empty'],
+      status: 'fail',
+    });
+  });
+
+  // `abortSignal` is a thin pass-through (surface -> kernel -> run options).
+  // Abort *semantics* are core's contract, tested in core's execute suite; a
+  // trivial blaze completes before any abort check, so asserting abort behavior
+  // here would test core through the library rather than the forwarding itself.
+  test('accepts an abort signal without breaking normal execution', async () => {
+    const lib = await surface(fixtureApp, {
+      ...surfaceOptions,
+      abortSignal: new AbortController().signal,
+    });
+    expect(await requireMethod(lib, 'widgetPing')({ message: 'hi' })).toEqual({
+      echo: 'hi',
+    });
+  });
+});
+
+describe('library surface parity with authored examples', () => {
+  test('every exported method honors its trail examples', async () => {
+    const lib = await surface(fixtureApp, surfaceOptions);
+
+    expect(lib.projection.exports.length).toBeGreaterThan(0);
+    let assertionsRun = 0;
+
+    for (const entry of lib.projection.exports) {
+      const trail = fixtureApp.get(entry.trailId);
+      const method = requireMethod(lib, entry.exportName);
+      const examples = trail?.examples ?? [];
+      // Every export must carry at least one example (parity fuel).
+      expect(examples.length).toBeGreaterThan(0);
+
+      for (const example of examples) {
+        if (example.error) {
+          let thrown: unknown;
+          try {
+            await method(example.input);
+          } catch (error) {
+            thrown = error;
+          }
+          expect((thrown as Error | undefined)?.name).toBe(example.error);
+          assertionsRun += 1;
+          continue;
+        }
+
+        const output = await method(example.input);
+        if (example.expected !== undefined) {
+          expect(output).toEqual(example.expected);
+          assertionsRun += 1;
+          continue;
+        }
+        if (example.expectedMatch !== undefined) {
+          expect(output).toMatchObject(
+            example.expectedMatch as Record<string, unknown>
+          );
+          assertionsRun += 1;
+          continue;
+        }
+        // A success example with no expectation is an under-specified example,
+        // not a pass — fail loudly rather than silently.
+        throw new Error(
+          `example "${example.name}" on ${entry.trailId} has no expected/expectedMatch/error`
+        );
+      }
+    }
+
+    // The loop must have actually asserted something across all exports.
+    expect(assertionsRun).toBeGreaterThan(0);
+  });
+});

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -22,4 +22,16 @@ export type {
   LibraryProjection,
 } from './derive.js';
 export { kernelRun } from './kernel.js';
-export type { Result, Topo } from './kernel.js';
+export type {
+  KernelRunOptions,
+  Result,
+  Topo,
+  TrailContextInit,
+} from './kernel.js';
+export { surface } from './surface.js';
+export type {
+  LibraryClient,
+  LibraryMethod,
+  LibraryResultMethod,
+  SurfaceLibraryOptions,
+} from './surface.js';

--- a/packages/library/src/kernel.ts
+++ b/packages/library/src/kernel.ts
@@ -18,9 +18,17 @@
  * emitter lanes land. Keep it minimal and dependency-light on purpose.
  */
 import { run } from '@ontrails/core';
-import type { Result, Topo } from '@ontrails/core';
+import type { Result, Topo, TrailContextInit } from '@ontrails/core';
 
-export type { Result, Topo };
+export type { Result, Topo, TrailContextInit };
+
+/** Runtime options the kernel forwards to execution (permit, abort, etc.). */
+export interface KernelRunOptions {
+  /** Partial context merged on top of the base context (e.g. `{ permit }`). */
+  readonly ctx?: Partial<TrailContextInit> | undefined;
+  /** Abort signal for the execution. */
+  readonly abortSignal?: AbortSignal | undefined;
+}
 
 /**
  * Execute a trail by id through the shared Trails pipeline. Never throws —
@@ -37,5 +45,6 @@ export type { Result, Topo };
 export const kernelRun = (
   topo: Topo,
   id: string,
-  input: unknown
-): Promise<Result<unknown, Error>> => run(topo, id, input);
+  input: unknown,
+  options: KernelRunOptions = {}
+): Promise<Result<unknown, Error>> => run(topo, id, input, options);

--- a/packages/library/src/surface.ts
+++ b/packages/library/src/surface.ts
@@ -1,0 +1,88 @@
+/**
+ * The in-memory library surface: `surface(graph, options)` returns a callable
+ * client. It is a peer of the CLI, MCP, and HTTP surfaces — same contract, same
+ * shared pipeline — and the first surface whose `surface()` returns a held
+ * client rather than opening a long-running endpoint.
+ *
+ * The client routes execution through the runtime kernel (`kernelRun`), never
+ * through ad hoc `@ontrails/core` deep imports, so the standalone trajectory
+ * stays a vendoring step. Root-call behavior: unwrap `Result.ok` to a return
+ * value, throw on `Result.err`. The held client also exposes a no-throw
+ * `result` lane with the same export names so downstream package emission can
+ * later map that lane to the generated `/result` subpath. Package-facing
+ * error-class mapping stays in the error lane — TRL-966.
+ */
+import { deriveLibraryApi } from './derive.js';
+import type { DeriveLibraryApiOptions, LibraryProjection } from './derive.js';
+import { kernelRun } from './kernel.js';
+import type { KernelRunOptions, Result, Topo } from './kernel.js';
+
+/**
+ * Options for the in-memory library surface: projection selectors plus the
+ * runtime context the client owns (e.g. a permit for permitted trails).
+ */
+export interface SurfaceLibraryOptions
+  extends DeriveLibraryApiOptions, KernelRunOptions {}
+
+/** A callable library method: validated input in, output out, throws on failure. */
+export type LibraryMethod = (input: unknown) => Promise<unknown>;
+
+/** A no-throw library method: validated input in, raw Result boundary out. */
+export type LibraryResultMethod = (
+  input: unknown
+) => Promise<Result<unknown, Error>>;
+
+/** The held in-memory client: one method per projected export, plus the projection. */
+export interface LibraryClient {
+  /** Invoke an exported trail by its consumer-native name. */
+  readonly call: Readonly<Record<string, LibraryMethod>>;
+  /** Invoke an exported trail by name without unwrapping the Result boundary. */
+  readonly result: Readonly<Record<string, LibraryResultMethod>>;
+  /** The resolved projection this client was built from (introspection). */
+  readonly projection: LibraryProjection;
+}
+
+/**
+ * Materialize a topo as an in-memory library client. Each projected export
+ * becomes a method that executes its trail through the shared pipeline and
+ * unwraps the Result — returning the value or throwing the error. The same
+ * export names are available under `result` for callers that want the raw
+ * `Result` boundary.
+ *
+ * @example
+ * const lib = await surface(app);
+ * const widget = await lib.call.widgetGet({ id: '1' });
+ */
+export const surface = async (
+  graph: Topo,
+  options: SurfaceLibraryOptions = {}
+  // oxlint-disable-next-line require-await -- async to match peer surfaces and allow future resource init
+): Promise<LibraryClient> => {
+  const projection = deriveLibraryApi(graph, options);
+  const runOptions: KernelRunOptions = {
+    abortSignal: options.abortSignal,
+    ctx: options.ctx,
+  };
+  const call: Record<string, LibraryMethod> = {};
+  const result: Record<string, LibraryResultMethod> = {};
+
+  for (const entry of projection.exports) {
+    const runExport: LibraryResultMethod = (input: unknown) =>
+      kernelRun(graph, entry.trailId, input, runOptions);
+    result[entry.exportName] = runExport;
+
+    call[entry.exportName] = async (input: unknown): Promise<unknown> => {
+      const outcome = await runExport(input);
+      if (outcome.isErr()) {
+        throw outcome.error;
+      }
+      return outcome.value;
+    };
+  }
+
+  return {
+    call: Object.freeze(call),
+    projection,
+    result: Object.freeze(result),
+  };
+};


### PR DESCRIPTION
## Context

Adds the in-memory library surface: a callable TypeScript client over a Trails topo, backed by the same runtime contract as the other surfaces.

## What Changed

- Added async `surface(graph, options)` returning a frozen `LibraryClient`.
- Exposes `client.call.*` for root-style unwrapped returns and typed throws on `Result.err`.
- Exposes `client.result.*` for no-throw `Result` returns.
- Threads context and abort-signal run options through the kernel path.

## Verification

- `bun run --cwd packages/library test`
- `bun run --cwd packages/library typecheck`
- `bun run --cwd packages/library lint`
- Full stack pre-push checks via Graphite submit.
