### PR TITLE
fix(warden): widen result pass-through hygiene

### DIFF
--- a/.changeset/trl-1010-result-pass-through.md
+++ b/.changeset/trl-1010-result-pass-through.md
@@ -1,0 +1,11 @@
+---
+"@ontrails/core": patch
+"@ontrails/http": patch
+"@ontrails/regrade": patch
+"@ontrails/topographer": patch
+"@ontrails/trails": patch
+"@ontrails/warden": patch
+---
+
+Preserve existing Result error boundaries directly and widen Warden pass-through
+coaching beyond trail blazes.

--- a/apps/trails/src/project-writes.ts
+++ b/apps/trails/src/project-writes.ts
@@ -151,12 +151,12 @@ export const renameContainedProjectPath = (
 ): TrailsResult<void, Error> => {
   const from = resolveProjectPath(projectDir, fromPath);
   if (from.isErr()) {
-    return Result.err(from.error);
+    return from;
   }
 
   const to = resolveProjectPath(projectDir, toPath);
   if (to.isErr()) {
-    return Result.err(to.error);
+    return to;
   }
 
   try {
@@ -238,7 +238,7 @@ const shouldApplyProjectOperation = (
   const { path } = operation;
   const target = resolveProjectPath(projectDir, path);
   if (target.isErr()) {
-    return Result.err(target.error);
+    return target;
   }
 
   return Result.ok(!existsSync(target.value));
@@ -257,7 +257,7 @@ const selectProjectOperations = (
       options
     );
     if (shouldApply.isErr()) {
-      return Result.err(shouldApply.error);
+      return shouldApply;
     }
     if (shouldApply.value) {
       selected.push(operation);
@@ -274,14 +274,14 @@ export const planProjectOperations = (
 ): TrailsResult<PlannedProjectOperation[], Error> => {
   const selected = selectProjectOperations(projectDir, operations, options);
   if (selected.isErr()) {
-    return Result.err(selected.error);
+    return selected;
   }
 
   const planned: PlannedProjectOperation[] = [];
   for (const operation of selected.value) {
     const result = planProjectOperation(projectDir, operation);
     if (result.isErr()) {
-      return Result.err(result.error);
+      return result;
     }
     planned.push(result.value);
   }
@@ -296,7 +296,7 @@ const applyProjectOperation = async (
     case 'mkdir': {
       const target = resolveProjectPath(projectDir, operation.path);
       if (target.isErr()) {
-        return Result.err(target.error);
+        return target;
       }
       try {
         mkdirSync(target.value, { recursive: true });
@@ -323,7 +323,7 @@ const applyProjectOperation = async (
     case 'write': {
       const target = resolveProjectPath(projectDir, operation.path);
       if (target.isErr()) {
-        return Result.err(target.error);
+        return target;
       }
       try {
         mkdirSync(dirname(target.value), { recursive: true });
@@ -358,18 +358,18 @@ export const applyProjectOperations = async (
 ): Promise<TrailsResult<PlannedProjectOperation[], Error>> => {
   const selected = selectProjectOperations(projectDir, operations, options);
   if (selected.isErr()) {
-    return Result.err(selected.error);
+    return selected;
   }
 
   const planned = planProjectOperations(projectDir, selected.value);
   if (planned.isErr()) {
-    return Result.err(planned.error);
+    return planned;
   }
 
   for (const operation of selected.value) {
     const applied = await applyProjectOperation(projectDir, operation);
     if (applied.isErr()) {
-      return Result.err(applied.error);
+      return applied;
     }
   }
 

--- a/apps/trails/src/run-completions-install.ts
+++ b/apps/trails/src/run-completions-install.ts
@@ -100,7 +100,7 @@ export const runCompletionsInstall = async (
 ): Promise<Result<CompletionsInstallResult, Error>> => {
   const shellResult = resolveTargetShell(options);
   if (shellResult.isErr()) {
-    return Result.err(shellResult.error);
+    return shellResult;
   }
 
   const shell = shellResult.value;
@@ -111,7 +111,7 @@ export const runCompletionsInstall = async (
     options.binName ?? COMPLETIONS_BIN_NAME
   );
   if (scriptResult.isErr()) {
-    return Result.err(scriptResult.error);
+    return scriptResult;
   }
 
   let existed: boolean;

--- a/apps/trails/src/trails/adapter-check.ts
+++ b/apps/trails/src/trails/adapter-check.ts
@@ -145,7 +145,7 @@ const validateAdapterCheckRoot = (
 
   const manifest = readWorkspaceManifest(packageJsonPath);
   if (manifest.isErr()) {
-    return Result.err(manifest.error);
+    return manifest;
   }
 
   if (workspacePatternsFromManifest(manifest.value).length === 0) {

--- a/apps/trails/src/trails/add-surface.ts
+++ b/apps/trails/src/trails/add-surface.ts
@@ -96,7 +96,7 @@ const updatePkgJsonForSurface = async (
 ): Promise<Result<string, Error>> => {
   const pkgPathResult = resolveProjectPath(cwd, 'package.json');
   if (pkgPathResult.isErr()) {
-    return Result.err(pkgPathResult.error);
+    return pkgPathResult;
   }
 
   const pkgPath = pkgPathResult.value;

--- a/apps/trails/src/trails/add-verify.ts
+++ b/apps/trails/src/trails/add-verify.ts
@@ -70,7 +70,7 @@ const updatePackageJsonForVerify = async (
 ): Promise<Result<void, Error>> => {
   const pkgPathResult = resolveProjectPath(projectDir, 'package.json');
   if (pkgPathResult.isErr()) {
-    return Result.err(pkgPathResult.error);
+    return pkgPathResult;
   }
 
   const pkgPath = pkgPathResult.value;
@@ -107,7 +107,7 @@ export const addVerify = trail('add.verify', {
     ): Promise<Result<void, Error>> => {
       const exists = projectPathExists(projectDir, relativePath);
       if (exists.isErr()) {
-        return Result.err(exists.error);
+        return exists;
       }
       if (exists.value) {
         return Result.ok();
@@ -115,7 +115,7 @@ export const addVerify = trail('add.verify', {
 
       const written = await writeProjectFile(projectDir, relativePath, content);
       if (written.isErr()) {
-        return Result.err(written.error);
+        return written;
       }
       files.push(written.value);
       return Result.ok();

--- a/apps/trails/src/trails/create-scaffold.ts
+++ b/apps/trails/src/trails/create-scaffold.ts
@@ -7,6 +7,7 @@
 import { resolve } from 'node:path';
 
 import { Result, trail, WORKSPACE_GITIGNORE_CONTENT } from '@ontrails/core';
+import type { Result as TrailsResult } from '@ontrails/core';
 import { z } from 'zod';
 
 import {
@@ -583,13 +584,16 @@ export const createScaffold = trail('create.scaffold', {
     const dryRun = input.dryRun === true;
     const fileMap = collectScaffoldFiles(input.name, starter);
     const operations = collectScaffoldOperations(fileMap);
-    const plannedOperations = dryRun
-      ? planProjectOperations(projectDir, operations, { existing: 'preserve' })
-      : await applyProjectOperations(projectDir, operations, {
-          existing: 'preserve',
-        });
+    const plannedOperations: TrailsResult<PlannedProjectOperation[], Error> =
+      dryRun
+        ? planProjectOperations(projectDir, operations, {
+            existing: 'preserve',
+          })
+        : await applyProjectOperations(projectDir, operations, {
+            existing: 'preserve',
+          });
     if (plannedOperations.isErr()) {
-      return Result.err(plannedOperations.error);
+      return plannedOperations;
     }
 
     const created = dryRun

--- a/apps/trails/src/trails/create.ts
+++ b/apps/trails/src/trails/create.ts
@@ -86,7 +86,7 @@ const collectSurfaceFiles = async (
   for (const surface of surfaces) {
     const result = await addSurface(surface);
     if (result.isErr()) {
-      return Result.err(result.error);
+      return result;
     }
     if (result.value.created !== null) {
       created.push(result.value.created);
@@ -181,7 +181,7 @@ const writeReadme = async (
 ): Promise<Result<string | null, Error>> => {
   const exists = projectPathExists(dir, 'README.md');
   if (exists.isErr()) {
-    return Result.err(exists.error);
+    return exists;
   }
   if (exists.value) {
     return Result.ok(null);
@@ -225,7 +225,7 @@ export const createTrail = trail('create', {
           )
       );
       if (surfaceFiles.isErr()) {
-        return Result.err(surfaceFiles.error);
+        return surfaceFiles;
       }
 
       const verifyFiles = await collectVerifyFiles(input.verify, () =>
@@ -235,12 +235,12 @@ export const createTrail = trail('create', {
         )
       );
       if (verifyFiles.isErr()) {
-        return Result.err(verifyFiles.error);
+        return verifyFiles;
       }
 
       const readmeFile = await writeReadme(input, scaffolded.value.dir);
       if (readmeFile.isErr()) {
-        return Result.err(readmeFile.error);
+        return readmeFile;
       }
 
       return Result.ok({

--- a/apps/trails/src/trails/draft-promote.ts
+++ b/apps/trails/src/trails/draft-promote.ts
@@ -571,7 +571,7 @@ const planRelativeImports = (
       operations
     );
     if (changed.isErr()) {
-      return Result.err(changed.error);
+      return changed;
     }
     if (changed.value) {
       updatedSourceFiles.add(filePath);
@@ -593,7 +593,7 @@ const rewritePromotionState = async (
   const initialFiles = collectTsFiles(rootDir);
   const sourcesResult = await readSourceFiles(initialFiles);
   if (sourcesResult.isErr()) {
-    return Result.err(sourcesResult.error);
+    return sourcesResult;
   }
   const sources = sourcesResult.value;
   const operations: ProjectWriteOperation[] = [];
@@ -608,14 +608,14 @@ const rewritePromotionState = async (
     operations
   );
   if (rewritten.isErr()) {
-    return Result.err(rewritten.error);
+    return rewritten;
   }
 
   const renamesResult = input.renameFiles
     ? collectFileRenames(initialFiles, sources)
     : Result.ok([] as FileRename[]);
   if (renamesResult.isErr()) {
-    return Result.err(renamesResult.error);
+    return renamesResult;
   }
 
   const valid = validateRenameTargets(renamesResult.value);
@@ -637,14 +637,14 @@ const rewritePromotionState = async (
     operations
   );
   if (importUpdates.isErr()) {
-    return Result.err(importUpdates.error);
+    return importUpdates;
   }
 
   const plannedOperations = input.dryRun
     ? planProjectOperations(rootDir, operations)
     : await applyProjectOperations(rootDir, operations);
   if (plannedOperations.isErr()) {
-    return Result.err(plannedOperations.error);
+    return plannedOperations;
   }
   return Result.ok({
     plannedOperations: plannedOperations.value,
@@ -837,7 +837,7 @@ const promoteDraftState = async (
 
   const rewriteResult = await rewritePromotionState(rootDirResult.value, input);
   if (rewriteResult.isErr()) {
-    return Result.err(rewriteResult.error);
+    return rewriteResult;
   }
 
   const { renames, updatedSourceFiles } = rewriteResult.value;

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -3,11 +3,13 @@
  */
 
 import { NotFoundError, Result, trail, validateOutput } from '@ontrails/core';
+import type { Result as TrailsResult } from '@ontrails/core';
 import {
   regradeReportOutput,
   runRegrade,
   wardenTermRewriteClasses,
 } from '@ontrails/regrade';
+import type { RegradeReport } from '@ontrails/regrade';
 import { z } from 'zod';
 
 import { resolveTrailRootDir } from './root-dir.js';
@@ -31,7 +33,7 @@ export const regradeTrail = trail('regrade', {
       return rootDirResult;
     }
 
-    const reportResult = runRegrade({
+    const reportResult: TrailsResult<RegradeReport | null, Error> = runRegrade({
       apply: input.apply,
       classes: wardenTermRewriteClasses,
       root: rootDirResult.value,
@@ -40,7 +42,7 @@ export const regradeTrail = trail('regrade', {
         : { selection: { classIds: input.classIds } }),
     });
     if (reportResult.isErr()) {
-      return Result.err(reportResult.error);
+      return reportResult;
     }
 
     const report = reportResult.value;
@@ -52,9 +54,12 @@ export const regradeTrail = trail('regrade', {
       );
     }
 
-    const validated = validateOutput(regradeReportOutput, report);
+    const validated: TrailsResult<
+      z.output<typeof regradeReportOutput>,
+      Error
+    > = validateOutput(regradeReportOutput, report);
     if (validated.isErr()) {
-      return Result.err(validated.error);
+      return validated;
     }
 
     return Result.ok(validated.value);

--- a/apps/trails/src/trails/run-example.ts
+++ b/apps/trails/src/trails/run-example.ts
@@ -354,7 +354,7 @@ const buildComparisonEnvelope = async (
 ): Promise<Result<RunExampleComparison, Error>> => {
   const exampleResult = findExample(app, trailId, exampleName);
   if (exampleResult.isErr()) {
-    return Result.err(exampleResult.error);
+    return exampleResult;
   }
   const example = exampleResult.value;
   const mode = determineMode(example);

--- a/apps/trails/src/trails/run.ts
+++ b/apps/trails/src/trails/run.ts
@@ -395,7 +395,7 @@ export const runTrail = trail('run', {
           ctx: ctx.permit === undefined ? {} : { permit: ctx.permit },
         });
         if (result.isErr()) {
-          return Result.err(result.error);
+          return result;
         }
         return Result.ok({
           kind: INNER_TRAIL_RESULT_KIND,

--- a/apps/trails/src/trails/version-lifecycle-support.ts
+++ b/apps/trails/src/trails/version-lifecycle-support.ts
@@ -568,7 +568,7 @@ export const reviseTrailSource = (
   );
   const written = writeLifecycleSourceFile(match.value.filePath, nextSource);
   if (written.isErr()) {
-    return Result.err(written.error);
+    return written;
   }
 
   return Result.ok({
@@ -731,7 +731,7 @@ export const setVersionStatusSource = (
   }
   const written = writeLifecycleSourceFile(match.value.filePath, nextSource);
   if (written.isErr()) {
-    return Result.err(written.error);
+    return written;
   }
 
   return Result.ok({
@@ -775,7 +775,7 @@ export const forkVersionEntrySource = (
   }
   const written = writeLifecycleSourceFile(match.value.filePath, nextSource);
   if (written.isErr()) {
-    return Result.err(written.error);
+    return written;
   }
 
   return Result.ok({

--- a/packages/core/src/execute.ts
+++ b/packages/core/src/execute.ts
@@ -388,7 +388,7 @@ const prepareContext = async (
   );
   const permitted = enforcePermitRequirement(trail, baseCtx);
   if (permitted.isErr()) {
-    return Result.err(permitted.error);
+    return permitted;
   }
 
   const resources = await createResources(
@@ -1412,7 +1412,7 @@ const executeRequestedTrailVersion = async (
 
   const resolved = resolveTrailVersion(trail, reference);
   if (resolved.isErr()) {
-    return Result.err(resolved.error);
+    return resolved;
   }
 
   if (resolved.value.current) {
@@ -1496,14 +1496,14 @@ const validateContextLayerInputs = (
 ): Result<TrailContext, ValidationError> => {
   const layerInputs = readContextLayerInputs(ctx);
   if (layerInputs.isErr()) {
-    return Result.err(layerInputs.error);
+    return layerInputs;
   }
   if (layerInputs.value === undefined) {
     return Result.ok(ctx);
   }
   const validated = validateLayerInputs(layers, layerInputs.value);
   if (validated.isErr()) {
-    return Result.err(validated.error);
+    return validated;
   }
   return Result.ok({
     ...ctx,
@@ -1540,7 +1540,7 @@ const executeTrailInternal = async (
 
     const resolvedCtx = await prepareContext(trail, options);
     if (resolvedCtx.isErr()) {
-      return Result.err(resolvedCtx.error);
+      return resolvedCtx;
     }
 
     const layers = composeAttachedLayers(trail, options);
@@ -1550,7 +1550,7 @@ const executeTrailInternal = async (
         layers
       );
       if (layerCtx.isErr()) {
-        return Result.err(layerCtx.error);
+        return layerCtx;
       }
       return await runTrail(
         trail,

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -1003,7 +1003,7 @@ export const createFireFn = (
       traceSink
     );
     if (dispatch.isErr()) {
-      return Result.err(dispatch.error);
+      return dispatch;
     }
     await recordSignalLifecycleTrace(
       trackedProducerCtx,

--- a/packages/core/src/resource-config.ts
+++ b/packages/core/src/resource-config.ts
@@ -401,7 +401,7 @@ const doCreateResourceInstance = async (
   try {
     const created = await declaredResource.create(resourceContext);
     if (created.isErr()) {
-      return Result.err(created.error);
+      return created;
     }
 
     const instance = created.unwrap();

--- a/packages/core/src/schedule-runtime.ts
+++ b/packages/core/src/schedule-runtime.ts
@@ -591,7 +591,7 @@ export const createScheduleRuntime = (
 
     const validated = validateTopo(graph);
     if (validated.isErr()) {
-      return Result.err(validated.error);
+      return validated;
     }
 
     const registrations = collectScheduleActivations(graph);

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -721,7 +721,7 @@ const createExecute =
       t.permit !== undefined
     );
     if (permitResolution.isErr()) {
-      return Result.err(permitResolution.error);
+      return permitResolution;
     }
     const permit = permitResolution.value;
     return await executeTrail(t, trailInput, {
@@ -811,7 +811,7 @@ const createWebhookConsumerExecute =
       t.permit !== undefined
     );
     if (permitResolution.isErr()) {
-      return Result.err(permitResolution.error);
+      return permitResolution;
     }
     const permit = permitResolution.value;
     return await executeTrail(t, trailInput, {
@@ -1382,7 +1382,7 @@ export const deriveHttpRoutes = (
 ): Result<HttpRouteDefinition[], Error> => {
   const validated = validateSurfaceTopo(graph, options);
   if (validated.isErr()) {
-    return Result.err(validated.error);
+    return validated;
   }
 
   const basePath = (options.basePath ?? '').replace(/\/+$/, '');

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -748,7 +748,7 @@ export const runRegrade = (params: {
 
   const applyResult = applyRegradeEvaluation(evaluation);
   if (applyResult.isErr()) {
-    return Result.err(applyResult.error);
+    return applyResult;
   }
 
   return Result.ok(withApplySummary(evaluation.report, applyResult.value));

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -1639,7 +1639,7 @@ export const createTopoSnapshot = (
 ): Result<TopoSnapshot, Error> => {
   const validated = validateEstablishedTopo(topo);
   if (validated.isErr()) {
-    return Result.err(validated.error);
+    return validated;
   }
   const cliAliasTargets = validateCliAliasTargets(topo, input);
   if (cliAliasTargets.isErr()) {

--- a/packages/warden/src/__tests__/implementation-returns-result.test.ts
+++ b/packages/warden/src/__tests__/implementation-returns-result.test.ts
@@ -1304,6 +1304,73 @@ trail("message.transmit", {
     expect(diagnostics.length).toBe(0);
   });
 
+  test('flags guarded pass-through when a helper Result is not inspectable', () => {
+    const code = `
+const validateExternal = (value: string) => externalValidate(value);
+
+trail("message.transmit", {
+  blaze: async (input, ctx) => {
+    const validated = validateExternal(input.replyTo);
+    if (validated.isErr()) {
+      return validated;
+    }
+
+    return Result.ok({ ok: true });
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.message).toContain(
+      'not a recognized Result expression'
+    );
+  });
+
+  test('allows guarded pass-through of explicitly annotated helper Results', () => {
+    const code = `
+const validateExternal = (value: string) => externalValidate(value);
+
+trail("message.transmit", {
+  blaze: async (input, ctx) => {
+    const validated: Result<object, Error> = validateExternal(input.replyTo);
+    if (validated.isErr()) {
+      return validated;
+    }
+
+    return Result.ok({ ok: true });
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(0);
+  });
+
+  test('flags guarded pass-through of plain objects with isErr methods', () => {
+    const code = `
+trail("message.transmit", {
+  blaze: async () => {
+    const maybeResult = {
+      isErr: () => true,
+      value: { ok: true },
+    };
+    if (maybeResult.isErr()) {
+      return maybeResult;
+    }
+
+    return Result.ok({ ok: true });
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics.length).toBe(1);
+    expect(diagnostics[0]?.message).toContain(
+      'not a recognized Result expression'
+    );
+  });
+
   test('flags helper calls when a local binding shadows a Result helper name', () => {
     const code = `
 const parseInput = (): Result<object, Error> =>

--- a/packages/warden/src/__tests__/no-redundant-result-error-wrap.test.ts
+++ b/packages/warden/src/__tests__/no-redundant-result-error-wrap.test.ts
@@ -235,4 +235,28 @@ trail('entity.load', {
 
     expect(noRedundantResultErrorWrap.check(code, TEST_FILE)).toEqual([]);
   });
+
+  test('flags Result.err(result.error) in non-blaze Result helpers', () => {
+    const code = `
+import { Result } from '@ontrails/core';
+import type { Result as ResultType } from '@ontrails/core';
+
+const readConfig = (): ResultType<{ readonly id: string }, Error> =>
+  Result.err(new Error('bad'));
+
+export const loadConfig = (): ResultType<{ readonly id: string }, Error> => {
+  const loaded = readConfig();
+  if (loaded.isErr()) {
+    return Result.err(loaded.error);
+  }
+  return Result.ok(loaded.value);
+};
+`;
+
+    const diagnostics = noRedundantResultErrorWrap.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('Function "loadConfig"');
+    expect(diagnostics[0]?.message).toContain('Return loaded directly');
+  });
 });

--- a/packages/warden/src/rules/implementation-returns-result.ts
+++ b/packages/warden/src/rules/implementation-returns-result.ts
@@ -390,6 +390,27 @@ export const trackScopedResultHelperDeclaration = (
 // Variable tracking
 // ---------------------------------------------------------------------------
 
+const hasResultVariableAnnotation = (
+  node: AstNode,
+  sourceCode: string,
+  resultTypeNames: ReadonlySet<string>
+): boolean => {
+  const { typeAnnotation } = node as unknown as { typeAnnotation?: AstNode };
+  if (!typeAnnotation) {
+    return false;
+  }
+  const annotationText = sourceCode.slice(
+    typeAnnotation.start,
+    typeAnnotation.end
+  );
+  for (const name of resultTypeNames) {
+    if (hasGenericTypeReference(annotationText, name)) {
+      return true;
+    }
+  }
+  return false;
+};
+
 /** Track a VariableDeclarator, adding to resultVars if it produces a Result. */
 const trackResultVariable = (
   node: AstNode,
@@ -397,13 +418,16 @@ const trackResultVariable = (
   helperNames: ReadonlySet<string>,
   namespaceHelpers: NamespaceHelperMap,
   scopes: readonly ReadonlySet<string>[],
-  scopedHelpers: ScopedHelperMap
+  scopedHelpers: ScopedHelperMap,
+  sourceCode: string,
+  resultTypeNames: ReadonlySet<string>
 ): void => {
   const { init } = node as unknown as { init?: AstNode };
   const { id } = node as unknown as { id?: AstNode };
   if (init && id?.type === 'Identifier') {
     const { name } = id as unknown as { name: string };
     if (
+      hasResultVariableAnnotation(id, sourceCode, resultTypeNames) ||
       isResultExpression(init) ||
       isHelperCall(init, helperNames, namespaceHelpers, scopes, scopedHelpers)
     ) {
@@ -452,7 +476,9 @@ const checkReturnStatements = (
           helperNames,
           namespaceHelpers,
           currentScopes,
-          scopedHelpers
+          scopedHelpers,
+          sourceCode,
+          resultTypeNames
         );
       }
 

--- a/packages/warden/src/rules/no-redundant-result-error-wrap.ts
+++ b/packages/warden/src/rules/no-redundant-result-error-wrap.ts
@@ -7,6 +7,7 @@ import {
   isMemberAccessNonComputed,
   offsetToLine,
   parse,
+  walkWithParents,
   walkWithScopes,
 } from './ast.js';
 import {
@@ -19,7 +20,7 @@ import {
   trackScopedResultHelperDeclaration,
 } from './implementation-returns-result.js';
 import { isTestFile } from './scan.js';
-import type { AstNode } from './ast.js';
+import type { AstNode, AstParentContext } from './ast.js';
 import type {
   MutableScopedHelperMap,
   NamespaceHelperMap,
@@ -115,12 +116,12 @@ const createDiagnostic = (
   filePath: string,
   sourceCode: string,
   node: AstNode,
-  trailId: string,
+  ownerLabel: string,
   variableName: string
 ): WardenDiagnostic => ({
   filePath,
   line: offsetToLine(sourceCode, node.start),
-  message: `Trail "${trailId}": Result.err(${variableName}.error) re-wraps a Result that already carries that error. Return ${variableName} directly to preserve the original Result boundary.`,
+  message: `${ownerLabel}: Result.err(${variableName}.error) re-wraps a Result that already carries that error. Return ${variableName} directly to preserve the original Result boundary.`,
   rule: RULE_NAME,
   severity: 'warn',
 });
@@ -202,7 +203,7 @@ const checkReturnStatement = (
   scopes: readonly ReadonlySet<string>[],
   filePath: string,
   sourceCode: string,
-  trailId: string,
+  ownerLabel: string,
   diagnostics: WardenDiagnostic[]
 ): void => {
   const { argument } = node as unknown as { argument?: AstNode };
@@ -218,13 +219,21 @@ const checkReturnStatement = (
     return;
   }
   diagnostics.push(
-    createDiagnostic(filePath, sourceCode, argument, trailId, variableName)
+    createDiagnostic(filePath, sourceCode, argument, ownerLabel, variableName)
   );
 };
 
-const checkBlazeBody = (
-  blaze: AstNode,
-  trailId: string,
+const functionBody = (node: AstNode): AstNode | null => {
+  const { body } = node as unknown as { body?: AstNode };
+  return body &&
+    (body.type === 'BlockStatement' || body.type === 'FunctionBody')
+    ? body
+    : null;
+};
+
+const checkFunctionBody = (
+  owner: AstNode,
+  ownerLabel: string,
   filePath: string,
   sourceCode: string,
   helperNames: ReadonlySet<string>,
@@ -232,17 +241,14 @@ const checkBlazeBody = (
   resultTypeNames: ReadonlySet<string>,
   diagnostics: WardenDiagnostic[]
 ): void => {
-  const { body } = blaze as unknown as { body?: AstNode };
-  if (
-    !body ||
-    (body.type !== 'BlockStatement' && body.type !== 'FunctionBody')
-  ) {
+  const body = functionBody(owner);
+  if (!body) {
     return;
   }
 
   const provenance: ResultProvenance = new Map();
   const scopedHelpers: MutableScopedHelperMap = new Map();
-  const implScope = collectScopeFrameBindings(blaze);
+  const implScope = collectScopeFrameBindings(owner);
   const initialScopes = implScope.size > 0 ? [implScope] : [];
 
   walkWithScopes(
@@ -284,7 +290,7 @@ const checkBlazeBody = (
           scopes,
           filePath,
           sourceCode,
-          trailId,
+          ownerLabel,
           diagnostics
         );
       }
@@ -292,6 +298,30 @@ const checkBlazeBody = (
     { initialScopes, stopAtNestedFunctions: true }
   );
 };
+
+const isFunctionLike = (node: AstNode): boolean =>
+  node.type === 'FunctionDeclaration' ||
+  node.type === 'FunctionExpression' ||
+  node.type === 'ArrowFunctionExpression';
+
+const functionName = (node: AstNode, context: AstParentContext): string => {
+  const declaredName = identifierName((node as unknown as { id?: AstNode }).id);
+  if (declaredName) {
+    return declaredName;
+  }
+  if (context.parent?.type === 'VariableDeclarator') {
+    const assignedName = identifierName(
+      (context.parent as unknown as { id?: AstNode }).id
+    );
+    if (assignedName) {
+      return assignedName;
+    }
+  }
+  return 'anonymous function';
+};
+
+const functionOwnerLabel = (node: AstNode, context: AstParentContext): string =>
+  `Function "${functionName(node, context)}"`;
 
 export const noRedundantResultErrorWrap: WardenRule = {
   check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
@@ -308,11 +338,13 @@ export const noRedundantResultErrorWrap: WardenRule = {
     const helperNames = collectAllResultHelperNames(ast, sourceCode, filePath);
     const namespaceHelpers = collectNamespaceHelperImports(ast, filePath);
     const resultTypeNames = collectResultTypeNames(ast);
+    const blazeStarts = new Set<number>();
     for (const def of findTrailDefinitions(ast)) {
       for (const blaze of findBlazeBodies(def.config)) {
-        checkBlazeBody(
+        blazeStarts.add(blaze.start);
+        checkFunctionBody(
           blaze,
-          def.id,
+          `Trail "${def.id}"`,
           filePath,
           sourceCode,
           helperNames,
@@ -322,10 +354,25 @@ export const noRedundantResultErrorWrap: WardenRule = {
         );
       }
     }
+    walkWithParents(ast, (node, context) => {
+      if (!isFunctionLike(node) || blazeStarts.has(node.start)) {
+        return;
+      }
+      checkFunctionBody(
+        node,
+        functionOwnerLabel(node, context),
+        filePath,
+        sourceCode,
+        helperNames,
+        namespaceHelpers,
+        resultTypeNames,
+        diagnostics
+      );
+    });
     return diagnostics;
   },
   description:
-    'Warn when blazes re-wrap an existing Result error with Result.err(x.error) instead of returning the Result directly.',
+    'Warn when code re-wraps an existing Result error with Result.err(x.error) instead of returning the Result directly.',
   name: RULE_NAME,
   severity: 'warn',
 };


### PR DESCRIPTION
## Context

TRL-1010 widens Result pass-through hygiene beyond blaze bodies and cleans up redundant Result error re-wrapping.

## Changes

- Extends `no-redundant-result-error-wrap` to inspect non-blaze functions.
- Preserves safe pass-throughs by requiring stronger Result evidence, such as explicit Result annotations.
- Tightens `implementation-returns-result` so arbitrary objects with `isErr()` do not bypass validation.
- Cleans redundant `Result.err(result.error)` pass-throughs across source packages.
- Adds focused Warden regressions for non-blaze pass-throughs, annotated Result pass-throughs, and false `isErr()` objects.
- Adds branch-local release intent for affected packages.

## Verification

- `bun test packages/warden/src/__tests__/implementation-returns-result.test.ts packages/warden/src/__tests__/no-redundant-result-error-wrap.test.ts packages/warden/src/__tests__/dead-public-trail.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run --cwd apps/trails typecheck`
- `bun run trails:check`
- Full stack verification before submit: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`

## Risks

The rule is intentionally stricter around untyped helper values. Places that intentionally pass a Result through should make that Result shape explicit.
