### PR TITLE
refactor(trails): centralize operator app context

### DIFF
--- a/.changeset/trl-1009-operator-context.md
+++ b/.changeset/trl-1009-operator-context.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Centralize the Trails operator root-directory and fresh-app lease preamble so topo-reading commands share the same load/release flow.

--- a/apps/trails/src/trails/compile.ts
+++ b/apps/trails/src/trails/compile.ts
@@ -2,8 +2,7 @@ import { trail } from '@ontrails/core';
 import type { CliCommandAliasInput, Result, Topo } from '@ontrails/core';
 import { z } from 'zod';
 
-import { tryLoadFreshAppLease } from './load-app.js';
-import { resolveTrailRootDir } from './root-dir.js';
+import { withFreshOperatorApp } from './operator-context.js';
 import { exportCurrentTopo } from './topo-store-support.js';
 import type { TopoExportReport } from './topo-support.js';
 import {
@@ -34,27 +33,14 @@ const compileTrailInputSchema = z.object({
 type CompileTrailInput = z.output<typeof compileTrailInputSchema>;
 
 export const compileTrail = trail('compile', {
-  blaze: async (input: CompileTrailInput, ctx) => {
-    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
-    if (rootDirResult.isErr()) {
-      return rootDirResult;
-    }
-    const rootDir = rootDirResult.value;
-    const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
-    if (leaseResult.isErr()) {
-      return leaseResult;
-    }
-    const lease = leaseResult.value;
-    try {
-      return await compileCurrentTopo(lease.app, {
+  blaze: async (input: CompileTrailInput, ctx) =>
+    withFreshOperatorApp(input, ctx, ({ lease, rootDir }) =>
+      compileCurrentTopo(lease.app, {
         cliAliases: lease.cliAliases,
         force: input.force,
         rootDir,
-      });
-    } finally {
-      lease.release();
-    }
-  },
+      })
+    ),
   description: 'Compile the current topo to .trails artifacts',
   examples: [
     {

--- a/apps/trails/src/trails/guide.ts
+++ b/apps/trails/src/trails/guide.ts
@@ -7,7 +7,7 @@
 import { NotFoundError, Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
-import { tryLoadFreshAppLease } from './load-app.js';
+import { withFreshOperatorApp } from './operator-context.js';
 import { trailDetailOutput } from './topo-output-schemas.js';
 import {
   buildCurrentGuideEntries,
@@ -15,7 +15,6 @@ import {
   readSurfaceLayerNamesFromContext,
 } from './topo-read-support.js';
 import { createIsolatedExampleInput } from './topo-support.js';
-import { resolveTrailRootDir } from './root-dir.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -27,6 +26,16 @@ interface GuideEntry {
   readonly id: string;
   readonly kind: 'trail';
 }
+
+type GuideTrailOutput =
+  | {
+      readonly entries: GuideEntry[];
+      readonly mode: 'list';
+    }
+  | {
+      readonly detail: z.output<typeof trailDetailOutput>;
+      readonly mode: 'detail';
+    };
 
 const guideTrailInputSchema = z.object({
   module: z.string().optional().describe('Path to the app module'),
@@ -41,19 +50,8 @@ type GuideTrailInput = z.output<typeof guideTrailInputSchema>;
 // ---------------------------------------------------------------------------
 
 export const guideTrail = trail('guide', {
-  blaze: async (input: GuideTrailInput, ctx) => {
-    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
-    if (rootDirResult.isErr()) {
-      return rootDirResult;
-    }
-    const rootDir = rootDirResult.value;
-    const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
-    if (leaseResult.isErr()) {
-      return leaseResult;
-    }
-    const lease = leaseResult.value;
-
-    try {
+  blaze: async (input: GuideTrailInput, ctx) =>
+    withFreshOperatorApp<GuideTrailOutput>(input, ctx, ({ lease, rootDir }) => {
       if (input.trailId) {
         const detail = buildCurrentTopoDetail(lease.app, input.trailId, {
           cliAliases: lease.cliAliases,
@@ -77,10 +75,7 @@ export const guideTrail = trail('guide', {
         }) as GuideEntry[],
         mode: 'list' as const,
       });
-    } finally {
-      lease.release();
-    }
-  },
+    }),
   description: 'Runtime guidance for trails',
   examples: [
     {

--- a/apps/trails/src/trails/operator-context.ts
+++ b/apps/trails/src/trails/operator-context.ts
@@ -1,0 +1,66 @@
+import type { Result } from '@ontrails/core';
+
+import { tryLoadFreshAppLease } from './load-app.js';
+import type { FreshAppLease } from './load-app.js';
+import { resolveTrailRootDir } from './root-dir.js';
+
+interface RootDirInput {
+  readonly rootDir?: string | undefined;
+}
+
+interface FreshAppInput extends RootDirInput {
+  readonly module?: string | undefined;
+}
+
+interface RootDirContext {
+  readonly cwd?: string | undefined;
+}
+
+interface FreshAppContext {
+  readonly lease: FreshAppLease;
+  readonly rootDir: string;
+}
+
+export const withOperatorRootDir = async <T>(
+  input: RootDirInput,
+  ctx: RootDirContext,
+  consume: (rootDir: string) => Result<T, Error> | Promise<Result<T, Error>>
+): Promise<Result<T, Error>> => {
+  const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
+  if (rootDirResult.isErr()) {
+    return rootDirResult;
+  }
+  return await consume(rootDirResult.value);
+};
+
+export const withFreshAppLease = async <T>(
+  modulePath: string | undefined,
+  rootDir: string,
+  consume: (
+    lease: FreshAppLease
+  ) => Result<T, Error> | Promise<Result<T, Error>>
+): Promise<Result<T, Error>> => {
+  const leaseResult = await tryLoadFreshAppLease(modulePath, rootDir);
+  if (leaseResult.isErr()) {
+    return leaseResult;
+  }
+  const lease = leaseResult.value;
+  try {
+    return await consume(lease);
+  } finally {
+    lease.release();
+  }
+};
+
+export const withFreshOperatorApp = async <T>(
+  input: FreshAppInput,
+  ctx: RootDirContext,
+  consume: (
+    context: FreshAppContext
+  ) => Result<T, Error> | Promise<Result<T, Error>>
+): Promise<Result<T, Error>> =>
+  withOperatorRootDir(input, ctx, (rootDir) =>
+    withFreshAppLease(input.module, rootDir, (lease) =>
+      consume({ lease, rootDir })
+    )
+  );

--- a/apps/trails/src/trails/run-example.ts
+++ b/apps/trails/src/trails/run-example.ts
@@ -13,9 +13,8 @@ import {
 import type { BasePermit, StructuredTrailExample, Topo } from '@ontrails/core';
 import { z } from 'zod';
 
-import { tryLoadFreshAppLease } from './load-app.js';
+import { withFreshAppLease, withOperatorRootDir } from './operator-context.js';
 import { resolveRunModulePath } from './run.js';
-import { resolveTrailRootDir } from './root-dir.js';
 import { createIsolatedExampleInput } from './topo-support.js';
 
 export const RUN_EXAMPLE_COMPARISON_KIND = 'example-comparison' as const;
@@ -440,42 +439,27 @@ type RunExampleTrailInput = z.output<typeof runExampleTrailInputSchema>;
 
 export const runExampleTrail = trail('run.example', {
   args: ['id', 'exampleName'],
-  blaze: async (input: RunExampleTrailInput, ctx) => {
-    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
-    if (rootDirResult.isErr()) {
-      return rootDirResult;
-    }
-    const rootDir = rootDirResult.value;
-    const moduleResolution = await resolveRunModulePath(
-      rootDir,
-      input.module,
-      input.id,
-      input.app
-    );
-    if (moduleResolution.isErr()) {
-      return moduleResolution;
-    }
-
-    const leaseResult = await tryLoadFreshAppLease(
-      moduleResolution.value,
-      rootDir
-    );
-    if (leaseResult.isErr()) {
-      return leaseResult;
-    }
-    const lease = leaseResult.value;
-
-    try {
-      return await buildComparisonEnvelope(
-        lease.app,
+  blaze: async (input: RunExampleTrailInput, ctx) =>
+    withOperatorRootDir(input, ctx, async (rootDir) => {
+      const moduleResolution = await resolveRunModulePath(
+        rootDir,
+        input.module,
         input.id,
-        input.exampleName,
-        ctx.permit
+        input.app
       );
-    } finally {
-      lease.release();
-    }
-  },
+      if (moduleResolution.isErr()) {
+        return moduleResolution;
+      }
+
+      return withFreshAppLease(moduleResolution.value, rootDir, (lease) =>
+        buildComparisonEnvelope(
+          lease.app,
+          input.id,
+          input.exampleName,
+          ctx.permit
+        )
+      );
+    }),
   description: 'Run a named example on a trail and compare actual vs expected',
   examples: [
     {

--- a/apps/trails/src/trails/run-examples.ts
+++ b/apps/trails/src/trails/run-examples.ts
@@ -11,9 +11,8 @@ import {
 import type { StructuredTrailExample, Topo } from '@ontrails/core';
 import { z } from 'zod';
 
-import { tryLoadFreshAppLease } from './load-app.js';
+import { withFreshAppLease, withOperatorRootDir } from './operator-context.js';
 import { resolveRunModulePath } from './run.js';
-import { resolveTrailRootDir } from './root-dir.js';
 import { createIsolatedExampleInput } from './topo-support.js';
 
 export const RUN_EXAMPLES_LISTING_KIND = 'examples-listing' as const;
@@ -100,37 +99,22 @@ type RunExamplesTrailInput = z.output<typeof runExamplesTrailInputSchema>;
 
 export const runExamplesTrail = trail('run.examples', {
   args: ['id'],
-  blaze: async (input: RunExamplesTrailInput, ctx) => {
-    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
-    if (rootDirResult.isErr()) {
-      return rootDirResult;
-    }
-    const rootDir = rootDirResult.value;
-    const moduleResolution = await resolveRunModulePath(
-      rootDir,
-      input.module,
-      input.id,
-      input.app
-    );
-    if (moduleResolution.isErr()) {
-      return moduleResolution;
-    }
+  blaze: async (input: RunExamplesTrailInput, ctx) =>
+    withOperatorRootDir(input, ctx, async (rootDir) => {
+      const moduleResolution = await resolveRunModulePath(
+        rootDir,
+        input.module,
+        input.id,
+        input.app
+      );
+      if (moduleResolution.isErr()) {
+        return moduleResolution;
+      }
 
-    const leaseResult = await tryLoadFreshAppLease(
-      moduleResolution.value,
-      rootDir
-    );
-    if (leaseResult.isErr()) {
-      return leaseResult;
-    }
-    const lease = leaseResult.value;
-
-    try {
-      return buildExamplesListing(lease.app, input.id);
-    } finally {
-      lease.release();
-    }
-  },
+      return withFreshAppLease(moduleResolution.value, rootDir, (lease) =>
+        buildExamplesListing(lease.app, input.id)
+      );
+    }),
   description: "List a trail's examples without executing it",
   examples: [
     {

--- a/apps/trails/src/trails/run.ts
+++ b/apps/trails/src/trails/run.ts
@@ -50,8 +50,7 @@ import {
   writeIsolatedExampleTextFile,
 } from '../local-state-io.js';
 
-import { tryLoadFreshAppLease } from './load-app.js';
-import { resolveTrailRootDir } from './root-dir.js';
+import { withFreshAppLease, withOperatorRootDir } from './operator-context.js';
 import { createIsolatedExampleInput } from './topo-support.js';
 
 export const INNER_TRAIL_RESULT_KIND = 'inner-trail-result' as const;
@@ -372,51 +371,39 @@ const resolveInnerTrailInput = (
 
 export const runTrail = trail('run', {
   args: ['id'],
-  blaze: async (input: RunTrailInput, ctx) => {
-    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
-    if (rootDirResult.isErr()) {
-      return rootDirResult;
-    }
-    const rootDir = rootDirResult.value;
-    const innerInput = resolveInnerTrailInput(input);
-    if (innerInput.isErr()) {
-      return innerInput;
-    }
-
-    // Single-app back-compat: if the caller provided `module`, trust it.
-    const moduleResolution = await resolveRunModulePath(
-      rootDir,
-      input.module,
-      input.id,
-      input.app
-    );
-    if (moduleResolution.isErr()) {
-      return moduleResolution;
-    }
-    const modulePath = moduleResolution.value;
-
-    const leaseResult = await tryLoadFreshAppLease(modulePath, rootDir);
-    if (leaseResult.isErr()) {
-      return leaseResult;
-    }
-    const lease = leaseResult.value;
-
-    try {
-      const result = await run(lease.app, input.id, innerInput.value, {
-        ctx: ctx.permit === undefined ? {} : { permit: ctx.permit },
-      });
-      if (result.isErr()) {
-        return Result.err(result.error);
+  blaze: async (input: RunTrailInput, ctx) =>
+    withOperatorRootDir(input, ctx, async (rootDir) => {
+      const innerInput = resolveInnerTrailInput(input);
+      if (innerInput.isErr()) {
+        return innerInput;
       }
-      return Result.ok({
-        kind: INNER_TRAIL_RESULT_KIND,
-        trailId: input.id,
-        value: result.value,
+
+      // Single-app back-compat: if the caller provided `module`, trust it.
+      const moduleResolution = await resolveRunModulePath(
+        rootDir,
+        input.module,
+        input.id,
+        input.app
+      );
+      if (moduleResolution.isErr()) {
+        return moduleResolution;
+      }
+      const modulePath = moduleResolution.value;
+
+      return withFreshAppLease(modulePath, rootDir, async (lease) => {
+        const result = await run(lease.app, input.id, innerInput.value, {
+          ctx: ctx.permit === undefined ? {} : { permit: ctx.permit },
+        });
+        if (result.isErr()) {
+          return Result.err(result.error);
+        }
+        return Result.ok({
+          kind: INNER_TRAIL_RESULT_KIND,
+          trailId: input.id,
+          value: result.value,
+        });
       });
-    } finally {
-      lease.release();
-    }
-  },
+    }),
   description:
     'Resolve a trail by ID in the current app and execute it through the shared pipeline',
   examples: [

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -28,8 +28,7 @@ import { z } from 'zod';
 
 import { writeIsolatedExampleJsonFile } from '../local-state-io.js';
 
-import { tryLoadFreshAppLease } from './load-app.js';
-import { resolveTrailRootDir } from './root-dir.js';
+import { withFreshAppLease, withOperatorRootDir } from './operator-context.js';
 import {
   buildCurrentTopoBrief,
   buildCurrentTopoList,
@@ -647,18 +646,10 @@ const withFreshSurveyApp = async <T>(
       | Readonly<Record<string, readonly CliCommandAliasInput[]>>
       | undefined
   ) => Promise<Result<T, Error>> | Result<T, Error>
-): Promise<Result<T, Error>> => {
-  const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
-  if (leaseResult.isErr()) {
-    return Result.err(leaseResult.error);
-  }
-  const lease = leaseResult.value;
-  try {
-    return await consume(lease.app, lease.cliAliases);
-  } finally {
-    lease.release();
-  }
-};
+): Promise<Result<T, Error>> =>
+  withFreshAppLease(input.module, rootDir, (lease) =>
+    consume(lease.app, lease.cliAliases)
+  );
 
 const withResolvedSurveyApp = async <T>(
   input: {
@@ -673,16 +664,12 @@ const withResolvedSurveyApp = async <T>(
       | Readonly<Record<string, readonly CliCommandAliasInput[]>>
       | undefined
   ) => Promise<Result<T, Error>> | Result<T, Error>
-): Promise<Result<T, Error>> => {
-  const rootDirResult = resolveTrailRootDir(input.rootDir, cwd);
-  if (rootDirResult.isErr()) {
-    return Result.err(rootDirResult.error);
-  }
-  const rootDir = rootDirResult.value;
-  return withFreshSurveyApp(input, rootDir, (app, cliAliases) =>
-    consume(app, rootDir, cliAliases)
+): Promise<Result<T, Error>> =>
+  withOperatorRootDir(input, { cwd }, (rootDir) =>
+    withFreshSurveyApp(input, rootDir, (app, cliAliases) =>
+      consume(app, rootDir, cliAliases)
+    )
   );
-};
 
 const moduleInputSchema = z.object({
   module: z.string().optional().describe('Path to the app module'),

--- a/apps/trails/src/trails/topo-pin.ts
+++ b/apps/trails/src/trails/topo-pin.ts
@@ -1,8 +1,7 @@
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
-import { tryLoadFreshAppLease } from './load-app.js';
-import { resolveTrailRootDir } from './root-dir.js';
+import { withFreshOperatorApp } from './operator-context.js';
 import {
   createIsolatedExampleInput,
   pinCurrentTopoSnapshot,
@@ -10,25 +9,12 @@ import {
 } from './topo-support.js';
 
 export const topoPinTrail = trail('topo.pin', {
-  blaze: async (input, ctx) => {
-    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
-    if (rootDirResult.isErr()) {
-      return rootDirResult;
-    }
-    const rootDir = rootDirResult.value;
-    const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
-    if (leaseResult.isErr()) {
-      return leaseResult;
-    }
-    const lease = leaseResult.value;
-    try {
-      return Result.ok(
+  blaze: async (input, ctx) =>
+    withFreshOperatorApp(input, ctx, ({ lease, rootDir }) =>
+      Result.ok(
         pinCurrentTopoSnapshot(lease.app, { name: input.name, rootDir })
-      );
-    } finally {
-      lease.release();
-    }
-  },
+      )
+    ),
   description: 'Pin the current topo under a durable name',
   examples: [
     {

--- a/apps/trails/src/trails/topo.ts
+++ b/apps/trails/src/trails/topo.ts
@@ -1,8 +1,7 @@
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
-import { tryLoadFreshAppLease } from './load-app.js';
-import { resolveTrailRootDir } from './root-dir.js';
+import { withFreshOperatorApp } from './operator-context.js';
 import { activationOverviewOutput } from './topo-output-schemas.js';
 import { buildTopoSummary } from './topo-read-support.js';
 import { createIsolatedExampleInput } from './topo-support.js';
@@ -73,23 +72,10 @@ const summaryOutput = z.object({
 });
 
 export const topoTrail = trail('topo', {
-  blaze: async (input, ctx) => {
-    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
-    if (rootDirResult.isErr()) {
-      return rootDirResult;
-    }
-    const rootDir = rootDirResult.value;
-    const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
-    if (leaseResult.isErr()) {
-      return leaseResult;
-    }
-    const lease = leaseResult.value;
-    try {
-      return Result.ok(buildTopoSummary(lease.app, { rootDir }));
-    } finally {
-      lease.release();
-    }
-  },
+  blaze: async (input, ctx) =>
+    withFreshOperatorApp(input, ctx, ({ lease, rootDir }) =>
+      Result.ok(buildTopoSummary(lease.app, { rootDir }))
+    ),
   description: 'Show the current topo summary and entry list',
   examples: [
     {

--- a/apps/trails/src/trails/validate.ts
+++ b/apps/trails/src/trails/validate.ts
@@ -1,31 +1,17 @@
 import { trail } from '@ontrails/core';
 import { z } from 'zod';
 
-import { tryLoadFreshAppLease } from './load-app.js';
-import { resolveTrailRootDir } from './root-dir.js';
+import { withFreshOperatorApp } from './operator-context.js';
 import { validateCurrentTopo } from './topo-read-support.js';
 
 export const validateTrail = trail('validate', {
-  blaze: async (input, ctx) => {
-    const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
-    if (rootDirResult.isErr()) {
-      return rootDirResult;
-    }
-    const rootDir = rootDirResult.value;
-    const leaseResult = await tryLoadFreshAppLease(input.module, rootDir);
-    if (leaseResult.isErr()) {
-      return leaseResult;
-    }
-    const lease = leaseResult.value;
-    try {
-      return await validateCurrentTopo(lease.app, {
+  blaze: async (input, ctx) =>
+    withFreshOperatorApp(input, ctx, ({ lease, rootDir }) =>
+      validateCurrentTopo(lease.app, {
         cliAliases: lease.cliAliases,
         rootDir,
-      });
-    } finally {
-      lease.release();
-    }
-  },
+      })
+    ),
   description: 'Validate that committed topo artifacts match the current topo',
   input: z.object({
     module: z.string().optional().describe('Path to the app module'),

--- a/apps/trails/src/trails/version-lifecycle-support.ts
+++ b/apps/trails/src/trails/version-lifecycle-support.ts
@@ -7,12 +7,11 @@ import { deriveTopoGraph } from '@ontrails/topographer';
 import type { TopoGraph, TopoGraphForceEntry } from '@ontrails/topographer';
 import { findTrailDefinitions, parse } from '@ontrails/warden/ast';
 
-import { tryLoadFreshAppLease } from './load-app.js';
 import {
   readLifecycleSourceFile,
   writeLifecycleSourceFile,
 } from '../lifecycle-source-io.js';
-import { resolveTrailRootDir } from './root-dir.js';
+import { withFreshAppLease, withOperatorRootDir } from './operator-context.js';
 
 export type LifecycleEntryKind = 'revision' | 'fork';
 export type LifecycleStatusKind = 'deprecated' | 'archived';
@@ -798,21 +797,12 @@ export const withLifecycleApp = async <T>(
     app: Topo,
     rootDir: string
   ) => Result<T, Error> | Promise<Result<T, Error>>
-): Promise<Result<T, Error>> => {
-  const root = resolveTrailRootDir(input.rootDir, cwd);
-  if (root.isErr()) {
-    return root;
-  }
-  const lease = await tryLoadFreshAppLease(input.module, root.value);
-  if (lease.isErr()) {
-    return Result.err(lease.error);
-  }
-  try {
-    return await consume(lease.value.app, root.value);
-  } finally {
-    lease.value.release();
-  }
-};
+): Promise<Result<T, Error>> =>
+  withOperatorRootDir(input, { cwd }, (rootDir) =>
+    withFreshAppLease(input.module, rootDir, (lease) =>
+      consume(lease.app, rootDir)
+    )
+  );
 
 export const findLifecycleTrail = (
   app: Topo,


### PR DESCRIPTION
## Context

TRL-1009 reduces repeated operator-trail prologue code around root resolution, fresh app loading, and lease release.

## Changes

- Adds `operator-context.ts` helpers for root-dir resolution and fresh app lease handling.
- Migrates compile, validate, topo, guide, run, run-example, run-examples, survey helpers, and version lifecycle support to the shared helpers.
- Leaves specialized root-only flows alone where the shared helper would hide meaning.
- Adds branch-local release intent for `@ontrails/trails`.

## Verification

- `bun run --cwd apps/trails typecheck`
- `bun test apps/trails/src/__tests__/run.test.ts apps/trails/src/__tests__/run-example.test.ts apps/trails/src/__tests__/run-examples.test.ts apps/trails/src/__tests__/survey.test.ts apps/trails/src/__tests__/mcp.test.ts apps/trails/src/__tests__/load-app.test.ts`
- Full stack verification before submit: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`

## Risks

This is a refactor around existing behavior. Specialized flows that need custom root handling remain explicit.
