### PR TITLE
fix(library): project layer inputs through generated clients

### DIFF
--- a/.changeset/library-layer-input-projection.md
+++ b/.changeset/library-layer-input-projection.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/library": patch
+---
+
+Project typed layer inputs through the library surface and generated packages. The runtime now validates the combined public input, routes layer-owned fields into per-layer input slots, and generated packages share one held client across root and result subpaths while avoiding Bun-only ambient type assumptions in their emitted tsconfig.

--- a/packages/library/README.md
+++ b/packages/library/README.md
@@ -37,6 +37,8 @@ Generated packages use one package with subpath exports:
 
 Stateless trails project to root named exports. Resource-bearing trails project behind a generated `createX(options)` factory so callers can provide resource configuration once and call several related methods from the same client.
 
+Generated root and `/result` subpaths share one internal client module, so importing both subpaths does not open separate root library surfaces.
+
 ## Typed signatures
 
 Topo artifacts carry durable contract facts, but they do not preserve erased source-level TypeScript generics. Generated packages therefore stay honest by defaulting method signatures to `unknown` unless the caller binds a projected trail id to the source trail export that owns its schema types:
@@ -54,6 +56,8 @@ const files = compile(app, {
 ```
 
 With that binding, `/schemas` emits aliases such as `WidgetPingInput = TrailInput<typeof pingTrail>` and the root and `/result` subpaths use those aliases in their public signatures.
+
+Typed layer inputs are projected into the same public method input object as trail fields. When a layer field collides with a trail field or reserved surface name, the generated library input uses the same deterministic `<layerName><Field>` rename rule as other object-shaped surfaces. Runtime calls validate the projected input, strip layer-owned fields before trail validation, and route them to the layer's own input slot. When a source trail type binding is provided, generated signatures widen layer-projected inputs with `Record<string, unknown>` until layer input type exports have a source-level owner.
 
 ## Errors
 

--- a/packages/library/src/__tests__/compile-smoke.test.ts
+++ b/packages/library/src/__tests__/compile-smoke.test.ts
@@ -117,8 +117,15 @@ describe('generated library package smoke', () => {
         result.files.find((file) => file.path === 'package.json')?.content ??
           '{}'
       ) as { readonly dependencies?: Record<string, string> };
+      const tsconfig = JSON.parse(
+        result.files.find((file) => file.path === 'tsconfig.json')?.content ??
+          '{}'
+      ) as {
+        readonly compilerOptions?: { readonly types?: readonly string[] };
+      };
       expect(JSON.stringify(manifest)).not.toContain('workspace:');
       expect(JSON.stringify(manifest)).not.toContain('catalog:');
+      expect(tsconfig.compilerOptions?.types).toBeUndefined();
 
       await run(['tsc', '-p', 'tsconfig.json', '--noEmit'], packageRoot);
       const pack = await run(['bun', 'pm', 'pack', '--dry-run'], packageRoot);

--- a/packages/library/src/__tests__/compile.test.ts
+++ b/packages/library/src/__tests__/compile.test.ts
@@ -23,6 +23,7 @@ describe('compile', () => {
     const result = compile(fixtureApp, options);
     expect(result.files.map((file) => file.path).toSorted()).toEqual([
       'package.json',
+      'src/client.ts',
       'src/index.ts',
       'src/result.ts',
       'src/schemas.ts',
@@ -71,30 +72,41 @@ describe('compile', () => {
     expect(index).toContain('export const widgetPing = (\n  input: unknown');
     expect(index).toContain('export const widgetCheck = (\n  input: unknown');
     expect(index).toContain('export const widgetGreet = (\n  input: unknown');
+    expect(index).toContain(
+      'export const widgetAudited = (\n  input: Record<string, unknown>'
+    );
+    expect(index).toContain(
+      'The runtime validates declared output schemas before this unwrap returns.'
+    );
     // Resource-bearing trails project behind a createX factory.
     expect(index).toContain('import type { SurfaceLibraryOptions }');
-    expect(index).toContain('const rootClient = await surface(fixtureApp);');
+    expect(index).toContain(
+      "import { createClient, rootClient } from './client.js';"
+    );
     expect(index).toContain('export const createLibraryFixture = async (');
     expect(index).toContain('options: SurfaceLibraryOptions = {}');
-    expect(index).toContain(
-      'const client = await surface(fixtureApp, options);'
-    );
+    expect(index).toContain('const client = await createClient(options);');
     expect(index).toContain('Get a widget by id.');
     expect(index).toContain('widgetGet: (\n      input: unknown');
     expect(index).toContain('widgetAdd: (\n      input: unknown');
-    // The generated code imports the source topo by the configured specifier.
-    expect(index).toContain("import { fixtureApp } from '@fixture/app';");
+    // The generated client shares one held surface through the local topo subpath.
+    expect(
+      fileContent(compile(fixtureApp, options), 'src/client.ts')
+    ).toContain("import { app } from './trails.js';");
   });
 
   test('result subpath mirrors exports as no-throw methods', () => {
     const result = fileContent(compile(fixtureApp, options), 'src/result.ts');
     expect(result).toContain(
-      "import { runLibraryResult, surface } from '@ontrails/library';"
+      "import { runLibraryResult } from '@ontrails/library';"
     );
     expect(result).toContain(
       'import type { LibraryError, Result, SurfaceLibraryOptions }'
     );
-    expect(result).toContain('const resultClient = await surface(fixtureApp);');
+    expect(result).toContain(
+      "import { createClient, rootClient } from './client.js';"
+    );
+    expect(result).toContain('const resultClient = rootClient;');
     expect(result).toContain('export const widgetPing = (');
     expect(result).toContain(
       'Returns the raw Result boundary for trail `widget.ping`.'
@@ -103,10 +115,19 @@ describe('compile', () => {
     expect(result).toContain(
       'resultClient.result.widgetPing(input) as Promise<Result<unknown, LibraryError>>;'
     );
+    expect(result).toContain('input: Record<string, unknown>');
     expect(result).toContain('export const createLibraryFixture = async (');
     expect(result).toContain('client.result.widgetGet(input)');
-    expect(result).toContain(
-      ') => runLibraryResult(fixtureApp, id, input, options);'
+    expect(result).toContain(') => runLibraryResult(app, id, input, options);');
+  });
+
+  test('client module owns the generated surface initialization', () => {
+    const client = fileContent(compile(fixtureApp, options), 'src/client.ts');
+    expect(client).toContain("import { surface } from '@ontrails/library';");
+    expect(client).toContain("import { app } from './trails.js';");
+    expect(client).toContain('export const rootClient = await surface(app);');
+    expect(client).toContain(
+      'export const createClient = (options: SurfaceLibraryOptions = {}) =>'
     );
   });
 
@@ -118,6 +139,9 @@ describe('compile', () => {
     );
     expect(schemas).toContain(
       'export const widgetPingInputSchema = requireExport'
+    );
+    expect(schemas).toContain(
+      'export const widgetAuditedInputSchema = requireExport'
     );
     expect(schemas).toContain(
       'export const widgetPingOutputSchema = requireExport'
@@ -170,6 +194,7 @@ describe('compile', () => {
     );
     expect(index).toContain('input: WidgetGetInput');
     expect(index).toContain('): Promise<WidgetGetOutput> =>');
+    expect(index).toContain('input: Record<string, unknown>');
 
     const result = fileContent(typed, 'src/result.ts');
     expect(result).toContain('input: WidgetPingInput');
@@ -208,7 +233,7 @@ describe('compile', () => {
 
   test('carries the resolved projection on the result', () => {
     const result = compile(fixtureApp, options);
-    expect(result.projection.exports).toHaveLength(5);
+    expect(result.projection.exports).toHaveLength(6);
     expect(result.projection.app).toBe('library-fixture');
   });
 });

--- a/packages/library/src/__tests__/derive.test.ts
+++ b/packages/library/src/__tests__/derive.test.ts
@@ -11,6 +11,7 @@ describe('deriveLibraryApi', () => {
     expect(projection.app).toBe('library-fixture');
     expect(projection.exports.map((entry) => entry.exportName)).toEqual([
       'widgetAdd',
+      'widgetAudited',
       'widgetCheck',
       'widgetGet',
       'widgetGreet',
@@ -50,6 +51,18 @@ describe('deriveLibraryApi', () => {
     expect(byName.get('widgetAdd')?.resources).toEqual(['widget.store']);
     expect(byName.get('widgetPing')?.resources).toEqual([]);
     expect(byName.get('widgetCheck')?.resources).toEqual([]);
+    expect(byName.get('widgetAudited')?.layerInputs).toHaveLength(1);
+    expect(
+      byName
+        .get('widgetAudited')
+        ?.layerInputs[0]?.fields.map((field) => [
+          field.claimedName,
+          field.routingTarget,
+        ])
+    ).toEqual([
+      ['auditMessage', 'message'],
+      ['auditToken', 'token'],
+    ]);
 
     // Intent is carried verbatim (no fallback); write/read preserved.
     expect(byName.get('widgetAdd')?.intent).toBe('write');
@@ -93,6 +106,7 @@ describe('deriveLibraryApi', () => {
       include: ['widget.*'],
     });
     expect(projection.exports.map((entry) => entry.exportName)).toEqual([
+      'widgetAudited',
       'widgetCheck',
       'widgetGet',
       'widgetGreet',

--- a/packages/library/src/__tests__/errors.test.ts
+++ b/packages/library/src/__tests__/errors.test.ts
@@ -1,31 +1,72 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  AuthError,
+  CancelledError,
+  ConflictError,
   InternalError,
   NetworkError,
   NotFoundError,
+  PermissionError,
+  RateLimitError,
+  TimeoutError,
   ValidationError,
+  WorkspaceShiftError,
 } from '@ontrails/core';
 
 import {
+  LibraryAuthError,
+  LibraryCancelledError,
+  LibraryConflictError,
   LibraryInternalError,
   LibraryNetworkError,
   LibraryNotFoundError,
+  LibraryPermissionError,
+  LibraryRateLimitError,
+  LibraryShiftError,
+  LibraryTimeoutError,
   LibraryValidationError,
   toLibraryError,
 } from '../errors.js';
 
 describe('library error mapping', () => {
   test('maps TrailsError categories to package-facing error classes', () => {
-    expect(toLibraryError(new ValidationError('bad'))).toBeInstanceOf(
-      LibraryValidationError
-    );
-    expect(toLibraryError(new NotFoundError('missing'))).toBeInstanceOf(
-      LibraryNotFoundError
-    );
-    expect(toLibraryError(new NetworkError('offline'))).toBeInstanceOf(
-      LibraryNetworkError
-    );
+    const cases = [
+      {
+        ErrorClass: LibraryValidationError,
+        error: new ValidationError('bad'),
+      },
+      {
+        ErrorClass: LibraryNotFoundError,
+        error: new NotFoundError('missing'),
+      },
+      { ErrorClass: LibraryConflictError, error: new ConflictError('dupe') },
+      {
+        ErrorClass: LibraryPermissionError,
+        error: new PermissionError('denied'),
+      },
+      { ErrorClass: LibraryTimeoutError, error: new TimeoutError('slow') },
+      {
+        ErrorClass: LibraryRateLimitError,
+        error: new RateLimitError('wait'),
+      },
+      { ErrorClass: LibraryNetworkError, error: new NetworkError('offline') },
+      {
+        ErrorClass: LibraryShiftError,
+        error: new WorkspaceShiftError('workspace moved'),
+      },
+      { ErrorClass: LibraryInternalError, error: new InternalError('boom') },
+      { ErrorClass: LibraryAuthError, error: new AuthError('login') },
+      { ErrorClass: LibraryCancelledError, error: new CancelledError('stop') },
+    ] as const;
+
+    for (const { ErrorClass, error } of cases) {
+      const mapped = toLibraryError(error);
+      expect(mapped).toBeInstanceOf(ErrorClass);
+      expect(mapped.category).toBe(error.category);
+      expect(mapped.retryable).toBe(error.retryable);
+      expect(mapped.originalName).toBe(error.name);
+    }
   });
 
   test('preserves category, retryability, and original Trails error name', () => {

--- a/packages/library/src/__tests__/fixture.test.ts
+++ b/packages/library/src/__tests__/fixture.test.ts
@@ -1,8 +1,16 @@
 /* oxlint-disable eslint-plugin-jest/require-hook -- testExamples registers tests at module scope. */
 import { testExamples } from '@ontrails/testing';
+import { LAYER_INPUTS_KEY } from '@ontrails/core';
 
 import { fixtureApp } from './fixtures/app.js';
 
 testExamples(fixtureApp, {
-  ctx: { permit: { id: 'library-fixture', scopes: ['widget:write'] } },
+  ctx: {
+    extensions: {
+      [LAYER_INPUTS_KEY]: {
+        audit: { message: 'default audit', token: 'default token' },
+      },
+    },
+    permit: { id: 'library-fixture', scopes: ['widget:write'] },
+  },
 });

--- a/packages/library/src/__tests__/fixtures/trails.ts
+++ b/packages/library/src/__tests__/fixtures/trails.ts
@@ -4,7 +4,15 @@
  * resource-free or happy-path-only assumptions. Each trail exercises one
  * projection path the foundation must prove.
  */
-import { NotFoundError, Result, resource, signal, trail } from '@ontrails/core';
+import {
+  LAYER_INPUTS_KEY,
+  NotFoundError,
+  Result,
+  resource,
+  signal,
+  trail,
+} from '@ontrails/core';
+import type { Layer } from '@ontrails/core';
 import { z } from 'zod';
 
 // --- resource with a mock factory (testAll works without configuration) ---
@@ -174,6 +182,52 @@ export const greet = trail('widget.greet', {
       status: { state: 'archived' },
     },
   },
+});
+
+export const auditLayer: Layer = {
+  input: z.object({
+    message: z.string().default('default audit'),
+    token: z.string().default('default token'),
+  }),
+  name: 'audit',
+  wrap: (_trail, implementation) => async (input, ctx) =>
+    await implementation(input, ctx),
+};
+
+// --- typed layer input: library projects and routes layer fields ---
+
+export const audited = trail('widget.audited', {
+  blaze: (input, ctx) => {
+    const layers = ctx.extensions?.[LAYER_INPUTS_KEY] as
+      | Record<string, { readonly message?: string; readonly token?: string }>
+      | undefined;
+    return Result.ok({
+      auditMessage: layers?.['audit']?.message,
+      auditToken: layers?.['audit']?.token,
+      message: input.message,
+    });
+  },
+  description:
+    'Audited widget call; proves library projection includes typed layer inputs.',
+  examples: [
+    {
+      expected: {
+        auditMessage: 'default audit',
+        auditToken: 'default token',
+        message: 'hello',
+      },
+      input: { message: 'hello' },
+      name: 'audited',
+    },
+  ],
+  input: z.object({ message: z.string() }),
+  intent: 'read',
+  layers: [auditLayer],
+  output: z.object({
+    auditMessage: z.string(),
+    auditToken: z.string(),
+    message: z.string(),
+  }),
 });
 
 // --- internal visibility: MUST be excluded from the projection ---

--- a/packages/library/src/__tests__/surface.test.ts
+++ b/packages/library/src/__tests__/surface.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { LibraryError, LibraryNotFoundError } from '../errors.js';
-import { surface } from '../surface.js';
+import { runLibraryResult, surface } from '../surface.js';
 import type {
   LibraryClient,
   LibraryMethod,
@@ -39,6 +39,7 @@ describe('library surface', () => {
     const lib = await surface(fixtureApp, surfaceOptions);
     expect(Object.keys(lib.call).toSorted()).toEqual([
       'widgetAdd',
+      'widgetAudited',
       'widgetCheck',
       'widgetGet',
       'widgetGreet',
@@ -94,6 +95,51 @@ describe('library surface', () => {
     expect(await requireMethod(lib, 'widgetCheck')({ name: '' })).toEqual({
       issues: ['name is empty'],
       status: 'fail',
+    });
+  });
+
+  test('projects and routes typed layer inputs through the library call', async () => {
+    const lib = await surface(fixtureApp, surfaceOptions);
+
+    await expect(
+      requireMethod(
+        lib,
+        'widgetAudited'
+      )({
+        auditMessage: 42,
+        auditToken: 'secret',
+        message: 'hello',
+      })
+    ).rejects.toThrow('Invalid input');
+
+    await expect(
+      requireMethod(
+        lib,
+        'widgetAudited'
+      )({
+        auditMessage: 'logged',
+        auditToken: 'secret',
+        message: 'hello',
+      })
+    ).resolves.toEqual({
+      auditMessage: 'logged',
+      auditToken: 'secret',
+      message: 'hello',
+    });
+  });
+
+  test('direct Result helper applies the same layer input projection', async () => {
+    const result = await runLibraryResult(fixtureApp, 'widget.audited', {
+      auditMessage: 'logged',
+      auditToken: 'secret',
+      message: 'hello',
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect(result.value).toEqual({
+      auditMessage: 'logged',
+      auditToken: 'secret',
+      message: 'hello',
     });
   });
 

--- a/packages/library/src/compile.ts
+++ b/packages/library/src/compile.ts
@@ -141,8 +141,15 @@ const resolveTypeBindings = (
   return bindings;
 };
 
-const inputTypeFor = (entry: LibraryExport, bindings: TypeBindings): string =>
-  bindings.get(entry.trailId)?.input ?? 'unknown';
+const inputTypeFor = (entry: LibraryExport, bindings: TypeBindings): string => {
+  const input = bindings.get(entry.trailId)?.input;
+  if (entry.layerInputs.length === 0) {
+    return input ?? 'unknown';
+  }
+  return input === undefined
+    ? 'Record<string, unknown>'
+    : `${input} & Record<string, unknown>`;
+};
 
 const outputTypeFor = (entry: LibraryExport, bindings: TypeBindings): string =>
   bindings.get(entry.trailId)?.output ?? 'unknown';
@@ -194,6 +201,7 @@ const statelessFunction = (
     `export const ${entry.exportName} = (`,
     `  input: ${inputTypeFor(entry, bindings)}`,
     `): Promise<${outputTypeFor(entry, bindings)}> =>`,
+    '  // The runtime validates declared output schemas before this unwrap returns.',
     `  rootClient.call.${entry.exportName}(input) as Promise<${outputTypeFor(entry, bindings)}>;`,
   ].join('\n');
 
@@ -209,27 +217,23 @@ const factoryMethod = (entry: LibraryExport, bindings: TypeBindings): string =>
     `    ${entry.exportName}: (`,
     `      input: ${inputTypeFor(entry, bindings)}`,
     `    ): Promise<${outputTypeFor(entry, bindings)}> =>`,
+    '      // The runtime validates declared output schemas before this unwrap returns.',
     `      client.call.${entry.exportName}(input) as Promise<${outputTypeFor(entry, bindings)}>,`,
   ].join('\n');
 
 const generateIndex = (
   projection: LibraryProjection,
-  options: CompileOptions,
   bindings: TypeBindings
 ): string => {
-  const appExport = options.appExportName ?? 'app';
   const stateless = statelessExports(projection);
   const resourceful = resourceExports(projection);
   const typedSchemas = schemaTypeImport(projection, bindings);
 
   const parts: string[] = [
-    "import { surface } from '@ontrails/library';",
     "import type { SurfaceLibraryOptions } from '@ontrails/library';",
     ...(typedSchemas ? [typedSchemas] : []),
     '',
-    `import { ${appExport} } from '${options.appImportPath}';`,
-    '',
-    `const rootClient = await surface(${appExport});`,
+    "import { createClient, rootClient } from './client.js';",
   ];
 
   for (const entry of stateless) {
@@ -242,7 +246,7 @@ const generateIndex = (
       `export const ${factoryName(projection)} = async (`,
       '  options: SurfaceLibraryOptions = {}',
       ') => {',
-      `  const client = await surface(${appExport}, options);`,
+      '  const client = await createClient(options);',
       '  return {',
       resourceful.map((entry) => factoryMethod(entry, bindings)).join('\n'),
       '  };',
@@ -252,6 +256,19 @@ const generateIndex = (
 
   return `${parts.join('\n')}\n`;
 };
+
+const generateClient = (): string =>
+  [
+    "import { surface } from '@ontrails/library';",
+    "import type { SurfaceLibraryOptions } from '@ontrails/library';",
+    '',
+    `import { app } from './trails.js';`,
+    '',
+    'export const rootClient = await surface(app);',
+    'export const createClient = (options: SurfaceLibraryOptions = {}) =>',
+    '  surface(app, options);',
+    '',
+  ].join('\n');
 
 const generateSchemas = (
   projection: LibraryProjection,
@@ -264,13 +281,15 @@ const generateSchemas = (
   );
   const sourceTypeExports = [
     ...new Set(
-      typedEntries.map(
-        (entry) => bindings.get(entry.trailId)?.sourceExport ?? ''
-      )
+      typedEntries.map((entry) => {
+        const binding = bindings.get(entry.trailId);
+        if (binding === undefined) {
+          throw new Error(`missing type binding for trail "${entry.trailId}"`);
+        }
+        return binding.sourceExport;
+      })
     ),
-  ]
-    .filter((name) => name.length > 0)
-    .toSorted((left, right) => left.localeCompare(right));
+  ].toSorted((left, right) => left.localeCompare(right));
   const lines = [
     `import { ${appExport} } from './trails.js';`,
     "import { deriveLibraryApi } from '@ontrails/library';",
@@ -353,6 +372,7 @@ const resultStatelessFunction = (
     `export const ${entry.exportName} = (`,
     `  input: ${inputTypeFor(entry, bindings)}`,
     `): Promise<Result<${outputTypeFor(entry, bindings)}, LibraryError>> =>`,
+    '  // The runtime validates declared output schemas before this Result resolves.',
     `  resultClient.result.${entry.exportName}(input) as Promise<Result<${outputTypeFor(entry, bindings)}, LibraryError>>;`,
   ].join('\n');
 
@@ -371,27 +391,27 @@ const resultFactoryMethod = (
     `    ${entry.exportName}: (`,
     `      input: ${inputTypeFor(entry, bindings)}`,
     `    ): Promise<Result<${outputTypeFor(entry, bindings)}, LibraryError>> =>`,
+    '      // The runtime validates declared output schemas before this Result resolves.',
     `      client.result.${entry.exportName}(input) as Promise<Result<${outputTypeFor(entry, bindings)}, LibraryError>>,`,
   ].join('\n');
 
 const generateResult = (
   projection: LibraryProjection,
-  options: CompileOptions,
   bindings: TypeBindings
 ): string => {
-  const appExport = options.appExportName ?? 'app';
   const stateless = statelessExports(projection);
   const resourceful = resourceExports(projection);
   const typedSchemas = schemaTypeImport(projection, bindings);
   const parts = [
     '// No-throw API: returns the Result envelope instead of unwrapping.',
-    "import { runLibraryResult, surface } from '@ontrails/library';",
+    "import { runLibraryResult } from '@ontrails/library';",
     "import type { LibraryError, Result, SurfaceLibraryOptions } from '@ontrails/library';",
     ...(typedSchemas ? [typedSchemas] : []),
     '',
-    `import { ${appExport} } from '${options.appImportPath}';`,
+    "import { createClient, rootClient } from './client.js';",
+    "import { app } from './trails.js';",
     '',
-    `const resultClient = await surface(${appExport});`,
+    'const resultClient = rootClient;',
   ];
 
   for (const entry of stateless) {
@@ -404,7 +424,7 @@ const generateResult = (
       `export const ${factoryName(projection)} = async (`,
       '  options: SurfaceLibraryOptions = {}',
       ') => {',
-      `  const client = await surface(${appExport}, options);`,
+      '  const client = await createClient(options);',
       '  return {',
       resourceful
         .map((entry) => resultFactoryMethod(entry, bindings))
@@ -420,7 +440,7 @@ const generateResult = (
     '  id: string,',
     '  input: unknown,',
     '  options: SurfaceLibraryOptions = {}',
-    `) => runLibraryResult(${appExport}, id, input, options);`,
+    ') => runLibraryResult(app, id, input, options);',
     ''
   );
 
@@ -435,7 +455,6 @@ const generateTsconfig = (): string =>
         moduleResolution: 'bundler',
         strict: true,
         target: 'esnext',
-        types: ['bun'],
       },
       include: ['src'],
     },
@@ -466,11 +485,15 @@ export const compile = (
     { content: generatePackageJson(options), path: 'package.json' },
     { content: generateTsconfig(), path: 'tsconfig.json' },
     {
-      content: generateIndex(projection, options, typeBindings),
+      content: generateClient(),
+      path: 'src/client.ts',
+    },
+    {
+      content: generateIndex(projection, typeBindings),
       path: 'src/index.ts',
     },
     {
-      content: generateResult(projection, options, typeBindings),
+      content: generateResult(projection, typeBindings),
       path: 'src/result.ts',
     },
     {

--- a/packages/library/src/derive.ts
+++ b/packages/library/src/derive.ts
@@ -8,8 +8,11 @@
  * selection. Pure — no fs/network/db reads (derive* purity contract).
  */
 import { filterSurfaceTrails, isDraftId } from '@ontrails/core';
-import type { Topo, Trail } from '@ontrails/core';
+import type { Layer, Topo, Trail } from '@ontrails/core';
 import type { ZodType } from 'zod';
+
+import { projectLibraryInput } from './layer-input.js';
+import type { LibraryLayerInputProjection } from './layer-input.js';
 
 type AnyTrail = Trail<unknown, unknown, unknown>;
 
@@ -39,6 +42,8 @@ export interface LibraryExport {
    * the projection is persisted to the artifact family.
    */
   readonly input: ZodType;
+  /** Layer input routing projected onto this export's public library input. */
+  readonly layerInputs: readonly LibraryLayerInputProjection[];
   /** Output schema reference, when the trail declares one. */
   readonly output: ZodType | undefined;
   /**
@@ -92,6 +97,8 @@ export interface DeriveLibraryApiOptions {
   readonly include?: readonly string[];
   /** Exclude patterns. */
   readonly exclude?: readonly string[];
+  /** Surface-scope layers to project alongside each trail's own input. */
+  readonly layers?: readonly Layer[] | undefined;
 }
 
 /**
@@ -176,11 +183,13 @@ export const deriveLibraryApi = (
       continue;
     }
     namesToTrailIds.set(exportName, [trail.id]);
+    const inputProjection = projectLibraryInput(graph, trail, options.layers);
     exports.push({
       description: trail.description,
       exportName,
-      input: trail.input,
+      input: inputProjection.input,
       intent: trail.intent,
+      layerInputs: inputProjection.layers,
       nameSource: 'derived',
       output: trail.output,
       resources: trail.resources.map((resource) => resource.id),

--- a/packages/library/src/kernel.ts
+++ b/packages/library/src/kernel.ts
@@ -18,17 +18,30 @@
  * emitter lanes land. Keep it minimal and dependency-light on purpose.
  */
 import { run } from '@ontrails/core';
-import type { Result, Topo, TrailContextInit } from '@ontrails/core';
+import type {
+  Result,
+  RunOptions,
+  Topo,
+  TrailContextInit,
+} from '@ontrails/core';
 
 export type { Result, Topo, TrailContextInit };
 
-/** Runtime options the kernel forwards to execution (permit, abort, etc.). */
-export interface KernelRunOptions {
-  /** Partial context merged on top of the base context (e.g. `{ permit }`). */
-  readonly ctx?: Partial<TrailContextInit> | undefined;
-  /** Abort signal for the execution. */
-  readonly abortSignal?: AbortSignal | undefined;
-}
+/** Runtime options the kernel forwards to execution (permit, abort, layers, etc.). */
+export type KernelRunOptions = Pick<
+  RunOptions,
+  | 'abortSignal'
+  | 'configValues'
+  | 'createContext'
+  | 'ctx'
+  | 'dryRun'
+  | 'layerInputs'
+  | 'permit'
+  | 'resources'
+  | 'surfaceLayers'
+  | 'topoLayers'
+  | 'version'
+>;
 
 /**
  * Execute a trail by id through the shared Trails pipeline. Never throws —

--- a/packages/library/src/layer-input.ts
+++ b/packages/library/src/layer-input.ts
@@ -1,0 +1,188 @@
+import type { AttachedTypedLayer, Layer, Topo, Trail } from '@ontrails/core';
+import {
+  LAYER_FIELD_RESERVED_NAMES,
+  collectAttachedTypedLayers,
+  projectLayerFieldName,
+  zodToJsonSchema,
+} from '@ontrails/core';
+import { z } from 'zod';
+
+type AnyTrail = Trail<unknown, unknown, unknown>;
+type MutableLayerShape = Record<string, z.ZodRawShape[string]>;
+
+export interface LibraryLayerFieldProjection {
+  readonly claimedName: string;
+  readonly routingTarget: string;
+}
+
+export interface LibraryLayerInputProjection {
+  readonly fields: readonly LibraryLayerFieldProjection[];
+  readonly input: z.ZodObject<z.ZodRawShape>;
+  readonly layerName: string;
+}
+
+export interface LibraryInputProjection {
+  readonly input: z.ZodType;
+  readonly layers: readonly LibraryLayerInputProjection[];
+}
+
+const isJsonObjectSchema = (
+  value: unknown
+): value is { properties?: Record<string, unknown> } =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isObjectRecord = (
+  value: unknown
+): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const capitalized = (value: string): string => {
+  if (value.length === 0) {
+    return value;
+  }
+  return `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+};
+
+const buildLibraryRenameTarget = (
+  layerName: string,
+  originalName: string
+): string => `${layerName}${capitalized(originalName)}`;
+
+const objectPropertiesFor = (schema: z.ZodType): readonly string[] => {
+  const jsonSchema = zodToJsonSchema(schema);
+  if (!isJsonObjectSchema(jsonSchema) || jsonSchema.properties === undefined) {
+    return [];
+  }
+  return Object.keys(jsonSchema.properties);
+};
+
+const isJsonObjectInput = (schema: z.ZodType): boolean =>
+  isJsonObjectSchema(zodToJsonSchema(schema));
+
+const projectLayerInputFields = (
+  attached: AttachedTypedLayer,
+  claimedNames: Set<string>,
+  layerShape: MutableLayerShape
+): LibraryLayerInputProjection => {
+  const { layer } = attached;
+  if (layer.input === undefined) {
+    return { fields: [], input: z.object({}), layerName: layer.name };
+  }
+
+  const fields: LibraryLayerFieldProjection[] = [];
+  for (const [fieldName, fieldSchema] of Object.entries(layer.input.shape)) {
+    const projection = projectLayerFieldName(
+      layer.name,
+      fieldName,
+      fieldName,
+      buildLibraryRenameTarget(layer.name, fieldName),
+      claimedNames,
+      LAYER_FIELD_RESERVED_NAMES
+    );
+    fields.push({
+      claimedName: projection.claimedName,
+      routingTarget: projection.routingTarget,
+    });
+    layerShape[projection.claimedName] = fieldSchema;
+  }
+
+  return { fields, input: layer.input, layerName: layer.name };
+};
+
+/**
+ * Project a trail's public library input: authored trail input plus any typed
+ * layer input fields attached at topo, surface, or trail scope.
+ */
+export const projectLibraryInput = (
+  graph: Topo,
+  trail: AnyTrail,
+  surfaceLayers?: readonly Layer[]
+): LibraryInputProjection => {
+  const attachedLayers = collectAttachedTypedLayers(
+    graph,
+    trail,
+    surfaceLayers
+  );
+  if (attachedLayers.length === 0) {
+    return { input: trail.input, layers: [] };
+  }
+
+  const trailProperties = objectPropertiesFor(trail.input);
+  const claimedNames = new Set(trailProperties);
+  if (trailProperties.length === 0 && !isJsonObjectInput(trail.input)) {
+    throw new Error(
+      `Library layer input projection requires object input for trail "${trail.id}".`
+    );
+  }
+
+  const layerShape: MutableLayerShape = {};
+  const layers: LibraryLayerInputProjection[] = [];
+  for (const attached of attachedLayers) {
+    const projection = projectLayerInputFields(
+      attached,
+      claimedNames,
+      layerShape
+    );
+    if (projection.fields.length > 0) {
+      layers.push(projection);
+    }
+  }
+
+  if (layers.length === 0) {
+    return { input: trail.input, layers: [] };
+  }
+
+  return {
+    input: trail.input.and(z.object(layerShape)),
+    layers,
+  };
+};
+
+/**
+ * Split a library method input back into trail input plus per-layer runtime
+ * input slots using the projection routing table.
+ */
+export const partitionLibraryInput = (
+  input: unknown,
+  projections: readonly LibraryLayerInputProjection[]
+): {
+  readonly layerInputs: Record<string, unknown>;
+  readonly trailInput: unknown;
+} => {
+  if (projections.length === 0 || !isObjectRecord(input)) {
+    return { layerInputs: {}, trailInput: input };
+  }
+
+  const claimedKeys = new Set<string>();
+  const layerInputs: Record<string, unknown> = {};
+  for (const projection of projections) {
+    const layerInput: Record<string, unknown> = {};
+    let received = false;
+    for (const field of projection.fields) {
+      claimedKeys.add(field.claimedName);
+      const value = input[field.claimedName];
+      if (value === undefined) {
+        continue;
+      }
+      layerInput[field.routingTarget] = value;
+      received = true;
+    }
+    if (received) {
+      layerInputs[projection.layerName] = layerInput;
+      continue;
+    }
+
+    const emptyInput = projection.input.safeParse({});
+    if (emptyInput.success) {
+      layerInputs[projection.layerName] = emptyInput.data;
+    }
+  }
+
+  const trailInput: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (!claimedKeys.has(key)) {
+      trailInput[key] = value;
+    }
+  }
+  return { layerInputs, trailInput };
+};

--- a/packages/library/src/surface.ts
+++ b/packages/library/src/surface.ts
@@ -11,19 +11,28 @@
  * `result` lane with the same export names so downstream package emission can
  * map that lane to the generated `/result` subpath.
  */
+import { Result, ValidationError } from '@ontrails/core';
+
 import { deriveLibraryApi } from './derive.js';
-import type { DeriveLibraryApiOptions, LibraryProjection } from './derive.js';
+import type {
+  DeriveLibraryApiOptions,
+  LibraryExport,
+  LibraryProjection,
+} from './derive.js';
 import { toLibraryError } from './errors.js';
 import type { LibraryError } from './errors.js';
+import { partitionLibraryInput } from './layer-input.js';
 import { kernelRun } from './kernel.js';
-import type { KernelRunOptions, Result, Topo } from './kernel.js';
+import type { KernelRunOptions, Topo } from './kernel.js';
 
 /**
  * Options for the in-memory library surface: projection selectors plus the
  * runtime context the client owns (e.g. a permit for permitted trails).
  */
 export interface SurfaceLibraryOptions
-  extends DeriveLibraryApiOptions, KernelRunOptions {}
+  extends
+    DeriveLibraryApiOptions,
+    Omit<KernelRunOptions, 'layerInputs' | 'surfaceLayers' | 'topoLayers'> {}
 
 /** A callable library method: validated input in, output out, throws on failure. */
 export type LibraryMethod = (input: unknown) => Promise<unknown>;
@@ -43,13 +52,67 @@ export interface LibraryClient {
   readonly projection: LibraryProjection;
 }
 
+const prepareLibraryInput = (
+  entry: LibraryExport,
+  input: unknown
+):
+  | {
+      readonly layerInputs: Record<string, unknown>;
+      readonly trailInput: unknown;
+    }
+  | ValidationError => {
+  const parsed = entry.input.safeParse(input);
+  if (!parsed.success) {
+    return new ValidationError(
+      `Invalid input for library export '${entry.exportName}': ${parsed.error.message}`,
+      {
+        cause: parsed.error,
+        context: { issues: parsed.error.issues, trailId: entry.trailId },
+      }
+    );
+  }
+  return partitionLibraryInput(parsed.data, entry.layerInputs);
+};
+
+const runtimeOptionsFor = (
+  graph: Topo,
+  options: SurfaceLibraryOptions
+): KernelRunOptions => ({
+  abortSignal: options.abortSignal,
+  configValues: options.configValues,
+  createContext: options.createContext,
+  ctx: options.ctx,
+  dryRun: options.dryRun,
+  permit: options.permit,
+  resources: options.resources,
+  surfaceLayers: options.layers,
+  topoLayers: graph.layers,
+  version: options.version,
+});
+
 export const runLibraryResult = async (
   graph: Topo,
   id: string,
   input: unknown,
-  options: KernelRunOptions = {}
+  options: SurfaceLibraryOptions = {}
 ): Promise<Result<unknown, LibraryError>> => {
-  const outcome = await kernelRun(graph, id, input, options);
+  const projection = deriveLibraryApi(graph, options);
+  const runOptions = runtimeOptionsFor(graph, options);
+  const entry = projection.exports.find(
+    (candidate) => candidate.trailId === id
+  );
+  const prepared = entry
+    ? prepareLibraryInput(entry, input)
+    : { layerInputs: {}, trailInput: input };
+  if (prepared instanceof ValidationError) {
+    return Result.err(toLibraryError(prepared));
+  }
+  const outcome = await kernelRun(graph, id, prepared.trailInput, {
+    ...runOptions,
+    ...(Object.keys(prepared.layerInputs).length === 0
+      ? {}
+      : { layerInputs: prepared.layerInputs }),
+  });
   return outcome.mapErr(toLibraryError);
 };
 
@@ -70,16 +133,29 @@ export const surface = async (
   // oxlint-disable-next-line require-await -- async to match peer surfaces and allow future resource init
 ): Promise<LibraryClient> => {
   const projection = deriveLibraryApi(graph, options);
-  const runOptions: KernelRunOptions = {
-    abortSignal: options.abortSignal,
-    ctx: options.ctx,
-  };
+  const runOptions = runtimeOptionsFor(graph, options);
   const call: Record<string, LibraryMethod> = {};
   const result: Record<string, LibraryResultMethod> = {};
 
   for (const entry of projection.exports) {
-    const runExport: LibraryResultMethod = (input: unknown) =>
-      runLibraryResult(graph, entry.trailId, input, runOptions);
+    const runExport: LibraryResultMethod = async (input: unknown) => {
+      const prepared = prepareLibraryInput(entry, input);
+      if (prepared instanceof ValidationError) {
+        return Result.err(toLibraryError(prepared));
+      }
+      const outcome = await kernelRun(
+        graph,
+        entry.trailId,
+        prepared.trailInput,
+        {
+          ...runOptions,
+          ...(Object.keys(prepared.layerInputs).length === 0
+            ? {}
+            : { layerInputs: prepared.layerInputs }),
+        }
+      );
+      return outcome.mapErr(toLibraryError);
+    };
     result[entry.exportName] = runExport;
 
     call[entry.exportName] = async (input: unknown): Promise<unknown> => {


### PR DESCRIPTION
## Context

Follow-up cleanup for the library surface finish-up: close the remaining typed layer input projection gap, remove generated Bun ambient type assumptions, and avoid duplicate generated surface initialization across root and result entrypoints.

## What changed

- Projects typed layer inputs into library public input schemas, then routes layer-owned fields back into per-layer runtime input slots.
- Shares one generated `src/client.ts` held surface across root and `/result` generated modules.
- Removes generated `tsconfig` Bun `types` assumptions.
- Hardens library error mapping coverage and compile/surface smoke tests.
- Adds a branch-local `@ontrails/library` patch changeset.

## Verification

- `bun test packages/library/src/__tests__/errors.test.ts packages/library/src/__tests__/surface.test.ts packages/library/src/__tests__/compile.test.ts packages/library/src/__tests__/compile-smoke.test.ts`
- `bun run --cwd packages/library typecheck`
- `bun run --cwd packages/library lint`
- `bun run format:check`
- `bun run library:smoke`
- `bun run library:dogfood:warden`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `git diff --check`
- Graphite pre-push hook passed
- GitHub CI green on #760

## Notes

Warden still reports the existing Wayfinder internal-trail warnings; no new Warden errors were introduced.