### PR TITLE
feat: add release policy automation

### DIFF
--- a/.changeset/trl-999-release-policy.md
+++ b/.changeset/trl-999-release-policy.md
@@ -1,0 +1,7 @@
+---
+'@ontrails/trails': minor
+---
+
+Add generated release PR policy automation with managed publish/channel/release
+labels, stack-boundary source evidence, and inverse active-changeset release
+fact validation.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,166 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  version:
+    name: Version Packages
+    if: github.repository == 'outfitter-dev/trails' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    outputs:
+      has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+      - name: Create or update version PR
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          commit: 'chore(release): version packages'
+          title: 'chore(release): version packages'
+          version: bun run version:packages
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Label version PR
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bun run publish:label-release-pr
+
+  publish-policy:
+    name: Publish Policy
+    needs: version
+    if: github.repository == 'outfitter-dev/trails' && github.ref == 'refs/heads/main' && needs.version.outputs.has_changesets == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      contents: read
+      pull-requests: read
+    outputs:
+      channel: ${{ steps.policy.outputs.channel }}
+      create_github_release: ${{ steps.policy.outputs.create_github_release }}
+      decision: ${{ steps.policy.outputs.decision }}
+      publish: ${{ steps.policy.outputs.publish }}
+      release: ${{ steps.policy.outputs.release }}
+      should_publish: ${{ steps.policy.outputs.should_publish }}
+      tag: ${{ steps.policy.outputs.tag }}
+      version: ${{ steps.policy.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+      - name: Resolve publish policy
+        id: policy
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TRAILS_RELEASE_POLICY_CI_ATTEMPTS: '30'
+          TRAILS_RELEASE_POLICY_CI_WAIT_MS: '10000'
+        run: bun run publish:policy
+
+  publish-auto:
+    name: Publish to npm automatically
+    needs: publish-policy
+    if: github.repository == 'outfitter-dev/trails' && github.ref == 'refs/heads/main' && needs.publish-policy.outputs.decision == 'auto' && needs.publish-policy.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    environment: npm-auto
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+      - name: Validate package before publish
+        run: bun run publish:check
+      - name: Publish packages
+        run: bun run publish:packages
+      - name: Verify published packages
+        run: bun run publish:registry-check:published --tag "${{ needs.publish-policy.outputs.tag }}"
+
+  publish:
+    name: Publish to npm manually
+    needs: publish-policy
+    if: github.repository == 'outfitter-dev/trails' && github.ref == 'refs/heads/main' && needs.publish-policy.outputs.decision == 'manual' && needs.publish-policy.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+      - name: Validate package before publish
+        run: bun run publish:check
+      - name: Publish packages
+        run: bun run publish:packages
+      - name: Verify published packages
+        run: bun run publish:registry-check:published --tag "${{ needs.publish-policy.outputs.tag }}"
+
+  github-release:
+    name: Create GitHub Release
+    needs: [publish-policy, publish-auto, publish]
+    if: always() && github.repository == 'outfitter-dev/trails' && github.ref == 'refs/heads/main' && needs.publish-policy.result == 'success' && needs.publish-policy.outputs.create_github_release == 'true' && (needs.publish-policy.outputs.should_publish == 'false' || needs.publish-auto.result == 'success' || needs.publish.result == 'success')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Create GitHub release
+        env:
+          DIST_TAG: ${{ needs.publish-policy.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.publish-policy.outputs.version }}
+        run: |
+          create_args=()
+          if [ "$DIST_TAG" != "latest" ]; then
+            create_args+=(--prerelease --latest=false)
+          else
+            create_args+=(--latest)
+          fi
+
+          tag="v$VERSION"
+          notes="Published @ontrails/* packages at $VERSION to npm with dist-tag \`$DIST_TAG\`."
+          version_target="$(git log -n 1 --format=%H -S "\"version\": \"$VERSION\"" -- apps/trails/package.json)"
+          if [ -z "$version_target" ]; then
+            echo "Could not resolve commit that introduced apps/trails/package.json version $VERSION" >&2
+            exit 1
+          fi
+
+          git fetch --force --tags origin
+          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+            tag_target="$(git rev-list -n 1 "$tag")"
+            if [ "$tag_target" != "$version_target" ]; then
+              echo "$tag points to $tag_target, expected $version_target" >&2
+              exit 1
+            fi
+          else
+            git tag "$tag" "$version_target"
+            git push origin "refs/tags/$tag"
+          fi
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "GitHub release $tag already exists"
+          else
+            gh release create "$tag" \
+              --verify-tag \
+              --title "Trails v$VERSION" \
+              --notes "$notes" \
+              "${create_args[@]}"
+          fi

--- a/apps/trails/src/__tests__/release-check.test.ts
+++ b/apps/trails/src/__tests__/release-check.test.ts
@@ -202,6 +202,56 @@ describe('checkReleaseRules', () => {
     }
   });
 
