### PR TITLE
docs(plugin): refresh Trails writing skills bundle

### DIFF
--- a/.agents/skills/clark/SKILL.md
+++ b/.agents/skills/clark/SKILL.md
@@ -102,7 +102,7 @@ Load the appropriate skill or reference based on the task. In Claude, load the n
 
 ## Vocabulary Enforcement
 
-This may be your most important ongoing responsibility. The framework's vocabulary was hand-crafted, and agents will casually introduce "handler," "middleware," "endpoint," "controller," "route" (for composition), "registry," "impl" (for blaze), and other terms that erode the Trails mental model.
+This may be your most important ongoing responsibility. The framework's vocabulary was hand-crafted, and agents will casually introduce "handler," "middleware," "endpoint," "controller," "route" (for composition), "registry," "impl," and other terms that erode the Trails mental model.
 
 Lexicon drift is invisible in the moment. No test fails. No type error fires. But six months later you have three words for the same concept and the framework's coherence is gone.
 
@@ -112,7 +112,7 @@ When you find lexicon drift:
 - Explain why it matters, briefly. Not a lecture, a reminder.
 - Give the correction. Do not just flag it. Fix it.
 
-This applies to code, comments, error messages, documentation, commit messages, and conversation. Refer to `docs/lexicon.md` for the full lexicon and `docs/contributing/language-styleguide.md` for prose grammar.
+This applies to code, comments, error messages, documentation, commit messages, and conversation. Refer to `docs/lexicon.md` for the full lexicon and `docs/contributing/language-styleguide.md` for prose grammar. Vocabulary is mid-cutover toward the v1 reset: describe current live code with current terms, and see `docs/lexicon-pending.md` for the terms ratified to change (and `trails-writing-style` for prose craft). Do not adopt the targets before the cutover lands.
 
 ## Decision Logging
 
@@ -135,6 +135,9 @@ Read at point of need. Do not rely on cached knowledge when specifics matter.
 - `docs/architecture.md` — hexagonal model, information categories
 - `docs/horizons.md` — future directions
 - `AGENTS.md` — repo conventions and workflow
+- `.agents/skills/trails-writing-voice/SKILL.md` — Trails writing stance
+- `.agents/skills/trails-writing-style/SKILL.md` — prose craft and vocabulary precision
+- `.agents/skills/trails-writing-docs/SKILL.md` — current docs structure and maintenance guidance
 - `./references/warden-guide.md` — generated Warden rule guidance for repo-tracked skills, agents, and plugin prompts
 
 When evaluating code, also check the actual package structure in `packages/` and the current API surface. The docs describe intent. The code describes reality. Both matter.

--- a/.agents/skills/clark/references/calibrate.md
+++ b/.agents/skills/clark/references/calibrate.md
@@ -35,13 +35,11 @@ Scan all changed or new files for vocabulary violations. Highest-priority check.
 | provision (legacy) | resource |
 | gate (legacy) | layer |
 
-For `blaze`, preserve the distinction that a `blaze` establishes how a trail runs. The runtime runs the blazed trail; surfaces expose trails, not blazes.
+`blaze` is the current live term for the authored behavior field; flag `impl`, `fn`, `handler`, action body, or endpoint language as `blaze`. `implementation` is the ratified target for the v1 reset — see `docs/lexicon-pending.md`. Do not flag live `blaze` as a violation or rewrite it to `implementation` before the cutover lands; when live code and ratified direction differ, say so explicitly.
 
-The current Trails lexicon canonicalizes `resource` (the declared infrastructure primitive — see `docs/lexicon.md` and ADR-0009) and
-`layer` (typed cross-cutting wrapper — see ADR-0043 Layer Evolution).
-Older Clark passes coached toward `provision`/`gate`; those terms are historical and should not appear in current vocabulary checks unless
-explicitly framed as deprecated. **Source of truth hierarchy:** when this reference file disagrees with `docs/tenets.md`, `docs/lexicon.md`,
-or `AGENTS.md`, the docs win — calibrate flags drift, not lexicon shifts.
+The current Trails lexicon canonicalizes `resource` (the declared infrastructure primitive — see `docs/lexicon.md` and ADR-0009) and `layer` (typed cross-cutting wrapper — see ADR-0043 Layer Evolution).
+
+Older Clark passes coached toward `provision`/`gate`; those terms are historical and should not appear in current vocabulary checks unless explicitly framed as deprecated. **Source of truth hierarchy:** when this reference file disagrees with `docs/tenets.md`, `docs/lexicon.md`, or `AGENTS.md`, the docs win — calibrate flags drift, not lexicon shifts.
 
 Also check that standard terms stay standard. `config` is not "settings." `Result` is not "response."
 

--- a/.agents/skills/trails-adrs/SKILL.md
+++ b/.agents/skills/trails-adrs/SKILL.md
@@ -33,6 +33,12 @@ When an ADR proposes something new, test it against these. Does it reinforce the
 
 Read related ADRs before drafting. Use `docs/adr/decision-map.json` or browse `docs/adr/` and `docs/adr/drafts/` to find ADRs that touch similar concerns. Good ADRs build on the existing decision graph — they reference specific sections of prior ADRs, link to their headings, and explain how the new decision compounds with or extends what's already decided.
 
+For voice, style, and document maintenance, also load the repo-local writing skills:
+
+- `trails-writing-voice`
+- `trails-writing-style`
+- `trails-writing-docs`
+
 When your ADR relates to an existing one:
 
 - Link to it in References with a one-line description of the relationship
@@ -263,7 +269,7 @@ Synthesized from ADR-000 (Core Premise) and ADR-001 (Naming Conventions).
 
 ### Vocabulary
 
-Use the accepted project vocabulary consistently: trail (not action/handler), topo (not registry), compose (not follow or cross), blaze (not handler/impl), surface (not transport), and tracing (not crumbs or tracker). For `blaze`, follow `docs/contributing/language-styleguide.md`: the runtime runs trails, not blazes.
+Use the accepted project vocabulary consistently: trail (not action/handler), topo (not registry), compose (not follow or cross), blaze (not handler/impl), surface (not transport), and tracing (not crumbs or tracker). Vocabulary is mid-cutover toward the v1 reset — write current ADRs in current terms and see `docs/lexicon-pending.md` for what is changing (and `trails-writing-style` for prose craft).
 
 Read `docs/tenets.md` before writing. Every ADR must be consistent with the tenets.
 

--- a/.agents/skills/trails-editorial/SKILL.md
+++ b/.agents/skills/trails-editorial/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: trails-editorial
+description: "Complete Trails editorial review workflow. Use when reviewing docs, ADRs, README changes, release notes, agent guidance, or docs-heavy PRs for voice, style, structure, correctness, and readiness."
+metadata:
+  version: 0.1.0
+  author: trails
+  category: documentation
+  skillset:
+    generator: scripts/codex/skillset.ts
+    target: codex
+    version: 1
+    source: .claude/skills/trails-editorial
+    source-file: .claude/skills/trails-editorial/SKILL.md
+---
+
+# Trails Editorial
+
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
+Run a complete editorial review for Trails documentation and prose-heavy changes. This is a workflow skill. It should work in Claude, Codex, or any agent harness that can read skills, inspect files, and run commands.
+
+## Load First
+
+Before reviewing, load:
+
+1. `trails-writing-voice`
+2. `trails-writing-style`
+3. `trails-writing-docs`
+
+If one is unavailable, continue only after reading the corresponding `.agents/skills/<name>/SKILL.md` file directly. If the file is missing, report that as part of the review.
+
+## Inputs
+
+The target can be:
+
+- one file;
+- a directory;
+- a PR diff;
+- a stack;
+- an ADR draft;
+- a release note;
+- agent guidance;
+- a question such as "is this ready to merge?"
+
+If no target is supplied, infer the smallest relevant target from the current conversation or working tree.
+
+## Workflow
+
+### 1. Establish Scope
+
+Identify:
+
+- target files;
+- source-of-truth docs or ADRs;
+- current branch and dirty state when working in a repo;
+- whether the review is read-only or may edit.
+
+Do not expand beyond the target unless a nearby file must change to keep the docs truthful.
+
+### 2. Classify The Document
+
+Classify each target as one of:
+
+- guide;
+- reference;
+- ADR;
+- release doc;
+- README;
+- agent guidance;
+- issue or PR prose;
+- working note.
+
+Use that classification to decide what "good" means. A reference page should not sound like a blog post. A working note can preserve uncertainty. An ADR must state the decision.
+
+### 3. Voice Review
+
+Check against `trails-writing-voice`:
+
+- Does it state decisions clearly?
+- Does it respect both human and agent readers?
+- Are claims evidence-backed?
+- Is the tone right for the container?
+- Does theme clarify rather than decorate?
+- Does the document preserve distribution-ready done?
+
+### 4. Style And Vocabulary Review
+
+Check against `trails-writing-style`:
+
+- Are terms current and consistent?
+- Are ratified future terms distinguished from live code when needed?
+- Are paragraphs focused?
+- Are examples concrete?
+- Is in-flight vocabulary handled per `docs/lexicon-pending.md` (current-live terms, not prematurely swapped to targets)?
+- Are old synonyms or retired terms creeping in?
+
+### 5. Structure Review
+
+Check against `trails-writing-docs`:
+
+- Does the information live in the right current repo location?
+- Is there one canonical home?
+- Are links, references, and examples current?
+- Does the doc include the sections its document type needs?
+- Does it avoid duplicating information that should be linked?
+
+### 6. Technical Verification
+
+Run the smallest useful checks for the target.
+
+Possible checks:
+
+```bash
+bun run docs:wrap-check
+bun scripts/adr.ts check
+bun scripts/adr.ts map
+bun run plugin:metadata:check
+bun run warden:agents:check
+bun run check
+git diff --check
+```
+
+Do not run broad checks just for ceremony. Choose the checks that prove the target.
+
+For claims about code behavior, inspect source or run targeted tests. For claims about CLI output, run the command or state that it was not verified.
+
+### 7. Findings
+
+Report findings by severity:
+
+- **P0:** materially false, unsafe, or blocks release correctness.
+- **P1:** likely to mislead users or agents into wrong behavior.
+- **P2:** vocabulary, structure, or missing-doc gap that will cause drift.
+- **P3:** polish, clarity, minor duplication, or optional tightening.
+
+Lead with P0-P2 findings. Include file paths and line numbers when possible. Keep P3s selective.
+
+### 8. Fix Loop
+
+If edits are allowed:
+
+1. Fix P0-P2 issues.
+2. Fix relevant P3 issues when they are nearby and low-risk.
+3. Re-run targeted verification.
+4. Repeat until the target is ready or blocked.
+
+If edits are not allowed, produce a concise review with exact recommended changes.
+
+### 9. Outcome
+
+End with one of:
+
+- `ready`;
+- `ready with nits`;
+- `needs fixes`;
+- `blocked`;
+- `wrong target`.
+
+Include:
+
+- files reviewed;
+- files changed, if any;
+- checks run and results;
+- unresolved risks;
+- exact next action.
+
+## Goal Invocation Shape
+
+For a larger editorial pass, use this generic goal shape:
+
+```markdown
+Goal: Bring [target docs/change/PR/stack] to Trails editorial readiness.
+
+Done when:
+
+- P0-P2 editorial, vocabulary, structure, and correctness issues are fixed or explicitly deferred with rationale.
+- Relevant P3s are handled when they improve clarity without expanding scope.
+- Required docs, skills, release notes, ADRs, and agent guidance are updated or marked not applicable.
+- Verification commands pass or failures are explained with evidence.
+- The final report lists changed files, checks, remaining risks, and exact next action.
+
+Constraints:
+
+- Follow `trails-writing-voice`, `trails-writing-style`, and `trails-writing-docs`.
+- Keep changes scoped to the target and necessary nearby truth.
+- Do not rewrite stable doctrine without an ADR or explicit approval.
+- Distinguish current live code from ratified future vocabulary.
+```
+
+## Report Template
+
+```markdown
+State: ready | ready with nits | needs fixes | blocked | wrong target
+
+Reviewed:
+
+- path
+- path
+
+Findings:
+
+- [P2] path:line - Issue and recommended fix.
+
+Changed:
+
+- path - Summary.
+
+Verification:
+
+- command - pass/fail/not run, with reason.
+
+Remaining:
+
+- Risk, decision, or follow-up.
+
+Next:
+
+- Exact next action.
+```

