### PR TITLE
feat(library): emit subpath package plan

### DIFF
--- a/packages/library/src/__tests__/compile.test.ts
+++ b/packages/library/src/__tests__/compile.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test';
+
+import { compile } from '../compile.js';
+import type { CompileResult } from '../compile.js';
+import { fixtureApp } from './fixtures/app.js';
+
+const options = {
+  appExportName: 'fixtureApp',
+  appImportPath: '@fixture/app',
+  packageName: '@fixture/widget',
+};
+
+const fileContent = (result: CompileResult, path: string): string => {
+  const file = result.files.find((entry) => entry.path === path);
+  if (!file) {
+    throw new Error(`expected generated file "${path}"`);
+  }
+  return file.content;
+};
+
+describe('compile', () => {
+  test('emits the subpath-shaped package file set', () => {
+    const result = compile(fixtureApp, options);
+    expect(result.files.map((file) => file.path).toSorted()).toEqual([
+      'package.json',
+      'src/index.ts',
+      'src/result.ts',
+      'src/schemas.ts',
+      'src/trails.ts',
+      'tsconfig.json',
+    ]);
+  });
+
+  test('package.json declares the consumer-facing subpath exports', () => {
+    const result = compile(fixtureApp, options);
+    const pkg = JSON.parse(fileContent(result, 'package.json')) as {
+      name: string;
+      exports: Record<string, string>;
+    };
+    expect(pkg.name).toBe('@fixture/widget');
+    expect(Object.keys(pkg.exports)).toEqual(
+      expect.arrayContaining(['.', './result', './schemas', './trails'])
+    );
+  });
+
+  test('root index emits stateless functions and a resource factory', () => {
+    const index = fileContent(compile(fixtureApp, options), 'src/index.ts');
+    // Stateless trails project to top-level named functions.
+    expect(index).toContain('export const widgetPing = (input: unknown)');
+    expect(index).toContain('export const widgetCheck = (input: unknown)');
+    expect(index).toContain('export const widgetGreet = (input: unknown)');
+    // Resource-bearing trails project behind a createX factory.
+    expect(index).toContain('import type { SurfaceLibraryOptions }');
+    expect(index).toContain('const rootClient = await surface(fixtureApp);');
+    expect(index).toContain('export const createLibraryFixture = async (');
+    expect(index).toContain('options: SurfaceLibraryOptions = {}');
+    expect(index).toContain(
+      'const client = await surface(fixtureApp, options);'
+    );
+    expect(index).toContain('widgetGet: (input: unknown)');
+    expect(index).toContain('widgetAdd: (input: unknown)');
+    // The generated code imports the source topo by the configured specifier.
+    expect(index).toContain("import { fixtureApp } from '@fixture/app';");
+  });
+
+  test('result subpath mirrors exports as no-throw methods', () => {
+    const result = fileContent(compile(fixtureApp, options), 'src/result.ts');
+    expect(result).toContain(
+      "import { kernelRun, surface } from '@ontrails/library';"
+    );
+    expect(result).toContain('import type { Result, SurfaceLibraryOptions }');
+    expect(result).toContain('const resultClient = await surface(fixtureApp);');
+    expect(result).toContain('export const widgetPing = (');
+    expect(result).toContain('): Promise<Result<unknown, Error>> =>');
+    expect(result).toContain('resultClient.result.widgetPing(input);');
+    expect(result).toContain('export const createLibraryFixture = async (');
+    expect(result).toContain('client.result.widgetGet(input)');
+    expect(result).toContain(') => kernelRun(fixtureApp, id, input, options);');
+  });
+
+  test('schemas subpath fails loudly if projection drifts', () => {
+    const schemas = fileContent(compile(fixtureApp, options), 'src/schemas.ts');
+    expect(schemas).toContain('const requireExport = (name: string) => {');
+    expect(schemas).toContain(
+      "throw new Error('missing projected library export: ' + name);"
+    );
+    expect(schemas).toContain("input: requireExport('widgetPing').input");
+    expect(schemas).not.toContain('?.input');
+    expect(schemas).not.toContain('?.output');
+  });
+
+  test('trails subpath re-exports the native topo', () => {
+    const trails = fileContent(compile(fixtureApp, options), 'src/trails.ts');
+    expect(trails).toContain(
+      "export { fixtureApp as app } from '@fixture/app';"
+    );
+  });
+
+  test('does not emit excluded (draft/internal/activation) trails', () => {
+    const index = fileContent(compile(fixtureApp, options), 'src/index.ts');
+    expect(index).not.toContain('diagnose');
+    expect(index).not.toContain('experiment');
+    expect(index).not.toContain('onCreated');
+    expect(index).not.toContain('secret');
+  });
+
+  test('carries the resolved projection on the result', () => {
+    const result = compile(fixtureApp, options);
+    expect(result.projection.exports).toHaveLength(5);
+    expect(result.projection.app).toBe('library-fixture');
+  });
+});

