### PR TITLE
feat(regrade): add class scan target control

### DIFF
--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -441,6 +441,88 @@ describe('runRegrade + regradeReportTrail', () => {
     }
   });
 
+  test('runRegrade derives collection extensions from selected classes', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-run-'));
+    try {
+      mkdirSync(join(root, 'src'), { recursive: true });
+      writeFileSync(join(root, 'README.md'), 'sourceTerm\n');
+      writeFileSync(
+        join(root, 'src', 'sourceTerm.ts'),
+        'export const sourceTerm = 1;\n'
+      );
+
+      const report = runRegrade({
+        classes: [
+          {
+            apply: (source) =>
+              source.includes('sourceTerm')
+                ? {
+                    kind: 'rewrite',
+                    nextSource: source.replaceAll('sourceTerm', 'targetTerm'),
+                    notes: ['Rewrote docs term.'],
+                  }
+                : { kind: 'no-op', notes: [] },
+            describe: 'Rewrite docs vocabulary.',
+            id: 'docs-term',
+            scanTargets: { extensions: ['.md'] },
+          },
+        ],
+        root,
+        selection: { classIds: ['docs-term'] },
+      });
+
+      expect(report?.entries.map((entry) => entry.path)).toEqual([
+        'README.md',
+        'src/sourceTerm.ts',
+      ]);
+      expect(
+        report?.entries.find((entry) => entry.path === 'src/sourceTerm.ts')
+          ?.outcome
+      ).toBe('skip');
+      expect(report?.rewritten).toBe(1);
+      expect(report?.scanned).toBe(1);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('unknown-only selection reports ids without collecting sources', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-run-unknown-only-'));
+    try {
+      mkdirSync(join(root, 'src'), { recursive: true });
+      mkdirSync(join(root, 'node_modules', 'pkg'), { recursive: true });
+      writeFileSync(join(root, 'src', 'a.ts'), 'export const signal = 1;\n');
+      writeFileSync(
+        join(root, 'node_modules', 'pkg', 'a.ts'),
+        'export const signal = 2;\n'
+      );
+
+      const report = runRegrade({
+        classes: [signalToPing],
+        root,
+        selection: { classIds: ['missing-class'] },
+      });
+
+      expect(report?.selectedClassIds).toEqual([]);
+      expect(report?.unknownClassIds).toEqual(['missing-class']);
+      expect(report?.scanned).toBe(0);
+      expect(report?.skipped).toBe(0);
+      expect(report?.entries).toEqual([]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('unknown-only selection still validates the root', () => {
+    expect(
+      runRegrade({
+        classes: [signalToPing],
+        root: join(import.meta.dir, 'does-not-exist-xyz'),
+        selection: { classIds: ['missing-class'] },
+      })
+    ).toBeNull();
+  });
+
   test('returns null for an unreadable root', () => {
     expect(
       runRegrade({

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -10,10 +10,14 @@ import {
   isWardenSourceScanTarget,
   wardenRules,
 } from '@ontrails/warden';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { z } from 'zod';
 
-import { collectDownstreamSources } from './collect.js';
+import {
+  collectDownstreamSources,
+  DEFAULT_IGNORED_DIRECTORIES,
+  DEFAULT_SOURCE_EXTENSIONS,
+} from './collect.js';
 import type { DownstreamCollectionOptions, SkippedSource } from './collect.js';
 
 /**
@@ -63,6 +67,14 @@ export interface RegradeClassContext {
   readonly absolutePath?: string;
 }
 
+/** Files a regrade class knows how to inspect. */
+export interface RegradeScanTargets {
+  /** Source extensions the class can inspect. */
+  readonly extensions?: readonly string[];
+  /** Directory names to skip during collection. */
+  readonly ignoredDirectories?: readonly string[];
+}
+
 /** One named, contract-aware transform. */
 export interface RegradeClass {
   /** Stable identifier, e.g. `term-rewrite:signal->ping`. */
@@ -74,6 +86,8 @@ export interface RegradeClass {
     source: string,
     context?: RegradeClassContext
   ) => RegradeClassResult;
+  /** Scan targets this class knows how to inspect. */
+  readonly scanTargets?: RegradeScanTargets;
 }
 
 /** Which regrade classes a run should execute. */
@@ -338,6 +352,35 @@ export const selectRegradeClasses = (
   return { selected, unknownClassIds };
 };
 
+const uniqueSorted = (values: readonly string[]): readonly string[] =>
+  [...new Set(values)].toSorted((a, b) => a.localeCompare(b));
+
+const deriveCollectionOptions = (
+  classes: readonly RegradeClass[],
+  collection: DownstreamCollectionOptions | undefined
+): DownstreamCollectionOptions => {
+  const targetExtensions = uniqueSorted(
+    classes.length === 0
+      ? DEFAULT_SOURCE_EXTENSIONS
+      : classes.flatMap(
+          (cls) => cls.scanTargets?.extensions ?? DEFAULT_SOURCE_EXTENSIONS
+        )
+  );
+  const ignoredDirectories = uniqueSorted(
+    classes.length === 0
+      ? DEFAULT_IGNORED_DIRECTORIES
+      : classes.flatMap(
+          (cls) =>
+            cls.scanTargets?.ignoredDirectories ?? DEFAULT_IGNORED_DIRECTORIES
+        )
+  );
+
+  return {
+    extensions: collection?.extensions ?? targetExtensions,
+    ignoredDirectories: collection?.ignoredDirectories ?? ignoredDirectories,
+  };
+};
+
 /** Per-entry detail describing what happened to one path. */
 export interface RegradeReportEntry {
   /** Root-relative POSIX path. */
@@ -597,15 +640,43 @@ const withApplySummary = (
   apply,
 });
 
+const canReadDownstreamRoot = (root: string): boolean => {
+  try {
+    readdirSync(root, { withFileTypes: true });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const runRegradeEvaluation = (params: {
   readonly root: string;
   readonly classes: readonly RegradeClass[];
   readonly selection?: RegradeSelection;
   readonly collection?: DownstreamCollectionOptions;
 }): RegradeEvaluation | null => {
+  const { selected, unknownClassIds } = selectRegradeClasses(
+    params.classes,
+    params.selection
+  );
+  if (selected.length === 0 && unknownClassIds.length > 0) {
+    if (!canReadDownstreamRoot(params.root)) {
+      return null;
+    }
+    return buildRegradeEvaluation({
+      classes: params.classes,
+      files: [],
+      root: params.root,
+      skipped: [],
+      ...(params.selection === undefined
+        ? {}
+        : { selection: params.selection }),
+    });
+  }
+
   const collected = collectDownstreamSources(
     params.root,
-    params.collection ?? {}
+    deriveCollectionOptions(selected, params.collection)
   );
   if (collected === null) {
     return null;


### PR DESCRIPTION
## Context

Lets Regrade classes declare their own scan target shape so each migration can say which files and directories it is meant to inspect. This avoids hard-coding repo-wide scan defaults around one class.

## Changes

- Add class-owned scan target configuration.
- Derive collection extensions and ignored directories from the selected classes unless an explicit collection override is provided.
- Add tests proving a Markdown-targeted class scans Markdown and skips TypeScript.

## Verification

- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `git diff --check`
- Remote CI is green.