--- a/.agents/skills/trails-writing-docs/SKILL.md
+++ b/.agents/skills/trails-writing-docs/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: trails-writing-docs
+description: "Trails documentation structure and maintenance guidance. Use when creating or reorganizing Trails docs, READMEs, guides, reference pages, release docs, or agent-facing documentation."
+metadata:
+  version: 0.1.0
+  author: trails
+  category: documentation
+  skillset:
+    generator: scripts/codex/skillset.ts
+    target: codex
+    version: 1
+    source: .claude/skills/trails-writing-docs
+    source-file: .claude/skills/trails-writing-docs/SKILL.md
+---
+
+# Trails Writing Docs
+
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
+This skill covers what a Trails document should include and where it should live. It reflects the current repository shape. The v1 ADR Canon Reset may revise the final docs taxonomy, so do not treat this as the permanent information architecture.
+
+For voice, load `trails-writing-voice`. For prose craft and vocabulary, load `trails-writing-style`.
+
+## Documentation Ladder
+
+Trails documentation follows the distribution-ready done rule:
+
+1. **Types and schemas** carry the contract closest to code.
+2. **Examples** prove and teach happy paths.
+3. **Tests and Warden rules** prevent drift.
+4. **Docs and guides** explain how to use the behavior.
+5. **Agent guidance and skills** teach agents how to preserve it.
+6. **Release notes and changesets** carry migration and publication intent.
+
+Feature work is not done until the affected docs layer is updated or explicitly marked not applicable.
+
+## Current Repo Map
+
+Use the current structure unless the docs-organization ADR says otherwise:
+
+| Location             | Use for                                                                  |
+| -------------------- | ------------------------------------------------------------------------ |
+| `README.md`          | Project entry point and pointers.                                        |
+| `AGENTS.md`          | Canonical guidance for agents working on Trails.                         |
+| `docs/`              | Public and contributor-facing documentation.                             |
+| `docs/contributing/` | Contributor guidance, code standards, language style, script graduation. |
+| `docs/surfaces/`     | Surface-specific docs and surface accommodation guidance.                |
+| `docs/releases/`     | Release runbooks, beta/stable cutover notes, migration details.          |
+| `docs/adr/`          | Accepted ADRs and decision maps.                                         |
+| `docs/adr/drafts/`   | Draft ADRs and future-facing proposals.                                  |
+| `plugin/skills/`     | Distributed skills for downstream agents using Trails.                   |
+| `.agents/skills/`    | Repo-local skills for contributors and local agents.                     |
+| `.agents/notes/`     | Gitignored working notes and handoff records.                            |
+
+When in doubt, update the nearest existing document instead of creating a new one.
+
+## Document Types
+
+### Guide
+
+Use a guide when the reader needs to apply a concept.
+
+Include:
+
+- the reader's starting point;
+- the minimal working example;
+- the common wrong shape;
+- surface or runtime implications;
+- verification commands;
+- links to reference and ADRs.
+
+### Reference
+
+Use reference docs for exact lookup.
+
+Include:
+
+- API names and signatures;
+- option tables;
+- input and output shapes;
+- defaults;
+- error behavior;
+- stability notes.
+
+Keep reference pages dense and predictable. Do not turn them into essays.
+
+### ADR
+
+Use an ADR when reversing the decision would materially change Trails.
+
+Load `trails-adrs` for ADR-specific structure. ADRs should explain the tension, the decision, the alternatives, and what this does not decide.
+
+### Release Doc
+
+Use release docs when existing users or release operators need a path.
+
+Include:
+
+- what changed;
+- why it matters;
+- exact commands;
+- migration or bridge steps;
+- compatibility window;
+- verification checks;
+- known non-support.
+
+### Agent Guidance
+
+Use agent guidance when future agents need to preserve a behavior.
+
+Include:
+
+- when to use the guidance;
+- source-of-truth files;
+- stop conditions;
+- exact commands;
+- known stale paths or noise;
+- what not to mutate.
+
+## README Rules
+
+READMEs should orient quickly and link out.
+
+Keep:
+
+- the first usable path near the top;
+- examples copy-pasteable;
+- explanation after the quick path;
+- links to deeper docs instead of duplicating them.
+
+Avoid:
+
+- long architecture essays;
+- stale command lists;
+- repeating docs that already have a canonical page.
+
+## Code Examples
+
+Every code example should be either runnable or clearly marked as abridged.
+
+Examples should:
+
+- include imports when they matter;
+- show definition and use;
+- show expected output for CLI examples;
+- use current package names;
+- avoid retired vocabulary;
+- prefer realistic domain examples over placeholders.
+
+When examples are part of a trail contract, treat them as both docs and tests.
+
+## Maintenance Checks
+
+Before considering docs done:
+
+- Run the repo's relevant docs or format checks when available.
+- Verify links and anchors touched by the change.
+- Search for stale duplicates when moving or renaming concepts.
+- Update distributed skills if downstream agents need the new guidance.
+- Add a changeset or release note when package behavior or public trails change.
+- Note "not applicable" when reviewers would reasonably expect docs but none are needed.
+
+## Docs Organization ADR Caveat
+
+The draft docs-organization ADR is allowed to change section names, placement rules, and generated docs behavior. Until that lands:
+
+- conform to the current repo;
+- avoid creating new top-level docs taxonomies;
+- write new docs so they can be moved cleanly later;
+- prefer clear frontmatter and unique filenames when adding new docs;
+- leave a note in the PR or issue when placement is provisional.
+
+## Review Checklist
+
+When creating or reviewing Trails docs:
+
+- Is there one canonical home for this information?
+- Is the audience clear?
+- Does the document teach use, lookup, decision, release operation, or agent workflow?
+- Are examples current and runnable?
+- Are links and commands verified?
+- Are vocabulary and reset-direction terms handled honestly?
+- Does the change satisfy distribution-ready done?
+- Would a future agent know where to update this next time?

--- a/.agents/skills/trails-writing-style/SKILL.md
+++ b/.agents/skills/trails-writing-style/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: trails-writing-style
+description: "Trails prose craft and lexicon style. Use when writing or reviewing docs, ADRs, examples, release notes, agent prompts, comments, PR descriptions, or issue language for rhythm, clarity, and vocabulary precision."
+metadata:
+  version: 0.1.0
+  author: trails
+  category: content
+  skillset:
+    generator: scripts/codex/skillset.ts
+    target: codex
+    version: 1
+    source: .claude/skills/trails-writing-style
+    source-file: .claude/skills/trails-writing-style/SKILL.md
+---
+
+# Trails Writing Style
+
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
+This skill covers how Trails prose should read: sentence rhythm, structural patterns, examples, and vocabulary discipline.
+
+For the larger stance, load `trails-writing-voice`. For document placement and required sections, load `trails-writing-docs`.
+
+## Start From The Contract
+
+Trails writing should follow the same shape as Trails itself:
+
+1. **Define** the authored truth.
+2. **Derive** facts the framework already knows.
+3. **Render** the right surface, doc, example, check, or report.
+
+This is both architecture and writing style. Avoid asking readers to reconcile three versions of the same idea.
+
+## Sentence Rhythm
+
+Use a mix of:
+
+- **Claim:** one sentence that can stand alone.
+- **Reason:** why the claim matters.
+- **Consequence:** what breaks or gets easier.
+- **Example:** code, command, or concrete output.
+
+Short sentences carry decisions. Longer sentences are allowed when they earn their room by explaining a real tradeoff.
+
+Avoid uniform paragraph sludge. If a paragraph has more than one job, split it.
+
+## Headers
+
+Headers should help the reader navigate.
+
+Prefer headers that name the work:
+
+- `Fresh App Loading`
+- `Release Intent`
+- `Surface Accommodations`
+- `What This Does Not Decide`
+
+Avoid decorative or vague headers:
+
+- `Overview`
+- `Background`
+- `More Details`
+- `Things To Consider`
+
+`Overview` and `Background` are acceptable only when the document template requires them. Even then, make the first sentence do real work.
+
+## Examples Are Primary Evidence
+
+An agent or developer should often understand the rule from the example before they read the prose.
+
+Good examples:
+
+- include imports when imports matter;
+- show the authored contract and the resulting surface or behavior;
+- include expected output for commands;
+- show failure cases when failure behavior is part of the contract;
+- are runnable or clearly marked as abridged.
+
+Avoid examples that hide the important part behind `...`.
+
+For worked good-and-bad samples across docs and narrative containers, see `assets/SAMPLES.md`.
+
+## Voice Mechanics
+
+Prefer:
+
+- active voice;
+- concrete nouns;
+- direct verbs;
+- exact file paths, commands, issue IDs, or ADR links when relevant;
+- "this means" lists after dense claims;
+- "the test:" heuristics when a reviewer needs to apply a rule.
+
+Avoid:
+
+- hedging settled decisions;
+- inventing synonyms for variety;
+- corporate filler;
+- marketing superlatives;
+- unexplained jargon;
+- clever metaphors that require decoding;
+- passive voice that hides who acts.
+
+## Vocabulary Discipline
+
+Use the current project vocabulary from `docs/lexicon.md`, `AGENTS.md`, ADRs, and `docs/lexicon-pending.md`.
+
+Current high-signal direction (stable terms; for terms mid-cutover see `docs/lexicon-pending.md`):
+
+- `trail`, not action, endpoint, handler, or route for the unit of work.
+- `surface`, not transport, when naming the outside boundary.
+- `topo` for the assembled Trails graph primitive.
+- `compose`, not cross, follow, call, invoke, route, or workflow for trail-to-trail composition.
+- `resource` for declared infrastructure dependencies.
+- `layer` for typed execution wrappers.
+
+The authored-behavior field, grouped surface entries, and the derive/render split are mid-cutover. Describe current code in current terms and follow `docs/lexicon-pending.md`. Do not silently rewrite history or pretend a cutover has already landed.
+
+`docs/lexicon-pending.md` is the transition control surface. Its Current column describes live reality; its Target column describes ratified reset direction. Do not adopt target terms in code, docs, examples, or plugin guidance before the cutover unless the work is explicitly part of that reset.
+
+## Theme Is Not A Checklist
+
+Outdoor language belongs when it clarifies official concepts. It does not belong as decorative prose.
+
+Good:
+
+> A `detour` names a recovery strategy for a failed trail, not general control flow.
+
+Bad:
+
+> Pack your gear before trekking into the terrain of release configuration.
+
+Use plain words unless the themed word carries the concept better.
+
+## Replacement Patterns
+
+| Weak phrasing | Stronger phrasing |
+| --- | --- |
+| "This is a flexible way to expose functionality." | "This renders the same trail contract on CLI and MCP without re-authoring behavior." |
+| "We might want to consider adding checks." | "Add a Warden rule when drift can be detected from authored facts." |
+| "The handler processes the request." | "The trail receives validated input; its blaze returns a `Result`." |
+| "Run the implementation directly." | "Run the trail through the shared execution pipeline." |
+| "The CLI route has different behavior." | "This needs a distinct trail unless the input normalizes into the same contract without lying." |
+
+## Review Checklist
+
+When reviewing Trails prose:
+
+- Is the first claim clear enough to quote?
+- Does each paragraph have one job?
+- Are examples concrete and aligned with current source?
+- Are themed terms official or genuinely clarifying?
+- Are ratified future terms distinguished from current live code when needed?
+- Are `derive` and `render` used with distinct meanings?
+- Does the text avoid synonym drift?
+- Does the document teach the check or heuristic an agent should apply later?

--- a/.agents/skills/trails-writing-style/assets/SAMPLES.md
+++ b/.agents/skills/trails-writing-style/assets/SAMPLES.md
@@ -1,0 +1,151 @@
+# Writing Samples
+
+Worked craft samples for Trails prose, adapted and expanded from the Outfitter styleguide samples. They cover both framework docs (ADRs, guides, reference, agent guidance, release notes) and trails.dev narrative and launch writing. Use them with `trails-writing-style` -- they illustrate the rules by example; they are not new rules.
+
+> Vocabulary note: examples here use only stable Trails terms on purpose. The framework's vocabulary is mid-cutover toward the v1 reset, so don't treat any single term as permanent -- when you write new samples, prefer terms that are settled.
+
+## Opening moves
+
+### Problem framing
+
+> "Every framework promises 'define it once.' Most still make you write it three times -- once for the CLI, once for the HTTP handler, once for the agent tool."
+
+Why it works: it names a real, specific pain the reader has felt, then sets up the resolution without overselling. "Three times" is concrete, not a vibe.
+
+### Earned honesty
+
+> "Trails won't make a bad API good. It makes a good API impossible to expose three inconsistent ways."
+
+Why it works: it states a limit before a benefit. The honesty buys the claim that follows.
+
+## Punch and flow
+
+Setup, pivot, punch, resolution.
+
+> "You define the trail once. Want it on MCP too? There's nothing to port -- the MCP tool and the CLI command read the same contract."
+
+The short sentences carry the decision; the longer one earns its room by naming the payoff. Read it aloud -- it has a beat.
+
+## Earned enthusiasm
+
+> "The CLI and the MCP server came out of the same forty lines. I kept waiting to write the second one."
+
+Why it works: a real reaction to a real result, not a marketing adjective. The specific detail carries the feeling. "Revolutionary" would carry nothing.
+
+## Status: precision and honesty
+
+### High status -- technical precision
+
+> "Input is a Zod schema. The same schema validates CLI flags, MCP tool parameters, and the HTTP body -- one parse, at the boundary, before your code runs."
+
+Names the real tool, then shows the payoff. Credible because it's exact.
+
+### Low status -- builder honesty
+
+> "WebSocket isn't a surface yet. The contract model is built for it; the surface isn't written."
+
+"Yet" signals trajectory without overpromising. Honesty about the edge builds trust in the center.
+
+### The blend
+
+> "Trails is opinionated about authoring and unopinionated about output. That's a real constraint -- you write contracts our way -- and it's the whole reason a CLI and an MCP server can't drift apart."
+
+Vulnerability (a real constraint) wrapped in the reason it's worth it.
+
+## Technical without gatekeeping
+
+> "The topo is the resolved graph of everything -- trails, resources, signals, and how they connect. Think of it as the app's table of contents, except it's queryable and the framework keeps it honest."
+
+Introduces the term, defines it plainly, gives an analogy, then states what's special. No jargon left undefined; nothing dumbed down.
+
+## Show the work
+
+An example should carry the rule before the prose does.
+
+Good -- the contract and the surfaces it produces, side by side:
+
+```typescript
+const show = trail('gist.show', {
+  input: z.object({ id: z.string() }),
+  intent: 'read',
+  output: Gist,
+  // returns Result.ok(gist)
+});
+```
+
+```bash
+gists show --id abc123     # CLI command, derived from the trail
+# the MCP tool `gist.show` exposes the identical contract
+```
+
+Why it works: the reader sees the authored contract and both surfaces it produces. The "one contract, many surfaces" claim is demonstrated, not asserted. Don't hide the part that proves the point behind `...`.
+
+## Metaphor: earned vs forced
+
+This is the self-explains test in sample form. A themed word earns its place only if the sentence survives stripping the theme.
+
+Earned:
+
+> "A `trail` is a defined path from typed input to a `Result`."
+
+`trail` carries the concept -- a path -- and the sentence still reads if you swap in "defined unit of work." The word reduces translation effort; it doesn't add it.
+
+Forced:
+
+> "Pack your provisions and blaze a path through the untamed wilderness of your domain logic."
+
+Strip the theme and nothing is lost, which means it was never carrying meaning. Reader eye-roll incoming.
+
+The test: remove the themed word. If the sentence still teaches, the word earned its place. If only the costume is left, cut it.
+
+## Generic vs concrete
+
+Generic -- avoid:
+
+> "Trails is a flexible, powerful framework that lets you build integrations across many platforms with ease."
+
+Concrete -- better:
+
+> "Define a `trail` once; it runs on CLI, MCP, and HTTP from one authored contract, with no per-surface reimplementation."
+
+The generic version gives the reader nothing to act on or verify. The concrete version names the unit, the surfaces, and the guarantee -- each of which is checkable.
+
+## Closing moves
+
+### Invitation
+
+> "If you're wiring agents to your own services, try defining one capability as a trail and surfacing it on MCP. The whole point is that the second surface is free."
+
+Clear audience, low-commitment ask, one concrete payoff -- not a vague promise.
+
+### Door left ajar
+
+> "Most of the interesting questions are still open: activation sources, cross-app composition, more surfaces. The contract model is the bet that those stay additive."
+
+Leaves the reader thinking forward, names real open ground honestly, and ties back to the core claim. Aspirational without being preachy -- and no borrowed quote required.
+
+## Anti-patterns to avoid
+
+### Generic tech-blog opener
+
+> "In today's fast-paced development landscape, building consistent APIs has never been more important. That's why we created Trails -- a revolutionary framework that transforms how you ship."
+
+What's wrong: "fast-paced landscape" is filler, "never been more important" says nothing, "revolutionary" and "transforms" are unearned superlatives. Cut all of it.
+
+### Hedge stack
+
+> "It is generally recommended that you should probably consider adding a Warden rule in most cases."
+
+What's wrong: four hedges around one instruction. Say it: "Add a Warden rule when drift can be caught from authored facts."
+
+## The Coffee Test
+
+Read the sentence aloud. Would you say it to a sharp colleague explaining what you built?
+
+Fails:
+
+> "Trails empowers developers to seamlessly leverage a unified contract abstraction across heterogeneous surfaces."
+
+Passes:
+
+> "You write the capability once, and it shows up on the CLI and as an agent tool without you doing it twice."