--- a/packages/library/src/compile.ts
+++ b/packages/library/src/compile.ts
@@ -1,0 +1,296 @@
+/**
+ * `compile` — the package emitter. Consumes the `LibraryProjection` (never the
+ * topo directly) and produces the source files of a generated TypeScript
+ * package: consumer-fluent root, `/result`, `/schemas`, `/trails` subpaths.
+ *
+ * v0 is runtime-backed: the generated package imports the source topo and the
+ * `@ontrails/library` runtime (the kernel seam), so execution delegates to the
+ * shared pipeline. The standalone trajectory (vendoring the kernel) does not
+ * change consumer code — see the runtime-kernel section of the ADR.
+ *
+ * This slice returns the file plan (path + content); writing it to disk is a
+ * thin apply step. Pure: derives the projection and builds strings, no I/O.
+ */
+import { deriveLibraryApi } from './derive.js';
+import type {
+  DeriveLibraryApiOptions,
+  LibraryExport,
+  LibraryProjection,
+} from './derive.js';
+import type { Topo } from './kernel.js';
+
+/** Options for emitting a generated library package. */
+export interface CompileOptions extends DeriveLibraryApiOptions {
+  /** The generated package name (e.g. `@acme/core`). */
+  readonly packageName: string;
+  /** Import specifier the generated code uses to reach the source topo. */
+  readonly appImportPath: string;
+  /** The exported binding name of the topo at `appImportPath` (default `app`). */
+  readonly appExportName?: string;
+  /** Generated package version. Defaults to `0.0.0`. */
+  readonly version?: string;
+}
+
+/** A single emitted file: project-relative path and full contents. */
+export interface CompiledFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+/** The result of compiling a topo into a generated library package. */
+export interface CompileResult {
+  readonly packageName: string;
+  /** The resolved projection the files were emitted from. */
+  readonly projection: LibraryProjection;
+  /** The emitted files, in stable path order. */
+  readonly files: readonly CompiledFile[];
+}
+
+const pascalCase = (value: string): string =>
+  value
+    .split(/[.\-_]/u)
+    .filter((word) => word.length > 0)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join('');
+
+const isStateless = (entry: LibraryExport): boolean =>
+  entry.resources.length === 0;
+
+const statelessExports = (
+  projection: LibraryProjection
+): readonly LibraryExport[] => projection.exports.filter(isStateless);
+
+const resourceExports = (
+  projection: LibraryProjection
+): readonly LibraryExport[] =>
+  projection.exports.filter((entry) => !isStateless(entry));
+
+const factoryName = (projection: LibraryProjection): string =>
+  `create${pascalCase(projection.app)}`;
+
+const generatePackageJson = (options: CompileOptions): string => {
+  const manifest = {
+    dependencies: {
+      '@ontrails/library': 'workspace:^',
+      zod: 'catalog:',
+    },
+    exports: {
+      '.': './src/index.ts',
+      './package.json': './package.json',
+      './result': './src/result.ts',
+      './schemas': './src/schemas.ts',
+      './trails': './src/trails.ts',
+    },
+    name: options.packageName,
+    type: 'module',
+    version: options.version ?? '0.0.0',
+  };
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+};
+
+// v0 generated methods are runtime-correct delegators typed `(input: unknown)
+// => Promise<unknown>`, matching the in-memory surface's own honesty. Specific
+// typed signatures need the source trail *types* (the projection's schema refs
+// are type-erased to `ZodType`, so `z.infer` yields `unknown`); that is a named
+// emitter refinement — see the worklog's emitter-lane design notes.
+
+const statelessFunction = (entry: LibraryExport): string =>
+  [
+    `export const ${entry.exportName} = (input: unknown): Promise<unknown> =>`,
+    `  rootClient.call.${entry.exportName}(input);`,
+  ].join('\n');
+
+const factoryMethod = (entry: LibraryExport): string =>
+  [
+    `    ${entry.exportName}: (input: unknown): Promise<unknown> =>`,
+    `      client.call.${entry.exportName}(input),`,
+  ].join('\n');
+
+const generateIndex = (
+  projection: LibraryProjection,
+  options: CompileOptions
+): string => {
+  const appExport = options.appExportName ?? 'app';
+  const stateless = statelessExports(projection);
+  const resourceful = resourceExports(projection);
+
+  const parts: string[] = [
+    "import { surface } from '@ontrails/library';",
+    "import type { SurfaceLibraryOptions } from '@ontrails/library';",
+    '',
+    `import { ${appExport} } from '${options.appImportPath}';`,
+    '',
+    `const rootClient = await surface(${appExport});`,
+  ];
+
+  for (const entry of stateless) {
+    parts.push('', statelessFunction(entry));
+  }
+
+  if (resourceful.length > 0) {
+    parts.push(
+      '',
+      `export const ${factoryName(projection)} = async (`,
+      '  options: SurfaceLibraryOptions = {}',
+      ') => {',
+      `  const client = await surface(${appExport}, options);`,
+      '  return {',
+      resourceful.map(factoryMethod).join('\n'),
+      '  };',
+      '};'
+    );
+  }
+
+  return `${parts.join('\n')}\n`;
+};
+
+const generateSchemas = (projection: LibraryProjection): string => {
+  const appExport = 'app';
+  const lines = [
+    `import { ${appExport} } from './trails.js';`,
+    "import { deriveLibraryApi } from '@ontrails/library';",
+    '',
+    '// Authored Zod schemas, keyed by export name, projected from the topo.',
+    'const projection = deriveLibraryApi(app);',
+    'const byName = new Map(',
+    '  projection.exports.map((entry) => [entry.exportName, entry])',
+    ');',
+    '',
+    'const requireExport = (name: string) => {',
+    '  const entry = byName.get(name);',
+    '  if (!entry) {',
+    "    throw new Error('missing projected library export: ' + name);",
+    '  }',
+    '  return entry;',
+    '};',
+    '',
+    'export const schemas = {',
+  ];
+  for (const entry of projection.exports) {
+    lines.push(
+      `  ${entry.exportName}: {`,
+      `    input: requireExport('${entry.exportName}').input,`,
+      `    output: requireExport('${entry.exportName}').output,`,
+      '  },'
+    );
+  }
+  lines.push('} as const;');
+  return `${lines.join('\n')}\n`;
+};
+
+const generateTrails = (options: CompileOptions): string => {
+  const appExport = options.appExportName ?? 'app';
+  return [
+    '// Full Trails-native entrypoint: the resolved topo for composition,',
+    '// contract tests, and graph inspection.',
+    `export { ${appExport} as app } from '${options.appImportPath}';`,
+    '',
+  ].join('\n');
+};
+
+const resultStatelessFunction = (entry: LibraryExport): string =>
+  [
+    `export const ${entry.exportName} = (`,
+    '  input: unknown',
+    '): Promise<Result<unknown, Error>> =>',
+    `  resultClient.result.${entry.exportName}(input);`,
+  ].join('\n');
+
+const resultFactoryMethod = (entry: LibraryExport): string =>
+  [
+    `    ${entry.exportName}: (input: unknown): Promise<Result<unknown, Error>> =>`,
+    `      client.result.${entry.exportName}(input),`,
+  ].join('\n');
+
+const generateResult = (
+  projection: LibraryProjection,
+  options: CompileOptions
+): string => {
+  const appExport = options.appExportName ?? 'app';
+  const stateless = statelessExports(projection);
+  const resourceful = resourceExports(projection);
+  const parts = [
+    '// No-throw API: returns the Result envelope instead of unwrapping.',
+    "import { kernelRun, surface } from '@ontrails/library';",
+    "import type { Result, SurfaceLibraryOptions } from '@ontrails/library';",
+    '',
+    `import { ${appExport} } from '${options.appImportPath}';`,
+    '',
+    `const resultClient = await surface(${appExport});`,
+  ];
+
+  for (const entry of stateless) {
+    parts.push('', resultStatelessFunction(entry));
+  }
+
+  if (resourceful.length > 0) {
+    parts.push(
+      '',
+      `export const ${factoryName(projection)} = async (`,
+      '  options: SurfaceLibraryOptions = {}',
+      ') => {',
+      `  const client = await surface(${appExport}, options);`,
+      '  return {',
+      resourceful.map(resultFactoryMethod).join('\n'),
+      '  };',
+      '};'
+    );
+  }
+
+  parts.push(
+    '',
+    'export const call = (',
+    '  id: string,',
+    '  input: unknown,',
+    '  options: SurfaceLibraryOptions = {}',
+    `) => kernelRun(${appExport}, id, input, options);`,
+    ''
+  );
+
+  return `${parts.join('\n')}\n`;
+};
+
+const generateTsconfig = (): string =>
+  `${JSON.stringify(
+    {
+      compilerOptions: {
+        module: 'preserve',
+        moduleResolution: 'bundler',
+        strict: true,
+        target: 'esnext',
+        types: [],
+      },
+      include: ['src'],
+    },
+    null,
+    2
+  )}\n`;
+
+/**
+ * Compile a topo into a generated library package. Returns the emitted file
+ * plan; the resolved projection is included for inspection and governance.
+ *
+ * @example
+ * const result = compile(app, {
+ *   packageName: '@acme/core',
+ *   appImportPath: '@acme/app',
+ * });
+ * for (const file of result.files) {
+ *   console.log(file.path);
+ * }
+ */
+export const compile = (
+  graph: Topo,
+  options: CompileOptions
+): CompileResult => {
+  const projection = deriveLibraryApi(graph, options);
+  const files: CompiledFile[] = [
+    { content: generatePackageJson(options), path: 'package.json' },
+    { content: generateTsconfig(), path: 'tsconfig.json' },
+    { content: generateIndex(projection, options), path: 'src/index.ts' },
+    { content: generateResult(projection, options), path: 'src/result.ts' },
+    { content: generateSchemas(projection), path: 'src/schemas.ts' },
+    { content: generateTrails(options), path: 'src/trails.ts' },
+  ];
+  return { files, packageName: options.packageName, projection };
+};

--- a/packages/library/src/index.ts
+++ b/packages/library/src/index.ts
@@ -11,6 +11,8 @@
  * "Library surface & compiler"). This scaffold establishes the package and the
  * runtime-kernel seam; see `./kernel` and the Library Surface and Compiler ADR.
  */
+export { compile } from './compile.js';
+export type { CompiledFile, CompileOptions, CompileResult } from './compile.js';
 export { deriveLibraryApi } from './derive.js';
 export type {
   DeriveLibraryApiOptions,


### PR DESCRIPTION
## Context

Adds the pure compiler emitter that produces a generated package file plan for the library surface without writing to disk.

## What Changed

- Added `compile(graph, options)` returning a `CompileResult` file plan.
- Emits package metadata plus `src/index.ts`, `src/result.ts`, `src/schemas.ts`, and `src/trails.ts`.
- Root exports unwrap and throw, result subpath returns `Result`, schemas subpath exposes contract schemas, and trails subpath re-exports the source topo.
- Keeps dependency versions configurable while defaulting to publish-safe package ranges.

## Verification

- `bun run --cwd packages/library test`
- `bun run --cwd packages/library typecheck`
- `bun run --cwd packages/library lint`
- Full stack pre-push checks via Graphite submit.
