### PR TITLE
feat(trails): expose regrade dogfood surface

### DIFF
--- a/.changeset/trl-828-regrade-dogfood-surface.md
+++ b/.changeset/trl-828-regrade-dogfood-surface.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/regrade": patch
+"@ontrails/trails": patch
+---
+
+Publish Regrade's downstream report and AST rewrite APIs, and expose a dry-run
+by default `trails regrade` operator command with explicit apply mode.

--- a/apps/trails/README.md
+++ b/apps/trails/README.md
@@ -18,6 +18,7 @@ Common workflows:
 - `trails wayfind overview`, `trails wayfind find`, `trails wf search`, and adjacent `trails wayfind ...` commands read saved topo artifacts through Wayfinder for local graph navigation.
 - `trails schema <command...>` shows accepted CLI routes, aliases, flags, and schemas for an operator command.
 - `trails warden` runs Trails governance checks for contract and architecture drift.
+- `trails regrade --root-dir <path> --json` dry-runs downstream migration checks; add `--apply` only to write safe rewrites.
 - `trails guide` shows available trails and examples from a project.
 
 Trails is contract-first: define trails once with typed input, Result output, examples, and meta; the framework derives CLI, MCP, HTTP, and future surfaces from the same contracts.

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -35,6 +35,7 @@
     "@ontrails/mcp": "workspace:^",
     "@ontrails/observe": "workspace:^",
     "@ontrails/permits": "workspace:^",