+  test('rejects active package changesets without a matching release fact', () => {
+    const { repoRoot } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'repo-only.md'),
+        "---\n'@ontrails/core': patch\n---\n\nRepo-only note.\n"
+      );
+    });
+
+    try {
+      const result = checkReleaseRules({
+        changedFiles: [
+          'docs/releases/release-rules-check.md',
+          '.changeset/repo-only.md',
+        ],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.activePackageChangesetsWithoutReleaseFacts).toEqual([
+        '.changeset/repo-only.md',
+      ]);
+      expect(result.errors).toEqual([
+        'Active changesets require a matching package or release fact on this branch. Remove .changeset/repo-only.md or include the package-facing change here.',
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('ignores deleted changesets when checking active release intent', () => {
+    const { repoRoot } = withTempRepo(() => {});
+
+    try {
+      const result = checkReleaseRules({
+        changedFiles: [
+          'docs/releases/release-rules-check.md',
+          '.changeset/deleted.md',
+        ],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.activePackageChangesetsWithoutReleaseFacts).toEqual([]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
   test('does not treat prerelease state plus source edits as a generated version release', () => {
     const { repoRoot } = withTempRepo(() => {});
 

--- a/apps/trails/src/__tests__/release-policy.test.ts
+++ b/apps/trails/src/__tests__/release-policy.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  evaluateReleasePolicy,
+  labelsForReleasePullRequest,
+  releaseIntentForVersionDelta,
+} from '../release/policy.js';
+import type { ReleasePolicyInput } from '../release/policy.js';
+
+const botCommit = {
+  authorEmail: '41898282+github-actions[bot]@users.noreply.github.com',
+  authorName: 'github-actions[bot]',
+  committerEmail: 'noreply@github.com',
+  committerName: 'GitHub',
+  subject: 'chore(release): version packages (#123)',
+};
+
+const releasePr = {
+  baseRefName: 'main',
+  body: '',
+  comments: [],
+  headRefName: 'changeset-release/main',
+  labels: ['publish:auto', 'channel:beta', 'release:patch'],
+  number: 123,
+  title: 'chore(release): version packages',
+  userLogin: 'github-actions[bot]',
+};
+
+const baseInput = (
+  overrides: Partial<ReleasePolicyInput> = {}
+): ReleasePolicyInput => ({
+  changedFiles: [
+    { path: '.changeset/core.md', status: 'D' },
+    { path: '.changeset/pre.json', status: 'M' },
+    { path: 'apps/trails/package.json', status: 'M' },
+    { path: 'apps/trails/CHANGELOG.md', status: 'M' },
+    { path: 'packages/core/package.json', status: 'M' },
+    { path: 'packages/core/CHANGELOG.md', status: 'M' },
+  ],
+  ciPassed: true,
+  commit: botCommit,
+  distTag: 'beta',
+  previousVersion: '1.0.0-beta.18',
+  ref: 'refs/heads/main',
+  registryPackages: [
+    {
+      expectedTagVersion: '1.0.0-beta.18',
+      name: '@ontrails/core',
+      status: 'published',
+      version: '1.0.0-beta.19',
+    },
+  ],
+  releasePullRequest: releasePr,
+  repository: 'outfitter-dev/trails',
+  sha: 'abc123',
+  sourcePullRequests: [
+    {
+      commitShas: ['abc123'],
+      hasChangeset: true,
+      labels: ['stack:boundary'],
+      number: 99,
+      title: 'feat: add release fact',
+    },
+  ],
+  version: '1.0.0-beta.19',
+  ...overrides,
+});
+
+describe('evaluateReleasePolicy', () => {
+  test('allows publish:auto when generated release and stack evidence are complete', () => {
+    const report = evaluateReleasePolicy(baseInput());
+
+    expect(report.decision).toBe('auto');
+    expect(report.autoEligible).toBe(true);
+    expect(report.shouldPublish).toBe(true);
+    expect(report.blockers).toEqual([]);
+    expect(report.diagnostics).toEqual([]);
+  });
+
+  test('blocks conflicting labels in managed families', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        releasePullRequest: {
+          ...releasePr,
+          labels: ['publish:auto', 'publish:manual', 'channel:beta'],
+        },
+      })
+    );
+
+    expect(report.decision).toBe('block');
+    expect(report.blockers).toContain(
+      'Conflicting publish: labels: publish:auto, publish:manual'
+    );
+  });
+
+  test('blocks unknown managed labels', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        releasePullRequest: {
+          ...releasePr,
+          labels: ['publish:auto', 'channel:nightly', 'release:patch'],
+        },
+      })
+    );
+
+    expect(report.decision).toBe('block');
+    expect(report.blockers).toContain(
+      'Unknown channel: label: channel:nightly'
+    );
+  });
+
+  test('routes missing stack boundary evidence to manual for publish:auto', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        sourcePullRequests: [
+          {
+            commitShas: ['abc123'],
+            hasChangeset: true,
+            labels: [],
+            number: 99,
+            title: 'feat: add release fact',
+          },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe('manual');
+    expect(report.diagnostics).toContain(
+      'publish:auto requires stack:boundary on every changeset source PR in the release range; missing: #99'
+    );
+  });
+
+  test('routes unexpected generated release diff entries to manual', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        changedFiles: [
+          { path: '.changeset/core.md', status: 'D' },
+          { path: 'apps/trails/package.json', status: 'M' },
+          { path: '.github/workflows/release.yml', status: 'M' },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe('manual');
+    expect(report.diagnostics).toContain(
+      'Unexpected release diff entry: M .github/workflows/release.yml'
+    );
+  });
+
+  test('skips publish when registry state is already complete', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        registryPackages: [
+          {
+            expectedTagVersion: '1.0.0-beta.19',
+            name: '@ontrails/core',
+            status: 'published',
+            version: '1.0.0-beta.19',
+          },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe('auto');
+    expect(report.shouldPublish).toBe(false);
+    expect(report.createGitHubRelease).toBe(true);
+  });
+
+  test('blocks registry drift before publication routing', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        registryPackages: [
+          {
+            expectedTagVersion: '1.0.0-beta.20',
+            name: '@ontrails/core',
+            status: 'published',
+            version: '1.0.0-beta.19',
+          },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe('block');
+    expect(report.blockers).toContain(
+      '@ontrails/core: dist-tag beta points to 1.0.0-beta.20, expected 1.0.0-beta.19'
+    );
+  });
+
+  test('blocks already-published versions when the release tag is stale', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        registryPackages: [
+          {
+            expectedTagVersion: '1.0.0-beta.18',
+            name: '@ontrails/core',
+            status: 'published',
+            version: '1.0.0-beta.19',
+            versionPublished: true,
+          },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe('block');
+    expect(report.blockers).toContain(
+      '@ontrails/core: version 1.0.0-beta.19 is already published but dist-tag beta points to 1.0.0-beta.18'
+    );
+  });
+
+  test('orders numeric prerelease identifiers before blocking registry drift', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        previousVersion: '1.0.0-beta.9',
+        registryPackages: [
+          {
+            expectedTagVersion: '1.0.0-beta.9',
+            name: '@ontrails/core',
+            status: 'published',
+            version: '1.0.0-beta.10',
+          },
+        ],
+        version: '1.0.0-beta.10',
+      })
+    );
+
+    expect(report.decision).toBe('auto');
+    expect(report.blockers).toEqual([]);
+  });
+
+  test('requires publish:none audit reason', () => {
+    const blocked = evaluateReleasePolicy(
+      baseInput({
+        releasePullRequest: {
+          ...releasePr,
+          labels: ['publish:none', 'channel:beta'],
+        },
+      })
+    );
+    const allowed = evaluateReleasePolicy(
+      baseInput({
+        releasePullRequest: {
+          ...releasePr,
+          body: 'publish:none because this version PR only cleans generated state.',
+          labels: ['publish:none', 'channel:beta'],
+        },
+      })
+    );
+
+    expect(blocked.decision).toBe('block');
+    expect(allowed.decision).toBe('none');
+    expect(allowed.shouldPublish).toBe(false);
+    expect(allowed.createGitHubRelease).toBe(false);
+  });
+});
+
+describe('labelsForReleasePullRequest', () => {
+  test('fills missing release intent labels without overriding human labels', () => {
+    expect(
+      labelsForReleasePullRequest({
+        currentVersion: '1.0.0-beta.18',
+        existingLabels: [],
+        nextDistTag: 'beta',
+        nextVersion: '1.0.0-beta.19',
+        sourcePullRequests: [
+          {
+            commitShas: ['abc123'],
+            hasChangeset: true,
+            labels: ['stack:boundary'],
+            number: 99,
+            title: 'feat: release fact',
+          },
+        ],
+      })
+    ).toEqual(['publish:auto', 'channel:beta', 'release:patch']);
+
+    expect(
+      labelsForReleasePullRequest({
+        currentVersion: '1.0.0-beta.18',
+        existingLabels: ['publish:block'],
+        nextDistTag: 'beta',
+        nextVersion: '1.0.0-beta.19',
+        sourcePullRequests: [],
+      })
+    ).toEqual(['channel:beta', 'release:patch']);
+  });
+
+  test('maps stable generated versions to the stable channel label', () => {
+    expect(
+      labelsForReleasePullRequest({
+        currentVersion: '1.0.0-beta.19',
+        existingLabels: [],
+        nextDistTag: 'latest',
+        nextVersion: '1.0.0',
+        sourcePullRequests: [
+          {
+            commitShas: ['abc123'],
+            hasChangeset: true,
+            labels: ['stack:boundary'],
+            number: 99,
+            title: 'feat: release fact',
+          },
+        ],
+      })
+    ).toEqual(['publish:auto', 'channel:stable', 'release:patch']);
+  });
+});
+
+describe('releaseIntentForVersionDelta', () => {
+  test('maps semver movement to release labels', () => {
+    expect(releaseIntentForVersionDelta('1.0.0', '1.0.1')).toBe(
+      'release:patch'
+    );
+    expect(releaseIntentForVersionDelta('1.0.0', '1.1.0')).toBe(
+      'release:minor'
+    );
+    expect(releaseIntentForVersionDelta('1.0.0', '2.0.0')).toBe(
+      'release:major'
+    );
+    expect(releaseIntentForVersionDelta('1.0.0-beta.9', '1.0.0-beta.10')).toBe(
+      'release:patch'
+    );
+  });
+});

