### PR TITLE
feat(regrade): add ast rewrite class builders

### DIFF
--- a/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
+++ b/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'bun:test';
+import { createSourceEdit } from '@ontrails/warden/ast';
+
+import {
+  createAstIdentifierRenameClass,
+  createAstRewriteClass,
+} from '../ast-rewrite.js';
+
+describe('createAstRewriteClass', () => {
+  test('rewrites AST-backed source-span edits', () => {
+    const cls = createAstRewriteClass({
+      describe: 'Rename exported sourceTerm identifiers.',
+      id: 'ast-test:sourceTerm',
+      visit: (node) => {
+        if (node.type !== 'Identifier') {
+          return null;
+        }
+        const { name } = node as unknown as { readonly name?: string };
+        return name === 'sourceTerm'
+          ? {
+              edit: createSourceEdit(node.start, node.end, 'targetTerm'),
+              kind: 'edit',
+              note: 'Renamed sourceTerm identifier.',
+            }
+          : null;
+      },
+    });
+
+    const result = cls.apply(
+      'export const sourceTerm = sourceTermFactory();\n',
+      {
+        path: 'src/sourceTerm.ts',
+      }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      'export const targetTerm = sourceTermFactory();\n'
+    );
+    expect(result.notes).toEqual(['Renamed sourceTerm identifier.']);
+  });
+
+  test('routes parser failures to review', () => {
+    const cls = createAstRewriteClass({
+      describe: 'Parse failure fixture.',
+      id: 'ast-test:parse',
+      visit: () => null,
+    });
+
+    const result = cls.apply('export const = ;', { path: 'src/broken.ts' });
+
+    expect(result.kind).toBe('needs-review');
+    expect(result.reason).toBe('ast-rewrite-parse-failed');
+    expect(result.nextSource).toBeUndefined();
+  });
+
+  test('routes overlapping source edits to review', () => {
+    const cls = createAstRewriteClass({
+      describe: 'Invalid edit fixture.',
+      id: 'ast-test:overlap',
+      visit: (node) =>
+        node.type === 'Program'
+          ? [
+              {
+                edit: createSourceEdit(0, 6, 'targetTerm'),
+                kind: 'edit',
+              },
+              {
+                edit: createSourceEdit(4, 11, 'newTerm'),
+                kind: 'edit',
+              },
+            ]
+          : null,
+    });
+
+    const result = cls.apply('const sourceTerm = 1;\n', {
+      path: 'src/sourceTerm.ts',
+    });
+
+    expect(result.kind).toBe('needs-review');
+    expect(result.reason).toBe('ast-rewrite-invalid-edits');
+    expect(result.nextSource).toBeUndefined();
+  });
+});
+
+describe('createAstIdentifierRenameClass', () => {
+  test('renames imports, exports, properties, and references by exact identifier', () => {
+    const cls = createAstIdentifierRenameClass({
+      from: 'sourceTerm',
+      to: 'targetTerm',
+    });
+    const result = cls.apply(
+      [
+        "import { sourceTerm } from './sourceTerms';",
+        'export const sourceTerm = { sourceTerm, nested: { sourceTerm } };',
+        'const value = obj.sourceTerm + sourceTerm;',
+        '',
+      ].join('\n'),
+      { path: 'src/sourceTerm.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        "import { targetTerm } from './sourceTerms';",
+        'export const targetTerm = { targetTerm, nested: { targetTerm } };',
+        'const value = obj.targetTerm + targetTerm;',
+        '',
+      ].join('\n')
+    );
+  });
+
+  test('routes configured shadowed declarations to review', () => {
+    const cls = createAstIdentifierRenameClass({
+      from: 'sourceTerm',
+      reviewDeclarationTypes: new Set(['FunctionParam']),
+      to: 'targetTerm',
+    });
+
+    const result = cls.apply(
+      [
+        "import { sourceTerm } from './sourceTerms';",
+        'export const current = sourceTerm();',
+        'function local(sourceTerm: () => void) {',
+        '  return sourceTerm();',
+        '}',
+        '',
+      ].join('\n'),
+      { path: 'src/sourceTerm.ts' }
+    );
+
+    expect(result.kind).toBe('needs-review');
+    expect(result.reason).toBe('ast-identifier-review-declaration');
+    expect(result.nextSource).toBeUndefined();
+    expect(result.notes.join('\n')).toContain('FunctionParam');
+  });
+});