--- a/.agents/skills/trails-writing-voice/SKILL.md
+++ b/.agents/skills/trails-writing-voice/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: trails-writing-voice
+description: "Trails writing voice and values. Use when drafting or reviewing Trails docs, ADRs, README content, release notes, agent guidance, or public explanations for stance, audience, and tone."
+metadata:
+  version: 0.1.0
+  author: trails
+  category: content
+  skillset:
+    generator: scripts/codex/skillset.ts
+    target: codex
+    version: 1
+    source: .claude/skills/trails-writing-voice
+    source-file: .claude/skills/trails-writing-voice/SKILL.md
+---
+
+# Trails Writing Voice
+
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
+Trails writes like a framework with a spine.
+
+We are opinionated because drift is expensive. We explain those opinions because agents and developers need to trust the path, not memorize it. The voice should feel calm, direct, practical, and awake to tradeoffs.
+
+## Core Stance
+
+| Principle | In practice |
+| --- | --- |
+| Contract-first | Lead from authored contracts and what they make possible. |
+| Agent-native | Structure for agents and humans at the same time. |
+| Drift-resistant | Explain how the framework makes consistency easier than divergence. |
+| Evidence-backed | Anchor claims in code, checks, examples, ADRs, or measured behavior. |
+| Plain by default | Use ordinary words when they carry the concept. Use Trails terms only when they earn the slot. |
+| Teachable | A good paragraph should make the next correct action easier. |
+| Distribution-aware | Feature work is not done until docs, examples, guidance, governance, and release posture are handled or explicitly not applicable. |
+
+## Audience
+
+Write for three readers at once:
+
+- **Developers** deciding whether the framework helps them ship.
+- **Contributors** trying to preserve the shape of the framework.
+- **Agents** navigating the repo, deriving behavior, and avoiding drift.
+
+This does not mean writing more. It means writing with structure:
+
+- clear headings;
+- concrete examples;
+- explicit inputs, outputs, and failure modes;
+- exact commands when commands are the point;
+- links to source-of-truth docs instead of repeated doctrine.
+
+## Voice
+
+Trails voice is:
+
+- **Confident, not inflated.** State decisions clearly. Do not market them.
+- **Precise, not brittle.** Name the concept, the boundary, and the exception.
+- **Warm, not chatty.** Help the reader feel oriented without adding filler.
+- **Practical, not abstract.** Show how the idea changes code, checks, or workflow.
+- **Curious, not tentative.** It is fine to name open questions. Do not hedge settled decisions.
+
+Prefer:
+
+> Define the trail once. Derive what the framework already knows. Render each surface from that shared contract.
+
+Avoid:
+
+> Trails aims to provide a flexible and potentially powerful way to create multiple integrations.
+
+## Tone By Container
+
+| Container          | Tone                                                           |
+| ------------------ | -------------------------------------------------------------- |
+| README quick start | Fast, concrete, copy-pasteable.                                |
+| Guide              | Practical and explanatory. Show patterns and failure modes.    |
+| Reference          | Dense and exact. Personality gets out of the way.              |
+| ADR                | Declarative and reasoned. Tell the tension, then the decision. |
+| Release note       | Operator-focused. What changed, why it matters, what to do.    |
+| Agent guidance     | Direct. Give rules, stop conditions, and verification.         |
+| Blog or narrative  | More room for voice, but claims still need evidence.           |
+
+## The Theme Rule
+
+Trails can use outdoor and wayfinding language when it clarifies the mental model. Theme is not a writing quota.
+
+Use themed terms when they are official vocabulary or carry the concept better than a plain word: `trail`, `topo`, `surface`, `warden`, `wayfinder`, and `detour`. (Some grouped-entry vocabulary is mid-cutover — see `docs/lexicon-pending.md`.)
+
+Do not decorate ordinary prose with theme language when a plain word is clearer.
+
+The test:
+
+> Does the word reduce translation effort for a new agent or developer?
+
+If yes, keep it. If no, say it plainly.
+
+## Earned Confidence
+
+Trails docs can be strongly worded when the claim is backed by proof.
+
+Good sources of proof:
+
+- runnable examples;
+- type signatures;
+- Warden rules;
+- tests;
+- CLI output;
+- ADRs;
+- fresh consumer smoke tests;
+- repository commands and generated artifacts.
+
+Weak sources:
+
+- vibes;
+- future promises;
+- "should be easy";
+- claims about other tools without citations;
+- unverified memory of older branches.
+
+## Ownership
+
+Use "we" when speaking as the project. Use direct imperatives when giving instructions.
+
+Prefer:
+
+> Add a changeset on the branch that changes the publishable package.
+
+Avoid:
+
+> It is recommended that a changeset should be considered.
+
+## Review Checklist
+
+When reviewing a Trails document for voice:
+
+- Does it state the decision or instruction without hedging?
+- Does it explain the why enough for an agent to preserve the behavior later?
+- Does it use Trails vocabulary because it helps, not because it sounds themed?
+- Are claims backed by source, command, test, ADR, or example evidence?
+- Does the container shape match the reader's job?
+- Does it avoid marketing language and corporate filler?
+- Does it make the next correct action clearer?

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Build with the Trails framework — contract-first trails, surfaces, testing, and governance.",
-    "version": "0.3.1"
+    "version": "0.3.2"
   },
   "repository": "https://github.com/outfitter-dev/trails",
   "plugins": [
     {
       "name": "trails",
       "source": "./plugin",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "description": "Skills for building Trails applications — trail creation, surfaces, testing, debugging, migration, and governance."
     }
   ]

--- a/.claude/skills/clark/SKILL.md
+++ b/.claude/skills/clark/SKILL.md
@@ -94,7 +94,7 @@ Load the appropriate skill or reference based on the task. In Claude, load the n
 
 ## Vocabulary Enforcement
 
-This may be your most important ongoing responsibility. The framework's vocabulary was hand-crafted, and agents will casually introduce "handler," "middleware," "endpoint," "controller," "route" (for composition), "registry," "impl" (for blaze), and other terms that erode the Trails mental model.
+This may be your most important ongoing responsibility. The framework's vocabulary was hand-crafted, and agents will casually introduce "handler," "middleware," "endpoint," "controller," "route" (for composition), "registry," "impl," and other terms that erode the Trails mental model.
 
 Lexicon drift is invisible in the moment. No test fails. No type error fires. But six months later you have three words for the same concept and the framework's coherence is gone.
 
@@ -104,7 +104,7 @@ When you find lexicon drift:
 - Explain why it matters, briefly. Not a lecture, a reminder.
 - Give the correction. Do not just flag it. Fix it.
 
-This applies to code, comments, error messages, documentation, commit messages, and conversation. Refer to `docs/lexicon.md` for the full lexicon and `docs/contributing/language-styleguide.md` for prose grammar.
+This applies to code, comments, error messages, documentation, commit messages, and conversation. Refer to `docs/lexicon.md` for the full lexicon and `docs/contributing/language-styleguide.md` for prose grammar. Vocabulary is mid-cutover toward the v1 reset: describe current live code with current terms, and see `docs/lexicon-pending.md` for the terms ratified to change (and `trails-writing-style` for prose craft). Do not adopt the targets before the cutover lands.
 
 ## Decision Logging
 
@@ -127,6 +127,9 @@ Read at point of need. Do not rely on cached knowledge when specifics matter.
 - `docs/architecture.md` — hexagonal model, information categories
 - `docs/horizons.md` — future directions
 - `AGENTS.md` — repo conventions and workflow
+- `.agents/skills/trails-writing-voice/SKILL.md` — Trails writing stance
+- `.agents/skills/trails-writing-style/SKILL.md` — prose craft and vocabulary precision
+- `.agents/skills/trails-writing-docs/SKILL.md` — current docs structure and maintenance guidance
 - `./references/warden-guide.md` — generated Warden rule guidance for repo-tracked skills, agents, and plugin prompts
 
 When evaluating code, also check the actual package structure in `packages/` and the current API surface. The docs describe intent. The code describes reality. Both matter.

--- a/.claude/skills/clark/references/calibrate.md
+++ b/.claude/skills/clark/references/calibrate.md
@@ -35,13 +35,11 @@ Scan all changed or new files for vocabulary violations. Highest-priority check.
 | provision (legacy) | resource |
 | gate (legacy) | layer |
 
-For `blaze`, preserve the distinction that a `blaze` establishes how a trail runs. The runtime runs the blazed trail; surfaces expose trails, not blazes.
+`blaze` is the current live term for the authored behavior field; flag `impl`, `fn`, `handler`, action body, or endpoint language as `blaze`. `implementation` is the ratified target for the v1 reset — see `docs/lexicon-pending.md`. Do not flag live `blaze` as a violation or rewrite it to `implementation` before the cutover lands; when live code and ratified direction differ, say so explicitly.
 
-The current Trails lexicon canonicalizes `resource` (the declared infrastructure primitive — see `docs/lexicon.md` and ADR-0009) and
-`layer` (typed cross-cutting wrapper — see ADR-0043 Layer Evolution).
-Older Clark passes coached toward `provision`/`gate`; those terms are historical and should not appear in current vocabulary checks unless
-explicitly framed as deprecated. **Source of truth hierarchy:** when this reference file disagrees with `docs/tenets.md`, `docs/lexicon.md`,
-or `AGENTS.md`, the docs win — calibrate flags drift, not lexicon shifts.
+The current Trails lexicon canonicalizes `resource` (the declared infrastructure primitive — see `docs/lexicon.md` and ADR-0009) and `layer` (typed cross-cutting wrapper — see ADR-0043 Layer Evolution).
+
+Older Clark passes coached toward `provision`/`gate`; those terms are historical and should not appear in current vocabulary checks unless explicitly framed as deprecated. **Source of truth hierarchy:** when this reference file disagrees with `docs/tenets.md`, `docs/lexicon.md`, or `AGENTS.md`, the docs win — calibrate flags drift, not lexicon shifts.
 
 Also check that standard terms stay standard. `config` is not "settings." `Result` is not "response."
 

--- a/.claude/skills/trails-adrs/SKILL.md
+++ b/.claude/skills/trails-adrs/SKILL.md
@@ -26,6 +26,12 @@ When an ADR proposes something new, test it against these. Does it reinforce the
 
 Read related ADRs before drafting. Use `docs/adr/decision-map.json` or browse `docs/adr/` and `docs/adr/drafts/` to find ADRs that touch similar concerns. Good ADRs build on the existing decision graph — they reference specific sections of prior ADRs, link to their headings, and explain how the new decision compounds with or extends what's already decided.
 
+For voice, style, and document maintenance, also load the repo-local writing skills:
+
+- `trails-writing-voice`
+- `trails-writing-style`
+- `trails-writing-docs`
+
 When your ADR relates to an existing one:
 
 - Link to it in References with a one-line description of the relationship
@@ -256,7 +262,7 @@ Synthesized from ADR-000 (Core Premise) and ADR-001 (Naming Conventions).
 
 ### Vocabulary
 
-Use the accepted project vocabulary consistently: trail (not action/handler), topo (not registry), compose (not follow or cross), blaze (not handler/impl), surface (not transport), and tracing (not crumbs or tracker). For `blaze`, follow `docs/contributing/language-styleguide.md`: the runtime runs trails, not blazes.
+Use the accepted project vocabulary consistently: trail (not action/handler), topo (not registry), compose (not follow or cross), blaze (not handler/impl), surface (not transport), and tracing (not crumbs or tracker). Vocabulary is mid-cutover toward the v1 reset — write current ADRs in current terms and see `docs/lexicon-pending.md` for what is changing (and `trails-writing-style` for prose craft).
 
 Read `docs/tenets.md` before writing. Every ADR must be consistent with the tenets.
 

