### PR TITLE
feat(regrade): enrich review report details

### DIFF
--- a/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
+++ b/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
@@ -133,5 +133,25 @@ describe('createAstIdentifierRenameClass', () => {
     expect(result.reason).toBe('ast-identifier-review-declaration');
     expect(result.nextSource).toBeUndefined();
     expect(result.notes.join('\n')).toContain('FunctionParam');
+    expect(result.reviewDetails).toEqual([
+      {
+        classId: 'ast-identifier-rename:sourceTerm->targetTerm',
+        expectedTarget: 'Rename identifier "sourceTerm" to "targetTerm".',
+        nodeKind: 'Identifier',
+        reason: 'ast-identifier-review-declaration',
+        span: { column: 16, end: 118, line: 3, start: 96 },
+        suggestedValidation: 'bun run typecheck',
+        symbol: 'sourceTerm',
+      },
+      {
+        classId: 'ast-identifier-rename:sourceTerm->targetTerm',
+        expectedTarget: 'Rename identifier "sourceTerm" to "targetTerm".',
+        nodeKind: 'Identifier',
+        reason: 'ast-identifier-review-declaration',
+        span: { column: 10, end: 141, line: 4, start: 131 },
+        suggestedValidation: 'bun run typecheck',
+        symbol: 'sourceTerm',
+      },
+    ]);
   });
 });

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -37,6 +37,49 @@ describe('createTermRewriteClass', () => {
     expect(result.kind).toBe('needs-review');
   });
 
