### PR TITLE
fix(trails): collapse diff onto survey contract

### DIFF
--- a/.changeset/trl-1008-diff-route.md
+++ b/.changeset/trl-1008-diff-route.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Collapse the duplicate `diff` trail into the canonical `survey.diff` contract while keeping `trails diff` available as a CLI route alias.

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -81,7 +81,6 @@ describe('Trails MCP surface shaping', () => {
     expect(inspectTool?.trailId).toBeUndefined();
     expect(inspectTool?.facetId).toBe('inspect');
     expect(inspectTool?.memberTrailIds?.toSorted()).toEqual([
-      'diff',
       'guide',
       'survey',
       'survey.brief',

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -40,7 +40,6 @@ import {
   deriveSignalDetail,
   deriveSurveyList,
   deriveTrailDetail,
-  diffTrail,
   surveyBriefTrail,
   surveyDiffTrail,
   surveyResourceTrail,
@@ -1611,13 +1610,23 @@ describe('trails compile', () => {
 });
 
 describe('trails survey diff', () => {
-  test('top-level diff projects as a root CLI command with target arg', () => {
+  test('top-level diff projects as a root CLI alias with target arg', () => {
     const commands = expectOk(
-      deriveCliCommands(topo('diff-cli', { diffTrail, surveyDiffTrail }))
+      deriveCliCommands(topo('diff-cli', { surveyDiffTrail }), {
+        aliases: { 'survey.diff': [['diff']] },
+      })
     );
-    const command = commands.find((candidate) => candidate.trail.id === 'diff');
+    const command = commands.find(
+      (candidate) => candidate.trail.id === 'survey.diff'
+    );
 
-    expect(command?.path).toEqual(['diff']);
+    expect(command?.path).toEqual(['survey', 'diff']);
+    expect(command?.routes).toContainEqual({
+      kind: 'alias',
+      path: ['diff'],
+      source: 'surface',
+      target: 'survey.diff',
+    });
     expect(command?.args.map((arg) => arg.name)).toContain('target');
     expect(command?.flags.map((flag) => flag.name)).toContain('breaks');
     expect(command?.flags.map((flag) => flag.name)).toContain('forces');
@@ -1698,11 +1707,11 @@ describe('trails survey diff', () => {
 
       writeSurveyAppFixture(dir, { withBye: true });
 
-      const byeDiff = await diffTrail.blaze(
+      const byeDiff = await surveyDiffTrail.blaze(
         { module: './src/app.ts', target: 'bye' },
         { cwd: dir } as never
       );
-      const helloDiff = await diffTrail.blaze(
+      const helloDiff = await surveyDiffTrail.blaze(
         { module: './src/app.ts', target: 'hello' },
         { cwd: dir } as never
       );
@@ -1728,7 +1737,7 @@ describe('trails survey diff', () => {
         dir: join(dir, '.trails'),
       });
 
-      const result = await diffTrail.blaze(
+      const result = await surveyDiffTrail.blaze(
         { module: './src/app.ts', target: 'missing.plain' },
         { cwd: dir } as never
       );
@@ -1776,7 +1785,7 @@ describe('trails survey diff', () => {
         } satisfies TopoGraph)
       );
 
-      const result = await diffTrail.blaze(
+      const result = await surveyDiffTrail.blaze(
         {
           against: 'baseline.json',
           forces: true,
@@ -1838,7 +1847,7 @@ describe('trails survey diff', () => {
 
       writeVersionedDiffAppFixture(dir, { archiveV1: true });
 
-      const result = await diffTrail.blaze(
+      const result = await surveyDiffTrail.blaze(
         {
           against: 'baselines',
           module: './src/app.ts',
@@ -1874,7 +1883,7 @@ describe('trails survey diff', () => {
         deprecateV2: true,
       });
 
-      const result = await diffTrail.blaze(
+      const result = await surveyDiffTrail.blaze(
         {
           against: 'baselines',
           module: './src/app.ts',
@@ -1922,7 +1931,7 @@ describe('trails survey diff', () => {
 
       writeVersionedDiffAppFixture(dir, { omitV1: true });
 
-      const result = await diffTrail.blaze(
+      const result = await surveyDiffTrail.blaze(
         {
           against: 'baselines',
           module: './src/app.ts',
@@ -1956,7 +1965,7 @@ describe('trails survey diff', () => {
         dir: join(dir, 'baselines'),
       });
 
-      const result = await diffTrail.blaze(
+      const result = await surveyDiffTrail.blaze(
         {
           against: 'baselines',
           module: './src/app.ts',
@@ -2156,7 +2165,7 @@ describe('trails survey output schema', () => {
       }).success
     ).toBe(true);
     expect(
-      diffTrail.output.safeParse({
+      surveyDiffTrail.output.safeParse({
         against: 'saved',
         breaking: [],
         hasBreaking: false,

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -106,6 +106,7 @@ export const trailsCliIncludedTrails = [
 ];
 
 export const trailsCliAliases = {
+  'survey.diff': [['diff']],
   'wayfind.search': [['wf', 'search']],
 } as const;
 

--- a/apps/trails/src/mcp-options.ts
+++ b/apps/trails/src/mcp-options.ts
@@ -11,7 +11,6 @@ export const trailsMcpIncludedTrails = [
   'dev.clean',
   'dev.reset',
   'dev.stats',
-  'diff',
   'doctor',
   'draft.promote',
   'guide',
@@ -53,7 +52,6 @@ export const trailsMcpFacets = {
     mcp: { loading: 'deferred' },
     trails: [
       'survey',
-      'diff',
       'topo',
       'guide',
       'survey.brief',

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -869,39 +869,6 @@ export const surveySurfacesTrail = trail('survey.surfaces', {
 });
 
 export const surveyDiffTrail = trail('survey.diff', {
-  blaze: async (input, ctx) =>
-    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
-      buildSurveyDiff(app, rootDir, input)
-    ),
-  description: 'Diff the current topo against a saved TopoGraph',
-  examples: [
-    {
-      description: 'Compare current topo to a saved TopoGraph directory',
-      input: createDiffExampleInput(),
-      name: 'Diff against baseline',
-    },
-    {
-      description: 'Reject an empty saved map target',
-      error: 'ValidationError',
-      input: { against: '' },
-      name: 'Reject empty diff target',
-    },
-    {
-      description: 'Reject an empty target before filtering breaking drift',
-      error: 'ValidationError',
-      input: {
-        against: '',
-        breakingOnly: true,
-      },
-      name: 'Reject empty breaking-only target',
-    },
-  ],
-  input: diffInputSchema,
-  intent: 'read',
-  output: diffOutput,
-});
-
-export const diffTrail = trail('diff', {
   args: ['target'],
   blaze: async (input, ctx) =>
     withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
@@ -923,6 +890,21 @@ export const diffTrail = trail('diff', {
       description: 'Show graph-only force audit events',
       input: { ...createDiffExampleInput(), forces: true },
       name: 'Force audit events',
+    },
+    {
+      description: 'Reject an empty saved map target',
+      error: 'ValidationError',
+      input: { against: '' },
+      name: 'Reject empty diff target',
+    },
+    {
+      description: 'Reject an empty target before filtering breaking drift',
+      error: 'ValidationError',
+      input: {
+        against: '',
+        breakingOnly: true,
+      },
+      name: 'Reject empty breaking-only target',
     },
   ],
   input: diffInputSchema,

--- a/docs/surfaces/surface-facets.md
+++ b/docs/surfaces/surface-facets.md
@@ -51,7 +51,7 @@ const facets = {
     description:
       'Inspect topo structure, contracts, resources, signals, surfaces, and diffs.',
     mcp: { loading: 'deferred' },
-    trails: ['survey', 'diff', 'topo', 'guide'],
+    trails: ['survey', 'survey.diff', 'topo', 'guide'],
   },
 } satisfies McpSurfaceFacetMap;
 


### PR DESCRIPTION
## Context

TRL-1008 collapses the duplicate `diff` capability onto the canonical `survey.diff` contract.

## Changes

- Moves the CLI positional target shape onto `survey.diff`.
- Replaces the separate `diff` trail with a CLI alias to `survey.diff`.
- Removes `diff` from MCP inclusion/facet references so MCP does not expose a duplicate contract.
- Updates survey, MCP, schema, and docs coverage.
- Adds branch-local release intent for `@ontrails/trails`.

## Verification

- `bun test apps/trails/src/__tests__/survey.test.ts apps/trails/src/__tests__/mcp.test.ts apps/trails/src/__tests__/schema-cli.test.ts apps/trails/src/__tests__/wayfind-cli.test.ts`
- `bun run --cwd apps/trails typecheck`
- Full stack verification before submit: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`

## Risks

The old CLI spelling is preserved as an alias. MCP intentionally exposes only the canonical `survey.diff` trail.