--- a/.claude/skills/trails-editorial/SKILL.md
+++ b/.claude/skills/trails-editorial/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: trails-editorial
+description: 'Complete Trails editorial review workflow. Use when reviewing docs, ADRs, README changes, release notes, agent guidance, or docs-heavy PRs for voice, style, structure, correctness, and readiness.'
+metadata:
+  version: '0.1.0'
+  author: trails
+  category: documentation
+---
+
+# Trails Editorial
+
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
+Run a complete editorial review for Trails documentation and prose-heavy changes. This is a workflow skill. It should work in Claude, Codex, or any agent harness that can read skills, inspect files, and run commands.
+
+## Load First
+
+Before reviewing, load:
+
+1. `trails-writing-voice`
+2. `trails-writing-style`
+3. `trails-writing-docs`
+
+If one is unavailable, continue only after reading the corresponding `.agents/skills/<name>/SKILL.md` file directly. If the file is missing, report that as part of the review.
+
+## Inputs
+
+The target can be:
+
+- one file;
+- a directory;
+- a PR diff;
+- a stack;
+- an ADR draft;
+- a release note;
+- agent guidance;
+- a question such as "is this ready to merge?"
+
+If no target is supplied, infer the smallest relevant target from the current conversation or working tree.
+
+## Workflow
+
+### 1. Establish Scope
+
+Identify:
+
+- target files;
+- source-of-truth docs or ADRs;
+- current branch and dirty state when working in a repo;
+- whether the review is read-only or may edit.
+
+Do not expand beyond the target unless a nearby file must change to keep the docs truthful.
+
+### 2. Classify The Document
+
+Classify each target as one of:
+
+- guide;
+- reference;
+- ADR;
+- release doc;
+- README;
+- agent guidance;
+- issue or PR prose;
+- working note.
+
+Use that classification to decide what "good" means. A reference page should not sound like a blog post. A working note can preserve uncertainty. An ADR must state the decision.
+
+### 3. Voice Review
+
+Check against `trails-writing-voice`:
+
+- Does it state decisions clearly?
+- Does it respect both human and agent readers?
+- Are claims evidence-backed?
+- Is the tone right for the container?
+- Does theme clarify rather than decorate?
+- Does the document preserve distribution-ready done?
+
+### 4. Style And Vocabulary Review
+
+Check against `trails-writing-style`:
+
+- Are terms current and consistent?
+- Are ratified future terms distinguished from live code when needed?
+- Are paragraphs focused?
+- Are examples concrete?
+- Is in-flight vocabulary handled per `docs/lexicon-pending.md` (current-live terms, not prematurely swapped to targets)?
+- Are old synonyms or retired terms creeping in?
+
+### 5. Structure Review
+
+Check against `trails-writing-docs`:
+
+- Does the information live in the right current repo location?
+- Is there one canonical home?
+- Are links, references, and examples current?
+- Does the doc include the sections its document type needs?
+- Does it avoid duplicating information that should be linked?
+
+### 6. Technical Verification
+
+Run the smallest useful checks for the target.
+
+Possible checks:
+
+```bash
+bun run docs:wrap-check
+bun scripts/adr.ts check
+bun scripts/adr.ts map
+bun run plugin:metadata:check
+bun run warden:agents:check
+bun run check
+git diff --check
+```
+
+Do not run broad checks just for ceremony. Choose the checks that prove the target.
+
+For claims about code behavior, inspect source or run targeted tests. For claims about CLI output, run the command or state that it was not verified.
+
+### 7. Findings
+
+Report findings by severity:
+
+- **P0:** materially false, unsafe, or blocks release correctness.
+- **P1:** likely to mislead users or agents into wrong behavior.
+- **P2:** vocabulary, structure, or missing-doc gap that will cause drift.
+- **P3:** polish, clarity, minor duplication, or optional tightening.
+
+Lead with P0-P2 findings. Include file paths and line numbers when possible. Keep P3s selective.
+
+### 8. Fix Loop
+
+If edits are allowed:
+
+1. Fix P0-P2 issues.
+2. Fix relevant P3 issues when they are nearby and low-risk.
+3. Re-run targeted verification.
+4. Repeat until the target is ready or blocked.
+
+If edits are not allowed, produce a concise review with exact recommended changes.
+
+### 9. Outcome
+
+End with one of:
+
+- `ready`;
+- `ready with nits`;
+- `needs fixes`;
+- `blocked`;
+- `wrong target`.
+
+Include:
+
+- files reviewed;
+- files changed, if any;
+- checks run and results;
+- unresolved risks;
+- exact next action.
+
+## Goal Invocation Shape
+
+For a larger editorial pass, use this generic goal shape:
+
+```markdown
+Goal: Bring [target docs/change/PR/stack] to Trails editorial readiness.
+
+Done when:
+
+- P0-P2 editorial, vocabulary, structure, and correctness issues are fixed or explicitly deferred with rationale.
+- Relevant P3s are handled when they improve clarity without expanding scope.
+- Required docs, skills, release notes, ADRs, and agent guidance are updated or marked not applicable.
+- Verification commands pass or failures are explained with evidence.
+- The final report lists changed files, checks, remaining risks, and exact next action.
+
+Constraints:
+
+- Follow `trails-writing-voice`, `trails-writing-style`, and `trails-writing-docs`.
+- Keep changes scoped to the target and necessary nearby truth.
+- Do not rewrite stable doctrine without an ADR or explicit approval.
+- Distinguish current live code from ratified future vocabulary.
+```
+
+## Report Template
+
+```markdown
+State: ready | ready with nits | needs fixes | blocked | wrong target
+
+Reviewed:
+
+- path
+- path
+
+Findings:
+
+- [P2] path:line - Issue and recommended fix.
+
+Changed:
+
+- path - Summary.
+
+Verification:
+
+- command - pass/fail/not run, with reason.
+
+Remaining:
+
+- Risk, decision, or follow-up.
+
+Next:
+
+- Exact next action.
+```

--- a/.claude/skills/trails-writing-docs/SKILL.md
+++ b/.claude/skills/trails-writing-docs/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: trails-writing-docs
+description: 'Trails documentation structure and maintenance guidance. Use when creating or reorganizing Trails docs, READMEs, guides, reference pages, release docs, or agent-facing documentation.'
+metadata:
+  version: '0.1.0'
+  author: trails
+  category: documentation
+---
+
+# Trails Writing Docs
+
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
+This skill covers what a Trails document should include and where it should live. It reflects the current repository shape. The v1 ADR Canon Reset may revise the final docs taxonomy, so do not treat this as the permanent information architecture.
+
+For voice, load `trails-writing-voice`. For prose craft and vocabulary, load `trails-writing-style`.
+
+## Documentation Ladder
+
+Trails documentation follows the distribution-ready done rule:
+
+1. **Types and schemas** carry the contract closest to code.
+2. **Examples** prove and teach happy paths.
+3. **Tests and Warden rules** prevent drift.
+4. **Docs and guides** explain how to use the behavior.
+5. **Agent guidance and skills** teach agents how to preserve it.
+6. **Release notes and changesets** carry migration and publication intent.
+
+Feature work is not done until the affected docs layer is updated or explicitly marked not applicable.
+
+## Current Repo Map
+
+Use the current structure unless the docs-organization ADR says otherwise:
+
+| Location             | Use for                                                                  |
+| -------------------- | ------------------------------------------------------------------------ |
+| `README.md`          | Project entry point and pointers.                                        |
+| `AGENTS.md`          | Canonical guidance for agents working on Trails.                         |
+| `docs/`              | Public and contributor-facing documentation.                             |
+| `docs/contributing/` | Contributor guidance, code standards, language style, script graduation. |
+| `docs/surfaces/`     | Surface-specific docs and surface accommodation guidance.                |
+| `docs/releases/`     | Release runbooks, beta/stable cutover notes, migration details.          |
+| `docs/adr/`          | Accepted ADRs and decision maps.                                         |
+| `docs/adr/drafts/`   | Draft ADRs and future-facing proposals.                                  |
+| `plugin/skills/`     | Distributed skills for downstream agents using Trails.                   |
+| `.agents/skills/`    | Repo-local skills for contributors and local agents.                     |
+| `.agents/notes/`     | Gitignored working notes and handoff records.                            |
+
+When in doubt, update the nearest existing document instead of creating a new one.
+
+## Document Types
+
+### Guide
+
+Use a guide when the reader needs to apply a concept.
+
+Include:
+
+- the reader's starting point;
+- the minimal working example;
+- the common wrong shape;
+- surface or runtime implications;
+- verification commands;
+- links to reference and ADRs.
+
+### Reference
+
+Use reference docs for exact lookup.
+
+Include:
+
+- API names and signatures;
+- option tables;
+- input and output shapes;
+- defaults;
+- error behavior;
+- stability notes.
+
+Keep reference pages dense and predictable. Do not turn them into essays.
+
+### ADR
+
+Use an ADR when reversing the decision would materially change Trails.
+
+Load `trails-adrs` for ADR-specific structure. ADRs should explain the tension, the decision, the alternatives, and what this does not decide.
+
+### Release Doc
+
+Use release docs when existing users or release operators need a path.
+
+Include:
+
+- what changed;
+- why it matters;
+- exact commands;
+- migration or bridge steps;
+- compatibility window;
+- verification checks;
+- known non-support.
+
+### Agent Guidance
+
+Use agent guidance when future agents need to preserve a behavior.
+
+Include:
+
+- when to use the guidance;
+- source-of-truth files;
+- stop conditions;
+- exact commands;
+- known stale paths or noise;
+- what not to mutate.
+
+## README Rules
+
+READMEs should orient quickly and link out.
+
+Keep:
+
+- the first usable path near the top;
+- examples copy-pasteable;
+- explanation after the quick path;
+- links to deeper docs instead of duplicating them.
+
+Avoid:
+
+- long architecture essays;
+- stale command lists;
+- repeating docs that already have a canonical page.
+
+## Code Examples
+
+Every code example should be either runnable or clearly marked as abridged.
+
+Examples should:
+
+- include imports when they matter;
+- show definition and use;
+- show expected output for CLI examples;
+- use current package names;
+- avoid retired vocabulary;
+- prefer realistic domain examples over placeholders.
+
+When examples are part of a trail contract, treat them as both docs and tests.
+
+## Maintenance Checks
+
+Before considering docs done:
+
+- Run the repo's relevant docs or format checks when available.
+- Verify links and anchors touched by the change.
+- Search for stale duplicates when moving or renaming concepts.
+- Update distributed skills if downstream agents need the new guidance.
+- Add a changeset or release note when package behavior or public trails change.
+- Note "not applicable" when reviewers would reasonably expect docs but none are needed.
+
+## Docs Organization ADR Caveat
+
+The draft docs-organization ADR is allowed to change section names, placement rules, and generated docs behavior. Until that lands:
+
+- conform to the current repo;
+- avoid creating new top-level docs taxonomies;
+- write new docs so they can be moved cleanly later;
+- prefer clear frontmatter and unique filenames when adding new docs;
+- leave a note in the PR or issue when placement is provisional.
+
+## Review Checklist
+
+When creating or reviewing Trails docs:
+
+- Is there one canonical home for this information?
+- Is the audience clear?
+- Does the document teach use, lookup, decision, release operation, or agent workflow?
+- Are examples current and runnable?
+- Are links and commands verified?
+- Are vocabulary and reset-direction terms handled honestly?
+- Does the change satisfy distribution-ready done?
+- Would a future agent know where to update this next time?

--- a/.claude/skills/trails-writing-style/SKILL.md
+++ b/.claude/skills/trails-writing-style/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: trails-writing-style
+description: 'Trails prose craft and lexicon style. Use when writing or reviewing docs, ADRs, examples, release notes, agent prompts, comments, PR descriptions, or issue language for rhythm, clarity, and vocabulary precision.'
+metadata:
+  version: '0.1.0'
+  author: trails
+  category: content
+---
+
+# Trails Writing Style
+
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
+This skill covers how Trails prose should read: sentence rhythm, structural patterns, examples, and vocabulary discipline.
+
+For the larger stance, load `trails-writing-voice`. For document placement and required sections, load `trails-writing-docs`.
+
+## Start From The Contract
+
+Trails writing should follow the same shape as Trails itself:
+
+1. **Define** the authored truth.
+2. **Derive** facts the framework already knows.
+3. **Render** the right surface, doc, example, check, or report.
+
+This is both architecture and writing style. Avoid asking readers to reconcile three versions of the same idea.
+
+## Sentence Rhythm
+
+Use a mix of:
+
+- **Claim:** one sentence that can stand alone.
+- **Reason:** why the claim matters.
+- **Consequence:** what breaks or gets easier.
+- **Example:** code, command, or concrete output.
+
+Short sentences carry decisions. Longer sentences are allowed when they earn their room by explaining a real tradeoff.
+
+Avoid uniform paragraph sludge. If a paragraph has more than one job, split it.
+
+## Headers
+
+Headers should help the reader navigate.
+
+Prefer headers that name the work:
+
+- `Fresh App Loading`
+- `Release Intent`
+- `Surface Accommodations`
+- `What This Does Not Decide`
+
+Avoid decorative or vague headers:
+
+- `Overview`
+- `Background`
+- `More Details`
+- `Things To Consider`
+
+`Overview` and `Background` are acceptable only when the document template requires them. Even then, make the first sentence do real work.
+
+## Examples Are Primary Evidence
+
+An agent or developer should often understand the rule from the example before they read the prose.
+
+Good examples:
+
+- include imports when imports matter;
+- show the authored contract and the resulting surface or behavior;
+- include expected output for commands;
+- show failure cases when failure behavior is part of the contract;
+- are runnable or clearly marked as abridged.
+
+Avoid examples that hide the important part behind `...`.
+
+For worked good-and-bad samples across docs and narrative containers, see `assets/SAMPLES.md`.
+
+## Voice Mechanics
+
+Prefer:
+
+- active voice;
+- concrete nouns;
+- direct verbs;
+- exact file paths, commands, issue IDs, or ADR links when relevant;
+- "this means" lists after dense claims;
+- "the test:" heuristics when a reviewer needs to apply a rule.
+
+Avoid:
+
+- hedging settled decisions;
+- inventing synonyms for variety;
+- corporate filler;
+- marketing superlatives;
+- unexplained jargon;
+- clever metaphors that require decoding;
+- passive voice that hides who acts.
+
+## Vocabulary Discipline
+
+Use the current project vocabulary from `docs/lexicon.md`, `AGENTS.md`, ADRs, and `docs/lexicon-pending.md`.
+
+Current high-signal direction (stable terms; for terms mid-cutover see `docs/lexicon-pending.md`):
+
+- `trail`, not action, endpoint, handler, or route for the unit of work.
+- `surface`, not transport, when naming the outside boundary.
+- `topo` for the assembled Trails graph primitive.
+- `compose`, not cross, follow, call, invoke, route, or workflow for trail-to-trail composition.
+- `resource` for declared infrastructure dependencies.
+- `layer` for typed execution wrappers.
+
+The authored-behavior field, grouped surface entries, and the derive/render split are mid-cutover. Describe current code in current terms and follow `docs/lexicon-pending.md`. Do not silently rewrite history or pretend a cutover has already landed.
+
+`docs/lexicon-pending.md` is the transition control surface. Its Current column describes live reality; its Target column describes ratified reset direction. Do not adopt target terms in code, docs, examples, or plugin guidance before the cutover unless the work is explicitly part of that reset.
+
+## Theme Is Not A Checklist
+
+Outdoor language belongs when it clarifies official concepts. It does not belong as decorative prose.
+
+Good:
+
+> A `detour` names a recovery strategy for a failed trail, not general control flow.
+
+Bad:
+
+> Pack your gear before trekking into the terrain of release configuration.
+
+Use plain words unless the themed word carries the concept better.
+
+## Replacement Patterns
+
+| Weak phrasing | Stronger phrasing |
+| --- | --- |
+| "This is a flexible way to expose functionality." | "This renders the same trail contract on CLI and MCP without re-authoring behavior." |
+| "We might want to consider adding checks." | "Add a Warden rule when drift can be detected from authored facts." |
+| "The handler processes the request." | "The trail receives validated input; its blaze returns a `Result`." |
+| "Run the implementation directly." | "Run the trail through the shared execution pipeline." |
+| "The CLI route has different behavior." | "This needs a distinct trail unless the input normalizes into the same contract without lying." |
+
+## Review Checklist
+
+When reviewing Trails prose:
+
+- Is the first claim clear enough to quote?
+- Does each paragraph have one job?
+- Are examples concrete and aligned with current source?
+- Are themed terms official or genuinely clarifying?
+- Are ratified future terms distinguished from current live code when needed?
+- Are `derive` and `render` used with distinct meanings?
+- Does the text avoid synonym drift?
+- Does the document teach the check or heuristic an agent should apply later?