+  test('carries structured review details into report entries', () => {
+    const report = buildRegradeReport({
+      classes: [
+        {
+          apply: () => ({
+            kind: 'needs-review',
+            notes: ['Manual review required.'],
+            reason: 'test-review',
+            reviewDetails: [
+              {
+                expectedTarget: 'Use targetTerm for grouped trail entries.',
+                nodeKind: 'Identifier',
+                reason: 'test-review',
+                span: { column: 14, end: 19, line: 1, start: 13 },
+                suggestedValidation: 'bun test packages/regrade',
+                symbol: 'sourceTerm',
+              },
+            ],
+          }),
+          describe: 'Review detail fixture.',
+          id: 'test-review-detail',
+        },
+      ],
+      files: [
+        { path: 'src/sourceTerm.ts', source: 'export const sourceTerm = 1;' },
+      ],
+      root: '/repo',
+      skipped: [],
+    });
+
+    expect(report.entries[0]?.reviewDetails).toEqual([
+      {
+        classId: 'test-review-detail',
+        expectedTarget: 'Use targetTerm for grouped trail entries.',
+        nodeKind: 'Identifier',
+        reason: 'test-review',
+        span: { column: 14, end: 19, line: 1, start: 13 },
+        suggestedValidation: 'bun test packages/regrade',
+        symbol: 'sourceTerm',
+      },
+    ]);
+  });
+
   test('routes mixed whole-word and partial matches to review', () => {
     const result = signalToPing.apply(
       'const signal = 1; const signalHandler = 2;'

--- a/packages/regrade/src/downstream/ast-rewrite.ts
+++ b/packages/regrade/src/downstream/ast-rewrite.ts
@@ -7,6 +7,7 @@ import {
   applySourceEdits,
   createSourceEdit,
   identifierName,
+  offsetToLineColumn,
   parseWithDiagnostics,
   validateSourceEdits,
   walkWithScopeContext,
@@ -16,6 +17,7 @@ import type {
   RegradeClass,
   RegradeClassContext,
   RegradeClassResult,
+  RegradeReviewDetail,
 } from './report.js';
 
 export interface AstRewriteContext extends AstScopeContext {
@@ -30,6 +32,7 @@ export type AstRewriteMatch =
       readonly note?: string;
     }
   | {
+      readonly detail?: RegradeReviewDetail;
       readonly kind: 'review';
       readonly note?: string;
       readonly reason: string;
@@ -99,6 +102,19 @@ const invalidEditsResult = (error: unknown): RegradeClassResult => ({
   reason: 'ast-rewrite-invalid-edits',
 });
 
+const reviewDetailsFor = (
+  classId: string,
+  matches: readonly AstRewriteMatch[]
+): readonly RegradeReviewDetail[] | undefined => {
+  const details = matches.flatMap((match) => {
+    if (match.kind !== 'review' || match.detail === undefined) {
+      return [];
+    }
+    return [{ ...match.detail, classId: match.detail.classId ?? classId }];
+  });
+  return details.length === 0 ? undefined : details;
+};
+
 export const createAstRewriteClass = (
   options: AstRewriteClassOptions
 ): RegradeClass => ({
@@ -144,10 +160,12 @@ export const createAstRewriteClass = (
 
     const reviewMatches = matches.filter((match) => match.kind === 'review');
     if (reviewMatches.length > 0) {
+      const reviewDetails = reviewDetailsFor(options.id, reviewMatches);
       return {
         kind: 'needs-review',
         notes: notesFor(reviewMatches),
         reason: reviewMatches[0]?.reason ?? 'ast-rewrite-review-required',
+        ...(reviewDetails === undefined ? {} : { reviewDetails }),
       };
     }
 
@@ -205,7 +223,21 @@ export const createAstIdentifierRenameClass = (
 
       const declaration = context.getDeclaration(options.from);
       if (declaration && reviewDeclarationTypes.has(declaration.type)) {
+        const location = offsetToLineColumn(context.source, node.start);
         return {
+          detail: {
+            expectedTarget: `Rename identifier "${options.from}" to "${options.to}".`,
+            nodeKind: node.type,
+            reason: 'ast-identifier-review-declaration',
+            span: {
+              column: location.column,
+              end: node.end,
+              line: location.line,
+              start: node.start,
+            },
+            suggestedValidation: 'bun run typecheck',
+            symbol: options.from,
+          },
           kind: 'review',
           note: `Identifier "${options.from}" resolves to ${declaration.type}; routed to review.`,
           reason: 'ast-identifier-review-declaration',

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -51,6 +51,8 @@ export interface RegradeClassResult {
   readonly notes: readonly string[];
   /** Machine-readable reason for review outcomes. */
   readonly reason?: string;
+  /** Structured details for review outcomes. */
+  readonly reviewDetails?: readonly RegradeReviewDetail[];
 }
 
 /** Source-file context passed to Regrade classes. */
@@ -92,6 +94,34 @@ export interface RegradeApplySummary {
   readonly review: number;
   /** Unknown selected class ids; apply mode writes nothing when non-zero. */
   readonly unknown: number;
+}
+
+/** Source location for a review-required match. */
+export interface RegradeReviewSpan {
+  readonly column: number;
+  readonly end: number;
+  readonly line: number;
+  readonly start: number;
+}
+
+/** Structured detail explaining why a source match needs review. */
+export interface RegradeReviewDetail {
+  /** Class that produced the review detail, injected by report building. */
+  readonly classId?: string;
+  /** Expected target shape when the class can describe one. */
+  readonly expectedTarget?: string;
+  /** Fixture or example reference that illustrates the expected migration. */
+  readonly fixture?: string;
+  /** AST node kind or source construct kind. */
+  readonly nodeKind?: string;
+  /** Machine-readable reason for review. */
+  readonly reason: string;
+  /** Source span and line/column for the review-required match. */
+  readonly span?: RegradeReviewSpan;
+  /** Suggested validation command after the review is resolved. */
+  readonly suggestedValidation?: string;
+  /** Symbol or term that triggered review. */
+  readonly symbol?: string;
 }
 
 const escapeRegExp = (value: string): string =>
@@ -320,6 +350,8 @@ export interface RegradeReportEntry {
   readonly reason?: string;
   /** Notes carried from the producing class. */
   readonly notes?: readonly string[];
+  /** Structured review details carried from the producing class. */
+  readonly reviewDetails?: readonly RegradeReviewDetail[];
 }
 
 /** Coverage report for a regrade run. */
@@ -405,6 +437,10 @@ const classifyFile = (
       };
     }
     if (result.kind === 'needs-review') {
+      const reviewDetails = result.reviewDetails?.map((detail) => ({
+        ...detail,
+        classId: detail.classId ?? cls.id,
+      }));
       return {
         entry: {
           classId: cls.id,
@@ -412,6 +448,7 @@ const classifyFile = (
           outcome: 'needs-review',
           path,
           reason: result.reason ?? 'needs-review',
+          ...(reviewDetails === undefined ? {} : { reviewDetails }),
         },
       };
     }
@@ -634,6 +671,44 @@ const regradeReportEntrySchema = z.object({
     .describe('What happened to the entry'),
   path: z.string().describe('Root-relative POSIX path'),
   reason: z.string().optional().describe('Reason for a skip or review outcome'),
+  reviewDetails: z
+    .array(
+      z.object({
+        classId: z
+          .string()
+          .optional()
+          .describe('Class that produced the review detail'),
+        expectedTarget: z
+          .string()
+          .optional()
+          .describe('Expected target shape for the migration'),
+        fixture: z
+          .string()
+          .optional()
+          .describe('Fixture or example reference for the migration'),
+        nodeKind: z
+          .string()
+          .optional()
+          .describe('AST node kind or source construct kind'),
+        reason: z.string().describe('Machine-readable review reason'),
+        span: z
+          .object({
+            column: z.number().describe('One-based source column'),
+            end: z.number().describe('Source end offset'),
+            line: z.number().describe('One-based source line'),
+            start: z.number().describe('Source start offset'),
+          })
+          .optional()
+          .describe('Source span that needs review'),
+        suggestedValidation: z
+          .string()
+          .optional()
+          .describe('Suggested validation command after resolving review'),
+        symbol: z.string().optional().describe('Symbol or term under review'),
+      })
+    )
+    .optional()
+    .describe('Structured review details from the producing class'),
 });
 
 export const regradeReportInput = z.object({


### PR DESCRIPTION
## Context

Makes Regrade review outcomes more useful before we point it at larger mechanical cutovers. A review result now carries enough detail for a human or agent to understand what was found and why it was not applied.

## Changes

- Add structured review details and spans to Regrade class/report output.
- Populate AST rewrite review details with symbol, node kind, span, expected target, and validation guidance.
- Extend report tests and output schemas for the richer review shape.

## Verification

- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `git diff --check`
- Remote CI is green.