### PR TITLE
test(library): smoke generated package artifacts

### DIFF
--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "test": "bun test",
+    "test": "bun test --timeout 30000",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint ./src",
     "clean": "rm -rf dist *.tsbuildinfo"

--- a/packages/library/src/__tests__/compile-smoke.test.ts
+++ b/packages/library/src/__tests__/compile-smoke.test.ts
@@ -1,0 +1,109 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { dirname, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, test } from 'bun:test';
+
+import { compile } from '../compile.js';
+import type { CompileResult } from '../compile.js';
+import { fixtureApp } from './fixtures/app.js';
+
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
+
+const toImportPath = (fromDir: string, toFile: string): string => {
+  const relativePath = relative(fromDir, toFile);
+  const raw = (
+    relativePath.endsWith('.ts')
+      ? relativePath.slice(0, -'.ts'.length)
+      : relativePath
+  )
+    .split(sep)
+    .join('/');
+  return raw.startsWith('.') ? raw : `./${raw}`;
+};
+
+const writePlan = async (
+  packageRoot: string,
+  result: CompileResult
+): Promise<void> => {
+  for (const file of result.files) {
+    const target = join(packageRoot, file.path);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, file.content);
+  }
+};
+
+const run = async (
+  cmd: readonly string[],
+  cwd: string
+): Promise<{ readonly stderr: string; readonly stdout: string }> => {
+  const proc = Bun.spawn(cmd as string[], {
+    cwd,
+    env: {
+      ...process.env,
+      PATH: `${join(repoRoot, 'node_modules', '.bin')}:${process.env.PATH ?? ''}`,
+    },
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(
+      `${cmd.join(' ')} failed with exit ${exitCode}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`
+    );
+  }
+  return { stderr, stdout };
+};
+
+describe('generated library package smoke', () => {
+  test('emitted package typechecks and dry-run packs', async () => {
+    const tempRoot = await mkdtemp(
+      join(repoRoot, '.trails-life-library-smoke-')
+    );
+    try {
+      const packageRoot = join(tempRoot, 'generated-widget');
+      await mkdir(packageRoot, { recursive: true });
+      const ontrailsModules = join(packageRoot, 'node_modules', '@ontrails');
+      await mkdir(ontrailsModules, { recursive: true });
+      await symlink(
+        join(repoRoot, 'packages/library'),
+        join(ontrailsModules, 'library'),
+        'dir'
+      );
+
+      const fixtureSource = join(
+        repoRoot,
+        'packages/library/src/__tests__/fixtures/app.ts'
+      );
+      await writeFile(
+        join(packageRoot, 'fixture-app.ts'),
+        `export { fixtureApp } from '${toImportPath(packageRoot, fixtureSource)}';\n`
+      );
+
+      const result = compile(fixtureApp, {
+        appExportName: 'fixtureApp',
+        appImportPath: '../fixture-app',
+        packageName: '@fixture/generated-widget',
+        version: '0.0.0-smoke',
+      });
+      await writePlan(packageRoot, result);
+
+      const manifest = JSON.parse(
+        result.files.find((file) => file.path === 'package.json')?.content ??
+          '{}'
+      ) as { readonly dependencies?: Record<string, string> };
+      expect(JSON.stringify(manifest)).not.toContain('workspace:');
+      expect(JSON.stringify(manifest)).not.toContain('catalog:');
+
+      await run(['tsc', '-p', 'tsconfig.json', '--noEmit'], packageRoot);
+      const pack = await run(['bun', 'pm', 'pack', '--dry-run'], packageRoot);
+      expect(pack.stdout).toContain('fixture-generated-widget-0.0.0-smoke.tgz');
+    } finally {
+      await rm(tempRoot, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/library/src/__tests__/compile.test.ts
+++ b/packages/library/src/__tests__/compile.test.ts
@@ -34,13 +34,33 @@ describe('compile', () => {
   test('package.json declares the consumer-facing subpath exports', () => {
     const result = compile(fixtureApp, options);
     const pkg = JSON.parse(fileContent(result, 'package.json')) as {
-      name: string;
+      dependencies: Record<string, string>;
       exports: Record<string, string>;
+      name: string;
     };
     expect(pkg.name).toBe('@fixture/widget');
+    expect(pkg.dependencies).toEqual({
+      '@ontrails/library': '^1.0.0',
+      zod: '^4.3.5',
+    });
+    expect(JSON.stringify(pkg)).not.toContain('workspace:');
+    expect(JSON.stringify(pkg)).not.toContain('catalog:');
     expect(Object.keys(pkg.exports)).toEqual(
       expect.arrayContaining(['.', './result', './schemas', './trails'])
     );
+  });
+
+  test('package.json dependency ranges can be overridden for workspace emission', () => {
+    const result = compile(fixtureApp, {
+      ...options,
+      libraryDependency: 'workspace:^',
+      zodDependency: 'catalog:',
+    });
+    const pkg = JSON.parse(fileContent(result, 'package.json')) as {
+      dependencies: Record<string, string>;
+    };
+    expect(pkg.dependencies['@ontrails/library']).toBe('workspace:^');
+    expect(pkg.dependencies.zod).toBe('catalog:');
   });
 
   test('root index emits stateless functions and a resource factory', () => {

--- a/packages/library/src/compile.ts
+++ b/packages/library/src/compile.ts
@@ -27,8 +27,12 @@ export interface CompileOptions extends DeriveLibraryApiOptions {
   readonly appImportPath: string;
   /** The exported binding name of the topo at `appImportPath` (default `app`). */
   readonly appExportName?: string;
+  /** Runtime dependency range for `@ontrails/library` in emitted package.json. */
+  readonly libraryDependency?: string;
   /** Generated package version. Defaults to `0.0.0`. */
   readonly version?: string;
+  /** Peer dependency range for Zod in emitted package.json. */
+  readonly zodDependency?: string;
 }
 
 /** A single emitted file: project-relative path and full contents. */
@@ -68,11 +72,15 @@ const resourceExports = (
 const factoryName = (projection: LibraryProjection): string =>
   `create${pascalCase(projection.app)}`;
 
+const DEFAULT_LIBRARY_DEPENDENCY = '^1.0.0';
+const DEFAULT_ZOD_DEPENDENCY = '^4.3.5';
+
 const generatePackageJson = (options: CompileOptions): string => {
   const manifest = {
     dependencies: {
-      '@ontrails/library': 'workspace:^',
-      zod: 'catalog:',
+      '@ontrails/library':
+        options.libraryDependency ?? DEFAULT_LIBRARY_DEPENDENCY,
+      zod: options.zodDependency ?? DEFAULT_ZOD_DEPENDENCY,
     },
     exports: {
       '.': './src/index.ts',
@@ -258,7 +266,7 @@ const generateTsconfig = (): string =>
         moduleResolution: 'bundler',
         strict: true,
         target: 'esnext',
-        types: [],
+        types: ['bun'],
       },
       include: ['src'],
     },


### PR DESCRIPTION
## Context

Adds a generated-package smoke test so the compiler output is proven as package-shaped TypeScript rather than only string snapshots.

## What Changed

- Emits a temporary generated package from the library fixture topo.
- Typechecks the generated package with `tsc --noEmit`.
- Runs `bun pm pack --dry-run` and asserts publish-safe manifest ranges.
- Gives the library package test script a longer timeout for this integration-style smoke on CI.

## Verification

- `bun run --cwd packages/library test`
- `bun run --cwd packages/library typecheck`
- `bun run --cwd packages/library lint`
- `git diff --check`
- `bun run test`
- Graphite submit pre-push checks passed after the timeout fix.

## Notes

The generated temp directory uses the repo hook-owned `.trails-life-*` prefix so tree-guard stays meaningful while permitting this smoke.