--- a/.claude/skills/trails-writing-style/assets/SAMPLES.md
+++ b/.claude/skills/trails-writing-style/assets/SAMPLES.md
@@ -1,0 +1,151 @@
+# Writing Samples
+
+Worked craft samples for Trails prose, adapted and expanded from the Outfitter styleguide samples. They cover both framework docs (ADRs, guides, reference, agent guidance, release notes) and trails.dev narrative and launch writing. Use them with `trails-writing-style` -- they illustrate the rules by example; they are not new rules.
+
+> Vocabulary note: examples here use only stable Trails terms on purpose. The framework's vocabulary is mid-cutover toward the v1 reset, so don't treat any single term as permanent -- when you write new samples, prefer terms that are settled.
+
+## Opening moves
+
+### Problem framing
+
+> "Every framework promises 'define it once.' Most still make you write it three times -- once for the CLI, once for the HTTP handler, once for the agent tool."
+
+Why it works: it names a real, specific pain the reader has felt, then sets up the resolution without overselling. "Three times" is concrete, not a vibe.
+
+### Earned honesty
+
+> "Trails won't make a bad API good. It makes a good API impossible to expose three inconsistent ways."
+
+Why it works: it states a limit before a benefit. The honesty buys the claim that follows.
+
+## Punch and flow
+
+Setup, pivot, punch, resolution.
+
+> "You define the trail once. Want it on MCP too? There's nothing to port -- the MCP tool and the CLI command read the same contract."
+
+The short sentences carry the decision; the longer one earns its room by naming the payoff. Read it aloud -- it has a beat.
+
+## Earned enthusiasm
+
+> "The CLI and the MCP server came out of the same forty lines. I kept waiting to write the second one."
+
+Why it works: a real reaction to a real result, not a marketing adjective. The specific detail carries the feeling. "Revolutionary" would carry nothing.
+
+## Status: precision and honesty
+
+### High status -- technical precision
+
+> "Input is a Zod schema. The same schema validates CLI flags, MCP tool parameters, and the HTTP body -- one parse, at the boundary, before your code runs."
+
+Names the real tool, then shows the payoff. Credible because it's exact.
+
+### Low status -- builder honesty
+
+> "WebSocket isn't a surface yet. The contract model is built for it; the surface isn't written."
+
+"Yet" signals trajectory without overpromising. Honesty about the edge builds trust in the center.
+
+### The blend
+
+> "Trails is opinionated about authoring and unopinionated about output. That's a real constraint -- you write contracts our way -- and it's the whole reason a CLI and an MCP server can't drift apart."
+
+Vulnerability (a real constraint) wrapped in the reason it's worth it.
+
+## Technical without gatekeeping
+
+> "The topo is the resolved graph of everything -- trails, resources, signals, and how they connect. Think of it as the app's table of contents, except it's queryable and the framework keeps it honest."
+
+Introduces the term, defines it plainly, gives an analogy, then states what's special. No jargon left undefined; nothing dumbed down.
+
+## Show the work
+
+An example should carry the rule before the prose does.
+
+Good -- the contract and the surfaces it produces, side by side:
+
+```typescript
+const show = trail('gist.show', {
+  input: z.object({ id: z.string() }),
+  intent: 'read',
+  output: Gist,
+  // returns Result.ok(gist)
+});
+```
+
+```bash
+gists show --id abc123     # CLI command, derived from the trail
+# the MCP tool `gist.show` exposes the identical contract
+```
+
+Why it works: the reader sees the authored contract and both surfaces it produces. The "one contract, many surfaces" claim is demonstrated, not asserted. Don't hide the part that proves the point behind `...`.
+
+## Metaphor: earned vs forced
+
+This is the self-explains test in sample form. A themed word earns its place only if the sentence survives stripping the theme.
+
+Earned:
+
+> "A `trail` is a defined path from typed input to a `Result`."
+
+`trail` carries the concept -- a path -- and the sentence still reads if you swap in "defined unit of work." The word reduces translation effort; it doesn't add it.
+
+Forced:
+
+> "Pack your provisions and blaze a path through the untamed wilderness of your domain logic."
+
+Strip the theme and nothing is lost, which means it was never carrying meaning. Reader eye-roll incoming.
+
+The test: remove the themed word. If the sentence still teaches, the word earned its place. If only the costume is left, cut it.
+
+## Generic vs concrete
+
+Generic -- avoid:
+
+> "Trails is a flexible, powerful framework that lets you build integrations across many platforms with ease."
+
+Concrete -- better:
+
+> "Define a `trail` once; it runs on CLI, MCP, and HTTP from one authored contract, with no per-surface reimplementation."
+
+The generic version gives the reader nothing to act on or verify. The concrete version names the unit, the surfaces, and the guarantee -- each of which is checkable.
+
+## Closing moves
+
+### Invitation
+
+> "If you're wiring agents to your own services, try defining one capability as a trail and surfacing it on MCP. The whole point is that the second surface is free."
+
+Clear audience, low-commitment ask, one concrete payoff -- not a vague promise.
+
+### Door left ajar
+
+> "Most of the interesting questions are still open: activation sources, cross-app composition, more surfaces. The contract model is the bet that those stay additive."
+
+Leaves the reader thinking forward, names real open ground honestly, and ties back to the core claim. Aspirational without being preachy -- and no borrowed quote required.
+
+## Anti-patterns to avoid
+
+### Generic tech-blog opener
+
+> "In today's fast-paced development landscape, building consistent APIs has never been more important. That's why we created Trails -- a revolutionary framework that transforms how you ship."
+
+What's wrong: "fast-paced landscape" is filler, "never been more important" says nothing, "revolutionary" and "transforms" are unearned superlatives. Cut all of it.
+
+### Hedge stack
+
+> "It is generally recommended that you should probably consider adding a Warden rule in most cases."
+
+What's wrong: four hedges around one instruction. Say it: "Add a Warden rule when drift can be caught from authored facts."
+
+## The Coffee Test
+
+Read the sentence aloud. Would you say it to a sharp colleague explaining what you built?
+
+Fails:
+
+> "Trails empowers developers to seamlessly leverage a unified contract abstraction across heterogeneous surfaces."
+
+Passes:
+
+> "You write the capability once, and it shows up on the CLI and as an agent tool without you doing it twice."

--- a/.claude/skills/trails-writing-voice/SKILL.md
+++ b/.claude/skills/trails-writing-voice/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: trails-writing-voice
+description: 'Trails writing voice and values. Use when drafting or reviewing Trails docs, ADRs, README content, release notes, agent guidance, or public explanations for stance, audience, and tone.'
+metadata:
+  version: '0.1.0'
+  author: trails
+  category: content
+---
+
+# Trails Writing Voice
+
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
+Trails writes like a framework with a spine.
+
+We are opinionated because drift is expensive. We explain those opinions because agents and developers need to trust the path, not memorize it. The voice should feel calm, direct, practical, and awake to tradeoffs.
+
+## Core Stance
+
+| Principle | In practice |
+| --- | --- |
+| Contract-first | Lead from authored contracts and what they make possible. |
+| Agent-native | Structure for agents and humans at the same time. |
+| Drift-resistant | Explain how the framework makes consistency easier than divergence. |
+| Evidence-backed | Anchor claims in code, checks, examples, ADRs, or measured behavior. |
+| Plain by default | Use ordinary words when they carry the concept. Use Trails terms only when they earn the slot. |
+| Teachable | A good paragraph should make the next correct action easier. |
+| Distribution-aware | Feature work is not done until docs, examples, guidance, governance, and release posture are handled or explicitly not applicable. |
+
+## Audience
+
+Write for three readers at once:
+
+- **Developers** deciding whether the framework helps them ship.
+- **Contributors** trying to preserve the shape of the framework.
+- **Agents** navigating the repo, deriving behavior, and avoiding drift.
+
+This does not mean writing more. It means writing with structure:
+
+- clear headings;
+- concrete examples;
+- explicit inputs, outputs, and failure modes;
+- exact commands when commands are the point;
+- links to source-of-truth docs instead of repeated doctrine.
+
+## Voice
+
+Trails voice is:
+
+- **Confident, not inflated.** State decisions clearly. Do not market them.
+- **Precise, not brittle.** Name the concept, the boundary, and the exception.
+- **Warm, not chatty.** Help the reader feel oriented without adding filler.
+- **Practical, not abstract.** Show how the idea changes code, checks, or workflow.
+- **Curious, not tentative.** It is fine to name open questions. Do not hedge settled decisions.
+
+Prefer:
+
+> Define the trail once. Derive what the framework already knows. Render each surface from that shared contract.
+
+Avoid:
+
+> Trails aims to provide a flexible and potentially powerful way to create multiple integrations.
+
+## Tone By Container
+
+| Container          | Tone                                                           |
+| ------------------ | -------------------------------------------------------------- |
+| README quick start | Fast, concrete, copy-pasteable.                                |
+| Guide              | Practical and explanatory. Show patterns and failure modes.    |
+| Reference          | Dense and exact. Personality gets out of the way.              |
+| ADR                | Declarative and reasoned. Tell the tension, then the decision. |
+| Release note       | Operator-focused. What changed, why it matters, what to do.    |
+| Agent guidance     | Direct. Give rules, stop conditions, and verification.         |
+| Blog or narrative  | More room for voice, but claims still need evidence.           |
+
+## The Theme Rule
+
+Trails can use outdoor and wayfinding language when it clarifies the mental model. Theme is not a writing quota.
+
+Use themed terms when they are official vocabulary or carry the concept better than a plain word: `trail`, `topo`, `surface`, `warden`, `wayfinder`, and `detour`. (Some grouped-entry vocabulary is mid-cutover — see `docs/lexicon-pending.md`.)
+
+Do not decorate ordinary prose with theme language when a plain word is clearer.
+
+The test:
+
+> Does the word reduce translation effort for a new agent or developer?
+
+If yes, keep it. If no, say it plainly.
+
+## Earned Confidence
+
+Trails docs can be strongly worded when the claim is backed by proof.
+
+Good sources of proof:
+
+- runnable examples;
+- type signatures;
+- Warden rules;
+- tests;
+- CLI output;
+- ADRs;
+- fresh consumer smoke tests;
+- repository commands and generated artifacts.
+
+Weak sources:
+
+- vibes;
+- future promises;
+- "should be easy";
+- claims about other tools without citations;
+- unverified memory of older branches.
+
+## Ownership
+
+Use "we" when speaking as the project. Use direct imperatives when giving instructions.
+
+Prefer:
+
+> Add a changeset on the branch that changes the publishable package.
+
+Avoid:
+
+> It is recommended that a changeset should be considered.
+
+## Review Checklist
+
+When reviewing a Trails document for voice:
+
+- Does it state the decision or instruction without hedging?
+- Does it explain the why enough for an agent to preserve the behavior later?
+- Does it use Trails vocabulary because it helps, not because it sounds themed?
+- Are claims backed by source, command, test, ADR, or example evidence?
+- Does the container shape match the reader's job?
+- Does it avoid marketing language and corporate filler?
+- Does it make the next correct action clearer?

--- a/.codex/agents/clark.toml
+++ b/.codex/agents/clark.toml
@@ -104,7 +104,7 @@ Load the appropriate skill or reference based on the task. In Claude, load the n
 
 ## Vocabulary Enforcement
 
-This may be your most important ongoing responsibility. The framework's vocabulary was hand-crafted, and agents will casually introduce "handler," "middleware," "endpoint," "controller," "route" (for composition), "registry," "impl" (for blaze), and other terms that erode the Trails mental model.
+This may be your most important ongoing responsibility. The framework's vocabulary was hand-crafted, and agents will casually introduce "handler," "middleware," "endpoint," "controller," "route" (for composition), "registry," "impl," and other terms that erode the Trails mental model.
 
 Lexicon drift is invisible in the moment. No test fails. No type error fires. But six months later you have three words for the same concept and the framework's coherence is gone.
 
@@ -114,7 +114,7 @@ When you find lexicon drift:
 - Explain why it matters, briefly. Not a lecture, a reminder.
 - Give the correction. Do not just flag it. Fix it.
 
-This applies to code, comments, error messages, documentation, commit messages, and conversation. Refer to `docs/lexicon.md` for the full lexicon and `docs/contributing/language-styleguide.md` for prose grammar.
+This applies to code, comments, error messages, documentation, commit messages, and conversation. Refer to `docs/lexicon.md` for the full lexicon and `docs/contributing/language-styleguide.md` for prose grammar. Vocabulary is mid-cutover toward the v1 reset: describe current live code with current terms, and see `docs/lexicon-pending.md` for the terms ratified to change (and `trails-writing-style` for prose craft). Do not adopt the targets before the cutover lands.
 
 ## Decision Logging
 
@@ -137,6 +137,9 @@ Read at point of need. Do not rely on cached knowledge when specifics matter.
 - `docs/architecture.md` — hexagonal model, information categories
 - `docs/horizons.md` — future directions
 - `AGENTS.md` — repo conventions and workflow
+- `.agents/skills/trails-writing-voice/SKILL.md` — Trails writing stance
+- `.agents/skills/trails-writing-style/SKILL.md` — prose craft and vocabulary precision
+- `.agents/skills/trails-writing-docs/SKILL.md` — current docs structure and maintenance guidance
 - `./references/warden-guide.md` — generated Warden rule guidance for repo-tracked skills, agents, and plugin prompts
 
 When evaluating code, also check the actual package structure in `packages/` and the current API surface. The docs describe intent. The code describes reality. Both matter.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ Use the project language consistently:
 
 `mount` is reserved for cross-app composition. See `docs/lexicon.md` for the full lexicon.
 
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
 ## Trail Rules
 
 - Blazes return `Result`, never throw.

--- a/docs/lexicon-pending.md
+++ b/docs/lexicon-pending.md
@@ -1,0 +1,21 @@
+# Pending Lexicon Changes
+
+`docs/lexicon.md` is the source of truth for current vocabulary. The terms below are ratified to change in the v1 ADR Canon Reset (TRL). This file is a heads-up, not a second lexicon — until the reset lands:
+
+- current code, docs, examples, and lexicon entries use the **Current** column — keep using it when describing live reality;
+- the **Target** column is the agreed direction — do not treat the current term as permanent;
+- do not adopt a target term in code, docs, or examples yet. Doing so before the cutover creates exactly the drift this file exists to prevent.
+
+| Current (live) | Target (v1 reset) | Scope |
+| --- | --- | --- |
+| `blaze` | `implementation` | the authored-behavior field on a trail |
+| `contour` | `entity` | the domain-object declaration (schema + identity + examples) |
+| `facet` | `trailhead` | one grouped surface entry fronting several trails |
+| `projection` / `project` (verb) | `derive` + `render` | split by stage: `derive` = canonical facts, `render` = surface presentation; the information-architecture category `Projected` becomes `Derived` |
+
+Also in flight, tracked for the reset:
+
+- `docs/horizons.md` is slated for deprecation.
+- The docs information architecture (the draft documentation-structure ADR) and the location of release notes are unsettled. Do not build on a specific docs taxonomy yet.
+
+This file is temporary. When the v1 reset lands, these changes fold into `docs/lexicon.md` and this file is deleted.