--- a/packages/regrade/src/downstream/ast-rewrite.ts
+++ b/packages/regrade/src/downstream/ast-rewrite.ts
@@ -1,0 +1,222 @@
+import type {
+  AstNode,
+  AstScopeContext,
+  SourceEdit,
+} from '@ontrails/warden/ast';
+import {
+  applySourceEdits,
+  createSourceEdit,
+  identifierName,
+  parseWithDiagnostics,
+  validateSourceEdits,
+  walkWithScopeContext,
+} from '@ontrails/warden/ast';
+
+import type {
+  RegradeClass,
+  RegradeClassContext,
+  RegradeClassResult,
+} from './report.js';
+
+export interface AstRewriteContext extends AstScopeContext {
+  readonly path: string;
+  readonly source: string;
+}
+
+export type AstRewriteMatch =
+  | {
+      readonly edit: SourceEdit;
+      readonly kind: 'edit';
+      readonly note?: string;
+    }
+  | {
+      readonly kind: 'review';
+      readonly note?: string;
+      readonly reason: string;
+    };
+
+export type AstRewriteVisitResult =
+  | AstRewriteMatch
+  | AstRewriteMatch[]
+  | null
+  | undefined;
+
+export interface AstRewriteClassOptions {
+  readonly describe: string;
+  readonly id: string;
+  readonly shouldScan?: (context: RegradeClassContext) => boolean;
+  readonly visit: (
+    node: AstNode,
+    context: AstRewriteContext
+  ) => AstRewriteVisitResult;
+}
+
+const defaultRegradeClassContext: RegradeClassContext = {
+  path: '<regrade-source>',
+};
+
+const toArray = (result: AstRewriteVisitResult): readonly AstRewriteMatch[] => {
+  if (result === undefined || result === null) {
+    return [];
+  }
+  return Array.isArray(result) ? result : [result];
+};
+
+const dedupeEdits = (edits: readonly SourceEdit[]): readonly SourceEdit[] => {
+  const seen = new Set<string>();
+  const unique: SourceEdit[] = [];
+
+  for (const edit of edits) {
+    const key = `${edit.start}:${edit.end}:${edit.replacement}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    unique.push(edit);
+  }
+
+  return unique;
+};
+
+const notesFor = (matches: readonly AstRewriteMatch[]): readonly string[] =>
+  matches.flatMap((match) => {
+    if (match.note) {
+      return [match.note];
+    }
+    if (match.kind === 'review') {
+      return [match.reason];
+    }
+    return [];
+  });
+
+const invalidEditsResult = (error: unknown): RegradeClassResult => ({
+  kind: 'needs-review',
+  notes: [
+    error instanceof Error
+      ? `AST rewrite edits could not be applied: ${error.message}`
+      : 'AST rewrite edits could not be applied.',
+  ],
+  reason: 'ast-rewrite-invalid-edits',
+});
+
+export const createAstRewriteClass = (
+  options: AstRewriteClassOptions
+): RegradeClass => ({
+  apply: (
+    source: string,
+    context: RegradeClassContext = defaultRegradeClassContext
+  ): RegradeClassResult => {
+    if (options.shouldScan && !options.shouldScan(context)) {
+      return {
+        kind: 'skipped',
+        notes: ['Skipped by AST rewrite scan-target filtering.'],
+        reason: 'ast-rewrite-scan-target-filtered',
+      };
+    }
+
+    const parsed = parseWithDiagnostics(context.path, source);
+    if (!parsed.ast || parsed.diagnostics.length > 0) {
+      return {
+        kind: 'needs-review',
+        notes:
+          parsed.diagnostics.length > 0
+            ? parsed.diagnostics.map(
+                (diagnostic) =>
+                  `Could not safely parse ${context.path}: ${diagnostic.message}`
+              )
+            : [`Could not parse ${context.path} for AST rewrite.`],
+        reason: 'ast-rewrite-parse-failed',
+      };
+    }
+
+    const matches: AstRewriteMatch[] = [];
+    walkWithScopeContext(parsed.ast, (node, scopeContext) => {
+      matches.push(
+        ...toArray(
+          options.visit(node, {
+            ...scopeContext,
+            path: context.path,
+            source,
+          })
+        )
+      );
+    });
+
+    const reviewMatches = matches.filter((match) => match.kind === 'review');
+    if (reviewMatches.length > 0) {
+      return {
+        kind: 'needs-review',
+        notes: notesFor(reviewMatches),
+        reason: reviewMatches[0]?.reason ?? 'ast-rewrite-review-required',
+      };
+    }
+
+    const edits = dedupeEdits(
+      matches.flatMap((match) => (match.kind === 'edit' ? [match.edit] : []))
+    );
+    if (edits.length === 0) {
+      return {
+        kind: 'no-op',
+        notes: ['No AST rewrite matches found.'],
+      };
+    }
+
+    try {
+      validateSourceEdits(edits);
+      return {
+        kind: 'rewrite',
+        nextSource: applySourceEdits(source, edits),
+        notes: notesFor(matches),
+      };
+    } catch (error) {
+      return invalidEditsResult(error);
+    }
+  },
+  describe: options.describe,
+  id: options.id,
+});
+
+export interface AstIdentifierRenameClassOptions {
+  readonly describe?: string;
+  readonly from: string;
+  readonly id?: string;
+  readonly reviewDeclarationTypes?: ReadonlySet<string>;
+  readonly to: string;
+}
+
+const isIdentifierNamed = (node: AstNode, name: string): boolean =>
+  node.type === 'Identifier' && identifierName(node) === name;
+
+export const createAstIdentifierRenameClass = (
+  options: AstIdentifierRenameClassOptions
+): RegradeClass => {
+  const reviewDeclarationTypes =
+    options.reviewDeclarationTypes ?? new Set<string>();
+
+  return createAstRewriteClass({
+    describe:
+      options.describe ??
+      `Rename identifier "${options.from}" to "${options.to}".`,
+    id: options.id ?? `ast-identifier-rename:${options.from}->${options.to}`,
+    visit: (node, context) => {
+      if (!isIdentifierNamed(node, options.from)) {
+        return null;
+      }
+
+      const declaration = context.getDeclaration(options.from);
+      if (declaration && reviewDeclarationTypes.has(declaration.type)) {
+        return {
+          kind: 'review',
+          note: `Identifier "${options.from}" resolves to ${declaration.type}; routed to review.`,
+          reason: 'ast-identifier-review-declaration',
+        };
+      }
+
+      return {
+        edit: createSourceEdit(node.start, node.end, options.to),
+        kind: 'edit',
+        note: `Renamed identifier "${options.from}" to "${options.to}".`,
+      };
+    },
+  });
+};


### PR DESCRIPTION
## Context

Builds on the Warden AST substrate to let Regrade define migration classes that produce concrete source edits from AST matches. This keeps the upcoming vocabulary reset from relying only on string replacement.

## Changes

- Add `createAstRewriteClass` and `createAstIdentifierRenameClass`.
- Route parse diagnostics, scope-sensitive declaration cases, and overlapping edits to review instead of applying them blindly.
- Cover rewrite, safe no-op, scope-review, and overlap-review behavior with focused tests.

## Verification

- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `git diff --check`
- Remote CI is green.