+    "@ontrails/regrade": "workspace:^",
     "@ontrails/topographer": "workspace:^",
     "@ontrails/tracing": "workspace:^",
     "@ontrails/warden": "workspace:^",

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -1,0 +1,122 @@
+import { deriveCliCommands } from '@ontrails/cli';
+import { describe, expect, test } from 'bun:test';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { operatorApp } from '../app.js';
+import { regradeTrail } from '../trails/regrade.js';
+
+const makeTempDir = (): string =>
+  mkdtempSync(join(tmpdir(), `trails-regrade-test-${Date.now()}-`));
+
+const unwrapCommands = () => {
+  const result = deriveCliCommands(operatorApp);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
+
+describe('trails regrade', () => {
+  test('projects regrade as a CLI command', () => {
+    const commands = unwrapCommands();
+    const command = commands.find(
+      (candidate) => candidate.trail.id === 'regrade'
+    );
+
+    expect(command).toBeDefined();
+    expect(command?.path).toEqual(['regrade']);
+    expect(command?.trail.intent).toBe('write');
+  });
+
+  test('dry-runs safe downstream rewrites by default', async () => {
+    const dir = makeTempDir();
+    try {
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      const target = join(dir, 'src', 'play.ts');
+      writeFileSync(
+        target,
+        'export const play = trail("play", { crosses: [] });\n'
+      );
+
+      const result = await regradeTrail.blaze({ rootDir: dir }, {
+        cwd: dir,
+        env: {},
+      } as never);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.rewritten).toBe(1);
+      expect(result.value.apply).toBeUndefined();
+      expect(readFileSync(target, 'utf8')).toContain('crosses');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('apply mode writes only safe downstream rewrites', async () => {
+    const dir = makeTempDir();
+    try {
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      const target = join(dir, 'src', 'play.ts');
+      writeFileSync(
+        target,
+        'export const play = trail("play", { crosses: [] });\n'
+      );
+
+      const result = await regradeTrail.blaze({ apply: true, rootDir: dir }, {
+        cwd: dir,
+        env: {},
+      } as never);
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.apply).toMatchObject({
+        applied: 1,
+        filesChanged: 1,
+        review: 0,
+      });
+      expect(readFileSync(target, 'utf8')).toContain('composes');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('apply mode returns a Trails error when a rewrite cannot be written', async () => {
+    const dir = makeTempDir();
+    try {
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      const target = join(dir, 'src', 'play.ts');
+      writeFileSync(
+        target,
+        'export const play = trail("play", { crosses: [] });\n'
+      );
+      chmodSync(target, 0o444);
+
+      const result = await regradeTrail.blaze({ apply: true, rootDir: dir }, {
+        cwd: dir,
+        env: {},
+      } as never);
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.constructor.name).toBe('InternalError');
+      }
+    } finally {
+      chmodSync(join(dir, 'src', 'play.ts'), 0o644);
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+});

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -30,6 +30,7 @@ import * as devStats from './trails/dev-stats.js';
 import * as doctor from './trails/doctor.js';
 import * as draftPromote from './trails/draft-promote.js';
 import * as guide from './trails/guide.js';
+import * as regrade from './trails/regrade.js';
 import * as releaseCheck from './trails/release-check.js';
 import * as releaseSmoke from './trails/release-smoke.js';
 import * as revise from './trails/revise.js';
@@ -64,6 +65,7 @@ export const operatorApp = topo(
   devClean,
   devReset,
   guide,
+  regrade,
   releaseCheck,
   releaseSmoke,
   draftPromote,

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -1,0 +1,67 @@
+/**
+ * `regrade` trail -- Run downstream migration checks and safe rewrites.
+ */
+
+import { NotFoundError, Result, trail, validateOutput } from '@ontrails/core';
+import {
+  regradeReportOutput,
+  runRegrade,
+  wardenTermRewriteClasses,
+} from '@ontrails/regrade';
+import { z } from 'zod';
+
+import { resolveTrailRootDir } from './root-dir.js';
+
+const regradeInputSchema = z.object({
+  apply: z
+    .boolean()
+    .default(false)
+    .describe('Write safe rewrites to disk; dry-run report only by default'),
+  classIds: z
+    .array(z.string())
+    .optional()
+    .describe('Regrade class ids to run (defaults to all built-in classes)'),
+  rootDir: z.string().optional().describe('Workspace root directory'),
+});
+
+export const regradeTrail = trail('regrade', {
+  blaze: (input, ctx) => {
+    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+    if (rootDirResult.isErr()) {
+      return rootDirResult;
+    }
+
+    const reportResult = runRegrade({
+      apply: input.apply,
+      classes: wardenTermRewriteClasses,
+      root: rootDirResult.value,
+      ...(input.classIds === undefined
+        ? {}
+        : { selection: { classIds: input.classIds } }),
+    });
+    if (reportResult.isErr()) {
+      return Result.err(reportResult.error);
+    }
+
+    const report = reportResult.value;
+    if (report === null) {
+      return Result.err(
+        new NotFoundError(
+          `Regrade root "${rootDirResult.value}" could not be read as a directory.`
+        )
+      );
+    }
+
+    const validated = validateOutput(regradeReportOutput, report);
+    if (validated.isErr()) {
+      return Result.err(validated.error);
+    }
+
+    return Result.ok(validated.value);
+  },
+  description: 'Run downstream migration checks and safe rewrites',
+  input: regradeInputSchema,
+  intent: 'write',
+  output: regradeReportOutput,
+  permit: 'public',
+});

--- a/bun.lock
+++ b/bun.lock
@@ -86,6 +86,7 @@
         "@ontrails/mcp": "workspace:^",
         "@ontrails/observe": "workspace:^",
         "@ontrails/permits": "workspace:^",
+        "@ontrails/regrade": "workspace:^",
         "@ontrails/topographer": "workspace:^",
         "@ontrails/tracing": "workspace:^",
         "@ontrails/warden": "workspace:^",

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -462,14 +462,46 @@ RuleInput, ProjectAwareRuleInput, RuleOutput, TopoAwareRuleInput
 ## `@ontrails/warden/ast`
 
 ```typescript
-parse(filePath, sourceCode), walk(ast, visitor), offsetToLine(source, offset)
-walkScope(ast, visitor)
+parse(filePath, sourceCode), parseWithDiagnostics(filePath, sourceCode)
+walk(ast, visitor), walkScope(ast, visitor)
+walkWithParents(ast, visitor), walkWithScopeContext(ast, visitor)
+offsetToLine(source, offset), offsetToLineColumn(source, offset)
+createSourceEdit(start, end, replacement)
+validateSourceEdits(edits), applySourceEdits(source, edits)
 findTrailDefinitions(ast), findBlazeBodies(node)
 findContourDefinitions(ast, context?, options?), isBlazeCall(node)
 findStringLiterals(ast, predicate?), isStringLiteral(node), getStringValue(node)
 
 AstNode, TrailDefinition, ContourDefinition, FindContourDefinitionsOptions
 FrameworkNamespaceContext, StringLiteralMatch
+AstParentContext, AstScopeContext, AstScopeDeclaration
+AstParseResult, AstParseDiagnostic, SourceEdit, SourceLocation
+```
+
+## `@ontrails/regrade`
+
+```typescript
+// Downstream migration reporting and safe rewrites
+runRegrade({ root, classes, selection?, collection?, apply? }) // Result<RegradeReport | null, InternalError>
+buildRegradeReport({ root, files, skipped, classes, selection? })
+selectRegradeClasses(classes, selection?)
+
+// Built-in Warden-backed migration classes
+wardenTermRewriteClasses
+createWardenTermRewriteClass(rule)
+createTermRewriteClass({ from, to, id?, describe? })
+
+// AST-backed class builders
+createAstRewriteClass({ id, describe, shouldScan?, visit })
+createAstIdentifierRenameClass({ from, to, id?, describe?, reviewDeclarationTypes? })
+
+// Trails and schemas
+regradeReportTrail, regradeReportInput, regradeReportOutput
+literalRegradeTopo, literalRegradeTrail
+
+// Types
+RegradeClass, RegradeClassResult, RegradeReport, RegradeReportEntry
+RegradeReviewDetail, RegradeReviewSpan, RegradeScanTargets, RegradeSelection
 ```
 
 ## `@ontrails/config`

--- a/packages/regrade/package.json
+++ b/packages/regrade/package.json
@@ -1,8 +1,14 @@
 {
   "name": "@ontrails/regrade",
   "version": "1.0.0-beta.24",
-  "private": true,
-  "description": "Experimental Regrade tracer proving whether transform units can be literal Trails trails.",
+  "description": "Downstream migration reporting and safe rewrite helpers for Trails.",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "CHANGELOG.md"
+  ],
   "type": "module",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
+++ b/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
@@ -81,6 +81,45 @@ describe('createAstRewriteClass', () => {
     expect(result.reason).toBe('ast-rewrite-invalid-edits');
     expect(result.nextSource).toBeUndefined();
   });
+
+  test('routes visitor failures to review', () => {
+    const cls = createAstRewriteClass({
+      describe: 'Throwing visitor fixture.',
+      id: 'ast-test:visitor-failure',
+      visit: () => {
+        throw new Error('visitor boom');
+      },
+    });
+
+    const result = cls.apply('export const value = 1;\n', {
+      path: 'src/value.ts',
+    });
+
+    expect(result.kind).toBe('needs-review');
+    expect(result.reason).toBe('ast-rewrite-visitor-failed');
+    expect(result.notes.join('\n')).toContain('visitor boom');
+    expect(result.nextSource).toBeUndefined();
+  });
+
+  test('routes scan predicate failures to review', () => {
+    const cls = createAstRewriteClass({
+      describe: 'Throwing scan predicate fixture.',
+      id: 'ast-test:scan-failure',
+      shouldScan: () => {
+        throw new Error('scan boom');
+      },
+      visit: () => null,
+    });
+
+    const result = cls.apply('export const value = 1;\n', {
+      path: 'src/value.ts',
+    });
+
+    expect(result.kind).toBe('needs-review');
+    expect(result.reason).toBe('ast-rewrite-scan-target-failed');
+    expect(result.notes.join('\n')).toContain('scan boom');
+    expect(result.nextSource).toBeUndefined();
+  });
 });
 
 describe('createAstIdentifierRenameClass', () => {

--- a/packages/regrade/src/downstream/__tests__/radio-fixture.test.ts
+++ b/packages/regrade/src/downstream/__tests__/radio-fixture.test.ts
@@ -91,11 +91,16 @@ describe('Radio-shaped downstream fixture (TRL-846)', () => {
   test('regrade coverage over the fixture is deterministic', () => {
     const root = materializeFixture();
     try {
-      const report = runRegrade({
+      const result = runRegrade({
         classes: wardenTermRewriteClasses,
         root,
         selection: { classIds: [crossToComposeClassId] },
       });
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      const report = result.value;
       expect(report).not.toBeNull();
       const r = report as NonNullable<typeof report>;
 

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { executeTrail } from '@ontrails/core';
 import type { WardenRule } from '@ontrails/warden';
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -9,7 +10,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import {
   buildRegradeReport,
@@ -20,9 +21,20 @@ import {
   selectRegradeClasses,
   wardenTermRewriteClasses,
 } from '../report.js';
-import type { RegradeClass } from '../report.js';
+import type { RegradeClass, RegradeReport } from '../report.js';
 
 const signalToPing = createTermRewriteClass({ from: 'signal', to: 'ping' });
+
+const expectRunRegradeOk = (
+  params: Parameters<typeof runRegrade>[0]
+): RegradeReport | null => {
+  const result = runRegrade(params);
+  expect(result.isOk()).toBe(true);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value;
+};
 
 describe('createTermRewriteClass', () => {
   test('rewrites whole-word occurrences', () => {
@@ -423,10 +435,14 @@ const writeApplyFixture = (): string => {
 };
 
 describe('runRegrade + regradeReportTrail', () => {
+  test('trail intent reflects apply-mode write capability', () => {
+    expect(regradeReportTrail.intent).toBe('write');
+  });
+
   test('runRegrade reports coverage over a real root', () => {
     const root = writeReportFixture();
     try {
-      const report = runRegrade({ classes: [signalToPing], root });
+      const report = expectRunRegradeOk({ classes: [signalToPing], root });
       expect(report).not.toBeNull();
       const r = report as NonNullable<typeof report>;
       // dist/out.ts is skipped at the directory level, so only 2 files scanned.
@@ -451,7 +467,7 @@ describe('runRegrade + regradeReportTrail', () => {
         'export const sourceTerm = 1;\n'
       );
 
-      const report = runRegrade({
+      const report = expectRunRegradeOk({
         classes: [
           {
             apply: (source) =>
@@ -497,7 +513,7 @@ describe('runRegrade + regradeReportTrail', () => {
         'export const signal = 2;\n'
       );
 
-      const report = runRegrade({
+      const report = expectRunRegradeOk({
         classes: [signalToPing],
         root,
         selection: { classIds: ['missing-class'] },
@@ -515,7 +531,7 @@ describe('runRegrade + regradeReportTrail', () => {
 
   test('unknown-only selection still validates the root', () => {
     expect(
-      runRegrade({
+      expectRunRegradeOk({
         classes: [signalToPing],
         root: join(import.meta.dir, 'does-not-exist-xyz'),
         selection: { classIds: ['missing-class'] },
@@ -524,19 +540,23 @@ describe('runRegrade + regradeReportTrail', () => {
   });
 
   test('returns null for an unreadable root', () => {
-    expect(
-      runRegrade({
-        classes: [signalToPing],
-        root: join(import.meta.dir, 'does-not-exist-xyz'),
-      })
-    ).toBeNull();
+    const result = runRegrade({
+      classes: [signalToPing],
+      root: join(import.meta.dir, 'does-not-exist-xyz'),
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isErr()) {
+      throw result.error;
+    }
+    expect(result.value).toBeNull();
   });
 
   test('dry-run is the default and does not write rewrite outcomes', () => {
     const root = writeApplyFixture();
     try {
       const target = join(root, 'src', 'a.ts');
-      const report = runRegrade({ classes: [signalToPing], root });
+      const report = expectRunRegradeOk({ classes: [signalToPing], root });
 
       expect(report?.rewritten).toBe(1);
       expect(report?.apply).toBeUndefined();
@@ -549,7 +569,7 @@ describe('runRegrade + regradeReportTrail', () => {
   test('apply mode writes only safe rewrite outcomes with nextSource', () => {
     const root = writeApplyFixture();
     try {
-      const report = runRegrade({
+      const report = expectRunRegradeOk({
         apply: true,
         classes: [signalToPing],
         root,
@@ -584,7 +604,7 @@ describe('runRegrade + regradeReportTrail', () => {
     mkdirSync(join(root, 'src'), { recursive: true });
     writeFileSync(join(root, 'src', 'a.ts'), 'export const signal = 1;\n');
     try {
-      const report = runRegrade({
+      const report = expectRunRegradeOk({
         apply: true,
         classes: [signalToPing],
         root,
@@ -604,6 +624,50 @@ describe('runRegrade + regradeReportTrail', () => {
       expect(readFileSync(join(root, 'src', 'a.ts'), 'utf8')).toBe(
         'export const signal = 1;\n'
       );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('apply mode returns InternalError when a rewrite cannot be written', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-apply-write-error-'));
+    mkdirSync(join(root, 'src'), { recursive: true });
+    writeFileSync(join(root, 'src', 'a.ts'), 'export const signal = 1;\n');
+    try {
+      const result = runRegrade({
+        apply: true,
+        classes: [
+          {
+            apply: (_source, context) => {
+              if (context?.absolutePath !== undefined) {
+                rmSync(dirname(context.absolutePath), {
+                  force: true,
+                  recursive: true,
+                });
+              }
+              return {
+                kind: 'rewrite',
+                nextSource: 'export const ping = 1;\n',
+                notes: ['Simulated a write race.'],
+              };
+            },
+            describe: 'Simulate a file disappearing before write.',
+            id: 'test-write-error',
+          },
+        ],
+        root,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.constructor.name).toBe('InternalError');
+        expect(result.error.context).toMatchObject({
+          applied: 0,
+          classId: 'test-write-error',
+          filesChanged: 0,
+          path: 'src/a.ts',
+        });
+      }
     } finally {
       rmSync(root, { force: true, recursive: true });
     }
@@ -669,6 +733,32 @@ describe('runRegrade + regradeReportTrail', () => {
         expect(value.apply?.applied).toBe(1);
       }
     } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('trail apply input returns InternalError when writing fails', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-trail-apply-error-'));
+    mkdirSync(join(root, 'src'), { recursive: true });
+    const target = join(root, 'src', 'play.ts');
+    writeFileSync(
+      target,
+      'export const play = trail("play", { crosses: [] });\n'
+    );
+    chmodSync(target, 0o444);
+    try {
+      const result = await executeTrail(regradeReportTrail, {
+        apply: true,
+        classIds: ['term-rewrite:no-retired-cross-vocabulary'],
+        root,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.constructor.name).toBe('InternalError');
+      }
+    } finally {
+      chmodSync(target, 0o644);
       rmSync(root, { force: true, recursive: true });
     }
   });

--- a/packages/regrade/src/downstream/ast-rewrite.ts
+++ b/packages/regrade/src/downstream/ast-rewrite.ts
@@ -102,6 +102,20 @@ const invalidEditsResult = (error: unknown): RegradeClassResult => ({
   reason: 'ast-rewrite-invalid-edits',
 });
 
+const astRewriteFailureResult = (
+  context: RegradeClassContext,
+  reason: string,
+  error: unknown
+): RegradeClassResult => ({
+  kind: 'needs-review',
+  notes: [
+    error instanceof Error
+      ? `AST rewrite failed for ${context.path}: ${error.message}`
+      : `AST rewrite failed for ${context.path}.`,
+  ],
+  reason,
+});
+
 const reviewDetailsFor = (
   classId: string,
   matches: readonly AstRewriteMatch[]
@@ -122,12 +136,22 @@ export const createAstRewriteClass = (
     source: string,
     context: RegradeClassContext = defaultRegradeClassContext
   ): RegradeClassResult => {
-    if (options.shouldScan && !options.shouldScan(context)) {
-      return {
-        kind: 'skipped',
-        notes: ['Skipped by AST rewrite scan-target filtering.'],
-        reason: 'ast-rewrite-scan-target-filtered',
-      };
+    if (options.shouldScan) {
+      try {
+        if (!options.shouldScan(context)) {
+          return {
+            kind: 'skipped',
+            notes: ['Skipped by AST rewrite scan-target filtering.'],
+            reason: 'ast-rewrite-scan-target-filtered',
+          };
+        }
+      } catch (error: unknown) {
+        return astRewriteFailureResult(
+          context,
+          'ast-rewrite-scan-target-failed',
+          error
+        );
+      }
     }
 
     const parsed = parseWithDiagnostics(context.path, source);
@@ -146,17 +170,25 @@ export const createAstRewriteClass = (
     }
 
     const matches: AstRewriteMatch[] = [];
-    walkWithScopeContext(parsed.ast, (node, scopeContext) => {
-      matches.push(
-        ...toArray(
-          options.visit(node, {
-            ...scopeContext,
-            path: context.path,
-            source,
-          })
-        )
+    try {
+      walkWithScopeContext(parsed.ast, (node, scopeContext) => {
+        matches.push(
+          ...toArray(
+            options.visit(node, {
+              ...scopeContext,
+              path: context.path,
+              source,
+            })
+          )
+        );
+      });
+    } catch (error: unknown) {
+      return astRewriteFailureResult(
+        context,
+        'ast-rewrite-visitor-failed',
+        error
       );
-    });
+    }
 
     const reviewMatches = matches.filter((match) => match.kind === 'review');
     if (reviewMatches.length > 0) {

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -1,5 +1,11 @@
 import type { ValidationError } from '@ontrails/core';
-import { NotFoundError, Result, trail, validateOutput } from '@ontrails/core';
+import {
+  InternalError,
+  NotFoundError,
+  Result,
+  trail,
+  validateOutput,
+} from '@ontrails/core';
 import type {
   WardenDiagnostic,
   WardenFixEdit,
@@ -606,30 +612,49 @@ export const buildRegradeReport = (params: {
 
 const applyRegradeEvaluation = (
   evaluation: RegradeEvaluation
-): RegradeApplySummary => {
+): Result<RegradeApplySummary, InternalError> => {
   if (evaluation.report.unknownClassIds.length > 0) {
-    return {
+    return Result.ok({
       applied: 0,
       filesChanged: 0,
       review: evaluation.report.review,
       skipped: evaluation.report.skipped + evaluation.rewrites.length,
       unknown: evaluation.report.unknownClassIds.length,
-    };
+    });
   }
 
   const changedFiles = new Set<string>();
+  let applied = 0;
   for (const rewrite of evaluation.rewrites) {
-    writeFileSync(rewrite.absolutePath, rewrite.nextSource, 'utf8');
+    try {
+      writeFileSync(rewrite.absolutePath, rewrite.nextSource, 'utf8');
+    } catch (error: unknown) {
+      return Result.err(
+        new InternalError(
+          `Failed to apply regrade rewrite for "${rewrite.path}".`,
+          {
+            cause: error instanceof Error ? error : new Error(String(error)),
+            context: {
+              applied,
+              classId: rewrite.classId,
+              filesChanged: changedFiles.size,
+              path: rewrite.path,
+            },
+          }
+        )
+      );
+    }
+    applied += 1;
     changedFiles.add(rewrite.path);
   }
 
-  return {
+  return Result.ok({
     applied: evaluation.rewrites.length,
     filesChanged: changedFiles.size,
     review: evaluation.report.review,
     skipped: evaluation.report.skipped,
     unknown: 0,
-  };
+  });
 };
 
 const withApplySummary = (
@@ -718,20 +743,22 @@ export const runRegrade = (params: {
   readonly selection?: RegradeSelection;
   readonly collection?: DownstreamCollectionOptions;
   readonly apply?: boolean;
-}): RegradeReport | null => {
+}): Result<RegradeReport | null, InternalError> => {
   const evaluation = runRegradeEvaluation(params);
   if (evaluation === null) {
-    return null;
+    return Result.ok(null);
   }
 
   if (params.apply !== true) {
-    return evaluation.report;
+    return Result.ok(evaluation.report);
   }
 
-  return withApplySummary(
-    evaluation.report,
-    applyRegradeEvaluation(evaluation)
-  );
+  const applyResult = applyRegradeEvaluation(evaluation);
+  if (applyResult.isErr()) {
+    return Result.err(applyResult.error);
+  }
+
+  return Result.ok(withApplySummary(evaluation.report, applyResult.value));
 };
 
 const regradeReportEntrySchema = z.object({
@@ -851,7 +878,7 @@ export const wardenTermRewriteClasses: readonly RegradeClass[] = Object.freeze(
  */
 export const regradeReportTrail = trail('regrade.downstream.report', {
   blaze: (input) => {
-    const report = runRegrade({
+    const reportResult = runRegrade({
       apply: input.apply,
       classes: wardenTermRewriteClasses,
       root: input.root,
@@ -859,6 +886,11 @@ export const regradeReportTrail = trail('regrade.downstream.report', {
         ? {}
         : { selection: { classIds: input.classIds } }),
     });
+    if (reportResult.isErr()) {
+      return reportResult;
+    }
+
+    const report = reportResult.value;
     if (report === null) {
       return Result.err(
         new NotFoundError(
@@ -873,6 +905,6 @@ export const regradeReportTrail = trail('regrade.downstream.report', {
     return validateRegradeReportOutput(report);
   },
   input: regradeReportInput,
-  intent: 'read',
+  intent: 'write',
   output: regradeReportOutput,
 });

--- a/packages/regrade/src/index.ts
+++ b/packages/regrade/src/index.ts
@@ -1,10 +1,39 @@
 // Root package surface for `@ontrails/regrade`.
-//
-// Only the runnable graph and its public parent trail are exported here. The
-// internal child transform trail stays reachable through the topo and the
-// parent's `composes` declaration. The transform schemas remain internal
-// package test harness details until Regrade has a deliberate public contract.
 export {
   literalRegradeTopo,
   literalRegradeTrail,
 } from './literal-transform.js';
+export {
+  buildRegradeReport,
+  createTermRewriteClass,
+  createWardenTermRewriteClass,
+  regradeReportInput,
+  regradeReportOutput,
+  regradeReportTrail,
+  runRegrade,
+  selectRegradeClasses,
+  wardenTermRewriteClasses,
+} from './downstream/report.js';
+export type {
+  RegradeApplySummary,
+  RegradeClass,
+  RegradeClassContext,
+  RegradeClassResult,
+  RegradeReport,
+  RegradeReportEntry,
+  RegradeReviewDetail,
+  RegradeReviewSpan,
+  RegradeScanTargets,
+  RegradeSelection,
+} from './downstream/report.js';
+export {
+  createAstIdentifierRenameClass,
+  createAstRewriteClass,
+} from './downstream/ast-rewrite.js';
+export type {
+  AstIdentifierRenameClassOptions,
+  AstRewriteClassOptions,
+  AstRewriteContext,
+  AstRewriteMatch,
+  AstRewriteVisitResult,
+} from './downstream/ast-rewrite.js';


### PR DESCRIPTION
## Context

Exposes Regrade through the Trails operator app as a dogfood surface. The command defaults to dry-run and requires explicit `--apply` before writing safe rewrite outcomes.

## Changes

- Make `@ontrails/regrade` publishable and export the downstream report and AST APIs.
- Add `@ontrails/regrade` to the Trails app and wire the `trails regrade` trail into `operatorApp`.
- Add CLI tests for command exposure, dry-run behavior, and explicit apply writes.
- Update app README and API reference docs, with a branch-local changeset.

## Verification

- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `git diff --check`
- Remote CI is green.