--- a/apps/trails/src/release/check.ts
+++ b/apps/trails/src/release/check.ts
@@ -34,6 +34,7 @@ export interface ReleaseCheckInput {
 
 export interface ReleaseCheckResult {
   readonly affectedPackages: readonly string[];
+  readonly activePackageChangesetsWithoutReleaseFacts: readonly string[];
   readonly changedChangesets: readonly string[];
   readonly contractFacts: readonly ContractReleaseFact[];
   readonly coveredPackages: readonly string[];
@@ -315,6 +316,14 @@ const findChangedChangesetPaths = (
     .map(normalizePath)
     .filter((path) => CHANGESET_PATH_PATTERN.test(path));
 
+const findActiveChangedChangesetPaths = (
+  changedFiles: readonly string[],
+  repoRoot: string
+): readonly string[] =>
+  findChangedChangesetPaths(changedFiles).filter((path) =>
+    existsSync(join(repoRoot, path))
+  );
+
 const findChangedChangesets = (
   changedChangesetPaths: readonly string[],
   repoRoot: string
@@ -387,6 +396,10 @@ export const checkReleaseRules = (
     input.workspaces
   );
   const changedChangesets = findChangedChangesetPaths(input.changedFiles);
+  const activeChangedChangesets = findActiveChangedChangesetPaths(
+    input.changedFiles,
+    input.repoRoot
+  );
   const changesets = findChangedChangesets(changedChangesets, input.repoRoot);
   const coveredPackages = [
     ...new Set(changesets.flatMap((changeset) => changeset.packages)),
@@ -403,6 +416,12 @@ export const checkReleaseRules = (
   const uncoveredContractFacts = contractFacts.filter(
     (fact) => !isContractFactCovered(fact, coveredPackages)
   );
+  const hasReleaseFacts =
+    affectedPackages.length > 0 || contractFacts.length > 0 || versionRelease;
+  const activePackageChangesetsWithoutReleaseFacts =
+    activeChangedChangesets.length > 0 && !hasReleaseFacts
+      ? activeChangedChangesets
+      : [];
   const matchedRuleIds = findMatchedRuleIds(input);
   const requiresPackageIntent = ruleMatchesFactType(input, 'package-content');
   const requiresPublicContractIntent = ruleMatchesFactType(
@@ -414,6 +433,12 @@ export const checkReleaseRules = (
   if (noReleaseOverride && changedChangesets.length > 0) {
     errors.push(
       '`release:none` conflicts with changed changeset files. Remove the label or the changeset.'
+    );
+  }
+
+  if (activePackageChangesetsWithoutReleaseFacts.length > 0) {
+    errors.push(
+      `Active changesets require a matching package or release fact on this branch. Remove ${activePackageChangesetsWithoutReleaseFacts.join(', ')} or include the package-facing change here.`
     );
   }
 
@@ -442,6 +467,7 @@ export const checkReleaseRules = (
   }
 
   return {
+    activePackageChangesetsWithoutReleaseFacts,
     affectedPackages,
     changedChangesets,
     contractFacts,

--- a/apps/trails/src/release/index.ts
+++ b/apps/trails/src/release/index.ts
@@ -60,6 +60,7 @@ export {
   checkRegistryPosture,
   discoverRegistryWorkspaces,
   formatDistTagSummary,
+  npmRegistryView,
   registryPostureErrors,
   runRegistryPreflight,
   runRegistryPreflightCli,
@@ -68,6 +69,25 @@ export {
   type RegistryView,
   type RegistryWorkspace,
 } from './native-bun-registry.js';
+export {
+  channelIntentForDistTag,
+  evaluateReleasePolicy,
+  labelsForReleasePullRequest,
+  releaseIntentForVersionDelta,
+  runReleasePolicyCli,
+  type ChannelIntent,
+  type PublishIntent,
+  type ReleaseIntent,
+  type ReleasePolicyChangedFile,
+  type ReleasePolicyCommit,
+  type ReleasePolicyDecision,
+  type ReleasePolicyInput,
+  type ReleasePolicyPullRequest,
+  type ReleasePolicyRegistryPackage,
+  type ReleasePolicyReport,
+  type ReleasePolicySourcePullRequest,
+  type StackIntent,
+} from './policy.js';
 export {
   releaseSmokeCheckValues,
   runReleaseSmoke,

--- a/apps/trails/src/release/policy.ts
+++ b/apps/trails/src/release/policy.ts
@@ -1,0 +1,1535 @@
+/* eslint-disable no-use-before-define -- release policy keeps exported entrypoints before the local CLI/GitHub helpers. */
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+import { discoverRegistryWorkspaces } from './native-bun-registry.js';
+import type { RegistryResult } from './native-bun-registry.js';
+
+export type PublishIntent =
+  | 'publish:auto'
+  | 'publish:block'
+  | 'publish:manual'
+  | 'publish:none';
+export type ChannelIntent = 'channel:beta' | 'channel:stable';
+export type ReleaseIntent = 'release:major' | 'release:minor' | 'release:patch';
+export type ReleasePolicyDecision = 'auto' | 'block' | 'manual' | 'none';
+export type StackIntent = 'stack:boundary';
+
+export interface ReleasePolicyChangedFile {
+  readonly path: string;
+  readonly status?: string;
+}
+
+export interface ReleasePolicyCommit {
+  readonly authorEmail: string;
+  readonly authorName: string;
+  readonly committerEmail: string;
+  readonly committerName: string;
+  readonly subject: string;
+}
+
+export interface ReleasePolicyPullRequest {
+  readonly baseRefName: string;
+  readonly body: string;
+  readonly comments: readonly string[];
+  readonly headRefName: string;
+  readonly labels: readonly string[];
+  readonly number: number;
+  readonly title: string;
+  readonly userLogin: string;
+}
+
+export interface ReleasePolicySourcePullRequest {
+  readonly commitShas: readonly string[];
+  readonly hasChangeset: boolean;
+  readonly labels: readonly string[];
+  readonly number: number;
+  readonly title: string;
+}
+
+export interface ReleasePolicyRegistryPackage {
+  readonly expectedTagVersion?: string | undefined;
+  readonly name: string;
+  readonly status: 'inaccessible' | 'missing' | 'published';
+  readonly version: string;
+  readonly versionPublished?: boolean | undefined;
+}
+
+export interface ReleasePolicyInput {
+  readonly changedFiles: readonly ReleasePolicyChangedFile[];
+  readonly ciPassed: boolean;
+  readonly commit: ReleasePolicyCommit;
+  readonly distTag: string;
+  readonly previousVersion?: string | undefined;
+  readonly ref: string;
+  readonly registryPackages: readonly ReleasePolicyRegistryPackage[];
+  readonly releasePullRequest?: ReleasePolicyPullRequest | undefined;
+  readonly repository: string;
+  readonly sha: string;
+  readonly sourcePullRequests?: readonly ReleasePolicySourcePullRequest[];
+  readonly version: string;
+}
+
+export interface ReleasePolicyReport {
+  readonly autoEligible: boolean;
+  readonly blockers: readonly string[];
+  readonly channel: ChannelIntent | undefined;
+  readonly createGitHubRelease: boolean;
+  readonly decision: ReleasePolicyDecision;
+  readonly diagnostics: readonly string[];
+  readonly publish: PublishIntent | undefined;
+  readonly reasons: readonly string[];
+  readonly release: ReleaseIntent | undefined;
+  readonly shouldPublish: boolean;
+  readonly stack: StackIntent | undefined;
+}
+
+interface FamilyResult<T extends string> {
+  readonly conflicts: readonly string[];
+  readonly unknown: readonly string[];
+  readonly value?: T;
+}
+
+const repoRoot = resolve(process.cwd());
+const publishIntents = new Set<PublishIntent>([
+  'publish:auto',
+  'publish:block',
+  'publish:manual',
+  'publish:none',
+]);
+const channelIntents = new Set<ChannelIntent>([
+  'channel:beta',
+  'channel:stable',
+]);
+const releaseIntents = new Set<ReleaseIntent>([
+  'release:major',
+  'release:minor',
+  'release:patch',
+]);
+const stackIntents = new Set<StackIntent>(['stack:boundary']);
+
+export const channelIntentForDistTag = (
+  distTag: string
+): ChannelIntent | undefined => {
+  if (distTag === 'beta') {
+    return 'channel:beta';
+  }
+  if (distTag === 'latest') {
+    return 'channel:stable';
+  }
+  return undefined;
+};
+
+export const evaluateReleasePolicy = (
+  input: ReleasePolicyInput
+): ReleasePolicyReport => {
+  const labels = input.releasePullRequest?.labels ?? [];
+  const publish = readLabelFamily(labels, 'publish:', publishIntents);
+  const channel = readLabelFamily(labels, 'channel:', channelIntents);
+  const release = readLabelFamily(labels, 'release:', releaseIntents);
+  const stack = readSourceStackLabels(input.sourcePullRequests);
+  const blockers = [
+    ...publish.conflicts,
+    ...channel.conflicts,
+    ...release.conflicts,
+    ...stack.conflicts,
+    ...publish.unknown,
+    ...channel.unknown,
+    ...release.unknown,
+    ...stack.unknown,
+    ...registryBlockers(input.registryPackages, input.distTag),
+  ];
+  const diagnostics: string[] = [];
+  const reasons: string[] = [];
+
+  if (publish.value === 'publish:block') {
+    blockers.push('publish:block is set');
+  }
+
+  if (blockers.length > 0) {
+    return makeReport(input, {
+      blockers,
+      channel: channel.value,
+      decision: 'block',
+      diagnostics,
+      publish: publish.value,
+      reasons,
+      release: release.value,
+      stack: stack.value,
+    });
+  }
+
+  if (publish.value === 'publish:none') {
+    if (!hasPublishNoneReason(input.releasePullRequest)) {
+      return makeReport(input, {
+        blockers: [
+          'publish:none requires an audit reason in the release PR body or comments',
+        ],
+        channel: channel.value,
+        decision: 'block',
+        diagnostics,
+        publish: publish.value,
+        reasons,
+        release: release.value,
+        stack: stack.value,
+      });
+    }
+
+    reasons.push(
+      'publish:none is set, so npm publish and GitHub release creation are skipped'
+    );
+    return makeReport(input, {
+      blockers,
+      channel: channel.value,
+      decision: 'none',
+      diagnostics,
+      publish: publish.value,
+      reasons,
+      release: release.value,
+      stack: stack.value,
+    });
+  }
+
+  if (!publish.value) {
+    reasons.push('No publish:* label is set; routing to manual approval');
+    return makeReport(input, {
+      blockers,
+      channel: channel.value,
+      decision: 'manual',
+      diagnostics,
+      reasons,
+      release: release.value,
+      stack: stack.value,
+    });
+  }
+
+  if (publish.value === 'publish:manual') {
+    reasons.push('publish:manual is set');
+    return makeReport(input, {
+      blockers,
+      channel: channel.value,
+      decision: 'manual',
+      diagnostics,
+      publish: publish.value,
+      reasons,
+      release: release.value,
+      stack: stack.value,
+    });
+  }
+
+  const autoChecks = evaluateAutoChecks(
+    input,
+    channel.value,
+    release.value,
+    stack.value
+  );
+  diagnostics.push(...autoChecks.diagnostics);
+
+  if (!autoChecks.ok) {
+    reasons.push(
+      'publish:auto requested, but one or more low-risk checks failed; routing to manual approval'
+    );
+    return makeReport(input, {
+      blockers,
+      channel: channel.value,
+      decision: 'manual',
+      diagnostics,
+      publish: publish.value,
+      reasons,
+      release: release.value,
+      stack: stack.value,
+    });
+  }
+
+  reasons.push(
+    'publish:auto is set and low-risk release checks passed for the generated release'
+  );
+  return makeReport(input, {
+    autoEligible: true,
+    blockers,
+    channel: channel.value,
+    decision: 'auto',
+    diagnostics,
+    publish: publish.value,
+    reasons,
+    release: release.value,
+    stack: stack.value,
+  });
+};
+
+export const labelsForReleasePullRequest = ({
+  currentVersion,
+  existingLabels,
+  nextDistTag,
+  nextVersion,
+  sourcePullRequests,
+}: {
+  readonly currentVersion: string;
+  readonly existingLabels: readonly string[];
+  readonly nextDistTag: string;
+  readonly nextVersion: string;
+  readonly sourcePullRequests?: readonly ReleasePolicySourcePullRequest[];
+}): readonly string[] => {
+  const labels = new Set(existingLabels);
+  const labelsToAdd: string[] = [];
+  const stack = readSourceStackLabels(sourcePullRequests);
+  const stackDiagnostics = [
+    ...stack.conflicts,
+    ...stack.unknown,
+    ...evaluateSourceStackEvidence(sourcePullRequests, stack.value),
+  ];
+  const expectedChannel = channelIntentForDistTag(nextDistTag);
+  const expectedRelease = releaseIntentForVersionDelta(
+    currentVersion,
+    nextVersion
+  );
+
+  if (!hasLabelFamily(labels, 'publish:')) {
+    labelsToAdd.push(
+      stackDiagnostics.length === 0 && expectedChannel
+        ? 'publish:auto'
+        : 'publish:manual'
+    );
+  }
+
+  if (expectedChannel && !hasLabelFamily(labels, 'channel:')) {
+    labelsToAdd.push(expectedChannel);
+  }
+
+  if (expectedRelease && !hasLabelFamily(labels, 'release:')) {
+    labelsToAdd.push(expectedRelease);
+  }
+
+  return labelsToAdd;
+};
+
+const makeReport = (
+  input: ReleasePolicyInput,
+  options: {
+    readonly autoEligible?: boolean;
+    readonly blockers: readonly string[];
+    readonly channel: ChannelIntent | undefined;
+    readonly decision: ReleasePolicyDecision;
+    readonly diagnostics: readonly string[];
+    readonly publish?: PublishIntent | undefined;
+    readonly reasons: readonly string[];
+    readonly release: ReleaseIntent | undefined;
+    readonly stack: StackIntent | undefined;
+  }
+): ReleasePolicyReport => {
+  const canPublish =
+    options.decision === 'auto' || options.decision === 'manual';
+  return {
+    autoEligible: options.autoEligible ?? false,
+    blockers: options.blockers,
+    channel: options.channel,
+    createGitHubRelease: canPublish,
+    decision: options.decision,
+    diagnostics: options.diagnostics,
+    publish: options.publish,
+    reasons: options.reasons,
+    release: options.release,
+    shouldPublish: canPublish && !registryComplete(input.registryPackages),
+    stack: options.stack,
+  };
+};
+
+const readLabelFamily = <T extends string>(
+  labels: readonly string[],
+  prefix: string,
+  allowed: ReadonlySet<T>
+): FamilyResult<T> => {
+  const values = labels.filter((label) => label.startsWith(prefix));
+  const known = values.filter((label): label is T => allowed.has(label as T));
+  const unknown = values.filter((label) => !allowed.has(label as T));
+
+  if (known.length > 1) {
+    return {
+      conflicts: [`Conflicting ${prefix} labels: ${known.join(', ')}`],
+      unknown: unknown.map((label) => `Unknown ${prefix} label: ${label}`),
+    };
+  }
+
+  const result: { conflicts: string[]; unknown: string[]; value?: T } = {
+    conflicts: [],
+    unknown: unknown.map((label) => `Unknown ${prefix} label: ${label}`),
+  };
+  const [value] = known;
+  if (value) {
+    result.value = value;
+  }
+  return result;
+};
+
+const registryComplete = (
+  packages: readonly ReleasePolicyRegistryPackage[]
+): boolean =>
+  packages.length > 0 &&
+  packages.every(
+    (entry) =>
+      entry.status === 'published' &&
+      entry.expectedTagVersion === entry.version &&
+      (entry.versionPublished ?? true)
+  );
+
+const registryBlockers = (
+  packages: readonly ReleasePolicyRegistryPackage[],
+  distTag: string
+): readonly string[] =>
+  packages.flatMap((entry) => {
+    if (entry.status === 'inaccessible') {
+      return [`${entry.name}: registry state is inaccessible`];
+    }
+
+    if (
+      entry.status === 'published' &&
+      entry.expectedTagVersion !== undefined &&
+      entry.expectedTagVersion !== entry.version &&
+      compareSemver(entry.expectedTagVersion, entry.version) > 0
+    ) {
+      return [
+        `${entry.name}: dist-tag ${distTag} points to ${entry.expectedTagVersion}, expected ${entry.version}`,
+      ];
+    }
+
+    if (
+      entry.status === 'published' &&
+      entry.versionPublished === true &&
+      entry.expectedTagVersion !== entry.version
+    ) {
+      return [
+        `${entry.name}: version ${entry.version} is already published but dist-tag ${distTag} points to ${entry.expectedTagVersion ?? '(missing)'}`,
+      ];
+    }
+
+    return [];
+  });
+
+const evaluateAutoChecks = (
+  input: ReleasePolicyInput,
+  channel: ChannelIntent | undefined,
+  release: ReleaseIntent | undefined,
+  stack: StackIntent | undefined
+) => {
+  const diagnostics: string[] = [];
+  const generatedDiff = evaluateGeneratedReleaseDiff(input.changedFiles);
+  diagnostics.push(...generatedDiff.diagnostics);
+  diagnostics.push(
+    ...evaluateSourceStackEvidence(input.sourcePullRequests, stack)
+  );
+
+  if (input.repository !== 'outfitter-dev/trails') {
+    diagnostics.push(
+      `Expected repository outfitter-dev/trails, found ${input.repository}`
+    );
+  }
+
+  if (input.ref !== 'refs/heads/main') {
+    diagnostics.push(`Expected refs/heads/main, found ${input.ref}`);
+  }
+
+  const expectedChannel = channelIntentForDistTag(input.distTag);
+  if (!expectedChannel) {
+    diagnostics.push(
+      `Unsupported release dist-tag for automation: ${input.distTag}`
+    );
+  } else if (channel !== expectedChannel) {
+    diagnostics.push(
+      `Expected ${expectedChannel} for npm dist-tag ${input.distTag}, found ${channel ?? 'no channel:* label'}`
+    );
+  }
+
+  if (input.releasePullRequest) {
+    if (input.releasePullRequest.headRefName !== 'changeset-release/main') {
+      diagnostics.push(
+        `Expected release PR head changeset-release/main, found ${input.releasePullRequest.headRefName}`
+      );
+    }
+    if (input.releasePullRequest.baseRefName !== 'main') {
+      diagnostics.push(
+        `Expected release PR base main, found ${input.releasePullRequest.baseRefName}`
+      );
+    }
+    if (input.releasePullRequest.title !== 'chore(release): version packages') {
+      diagnostics.push(
+        `Expected release PR title "chore(release): version packages", found "${input.releasePullRequest.title}"`
+      );
+    }
+    if (input.releasePullRequest.userLogin !== 'github-actions[bot]') {
+      diagnostics.push(
+        `Expected release PR author github-actions[bot], found ${input.releasePullRequest.userLogin}`
+      );
+    }
+  } else {
+    diagnostics.push(
+      'Could not resolve the release pull request for the current commit'
+    );
+  }
+
+  if (
+    !/^chore\(release\): version packages \(#\d+\)$/u.test(input.commit.subject)
+  ) {
+    diagnostics.push(
+      `Expected squash commit subject chore(release): version packages (#<pr>), found "${input.commit.subject}"`
+    );
+  }
+
+  if (
+    !isGitHubActionsIdentity(input.commit.authorName, input.commit.authorEmail)
+  ) {
+    diagnostics.push(
+      `Expected GitHub Actions bot author, found ${input.commit.authorName} <${input.commit.authorEmail}>`
+    );
+  }
+
+  if (
+    !isGitHubCommitter(input.commit.committerName, input.commit.committerEmail)
+  ) {
+    diagnostics.push(
+      `Expected GitHub committer, found ${input.commit.committerName} <${input.commit.committerEmail}>`
+    );
+  }
+
+  const expectedRelease = input.previousVersion
+    ? releaseIntentForVersionDelta(input.previousVersion, input.version)
+    : undefined;
+  if (!input.previousVersion) {
+    diagnostics.push(
+      'Could not read previous @ontrails/trails package version'
+    );
+  } else if (!expectedRelease) {
+    diagnostics.push(
+      `Expected ${input.version} to be newer than previous version ${input.previousVersion}`
+    );
+  } else if (release && expectedRelease !== release) {
+    diagnostics.push(
+      `${release} is set, but ${input.previousVersion} -> ${input.version} looks like ${expectedRelease}`
+    );
+  }
+
+  if (!input.ciPassed) {
+    diagnostics.push('Exact-SHA CI checks have not passed');
+  }
+
+  return { diagnostics, ok: diagnostics.length === 0 };
+};
+
+const readSourceStackLabels = (
+  sourcePullRequests: readonly ReleasePolicySourcePullRequest[] | undefined
+) => {
+  if (!sourcePullRequests) {
+    return { conflicts: [], unknown: [] };
+  }
+  const labels = sourcePullRequests.flatMap((pull) =>
+    pull.labels
+      .filter((label) => label.startsWith('stack:'))
+      .map((label) => `${label} on #${pull.number}`)
+  );
+  const normalized = [
+    ...new Set(labels.map((label) => label.split(' on #', 1)[0] ?? label)),
+  ];
+  const result = readLabelFamily(normalized, 'stack:', stackIntents);
+
+  return {
+    conflicts: result.conflicts.map(
+      (conflict) => `${conflict} across source PRs`
+    ),
+    unknown: result.unknown.map((unknown) => {
+      const label = unknown.replace('Unknown stack: label: ', '');
+      const source = labels.find((candidate) => candidate.startsWith(label));
+      return source ? `Unknown stack: label: ${source}` : unknown;
+    }),
+    value: result.value,
+  };
+};
+
+const evaluateSourceStackEvidence = (
+  sourcePullRequests: readonly ReleasePolicySourcePullRequest[] | undefined,
+  stack: StackIntent | undefined
+): readonly string[] => {
+  if (!sourcePullRequests) {
+    return [
+      'Could not resolve source PR stack evidence for the generated release',
+    ];
+  }
+
+  const changesetPulls = sourcePullRequests.filter((pull) => pull.hasChangeset);
+  if (changesetPulls.length === 0) {
+    return [
+      'Could not find a source PR that introduced a consumed .changeset/*.md file',
+    ];
+  }
+
+  const missingBoundary = changesetPulls.filter(
+    (pull) => !pull.labels.includes('stack:boundary')
+  );
+  if (stack !== 'stack:boundary' || missingBoundary.length > 0) {
+    return [
+      `publish:auto requires stack:boundary on every changeset source PR in the release range; missing: ${missingBoundary
+        .map((pull) => `#${pull.number}`)
+        .join(', ')}`,
+    ];
+  }
+
+  return [];
+};
+
+const evaluateGeneratedReleaseDiff = (
+  changedFiles: readonly ReleasePolicyChangedFile[]
+) => {
+  const diagnostics: string[] = [];
+  let hasChangesetDeletion = false;
+  let hasPackageVersionFile = false;
+
+  for (const file of changedFiles) {
+    if (file.path === '.changeset/pre.json' && file.status === 'M') {
+      continue;
+    }
+
+    if (/^\.changeset\/[^/]+\.md$/u.test(file.path) && file.status === 'D') {
+      hasChangesetDeletion = true;
+      continue;
+    }
+
+    if (
+      /^packages\/[^/]+\/(?:CHANGELOG\.md|package\.json)$/u.test(file.path) &&
+      file.status === 'M'
+    ) {
+      hasPackageVersionFile = true;
+      continue;
+    }
+
+    if (
+      /^adapters\/[^/]+\/(?:CHANGELOG\.md|package\.json)$/u.test(file.path) &&
+      file.status === 'M'
+    ) {
+      hasPackageVersionFile = true;
+      continue;
+    }
+
+    if (
+      /^apps\/trails\/(?:CHANGELOG\.md|package\.json)$/u.test(file.path) &&
+      file.status === 'M'
+    ) {
+      hasPackageVersionFile = true;
+      continue;
+    }
+
+    diagnostics.push(
+      `Unexpected release diff entry: ${file.status ?? '?'} ${file.path}`
+    );
+  }
+
+  if (!hasPackageVersionFile) {
+    diagnostics.push(
+      'Generated release diff did not modify package.json or CHANGELOG.md files'
+    );
+  }
+  if (!hasChangesetDeletion) {
+    diagnostics.push(
+      'Generated release diff did not delete a consumed .changeset/*.md file'
+    );
+  }
+
+  return { diagnostics, ok: diagnostics.length === 0 };
+};
+
+const hasPublishNoneReason = (
+  pr: ReleasePolicyPullRequest | undefined
+): boolean => {
+  if (!pr) {
+    return false;
+  }
+  const texts = [pr.body, ...pr.comments].map((text) => text.toLowerCase());
+  return texts.some(
+    (text) =>
+      text.includes('publish:none') &&
+      /(because|intentional|reason|skip|no publish)/u.test(text)
+  );
+};
+
+const hasLabelFamily = (
+  labels: ReadonlySet<string>,
+  prefix: string
+): boolean => {
+  for (const label of labels) {
+    if (label.startsWith(prefix)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const isGitHubActionsIdentity = (name: string, email: string): boolean =>
+  name === 'github-actions[bot]' &&
+  email === '41898282+github-actions[bot]@users.noreply.github.com';
+
+const isGitHubCommitter = (name: string, email: string): boolean =>
+  name === 'GitHub' && email === 'noreply@github.com';
+
+export const releaseIntentForVersionDelta = (
+  previousVersion: string,
+  nextVersion: string
+): ReleaseIntent | undefined => {
+  const previous = parseSemver(previousVersion);
+  const next = parseSemver(nextVersion);
+  if (!previous || !next) {
+    return undefined;
+  }
+  if (compareSemver(nextVersion, previousVersion) <= 0) {
+    return undefined;
+  }
+  if (next.major !== previous.major) {
+    return 'release:major';
+  }
+  if (next.minor !== previous.minor) {
+    return 'release:minor';
+  }
+  if (
+    next.patch !== previous.patch ||
+    next.prerelease !== previous.prerelease
+  ) {
+    return 'release:patch';
+  }
+  return undefined;
+};
+
+const compareSemver = (leftVersion: string, rightVersion: string): number => {
+  const left = parseSemver(leftVersion);
+  const right = parseSemver(rightVersion);
+  if (!left || !right) {
+    return leftVersion.localeCompare(rightVersion);
+  }
+
+  for (const key of ['major', 'minor', 'patch'] as const) {
+    const delta = left[key] - right[key];
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+
+  if (left.prerelease === right.prerelease) {
+    return 0;
+  }
+  if (!left.prerelease) {
+    return 1;
+  }
+  if (!right.prerelease) {
+    return -1;
+  }
+  return comparePrerelease(left.prerelease, right.prerelease);
+};
+
+const comparePrerelease = (leftValue: string, rightValue: string): number => {
+  const left = parsePrerelease(leftValue);
+  const right = parsePrerelease(rightValue);
+  const length = Math.max(left.length, right.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = left[index];
+    const rightPart = right[index];
+    if (leftPart === undefined) {
+      return -1;
+    }
+    if (rightPart === undefined) {
+      return 1;
+    }
+    if (leftPart === rightPart) {
+      continue;
+    }
+    if (typeof leftPart === 'number' && typeof rightPart === 'number') {
+      return leftPart - rightPart;
+    }
+    if (typeof leftPart === 'number') {
+      return -1;
+    }
+    if (typeof rightPart === 'number') {
+      return 1;
+    }
+    const delta = leftPart.localeCompare(rightPart);
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+
+  return 0;
+};
+
+const parsePrerelease = (value: string): (number | string)[] =>
+  value
+    .split('.')
+    .map((part) => (/^[0-9]+$/u.test(part) ? Number.parseInt(part, 10) : part));
+
+const parseSemver = (version: string) => {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/u);
+  if (!match) {
+    return;
+  }
+  const [, major, minor, patch, prerelease] = match;
+  if (!major || !minor || !patch) {
+    return;
+  }
+  return {
+    major: Number.parseInt(major, 10),
+    minor: Number.parseInt(minor, 10),
+    patch: Number.parseInt(patch, 10),
+    prerelease,
+  };
+};
+
+const writeGitHubOutput = async (
+  values: Record<string, boolean | number | string | undefined>
+): Promise<void> => {
+  const outputPath = process.env['GITHUB_OUTPUT'];
+  if (!outputPath) {
+    return;
+  }
+  const lines = Object.entries(values).map(
+    ([key, value]) => `${key}=${value ?? ''}`
+  );
+  await Bun.write(outputPath, `${lines.join('\n')}\n`);
+};
+
+const printReport = (report: ReleasePolicyReport): void => {
+  console.error(`trails: release policy decision is ${report.decision}`);
+  for (const reason of report.reasons) {
+    console.error(`trails: ${reason}`);
+  }
+  for (const diagnostic of report.diagnostics) {
+    console.error(`trails: policy diagnostic: ${diagnostic}`);
+  }
+  for (const blocker of report.blockers) {
+    console.error(`trails: policy blocker: ${blocker}`);
+  }
+};
+
+const runText = async (
+  command: readonly string[],
+  options: { readonly allowFailure?: boolean } = {}
+): Promise<string> => {
+  const subprocess = Bun.spawn([...command], {
+    cwd: repoRoot,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    subprocess.exited,
+    new Response(subprocess.stdout).text(),
+    new Response(subprocess.stderr).text(),
+  ]);
+
+  if (exitCode !== 0) {
+    if (options.allowFailure) {
+      return '';
+    }
+    throw new Error(`${command.join(' ')} failed: ${stderr.trim()}`);
+  }
+
+  return stdout.trim();
+};
+
+const readCommitInfo = async (): Promise<ReleasePolicyCommit> => {
+  const output = await runText([
+    'git',
+    'log',
+    '-1',
+    '--format=%an%n%ae%n%cn%n%ce%n%s',
+  ]);
+  const [authorName, authorEmail, committerName, committerEmail, ...subject] =
+    output.split('\n');
+  if (!authorName || !authorEmail || !committerName || !committerEmail) {
+    throw new Error('Could not read current commit identity');
+  }
+  return {
+    authorEmail,
+    authorName,
+    committerEmail,
+    committerName,
+    subject: subject.join('\n'),
+  };
+};
+
+const readChangedFiles = async (): Promise<ReleasePolicyChangedFile[]> => {
+  const parentExists = await runText(
+    ['git', 'rev-parse', '--verify', 'HEAD^'],
+    {
+      allowFailure: true,
+    }
+  );
+  if (!parentExists) {
+    return [];
+  }
+  const output = await runText([
+    'git',
+    'diff',
+    '--name-status',
+    'HEAD^',
+    'HEAD',
+  ]);
+  if (!output) {
+    return [];
+  }
+  return output.split('\n').map((line) => {
+    const [status, path] = line.split(/\s+/, 2);
+    if (!status || !path) {
+      throw new Error(`Could not parse git diff entry: ${line}`);
+    }
+    return { path, status };
+  });
+};
+
+interface PackageJson {
+  readonly name?: string;
+  readonly version?: string;
+}
+
+const readTrailsPackageVersion = async (ref = 'HEAD'): Promise<string> => {
+  const raw =
+    ref === 'HEAD'
+      ? await readFile(join(repoRoot, 'apps', 'trails', 'package.json'), 'utf8')
+      : await runText(['git', 'show', `${ref}:apps/trails/package.json`], {
+          allowFailure: true,
+        });
+  if (!raw) {
+    return '';
+  }
+  const packageJson = JSON.parse(raw) as PackageJson;
+  return packageJson.version ?? '';
+};
+
+const readPreviousVersion = async (): Promise<string | undefined> => {
+  const version = await readTrailsPackageVersion('HEAD^');
+  return version || undefined;
+};
+
+const distTagForVersion = async (version: string): Promise<string> => {
+  if (!version.includes('-')) {
+    return 'latest';
+  }
+
+  const prePath = join(repoRoot, '.changeset', 'pre.json');
+  if (await Bun.file(prePath).exists()) {
+    const pre = (await Bun.file(prePath).json()) as {
+      readonly mode?: string;
+      readonly tag?: string;
+    };
+    if (pre.mode === 'pre' && pre.tag) {
+      return pre.tag;
+    }
+  }
+  return version.includes('-')
+    ? (version.split('-')[1]?.split('.')[0] ?? 'latest')
+    : 'latest';
+};
+
+const registryPackagesFromResults = async (
+  results: readonly RegistryResult[]
+): Promise<readonly ReleasePolicyRegistryPackage[]> =>
+  Promise.all(
+    results.map(async (result) => {
+      const versionPublished =
+        result.status === 'published'
+          ? await readPackageVersionPublished(
+              result.name,
+              result.workspaceVersion
+            )
+          : false;
+
+      if (result.status === 'published') {
+        return {
+          expectedTagVersion: result.expectedTagVersion,
+          name: result.name,
+          status: 'published',
+          version: result.workspaceVersion,
+          versionPublished,
+        };
+      }
+      return {
+        name: result.name,
+        status: result.status,
+        version: result.workspaceVersion,
+        versionPublished,
+      };
+    })
+  );
+
+const readPackageVersionPublished = async (
+  name: string,
+  version: string
+): Promise<boolean> => {
+  const subprocess = Bun.spawn(
+    ['npm', 'view', `${name}@${version}`, 'version', '--json'],
+    {
+      cwd: repoRoot,
+      stderr: 'pipe',
+      stdin: 'ignore',
+      stdout: 'pipe',
+    }
+  );
+  const [exitCode, stdout, stderr] = await Promise.all([
+    subprocess.exited,
+    new Response(subprocess.stdout).text(),
+    new Response(subprocess.stderr).text(),
+  ]);
+
+  if (exitCode === 0) {
+    return JSON.parse(stdout.trim()) === version;
+  }
+
+  const combined = `${stdout}\n${stderr}`;
+  if (combined.includes('E404') || combined.includes('404 Not Found')) {
+    return false;
+  }
+
+  throw new Error(stderr.trim() || `npm view failed for ${name}@${version}`);
+};
+
+const readRegistryPackages = async (
+  distTag: string
+): Promise<readonly ReleasePolicyRegistryPackage[]> => {
+  const { checkRegistryPosture, npmRegistryView } =
+    await import('./native-bun-registry.js');
+  const workspaces = await discoverRegistryWorkspaces(repoRoot);
+  const results = await checkRegistryPosture(
+    workspaces,
+    npmRegistryView,
+    distTag
+  );
+  return registryPackagesFromResults(results);
+};
+
+const githubJson = async <T>(repository: string, path: string): Promise<T> => {
+  const headers: Record<string, string> = {
+    accept: 'application/vnd.github+json',
+    'x-github-api-version': '2022-11-28',
+  };
+  if (process.env['GITHUB_TOKEN']) {
+    headers['authorization'] = `Bearer ${process.env['GITHUB_TOKEN']}`;
+  }
+  const response = await fetch(
+    `https://api.github.com/repos/${repository}${path}`,
+    {
+      headers,
+    }
+  );
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API request failed for ${path}: ${response.status} ${response.statusText}`
+    );
+  }
+  return (await response.json()) as T;
+};
+
+interface GitHubPullRequest {
+  readonly base: { readonly ref: string };
+  readonly body?: string | null;
+  readonly head: { readonly ref: string };
+  readonly labels: readonly { readonly name: string }[];
+  readonly number: number;
+  readonly title: string;
+  readonly user: { readonly login: string };
+}
+
+interface GitHubComment {
+  readonly body?: string | null;
+}
+
+interface GitHubContentFile {
+  readonly content: string;
+}
+
+interface GitHubCheckRunsResponse {
+  readonly check_runs: readonly {
+    readonly check_suite?: { readonly app?: { readonly slug?: string } };
+    readonly conclusion?: string | null;
+    readonly name: string;
+    readonly status: string;
+  }[];
+}
+
+const managedGitHubLabels = [
+  {
+    color: '0e8a16',
+    description:
+      'Generated release PR may publish automatically after policy checks pass.',
+    name: 'publish:auto',
+  },
+  {
+    color: 'fbca04',
+    description:
+      'Generated release PR requires protected manual publish approval.',
+    name: 'publish:manual',
+  },
+  {
+    color: 'cfd3d7',
+    description:
+      'Generated release PR intentionally skips npm and GitHub release publication.',
+    name: 'publish:none',
+  },
+  {
+    color: 'b60205',
+    description: 'Generated release PR is blocked from publishing.',
+    name: 'publish:block',
+  },
+  {
+    color: '1d76db',
+    description:
+      'Release publishes prerelease packages to the beta npm dist-tag.',
+    name: 'channel:beta',
+  },
+  {
+    color: '5319e7',
+    description:
+      'Release publishes stable packages to the latest npm dist-tag.',
+    name: 'channel:stable',
+  },
+  {
+    color: 'c2e0c6',
+    description:
+      'Release changes package versions by a patch-sized semver movement.',
+    name: 'release:patch',
+  },
+  {
+    color: 'bfdadc',
+    description:
+      'Release changes package versions by a minor-sized semver movement.',
+    name: 'release:minor',
+  },
+  {
+    color: 'f9d0c4',
+    description:
+      'Release changes package versions by a major-sized semver movement.',
+    name: 'release:major',
+  },
+  {
+    color: 'd4c5f9',
+    description:
+      'Source PR is a stack boundary with complete release evidence.',
+    name: 'stack:boundary',
+  },
+] as const;
+
+const readReleasePullRequest = async (
+  repository: string,
+  sha: string
+): Promise<ReleasePolicyPullRequest | undefined> => {
+  const pulls = await githubJson<GitHubPullRequest[]>(
+    repository,
+    `/commits/${sha}/pulls`
+  );
+  const pull = pulls.find((candidate) => candidate.base.ref === 'main');
+  if (!pull) {
+    return undefined;
+  }
+  const comments = await githubJson<GitHubComment[]>(
+    repository,
+    `/issues/${pull.number}/comments`
+  );
+  return {
+    baseRefName: pull.base.ref,
+    body: pull.body ?? '',
+    comments: comments.map((comment) => comment.body ?? ''),
+    headRefName: pull.head.ref,
+    labels: pull.labels.map((label) => label.name),
+    number: pull.number,
+    title: pull.title,
+    userLogin: pull.user.login,
+  };
+};
+
+const readOpenReleasePullRequest = async (
+  repository: string
+): Promise<ReleasePolicyPullRequest | undefined> => {
+  const pulls = await githubJson<GitHubPullRequest[]>(
+    repository,
+    '/pulls?state=open&base=main&per_page=100'
+  );
+  const pull = pulls.find(
+    (candidate) => candidate.head.ref === 'changeset-release/main'
+  );
+  if (!pull) {
+    return undefined;
+  }
+  return {
+    baseRefName: pull.base.ref,
+    body: pull.body ?? '',
+    comments: [],
+    headRefName: pull.head.ref,
+    labels: pull.labels.map((label) => label.name),
+    number: pull.number,
+    title: pull.title,
+    userLogin: pull.user.login,
+  };
+};
+
+const readPackageVersionFromRef = async (
+  repository: string,
+  ref: string
+): Promise<string> => {
+  const file = await githubJson<GitHubContentFile>(
+    repository,
+    `/contents/apps/trails/package.json?ref=${encodeURIComponent(ref)}`
+  );
+  const packageJson = JSON.parse(
+    Buffer.from(file.content, 'base64').toString('utf8')
+  ) as PackageJson;
+  if (!packageJson.version) {
+    throw new Error(`Missing version in apps/trails/package.json at ${ref}`);
+  }
+  return packageJson.version;
+};
+
+const ensureGitHubLabels = async (repository: string): Promise<void> => {
+  await Promise.all(
+    managedGitHubLabels.map((label) =>
+      runText([
+        'gh',
+        'label',
+        'create',
+        label.name,
+        '--repo',
+        repository,
+        '--color',
+        label.color,
+        '--description',
+        label.description,
+        '--force',
+      ])
+    )
+  );
+};
+
+const readCommitChangedFiles = async (
+  commitSha: string
+): Promise<ReleasePolicyChangedFile[]> => {
+  const output = await runText([
+    'git',
+    'diff-tree',
+    '--no-commit-id',
+    '--name-status',
+    '-r',
+    commitSha,
+  ]);
+  if (!output) {
+    return [];
+  }
+  return output.split('\n').map((line) => {
+    const [status, path] = line.split(/\s+/, 2);
+    if (!status || !path) {
+      throw new Error(`Could not parse git diff entry: ${line}`);
+    }
+    return { path, status };
+  });
+};
+
+const readSourcePullRequests = async (
+  repository: string,
+  previousVersion: string,
+  endRef = 'HEAD^'
+): Promise<readonly ReleasePolicySourcePullRequest[] | undefined> => {
+  const previousVersionCommit = await runText([
+    'git',
+    'log',
+    '-n',
+    '1',
+    '--format=%H',
+    '-S',
+    `"version": "${previousVersion}"`,
+    endRef,
+    '--',
+    'apps/trails/package.json',
+  ]);
+  if (!previousVersionCommit) {
+    return undefined;
+  }
+
+  const output = await runText([
+    'git',
+    'rev-list',
+    '--reverse',
+    `${previousVersionCommit}..${endRef}`,
+  ]);
+  if (!output) {
+    return [];
+  }
+
+  const byNumber = new Map<number, ReleasePolicySourcePullRequest>();
+  for (const commitSha of output.split('\n')) {
+    const changedFiles = await readCommitChangedFiles(commitSha);
+    const hasChangeset = changedFiles.some(
+      (file) =>
+        /^\.changeset\/[^/]+\.md$/u.test(file.path) && file.status !== 'D'
+    );
+    const pulls = await githubJson<GitHubPullRequest[]>(
+      repository,
+      `/commits/${commitSha}/pulls`
+    );
+    const [pull] = pulls;
+
+    if (!pull) {
+      byNumber.set(-byNumber.size - 1, {
+        commitShas: [commitSha],
+        hasChangeset,
+        labels: [],
+        number: 0,
+        title: `Unresolved source commit ${commitSha.slice(0, 7)}`,
+      });
+      continue;
+    }
+
+    const existing = byNumber.get(pull.number);
+    if (existing) {
+      byNumber.set(pull.number, {
+        ...existing,
+        commitShas: [...existing.commitShas, commitSha],
+        hasChangeset: existing.hasChangeset || hasChangeset,
+      });
+      continue;
+    }
+
+    byNumber.set(pull.number, {
+      commitShas: [commitSha],
+      hasChangeset,
+      labels: pull.labels.map((label) => label.name),
+      number: pull.number,
+      title: pull.title,
+    });
+  }
+
+  return [...byNumber.values()];
+};
+
+const readCiPassed = async (
+  repository: string,
+  sha: string
+): Promise<boolean> => {
+  if (process.env['TRAILS_RELEASE_POLICY_ASSUME_CI_PASSED'] === '1') {
+    return true;
+  }
+
+  const attempts = Number.parseInt(
+    process.env['TRAILS_RELEASE_POLICY_CI_ATTEMPTS'] ?? '1',
+    10
+  );
+  const waitMs = Number.parseInt(
+    process.env['TRAILS_RELEASE_POLICY_CI_WAIT_MS'] ?? '0',
+    10
+  );
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const state = await readCiState(repository, sha);
+    if (state === 'passed') {
+      return true;
+    }
+    if (state === 'failed') {
+      return false;
+    }
+    if (attempt < attempts && waitMs > 0) {
+      console.error(
+        `trails: waiting for exact-SHA CI checks (${attempt}/${attempts})`
+      );
+      await Bun.sleep(waitMs);
+    }
+  }
+
+  return false;
+};
+
+const readCiState = async (
+  repository: string,
+  sha: string
+): Promise<'failed' | 'passed' | 'pending'> => {
+  const response = await githubJson<GitHubCheckRunsResponse>(
+    repository,
+    `/commits/${sha}/check-runs?per_page=100`
+  );
+  const requiredRuns = new Map(
+    response.check_runs
+      .filter((run) => run.check_suite?.app?.slug === 'github-actions')
+      .filter((run) =>
+        [
+          'Build',
+          'Lint & Format',
+          'Dead Code',
+          'Typecheck',
+          'Test',
+          'Governance',
+        ].includes(run.name)
+      )
+      .map((run) => [run.name, run])
+  );
+  const relevantRuns = [
+    'Build',
+    'Lint & Format',
+    'Dead Code',
+    'Typecheck',
+    'Test',
+    'Governance',
+  ].map((name) => requiredRuns.get(name));
+
+  if (relevantRuns.some((run) => !run || run.status !== 'completed')) {
+    return 'pending';
+  }
+  if (relevantRuns.some((run) => run?.conclusion !== 'success')) {
+    return 'failed';
+  }
+  return 'passed';
+};
+
+const readPolicyInput = async (): Promise<ReleasePolicyInput> => {
+  const version = await readTrailsPackageVersion();
+  const distTag = await distTagForVersion(version);
+  const repository =
+    process.env['GITHUB_REPOSITORY'] ??
+    (await runText([
+      'gh',
+      'repo',
+      'view',
+      '--json',
+      'nameWithOwner',
+      '--jq',
+      '.nameWithOwner',
+    ]));
+  const ref =
+    process.env['GITHUB_REF'] ??
+    `refs/heads/${await runText(['git', 'branch', '--show-current'])}`;
+  const sha =
+    process.env['GITHUB_SHA'] ?? (await runText(['git', 'rev-parse', 'HEAD']));
+  const previousVersion = await readPreviousVersion();
+  const registryPackages = await readRegistryPackages(distTag);
+  const [releasePullRequest, commit, changedFiles, ciPassed] =
+    await Promise.all([
+      readReleasePullRequest(repository, sha),
+      readCommitInfo(),
+      readChangedFiles(),
+      readCiPassed(repository, sha),
+    ]);
+  const sourcePullRequests = previousVersion
+    ? await readSourcePullRequests(repository, previousVersion)
+    : undefined;
+
+  return {
+    changedFiles,
+    ciPassed,
+    commit,
+    distTag,
+    ...(previousVersion === undefined ? {} : { previousVersion }),
+    ref,
+    registryPackages,
+    ...(releasePullRequest === undefined ? {} : { releasePullRequest }),
+    repository,
+    sha,
+    ...(sourcePullRequests === undefined ? {} : { sourcePullRequests }),
+    version,
+  };
+};
+
+const commandPolicy = async (): Promise<void> => {
+  const input = await readPolicyInput();
+  const report = evaluateReleasePolicy(input);
+  printReport(report);
+  await writeGitHubOutput({
+    channel: report.channel ?? '',
+    create_github_release: report.createGitHubRelease,
+    decision: report.decision,
+    publish: report.publish ?? '',
+    release: report.release ?? '',
+    should_publish: report.shouldPublish,
+    tag: input.distTag,
+    version: input.version,
+  });
+  if (report.decision === 'block') {
+    throw new Error(
+      `Release policy blocked publish: ${report.blockers.join('; ')}`
+    );
+  }
+};
+
+const commandLabelReleasePr = async (): Promise<void> => {
+  const currentVersion = await readTrailsPackageVersion();
+  const repository =
+    process.env['GITHUB_REPOSITORY'] ??
+    (await runText([
+      'gh',
+      'repo',
+      'view',
+      '--json',
+      'nameWithOwner',
+      '--jq',
+      '.nameWithOwner',
+    ]));
+  const releasePullRequest = await readOpenReleasePullRequest(repository);
+
+  if (!releasePullRequest) {
+    console.error('trails: no open changeset-release/main pull request found');
+    return;
+  }
+
+  const nextVersion = await readPackageVersionFromRef(
+    repository,
+    releasePullRequest.headRefName
+  );
+  const nextDistTag = await distTagForVersion(nextVersion);
+  const sourcePullRequests = await readSourcePullRequests(
+    repository,
+    currentVersion,
+    'HEAD'
+  );
+  const labelsToAdd = labelsForReleasePullRequest({
+    currentVersion,
+    existingLabels: releasePullRequest.labels,
+    nextDistTag,
+    nextVersion,
+    ...(sourcePullRequests === undefined ? {} : { sourcePullRequests }),
+  });
+
+  if (labelsToAdd.length === 0) {
+    console.error(
+      `trails: release PR #${releasePullRequest.number} already has release intent labels`
+    );
+    return;
+  }
+
+  await ensureGitHubLabels(repository);
+
+  for (const label of labelsToAdd) {
+    await runText([
+      'gh',
+      'issue',
+      'edit',
+      String(releasePullRequest.number),
+      '--repo',
+      repository,
+      '--add-label',
+      label,
+    ]);
+  }
+
+  console.error(
+    `trails: added ${labelsToAdd.join(', ')} to release PR #${releasePullRequest.number}`
+  );
+};
+
+export const runReleasePolicyCli = async (
+  args: readonly string[] = process.argv.slice(2)
+): Promise<number> => {
+  const [command = 'policy'] = args;
+  try {
+    if (command === 'policy') {
+      await commandPolicy();
+      return 0;
+    }
+    if (command === 'label-release-pr') {
+      await commandLabelReleasePr();
+      return 0;
+    }
+    throw new Error(`Unknown release policy command: ${command}`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+};
+
+if (import.meta.main) {
+  process.exit(await runReleasePolicyCli(process.argv.slice(2)));
+}

--- a/apps/trails/src/trails/release-check.ts
+++ b/apps/trails/src/trails/release-check.ts
@@ -45,6 +45,7 @@ const contractReleaseFactSchema = z.object({
 });
 
 const releaseCheckOutputSchema = z.object({
+  activePackageChangesetsWithoutReleaseFacts: z.array(z.string()).readonly(),
   affectedPackages: z.array(z.string()).readonly(),
   changedChangesets: z.array(z.string()).readonly(),
   configPath: z.string().optional(),

--- a/docs/releases/beta-channel-policy.md
+++ b/docs/releases/beta-channel-policy.md
@@ -105,18 +105,32 @@ Examples:
 After substantial stacks merge to `main`:
 
 1. Confirm all package-affecting PRs carried branch-local release intent. `trails release check --json` and `bun run changeset:check` are the local proof surfaces.
-2. Run `bunx changeset status --verbose` from clean, synced `main` to inspect
+2. Ensure source PRs that introduced consumed changesets carry
+   `stack:boundary` when the generated release should be eligible for
+   automatic publishing. Missing boundary evidence is safe, but it routes the
+   generated release PR to `publish:manual`.
+3. Run `bunx changeset status --verbose` from clean, synced `main` to inspect
    the next beta plan.
-3. When the next beta is warranted, create a dedicated version branch, run
+4. When the next beta is warranted, create a dedicated version branch, run
    `bunx changeset version`, then run `bun run scaffold-versions:sync` so
    generated third-party scaffold dependency versions and exact `@ontrails/*`
    pins are checked together.
-4. Review package versions, changelogs, generated lockfile changes, and
+5. Review package versions, changelogs, generated lockfile changes, and
    generated-app dependency ranges.
-5. Run the version-branch gates, including `bun run publish:check` and
+6. Run the version-branch gates, including `bun run publish:check` and
    `bun run publish:registry-check`.
-6. Submit and merge the version PR only after CI and review are clean.
-7. Publish only from clean, synced `main` after the version PR merges:
+7. Submit and merge the version PR only after CI and review are clean. The
+   GitHub release workflow creates or updates the generated
+   `changeset-release/main` PR, applies missing `publish:*`, `channel:*`, and
+   `release:*` labels without overriding human intent, and evaluates the
+   publish policy after the generated PR merges.
+8. Prefer the workflow publish path from clean `main`. `publish:auto` uses the
+   `npm-auto` environment only when generated release shape, exact-SHA CI,
+   registry posture, and `stack:boundary` source evidence are complete.
+   `publish:manual` uses the protected `npm` environment for incomplete or
+   ambiguous low-risk proof. `publish:block` and unknown/conflicting managed
+   labels stop the workflow.
+9. Use local publish commands only for diagnostics or explicit recovery:
    `bun run publish:check`, `bun run publish:registry-check`,
    `bun run publish:packages`, then
    `bun run publish:registry-check:published`.

--- a/docs/releases/release-rules-check.md
+++ b/docs/releases/release-rules-check.md
@@ -68,6 +68,8 @@ A branch-local `.changeset/*.md` entry is the normal intent source. It says the 
 
 `release:none` remains a compatibility no-release override. It is a claim, not the primitive. Use it only when the branch touches package files but does not ship user-visible package content, and record the reason in the PR, issue, or handoff. A branch with both `release:none` and changed changeset files fails.
 
+An active package changeset is also release intent. If a branch adds or modifies `.changeset/*.md` without any matching package-content, generated version release, or public trail contract fact, the check fails. Deleted changesets are ignored for this inverse guard so cleanup branches can remove mistaken release intent without adding package noise.
+
 ## Graphite Stacks
 
 The GitHub workflow validates the PR file list for the current branch. In a Graphite stack, that file list is branch-local because GitHub compares the branch against its immediate base PR or branch. Fix missing release intent on the owning branch, then restack upward. Do not hide lower-branch release gaps with a top-stack cleanup changeset.
@@ -94,6 +96,35 @@ That fallback compares `origin/main...HEAD`. It is useful while developing, but 
 For local reviews, missing branch-local release intent for package content or a public trail contract fact is a P2 release-quality blocker. Identify the owning branch, add the changeset or explicit no-release reason there, restack, and rerun the check upward.
 
 Log broader release ideas, such as imported schema tracing, error-taxonomy facts, permit facts, Warden joins, Wayfinder implications, or release targets, as follow-up P3s unless they expose a concrete user-visible release gap in the current branch.
+
+## Generated Release PR Policy
+
+The generated `changeset-release/main` PR uses a separate publish policy from branch-local `release.check`. Branch-local checks decide whether source PRs carry release facts. The generated release PR policy decides whether the already versioned package state can publish automatically, needs protected manual approval, intentionally publishes nothing, or must block.
+
+Managed release PR labels:
+
+| Family | Labels | Meaning |
+| --- | --- | --- |
+| Source evidence | `stack:boundary` | Applied to source PRs whose consumed changesets are complete enough for automatic publication. |
+| Publish intent | `publish:auto`, `publish:manual`, `publish:none`, `publish:block` | Select automatic publish, protected manual publish, intentional no-publish, or hard block. |
+| Channel intent | `channel:beta`, `channel:stable` | Declares the intended npm dist-tag family. `beta` maps to prerelease beta publication; `stable` maps to `latest`. |
+| Release size | `release:patch`, `release:minor`, `release:major` | Declares the semver movement expected on the generated release PR. |
+
+`publish:none` is only for generated release PRs. It is distinct from branch-local `release:none` and requires an audit reason in the release PR body or comments because it intentionally leaves generated package-version state unpublished.
+
+The release PR labeler fills missing publish/channel/release labels without overriding human-provided labels:
+
+```bash
+bun run publish:label-release-pr
+```
+
+The policy gate emits machine-readable GitHub Actions outputs and chooses `auto`, `manual`, `none`, or `block`:
+
+```bash
+bun run publish:policy
+```
+
+`publish:auto` is available only for the expected generated release PR shape: `changeset-release/main` into `main`, generated-only package version and changelog diffs, exact-SHA CI green, coherent registry/dist-tag state, no unknown or conflicting managed labels, and `stack:boundary` on every source PR that introduced a consumed changeset. Missing source PR evidence or missing `stack:boundary` routes to `publish:manual`; contradictory labels, unknown managed labels, registry contradictions, or `publish:block` block the workflow.
 
 ## Warden And Wayfinder
 

--- a/docs/releases/stable-cutover.md
+++ b/docs/releases/stable-cutover.md
@@ -17,6 +17,8 @@ There are two distinct phases:
 
 Never publish from an unmerged version PR. Never use `changeset publish`, `npm publish`, or ad hoc package publication for the normal stable cutover.
 
+Generated release PRs are policy-gated by labels. Source PRs that introduced consumed changesets should carry `stack:boundary` before the stable version PR is expected to reach `publish:auto`. Missing source evidence or missing `stack:boundary` routes publication to the protected manual environment; unknown/conflicting managed labels, registry contradictions, or `publish:block` stop the workflow. `publish:none` is only for generated release PRs and requires an audit reason in the release PR body or comments.
+
 ## Preconditions
 
 Before creating the version PR:
@@ -259,6 +261,11 @@ Keep the PR draft until CI is green and review is complete. The PR body should i
 
 - link to ADR-0047;
 - the intended stable version;
+- intended generated release PR labels, including `channel:stable`, release
+  size, and whether publication should be `publish:auto` or `publish:manual`;
+- `stack:boundary` evidence for source PRs that introduced consumed changesets,
+  or an explicit reason the release should use the protected manual publish
+  path;
 - `bunx changeset status --verbose` summary;
 - `bun run publish:check` result;
 - `bun run publish:registry-check` result;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "turbo run lint",
     "lint:ast-grep": "ast-grep scan --config .ast-grep/sgconfig.yml",
     "changeset:check": "bun apps/trails/bin/trails.ts release check",
+    "version:packages": "bunx changeset version",
     "vocab:audit": "bun scripts/vocab-cutover-audit.ts",
     "vocab:audit:json": "bun scripts/vocab-cutover-audit.ts --json",
     "vocab:rewrite": "bun scripts/vocab-cutover-rewrite.ts",
@@ -57,6 +58,8 @@
     "clean": "turbo run clean --no-cache && rm -rf node_modules",
     "oxlint-plugin:build": "bun run --cwd packages/oxlint-plugin build:oxlint",
     "publish:check": "bun scripts/publish.ts --check",
+    "publish:label-release-pr": "bun scripts/release-policy.ts label-release-pr",
+    "publish:policy": "bun scripts/release-policy.ts policy",
     "publish:registry-check": "bun scripts/check-registry-preflight.ts",
     "publish:registry-check:published": "bun scripts/check-registry-preflight.ts --require-published",
     "publish:packages": "bun scripts/publish.ts"

--- a/scripts/release-policy.ts
+++ b/scripts/release-policy.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env bun
+import { runReleasePolicyCli } from '@ontrails/trails/release';
+
+if (import.meta.main) {
+  process.exit(await runReleasePolicyCli(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Context

Implements TRL-999 by adding Skillset-style generated release PR policy labels and stack-boundary publish gating for Trails.

## What changed

- Added generated release PR policy evaluation for publish/channel/release labels, source PR stack-boundary evidence, exact-SHA CI, generated diff shape, and npm registry posture.
- Added a release workflow that creates/labels Changesets version PRs, gates publish through auto/manual/none/block decisions, publishes through protected npm environments, and creates GitHub releases after publish verification.
- Added branch-local inverse release intent validation so active `.changeset` entries without package or release facts fail locally.
- Documented release label families, stack-boundary source evidence, beta/stable publish policy, and stable cutover expectations.
- Fixed the Graphite review finding in prerelease ordering: release policy SemVer comparison now parses prerelease identifiers so `beta.10` sorts after `beta.9` before registry drift blockers run.

## Verification

- Focused release tests: `bun test apps/trails/src/__tests__/release-check.test.ts apps/trails/src/__tests__/release-policy.test.ts apps/trails/src/__tests__/release-check-trail.test.ts`
- Full repo check: `bun run check`
- Release checks: branch-local `bun run changeset:check -- --changed-files /tmp/trl-999-files.txt --base-ref HEAD`, `bun run publish:check`, `bun run publish:registry-check`
- Workflow lint: `actionlint .github/workflows/release.yml`
- Graphite submit dry-run passed before each submit.
- Graphite pre-push passed twice after the review fix and after rebasing on current `main`: Warden, ADR, full tests, typecheck, lint, ast-grep, format, and dead-code.

## Notes

- `bun run publish:registry-check` passes and reports the existing `@ontrails/library` first-time package candidate.
- PR was rebased onto current `main` after #762 merged.