--- a/docs/releases/plugin-release.md
+++ b/docs/releases/plugin-release.md
@@ -2,7 +2,7 @@
 
 This runbook covers the Trails Claude plugin and bundled skills under `plugin/` plus the marketplace manifest at `.claude-plugin/marketplace.json`. It is separate from the framework package publish path in [Stable Cutover Runbook](./stable-cutover.md).
 
-The current plugin manifest version is `0.3.1`. The bundled `trails` skill targets the current Trails framework package version through `metadata.trails.version`. Those versions are intentionally independent: plugin version names the Claude plugin bundle, while the skill target names the framework package line the guidance was refreshed against.
+The current plugin manifest version is `0.3.2`. The bundled `trails` skill targets the current Trails framework package version through `metadata.trails.version`. Those versions are intentionally independent: plugin version names the Claude plugin bundle, while the skill target names the framework package line the guidance was refreshed against.
 
 ## Stop Rules
 
@@ -52,16 +52,16 @@ Use the latest dogfood report from the active release packet before release. Eve
 
 The stable-RC refresh has newer framework evidence than the older beta.18 plugin refresh: generated apps install from the public registry, `trails release check --json` works in generated apps without workspace files, and the published beta line exposes top-level `compile`, `validate`, `diff`, `warden`, and release-check surfaces. Do not carry old beta.18 risk language forward without re-running the current dogfood gate.
 
-## Plugin 0.3.1 Bundle
+## Plugin 0.3.2 Bundle
 
-The refreshed bundle is recorded as plugin manifest version `0.3.1`. If the marketplace requires another version bump before publication, update `plugin/.claude-plugin/plugin.json`, then run:
+The refreshed bundle is recorded as plugin manifest version `0.3.2`. If the marketplace requires another version bump before publication, update `plugin/.claude-plugin/plugin.json`, then run:
 
 ```bash
 bun run plugin:metadata:sync
 bun run plugin:metadata:check
 ```
 
-The `0.3.1` bundle includes:
+The `0.3.2` bundle includes:
 
 - public README/API docs drift fixes and M1 packet archive;
 - refreshed main `trails` skill for CLI, MCP, Hono HTTP, Bun-native HTTP,
@@ -74,6 +74,8 @@ The `0.3.1` bundle includes:
   guidance;
 - stable-RC refreshes for release rules, Wayfinder-first navigation, current
   skill metadata, and binding vocabulary;
+- Trails writing/editorial skills and the compatibility pointer from the older
+  language styleguide skill;
 - disposable dogfood report and release-risk findings.
 
 ## Manual / External Checks
@@ -97,7 +99,7 @@ Before any external publication:
 3. Confirm `TRL-755` public-docs cleanup and M1 archive are included.
 4. Confirm `TRL-757` through `TRL-760` are either accepted deferred follow-ups
    or explicitly promoted into the release gate.
-5. Confirm whether plugin version remains `0.3.1` or is bumped again, then rerun
+5. Confirm whether plugin version remains `0.3.2` or is bumped again, then rerun
    metadata checks.
 6. Run the manual/external checks above only with explicit approval.
 

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "trails",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Build with the Trails framework — contract-first trails, surfaces, testing, and governance for agent-assisted development.",
   "author": {
     "name": "Outfitter",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -43,7 +43,7 @@ Plugin release and republish steps are tracked in the repo runbook:
 
 - [Plugin Release Runbook](../docs/releases/plugin-release.md)
 
-The runbook keeps plugin version `0.3.1` separate from the bundled skill's Trails framework target version. It also names the stop rules for marketplace, registry, `npx skills`, and global installed-skill mutations. Do not treat a local/global `trails` skill as current until `bun run plugin:installed-skill:check` passes or an operator explicitly chooses to keep it decoupled.
+The runbook keeps plugin version `0.3.2` separate from the bundled skill's Trails framework target version. It also names the stop rules for marketplace, registry, `npx skills`, and global installed-skill mutations. Do not treat a local/global `trails` skill as current until `bun run plugin:installed-skill:check` passes or an operator explicitly chooses to keep it decoupled.
 
 ## What's Included
 
@@ -58,7 +58,11 @@ The runbook keeps plugin version `0.3.1` separate from the bundled skill's Trail
 | `trails-error-format` | Review error taxonomy, projection, redaction, retryability, and Result-vs-throw boundaries. |
 | `trails-discriminate-union` | Review public/queryable union-like outputs for stable branch discriminants. |
 | `trails-primitive-parity` | Compare primitive maturity without forcing trail-equivalent scope or speculative public API. |
-| `trails-language-styleguide` | Tighten Trails prose, docs, ADRs, prompts, and examples against the lexicon and `blaze` grammar. |
+| `trails-writing-voice` | Review Trails docs, ADRs, release notes, README content, and agent guidance for stance, audience, and tone. |
+| `trails-writing-style` | Review Trails prose for rhythm, clarity, examples, and vocabulary discipline. |
+| `trails-writing-docs` | Place and maintain Trails docs in the current repo structure while the docs organization ADR is pending. |
+| `trails-editorial` | Run a full Trails editorial review across voice, style, structure, correctness, and readiness. |
+| `trails-language-styleguide` | Compatibility pointer to the newer Trails writing skills for older prompts. |
 
 ### Agent
 

--- a/plugin/agents/trail-engineer.md
+++ b/plugin/agents/trail-engineer.md
@@ -104,6 +104,17 @@ trails validate
 
 Review the diff, update the lock if the change is intentional.
 
+### 7. Finish Distribution-Ready
+
+Do not stop at green tests when the change reaches users, operators, or agents. Update or explicitly mark not applicable:
+
+- docs and examples that teach the behavior;
+- agent guidance, skills, or plugin prompts that need the new rule;
+- Warden rules, generated guides, or drift checks for governable boundaries;
+- branch-local release intent for publishable package changes;
+- Wayfinder dogfood smoke for framework surface, operator topo, Topographer artifact, Wayfinder, or fresh-loader changes;
+- migration or bridge guidance for existing apps.
+
 ## Debugging
 
 When tests fail or behavior is unexpected:

--- a/plugin/skills/trails-editorial/SKILL.md
+++ b/plugin/skills/trails-editorial/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: trails-editorial
+description: 'Complete Trails editorial review workflow. Use when reviewing docs, ADRs, README changes, release notes, agent guidance, or docs-heavy PRs for voice, style, structure, correctness, and readiness.'
+metadata:
+  version: '0.1.0'
+  author: trails
+  category: documentation
+---
+
+# Trails Editorial
+
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
+Run a complete editorial review for Trails documentation and prose-heavy changes. This is a workflow skill. It should work in Claude, Codex, or any agent harness that can read skills, inspect files, and run commands.
+
+## Load First
+
+Before reviewing, load:
+
+1. `trails-writing-voice`
+2. `trails-writing-style`
+3. `trails-writing-docs`
+
+If one is unavailable, continue only after reading the corresponding `../<name>/SKILL.md` sibling skill file directly. In the Trails repository, the same skill may also exist at `.agents/skills/<name>/SKILL.md`. If the file is missing, report that as part of the review.
+
+## Inputs
+
+The target can be:
+
+- one file;
+- a directory;
+- a PR diff;
+- a stack;
+- an ADR draft;
+- a release note;
+- agent guidance;
+- a question such as "is this ready to merge?"
+
+If no target is supplied, infer the smallest relevant target from the current conversation or working tree.
+
+## Workflow
+
+### 1. Establish Scope
+
+Identify:
+
+- target files;
+- source-of-truth docs or ADRs;
+- current branch and dirty state when working in a repo;
+- whether the review is read-only or may edit.
+
+Do not expand beyond the target unless a nearby file must change to keep the docs truthful.
+
+### 2. Classify The Document
+
+Classify each target as one of:
+
+- guide;
+- reference;
+- ADR;
+- release doc;
+- README;
+- agent guidance;
+- issue or PR prose;
+- working note.
+
+Use that classification to decide what "good" means. A reference page should not sound like a blog post. A working note can preserve uncertainty. An ADR must state the decision.
+
+### 3. Voice Review
+
+Check against `trails-writing-voice`:
+
+- Does it state decisions clearly?
+- Does it respect both human and agent readers?
+- Are claims evidence-backed?
+- Is the tone right for the container?
+- Does theme clarify rather than decorate?
+- Does the document preserve distribution-ready done?
+
+### 4. Style And Vocabulary Review
+
+Check against `trails-writing-style`:
+
+- Are terms current and consistent?
+- Are ratified future terms distinguished from live code when needed?
+- Are paragraphs focused?
+- Are examples concrete?
+- Is in-flight vocabulary handled per `docs/lexicon-pending.md` (current-live terms, not prematurely swapped to targets)?
+- Are old synonyms or retired terms creeping in?
+
+### 5. Structure Review
+
+Check against `trails-writing-docs`:
+
+- Does the information live in the right current repo location?
+- Is there one canonical home?
+- Are links, references, and examples current?
+- Does the doc include the sections its document type needs?
+- Does it avoid duplicating information that should be linked?
+
+### 6. Technical Verification
+
+Run the smallest useful checks for the target.
+
+Possible checks:
+
+```bash
+bun run docs:wrap-check
+bun scripts/adr.ts check
+bun scripts/adr.ts map
+bun run plugin:metadata:check
+bun run warden:agents:check
+bun run check
+git diff --check
+```
+
+Do not run broad checks just for ceremony. Choose the checks that prove the target.
+
+For claims about code behavior, inspect source or run targeted tests. For claims about CLI output, run the command or state that it was not verified.
+
+### 7. Findings
+
+Report findings by severity:
+
+- **P0:** materially false, unsafe, or blocks release correctness.
+- **P1:** likely to mislead users or agents into wrong behavior.
+- **P2:** vocabulary, structure, or missing-doc gap that will cause drift.
+- **P3:** polish, clarity, minor duplication, or optional tightening.
+
+Lead with P0-P2 findings. Include file paths and line numbers when possible. Keep P3s selective.
+
+### 8. Fix Loop
+
+If edits are allowed:
+
+1. Fix P0-P2 issues.
+2. Fix relevant P3 issues when they are nearby and low-risk.
+3. Re-run targeted verification.
+4. Repeat until the target is ready or blocked.
+
+If edits are not allowed, produce a concise review with exact recommended changes.
+
+### 9. Outcome
+
+End with one of:
+
+- `ready`;
+- `ready with nits`;
+- `needs fixes`;
+- `blocked`;
+- `wrong target`.
+
+Include:
+
+- files reviewed;
+- files changed, if any;
+- checks run and results;
+- unresolved risks;
+- exact next action.
+
+## Goal Invocation Shape
+
+For a larger editorial pass, use this generic goal shape:
+
+```markdown
+Goal: Bring [target docs/change/PR/stack] to Trails editorial readiness.
+
+Done when:
+
+- P0-P2 editorial, vocabulary, structure, and correctness issues are fixed or explicitly deferred with rationale.
+- Relevant P3s are handled when they improve clarity without expanding scope.
+- Required docs, skills, release notes, ADRs, and agent guidance are updated or marked not applicable.
+- Verification commands pass or failures are explained with evidence.
+- The final report lists changed files, checks, remaining risks, and exact next action.
+
+Constraints:
+
+- Follow `trails-writing-voice`, `trails-writing-style`, and `trails-writing-docs`.
+- Keep changes scoped to the target and necessary nearby truth.
+- Do not rewrite stable doctrine without an ADR or explicit approval.
+- Distinguish current live code from ratified future vocabulary.
+```
+
+## Report Template
+
+```markdown
+State: ready | ready with nits | needs fixes | blocked | wrong target
+
+Reviewed:
+
+- path
+- path
+
+Findings:
+
+- [P2] path:line - Issue and recommended fix.
+
+Changed:
+
+- path - Summary.
+
+Verification:
+
+- command - pass/fail/not run, with reason.
+
+Remaining:
+
+- Risk, decision, or follow-up.
+
+Next:
+
+- Exact next action.
+```

--- a/plugin/skills/trails-language-styleguide/SKILL.md
+++ b/plugin/skills/trails-language-styleguide/SKILL.md
@@ -1,84 +1,15 @@
 ---
 name: trails-language-styleguide
-description: Use when writing or reviewing Trails docs, ADRs, agent prompts, examples, comments, or contributor guidance for lexicon precision, especially `blaze` language.
+description: Compatibility pointer for older Trails prompts. Prefer `trails-writing-voice`, `trails-writing-style`, `trails-writing-docs`, or `trails-editorial` when writing or reviewing Trails docs, ADRs, agent prompts, examples, comments, or contributor guidance.
 ---
 
 # Trails Language Styleguide
 
-Use this skill to tighten Trails language across prose and code-adjacent text. It is for docs, ADRs, README files, plugin prompts, agent instructions, comments, examples, issue language, and PR descriptions.
+This skill remains for compatibility with older prompts and installed plugin versions. New writing work should load the current writing skills instead:
 
-Canonical sources:
+1. `trails-writing-voice` for stance, audience, and tone.
+2. `trails-writing-style` for prose craft, examples, and vocabulary discipline.
+3. `trails-writing-docs` for document placement and maintenance.
+4. `trails-editorial` for a full review workflow.
 
-- `docs/lexicon.md` defines the terms.
-- `docs/contributing/language-styleguide.md` defines how those terms should sound in prose.
-- ADR-0001 and ADR-0023 explain why the lexicon exists.
-
-## Blaze Doctrine
-
-Use this mental model:
-
-> A `trail()` defines the contract. A `blaze` establishes the path through it.
-> The runtime runs the blazed trail.
-
-Short form:
-
-> A blazed trail is a runnable contract.
-
-The `blaze` is the authored implementation that makes a trail runnable. It establishes the path from validated input to `Result` output. Use `implementation` as a clarifying word, not as the whole definition.
-
-## Preferred Grammar
-
-Prefer:
-
-- "The `blaze` establishes how the trail runs."
-- "A trail can be specified before it is blazed."
-- "Blaze the trail by writing the implementation that satisfies the contract."
-- "Run the blazed trail."
-- "The CLI surface runs the trail through the shared execution pipeline."
-- "Surfaces expose trails, not blazes."
-
-Avoid:
-
-- "Run the blaze."
-- "Call the blaze."
-- "Invoke the blaze."
-- "The blaze is runnable."
-- "The CLI exposes the blaze."
-- "A blaze is a handler."
-- "The blaze handles the request."
-
-## Review Checklist
-
-When reviewing a changed file, check:
-
-- Does the first definition of `blaze` include making a trail runnable?
-- Does any sentence imply a surface owns or directly implements behavior?
-- Does any sentence call `blaze` a handler, callback, action, endpoint, route, runner, or executor?
-- Does any sentence imply that the runtime runs a blaze rather than a trail?
-- Does the paragraph distinguish contract, blaze, runtime, and surface?
-- Does the wording preserve `run` for execution?
-- Does the wording connect `blaze` to authored behavior rather than projection?
-- Does the teaching order follow `trail()` -> `blaze:` -> `topo()` -> `surface()`?
-
-## Replacement Patterns
-
-| Weak phrasing | Stronger phrasing |
-| --- | --- |
-| "The `blaze` is the implementation." | "The `blaze` is the authored implementation that establishes how the trail runs." |
-| "Write the implementation in `blaze`." | "Blaze the trail by writing the implementation that satisfies the contract." |
-| "Run the blaze." | "Run the blazed trail." |
-| "The CLI calls the blaze." | "The CLI runs the trail through the shared execution pipeline." |
-| "The blaze handles the request." | "The trail receives validated input; its `blaze` returns a `Result`." |
-| "A trail is an action." | "A trail is a typed contract for a unit of work." |
-
-## Broader Lexicon Rules
-
-- Use `trail`, not action, handler, endpoint, or route for the unit of work.
-- Use `surface`, not transport or endpoint for the outside boundary.
-- Use `topo` for the primitive and `graph` for the local value returned by `topo()`.
-- Use `compose` for trail-to-trail composition.
-- Use `resource` for declared infrastructure dependencies.
-- Use `layer` for typed execution wrappers.
-- Use `meta`, not metadata, when naming the trail field.
-
-If the standard word would shrink the concept, use the Trails term. If the standard word already carries the right meaning, keep it plain.
+If a prompt explicitly asks for this older skill, continue by reading `trails-writing-style` and, when the task is broader than vocabulary, also read `trails-writing-voice` and `trails-writing-docs`.

--- a/plugin/skills/trails-writing-docs/SKILL.md
+++ b/plugin/skills/trails-writing-docs/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: trails-writing-docs
+description: 'Trails documentation structure and maintenance guidance. Use when creating or reorganizing Trails docs, READMEs, guides, reference pages, release docs, or agent-facing documentation.'
+metadata:
+  version: '0.1.0'
+  author: trails
+  category: documentation
+---
+
+# Trails Writing Docs
+
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
+This skill covers what a Trails document should include and where it should live. It reflects the current repository shape. The v1 ADR Canon Reset may revise the final docs taxonomy, so do not treat this as the permanent information architecture.
+
+For voice, load `trails-writing-voice`. For prose craft and vocabulary, load `trails-writing-style`.
+
+## Documentation Ladder
+
+Trails documentation follows the distribution-ready done rule:
+
+1. **Types and schemas** carry the contract closest to code.
+2. **Examples** prove and teach happy paths.
+3. **Tests and Warden rules** prevent drift.
+4. **Docs and guides** explain how to use the behavior.
+5. **Agent guidance and skills** teach agents how to preserve it.
+6. **Release notes and changesets** carry migration and publication intent.
+
+Feature work is not done until the affected docs layer is updated or explicitly marked not applicable.
+
+## Current Repo Map
+
+Use the current structure unless the docs-organization ADR says otherwise:
+
+| Location             | Use for                                                                  |
+| -------------------- | ------------------------------------------------------------------------ |
+| `README.md`          | Project entry point and pointers.                                        |
+| `AGENTS.md`          | Canonical guidance for agents working on Trails.                         |
+| `docs/`              | Public and contributor-facing documentation.                             |
+| `docs/contributing/` | Contributor guidance, code standards, language style, script graduation. |
+| `docs/surfaces/`     | Surface-specific docs and surface accommodation guidance.                |
+| `docs/releases/`     | Release runbooks, beta/stable cutover notes, migration details.          |
+| `docs/adr/`          | Accepted ADRs and decision maps.                                         |
+| `docs/adr/drafts/`   | Draft ADRs and future-facing proposals.                                  |
+| `plugin/skills/`     | Distributed skills for downstream agents using Trails.                   |
+| `.agents/skills/`    | Repo-local skills for contributors and local agents.                     |
+| `.agents/notes/`     | Gitignored working notes and handoff records.                            |
+
+When in doubt, update the nearest existing document instead of creating a new one.
+
+## Document Types
+
+### Guide
+
+Use a guide when the reader needs to apply a concept.
+
+Include:
+
+- the reader's starting point;
+- the minimal working example;
+- the common wrong shape;
+- surface or runtime implications;
+- verification commands;
+- links to reference and ADRs.
+
+### Reference
+
+Use reference docs for exact lookup.
+
+Include:
+
+- API names and signatures;
+- option tables;
+- input and output shapes;
+- defaults;
+- error behavior;
+- stability notes.
+
+Keep reference pages dense and predictable. Do not turn them into essays.
+
+### ADR
+
+Use an ADR when reversing the decision would materially change Trails.
+
+Load `trails-adrs` for ADR-specific structure. ADRs should explain the tension, the decision, the alternatives, and what this does not decide.
+
+### Release Doc
+
+Use release docs when existing users or release operators need a path.
+
+Include:
+
+- what changed;
+- why it matters;
+- exact commands;
+- migration or bridge steps;
+- compatibility window;
+- verification checks;
+- known non-support.
+
+### Agent Guidance
+
+Use agent guidance when future agents need to preserve a behavior.
+
+Include:
+
+- when to use the guidance;
+- source-of-truth files;
+- stop conditions;
+- exact commands;
+- known stale paths or noise;
+- what not to mutate.
+
+## README Rules
+
+READMEs should orient quickly and link out.
+
+Keep:
+
+- the first usable path near the top;
+- examples copy-pasteable;
+- explanation after the quick path;
+- links to deeper docs instead of duplicating them.
+
+Avoid:
+
+- long architecture essays;
+- stale command lists;
+- repeating docs that already have a canonical page.
+
+## Code Examples
+
+Every code example should be either runnable or clearly marked as abridged.
+
+Examples should:
+
+- include imports when they matter;
+- show definition and use;
+- show expected output for CLI examples;
+- use current package names;
+- avoid retired vocabulary;
+- prefer realistic domain examples over placeholders.
+
+When examples are part of a trail contract, treat them as both docs and tests.
+
+## Maintenance Checks
+
+Before considering docs done:
+
+- Run the repo's relevant docs or format checks when available.
+- Verify links and anchors touched by the change.
+- Search for stale duplicates when moving or renaming concepts.
+- Update distributed skills if downstream agents need the new guidance.
+- Add a changeset or release note when package behavior or public trails change.
+- Note "not applicable" when reviewers would reasonably expect docs but none are needed.
+
+## Docs Organization ADR Caveat
+
+The draft docs-organization ADR is allowed to change section names, placement rules, and generated docs behavior. Until that lands:
+
+- conform to the current repo;
+- avoid creating new top-level docs taxonomies;
+- write new docs so they can be moved cleanly later;
+- prefer clear frontmatter and unique filenames when adding new docs;
+- leave a note in the PR or issue when placement is provisional.
+
+## Review Checklist
+
+When creating or reviewing Trails docs:
+
+- Is there one canonical home for this information?
+- Is the audience clear?
+- Does the document teach use, lookup, decision, release operation, or agent workflow?
+- Are examples current and runnable?
+- Are links and commands verified?
+- Are vocabulary and reset-direction terms handled honestly?
+- Does the change satisfy distribution-ready done?
+- Would a future agent know where to update this next time?

--- a/plugin/skills/trails-writing-style/SKILL.md
+++ b/plugin/skills/trails-writing-style/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: trails-writing-style
+description: 'Trails prose craft and lexicon style. Use when writing or reviewing docs, ADRs, examples, release notes, agent prompts, comments, PR descriptions, or issue language for rhythm, clarity, and vocabulary precision.'
+metadata:
+  version: '0.1.0'
+  author: trails
+  category: content
+---
+
+# Trails Writing Style
+
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
+This skill covers how Trails prose should read: sentence rhythm, structural patterns, examples, and vocabulary discipline.
+
+For the larger stance, load `trails-writing-voice`. For document placement and required sections, load `trails-writing-docs`.
+
+## Start From The Contract
+
+Trails writing should follow the same shape as Trails itself:
+
+1. **Define** the authored truth.
+2. **Derive** facts the framework already knows.
+3. **Render** the right surface, doc, example, check, or report.
+
+This is both architecture and writing style. Avoid asking readers to reconcile three versions of the same idea.
+
+## Sentence Rhythm
+
+Use a mix of:
+
+- **Claim:** one sentence that can stand alone.
+- **Reason:** why the claim matters.
+- **Consequence:** what breaks or gets easier.
+- **Example:** code, command, or concrete output.
+
+Short sentences carry decisions. Longer sentences are allowed when they earn their room by explaining a real tradeoff.
+
+Avoid uniform paragraph sludge. If a paragraph has more than one job, split it.
+
+## Headers
+
+Headers should help the reader navigate.
+
+Prefer headers that name the work:
+
+- `Fresh App Loading`
+- `Release Intent`
+- `Surface Accommodations`
+- `What This Does Not Decide`
+
+Avoid decorative or vague headers:
+
+- `Overview`
+- `Background`
+- `More Details`
+- `Things To Consider`
+
+`Overview` and `Background` are acceptable only when the document template requires them. Even then, make the first sentence do real work.
+
+## Examples Are Primary Evidence
+
+An agent or developer should often understand the rule from the example before they read the prose.
+
+Good examples:
+
+- include imports when imports matter;
+- show the authored contract and the resulting surface or behavior;
+- include expected output for commands;
+- show failure cases when failure behavior is part of the contract;
+- are runnable or clearly marked as abridged.
+
+Avoid examples that hide the important part behind `...`.
+
+For worked good-and-bad samples across docs and narrative containers, see `assets/SAMPLES.md`.
+
+## Voice Mechanics
+
+Prefer:
+
+- active voice;
+- concrete nouns;
+- direct verbs;
+- exact file paths, commands, issue IDs, or ADR links when relevant;
+- "this means" lists after dense claims;
+- "the test:" heuristics when a reviewer needs to apply a rule.
+
+Avoid:
+
+- hedging settled decisions;
+- inventing synonyms for variety;
+- corporate filler;
+- marketing superlatives;
+- unexplained jargon;
+- clever metaphors that require decoding;
+- passive voice that hides who acts.
+
+## Vocabulary Discipline
+
+Use the current project vocabulary from `docs/lexicon.md`, `AGENTS.md`, ADRs, and `docs/lexicon-pending.md`.
+
+Current high-signal direction (stable terms; for terms mid-cutover see `docs/lexicon-pending.md`):
+
+- `trail`, not action, endpoint, handler, or route for the unit of work.
+- `surface`, not transport, when naming the outside boundary.
+- `topo` for the assembled Trails graph primitive.
+- `compose`, not cross, follow, call, invoke, route, or workflow for trail-to-trail composition.
+- `resource` for declared infrastructure dependencies.
+- `layer` for typed execution wrappers.
+
+The authored-behavior field, grouped surface entries, and the derive/render split are mid-cutover. Describe current code in current terms and follow `docs/lexicon-pending.md`. Do not silently rewrite history or pretend a cutover has already landed.
+
+`docs/lexicon-pending.md` is the transition control surface. Its Current column describes live reality; its Target column describes ratified reset direction. Do not adopt target terms in code, docs, examples, or plugin guidance before the cutover unless the work is explicitly part of that reset.
+
+## Theme Is Not A Checklist
+
+Outdoor language belongs when it clarifies official concepts. It does not belong as decorative prose.
+
+Good:
+
+> A `detour` names a recovery strategy for a failed trail, not general control flow.
+
+Bad:
+
+> Pack your gear before trekking into the terrain of release configuration.
+
+Use plain words unless the themed word carries the concept better.
+
+## Replacement Patterns
+
+| Weak phrasing | Stronger phrasing |
+| --- | --- |
+| "This is a flexible way to expose functionality." | "This renders the same trail contract on CLI and MCP without re-authoring behavior." |
+| "We might want to consider adding checks." | "Add a Warden rule when drift can be detected from authored facts." |
+| "The handler processes the request." | "The trail receives validated input; its blaze returns a `Result`." |
+| "Run the implementation directly." | "Run the trail through the shared execution pipeline." |
+| "The CLI route has different behavior." | "This needs a distinct trail unless the input normalizes into the same contract without lying." |
+
+## Review Checklist
+
+When reviewing Trails prose:
+
+- Is the first claim clear enough to quote?
+- Does each paragraph have one job?
+- Are examples concrete and aligned with current source?
+- Are themed terms official or genuinely clarifying?
+- Are ratified future terms distinguished from current live code when needed?
+- Are `derive` and `render` used with distinct meanings?
+- Does the text avoid synonym drift?
+- Does the document teach the check or heuristic an agent should apply later?

--- a/plugin/skills/trails-writing-style/assets/SAMPLES.md
+++ b/plugin/skills/trails-writing-style/assets/SAMPLES.md
@@ -1,0 +1,151 @@
+# Writing Samples
+
+Worked craft samples for Trails prose, adapted and expanded from the Outfitter styleguide samples. They cover both framework docs (ADRs, guides, reference, agent guidance, release notes) and trails.dev narrative and launch writing. Use them with `trails-writing-style` -- they illustrate the rules by example; they are not new rules.
+
+> Vocabulary note: examples here use only stable Trails terms on purpose. The framework's vocabulary is mid-cutover toward the v1 reset, so don't treat any single term as permanent -- when you write new samples, prefer terms that are settled.
+
+## Opening moves
+
+### Problem framing
+
+> "Every framework promises 'define it once.' Most still make you write it three times -- once for the CLI, once for the HTTP handler, once for the agent tool."
+
+Why it works: it names a real, specific pain the reader has felt, then sets up the resolution without overselling. "Three times" is concrete, not a vibe.
+
+### Earned honesty
+
+> "Trails won't make a bad API good. It makes a good API impossible to expose three inconsistent ways."
+
+Why it works: it states a limit before a benefit. The honesty buys the claim that follows.
+
+## Punch and flow
+
+Setup, pivot, punch, resolution.
+
+> "You define the trail once. Want it on MCP too? There's nothing to port -- the MCP tool and the CLI command read the same contract."
+
+The short sentences carry the decision; the longer one earns its room by naming the payoff. Read it aloud -- it has a beat.
+
+## Earned enthusiasm
+
+> "The CLI and the MCP server came out of the same forty lines. I kept waiting to write the second one."
+
+Why it works: a real reaction to a real result, not a marketing adjective. The specific detail carries the feeling. "Revolutionary" would carry nothing.
+
+## Status: precision and honesty
+
+### High status -- technical precision
+
+> "Input is a Zod schema. The same schema validates CLI flags, MCP tool parameters, and the HTTP body -- one parse, at the boundary, before your code runs."
+
+Names the real tool, then shows the payoff. Credible because it's exact.
+
+### Low status -- builder honesty
+
+> "WebSocket isn't a surface yet. The contract model is built for it; the surface isn't written."
+
+"Yet" signals trajectory without overpromising. Honesty about the edge builds trust in the center.
+
+### The blend
+
+> "Trails is opinionated about authoring and unopinionated about output. That's a real constraint -- you write contracts our way -- and it's the whole reason a CLI and an MCP server can't drift apart."
+
+Vulnerability (a real constraint) wrapped in the reason it's worth it.
+
+## Technical without gatekeeping
+
+> "The topo is the resolved graph of everything -- trails, resources, signals, and how they connect. Think of it as the app's table of contents, except it's queryable and the framework keeps it honest."
+
+Introduces the term, defines it plainly, gives an analogy, then states what's special. No jargon left undefined; nothing dumbed down.
+
+## Show the work
+
+An example should carry the rule before the prose does.
+
+Good -- the contract and the surfaces it produces, side by side:
+
+```typescript
+const show = trail('gist.show', {
+  input: z.object({ id: z.string() }),
+  intent: 'read',
+  output: Gist,
+  // returns Result.ok(gist)
+});
+```
+
+```bash
+gists show --id abc123     # CLI command, derived from the trail
+# the MCP tool `gist.show` exposes the identical contract
+```
+
+Why it works: the reader sees the authored contract and both surfaces it produces. The "one contract, many surfaces" claim is demonstrated, not asserted. Don't hide the part that proves the point behind `...`.
+
+## Metaphor: earned vs forced
+
+This is the self-explains test in sample form. A themed word earns its place only if the sentence survives stripping the theme.
+
+Earned:
+
+> "A `trail` is a defined path from typed input to a `Result`."
+
+`trail` carries the concept -- a path -- and the sentence still reads if you swap in "defined unit of work." The word reduces translation effort; it doesn't add it.
+
+Forced:
+
+> "Pack your provisions and blaze a path through the untamed wilderness of your domain logic."
+
+Strip the theme and nothing is lost, which means it was never carrying meaning. Reader eye-roll incoming.
+
+The test: remove the themed word. If the sentence still teaches, the word earned its place. If only the costume is left, cut it.
+
+## Generic vs concrete
+
+Generic -- avoid:
+
+> "Trails is a flexible, powerful framework that lets you build integrations across many platforms with ease."
+
+Concrete -- better:
+
+> "Define a `trail` once; it runs on CLI, MCP, and HTTP from one authored contract, with no per-surface reimplementation."
+
+The generic version gives the reader nothing to act on or verify. The concrete version names the unit, the surfaces, and the guarantee -- each of which is checkable.
+
+## Closing moves
+
+### Invitation
+
+> "If you're wiring agents to your own services, try defining one capability as a trail and surfacing it on MCP. The whole point is that the second surface is free."
+
+Clear audience, low-commitment ask, one concrete payoff -- not a vague promise.
+
+### Door left ajar
+
+> "Most of the interesting questions are still open: activation sources, cross-app composition, more surfaces. The contract model is the bet that those stay additive."
+
+Leaves the reader thinking forward, names real open ground honestly, and ties back to the core claim. Aspirational without being preachy -- and no borrowed quote required.
+
+## Anti-patterns to avoid
+
+### Generic tech-blog opener
+
+> "In today's fast-paced development landscape, building consistent APIs has never been more important. That's why we created Trails -- a revolutionary framework that transforms how you ship."
+
+What's wrong: "fast-paced landscape" is filler, "never been more important" says nothing, "revolutionary" and "transforms" are unearned superlatives. Cut all of it.
+
+### Hedge stack
+
+> "It is generally recommended that you should probably consider adding a Warden rule in most cases."
+
+What's wrong: four hedges around one instruction. Say it: "Add a Warden rule when drift can be caught from authored facts."
+
+## The Coffee Test
+
+Read the sentence aloud. Would you say it to a sharp colleague explaining what you built?
+
+Fails:
+
+> "Trails empowers developers to seamlessly leverage a unified contract abstraction across heterogeneous surfaces."
+
+Passes:
+
+> "You write the capability once, and it shows up on the CLI and as an agent tool without you doing it twice."

--- a/plugin/skills/trails-writing-voice/SKILL.md
+++ b/plugin/skills/trails-writing-voice/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: trails-writing-voice
+description: 'Trails writing voice and values. Use when drafting or reviewing Trails docs, ADRs, README content, release notes, agent guidance, or public explanations for stance, audience, and tone.'
+metadata:
+  version: '0.1.0'
+  author: trails
+  category: content
+---
+
+# Trails Writing Voice
+
+> **Vocabulary is mid-cutover toward the v1 reset.** Describe current code with current-live terms; see `docs/lexicon-pending.md` for terms ratified to change, and do not adopt the targets early.
+
+Trails writes like a framework with a spine.
+
+We are opinionated because drift is expensive. We explain those opinions because agents and developers need to trust the path, not memorize it. The voice should feel calm, direct, practical, and awake to tradeoffs.
+
+## Core Stance
+
+| Principle | In practice |
+| --- | --- |
+| Contract-first | Lead from authored contracts and what they make possible. |
+| Agent-native | Structure for agents and humans at the same time. |
+| Drift-resistant | Explain how the framework makes consistency easier than divergence. |
+| Evidence-backed | Anchor claims in code, checks, examples, ADRs, or measured behavior. |
+| Plain by default | Use ordinary words when they carry the concept. Use Trails terms only when they earn the slot. |
+| Teachable | A good paragraph should make the next correct action easier. |
+| Distribution-aware | Feature work is not done until docs, examples, guidance, governance, and release posture are handled or explicitly not applicable. |
+
+## Audience
+
+Write for three readers at once:
+
+- **Developers** deciding whether the framework helps them ship.
+- **Contributors** trying to preserve the shape of the framework.
+- **Agents** navigating the repo, deriving behavior, and avoiding drift.
+
+This does not mean writing more. It means writing with structure:
+
+- clear headings;
+- concrete examples;
+- explicit inputs, outputs, and failure modes;
+- exact commands when commands are the point;
+- links to source-of-truth docs instead of repeated doctrine.
+
+## Voice
+
+Trails voice is:
+
+- **Confident, not inflated.** State decisions clearly. Do not market them.
+- **Precise, not brittle.** Name the concept, the boundary, and the exception.
+- **Warm, not chatty.** Help the reader feel oriented without adding filler.
+- **Practical, not abstract.** Show how the idea changes code, checks, or workflow.
+- **Curious, not tentative.** It is fine to name open questions. Do not hedge settled decisions.
+
+Prefer:
+
+> Define the trail once. Derive what the framework already knows. Render each surface from that shared contract.
+
+Avoid:
+
+> Trails aims to provide a flexible and potentially powerful way to create multiple integrations.
+
+## Tone By Container
+
+| Container          | Tone                                                           |
+| ------------------ | -------------------------------------------------------------- |
+| README quick start | Fast, concrete, copy-pasteable.                                |
+| Guide              | Practical and explanatory. Show patterns and failure modes.    |
+| Reference          | Dense and exact. Personality gets out of the way.              |
+| ADR                | Declarative and reasoned. Tell the tension, then the decision. |
+| Release note       | Operator-focused. What changed, why it matters, what to do.    |
+| Agent guidance     | Direct. Give rules, stop conditions, and verification.         |
+| Blog or narrative  | More room for voice, but claims still need evidence.           |
+
+## The Theme Rule
+
+Trails can use outdoor and wayfinding language when it clarifies the mental model. Theme is not a writing quota.
+
+Use themed terms when they are official vocabulary or carry the concept better than a plain word: `trail`, `topo`, `surface`, `warden`, `wayfinder`, and `detour`. (Some grouped-entry vocabulary is mid-cutover — see `docs/lexicon-pending.md`.)
+
+Do not decorate ordinary prose with theme language when a plain word is clearer.
+
+The test:
+
+> Does the word reduce translation effort for a new agent or developer?
+
+If yes, keep it. If no, say it plainly.
+
+## Earned Confidence
+
+Trails docs can be strongly worded when the claim is backed by proof.
+
+Good sources of proof:
+
+- runnable examples;
+- type signatures;
+- Warden rules;
+- tests;
+- CLI output;
+- ADRs;
+- fresh consumer smoke tests;
+- repository commands and generated artifacts.
+
+Weak sources:
+
+- vibes;
+- future promises;
+- "should be easy";
+- claims about other tools without citations;
+- unverified memory of older branches.
+
+## Ownership
+
+Use "we" when speaking as the project. Use direct imperatives when giving instructions.
+
+Prefer:
+
+> Add a changeset on the branch that changes the publishable package.
+
+Avoid:
+
+> It is recommended that a changeset should be considered.
+
+## Review Checklist
+
+When reviewing a Trails document for voice:
+
+- Does it state the decision or instruction without hedging?
+- Does it explain the why enough for an agent to preserve the behavior later?
+- Does it use Trails vocabulary because it helps, not because it sounds themed?
+- Are claims backed by source, command, test, ADR, or example evidence?
+- Does the container shape match the reader's job?
+- Does it avoid marketing language and corporate filler?
+- Does it make the next correct action clearer?

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -76,6 +76,22 @@ Good changeset prose names the user-visible change: "Expose `wayfind.contract` t
 
 During local review, classify missing branch-local release intent for a public trail contract fact as P2. Selected P3 release ideas, such as imported schema tracing or future release targets, should be logged for follow-up rather than folded into the current branch unless they expose a concrete user-visible release gap.
 
+## Distribution-Ready Done
+
+Feature work is not complete until the surrounding developer experience is complete or explicitly marked not applicable. Treat docs, examples, guidance, governance, release intent, and migration notes as part of the implementation when the behavior reaches users or agents.
+
+Before moving work out of draft, check the affected surfaces:
+
+- **Docs and examples:** Update the nearest README, fieldguide, API doc, example, ADR, or runbook that teaches the behavior.
+- **Agent guidance:** Update skills, plugin guidance, AGENTS files, or tool-specific prompts when agents need a new rule, workflow, or vocabulary.
+- **Governance:** Add or update Warden rules, generated Warden guides, or drift checks when the behavior creates a governable boundary.
+- **Release path:** Add a branch-local changeset for publishable package changes, or carry an explicit no-release reason when the change is truly not user-visible.
+- **Wayfinder dogfood:** Run the Wayfinder dogfood smoke when changing framework surfaces, operator topo exposure, Topographer artifacts, Wayfinder queries, or fresh app loading.
+- **Migration path:** Document compatibility windows, bridge commands, or intentional non-support when existing apps may need to move.
+- **Publication readiness:** Run publish checks for package-impacting work and record first-time package, dist-tag, registry, or auth considerations.
+
+Small internal refactors do not need ceremonial docs. They do need an explicit "not applicable" callout when a reviewer or future agent could reasonably expect docs, skills, changesets, or migration notes.
+
 ## Agent Wayfinding
 
 When saved Topographer artifacts can answer a graph question, use Wayfinder before raw text search:
@@ -319,7 +335,11 @@ For the current generated rule index, read [warden-guide.md](references/warden-g
 | [getting-started.md](references/getting-started.md) | Full install-to-test walkthrough |
 | [architecture.md](references/architecture.md) | Hexagonal model, package boundaries, data flow |
 | [contract-patterns.md](references/contract-patterns.md) | ID naming, schema design, example authoring |
-| [trails-language-styleguide](../trails-language-styleguide/SKILL.md) | Prose grammar for lexicon-sensitive docs, ADRs, prompts, and examples |
+| [trails-writing-voice](../trails-writing-voice/SKILL.md) | Trails writing stance, audience, and tone |
+| [trails-writing-style](../trails-writing-style/SKILL.md) | Trails prose craft, examples, and vocabulary discipline |
+| [trails-writing-docs](../trails-writing-docs/SKILL.md) | Trails documentation placement and maintenance guidance |
+| [trails-editorial](../trails-editorial/SKILL.md) | Full editorial review workflow for docs-heavy changes |
+| [trails-language-styleguide](../trails-language-styleguide/SKILL.md) | Compatibility pointer for older prompts; prefer the newer writing skills |
 | CLI surface docs | Flag derivation, output modes, exit codes |
 | MCP surface docs | Tool naming, annotations, progress |
 | [http-surface.md](references/http-surface.md) | Route derivation, OpenAPI, Hono, Bun-native HTTP, fetch kernel |

--- a/scripts/check-hardwrap.ts
+++ b/scripts/check-hardwrap.ts
@@ -29,16 +29,24 @@ import { relative, resolve } from 'node:path';
 
 const repoRoot = resolve(import.meta.dir, '..');
 
-const scanRoots = ['docs', 'plugin', 'packages', 'apps', 'adapters'] as const;
+const scanRoots = [
+  'docs',
+  'plugin',
+  'packages',
+  'apps',
+  'adapters',
+  '.agents/skills',
+] as const;
 const rootFiles = ['README.md', 'AGENTS.md', 'CLAUDE.md'] as const;
 
 // Globs intentionally excluded from the check. These are managed by other
 // tools (changesets), internal planning state, or hidden agent dirs that
-// don't ship to Notion/Basecamp.
+// don't ship to Notion/Basecamp. Exception: `.agents/skills/**` is repo-local
+// skill content and IS wrap-checked, so the `.agents` exclude spares it.
 const excludePatterns: readonly RegExp[] = [
   /\/CHANGELOG\.md$/,
   /^\.changeset\//,
-  /^\.agents\//,
+  /^\.agents\/(?!skills\/)/,
   /^\.claude\//,
   /^node_modules\//,
 ];


### PR DESCRIPTION
## Summary

- add repo-local Trails writing voice, style, docs, and editorial skills, plus generated Claude/Codex mirrors
- include the same writing/editorial skills in the plugin bundle and bump the plugin metadata/runbook to 0.3.2
- turn `trails-language-styleguide` into a compatibility pointer to the newer writing skills
- add `docs/lexicon-pending.md` and update Clark/ADR guidance so the v1 vocabulary reset is visible without adopting target terms before cutover

## Verification

- `bun run skillset:check`
- `bun run plugin:metadata:check`
- `bun run docs:wrap-check`
- `bun run warden:skills:check`
- `bun run warden:agents:check`
- `bun run format:check`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`
- Graphite pre-push: Warden, ADR check, test, typecheck, lint, ast-grep, format, dead-code

## Notes

- `docs/lexicon-pending.md` is a transition guardrail, not a live replacement for `docs/lexicon.md`.
- The plugin bundle intentionally includes the writing/editorial skills per latest scope, while keeping pending vocabulary as pending.
- Warden passes with the existing Wayfinder `dead-internal-trail` warnings.
