### PR TITLE
docs: capture regrade contract migration framing

### DIFF
--- a/docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md
+++ b/docs/adr/drafts/20260530-fixes-are-warden-diagnostic-metadata.md
@@ -113,6 +113,20 @@ Regrade does not own rule detection, severity, migration facts, or old-to-new te
 
 This means Warden fix metadata blocks rename-class Regrade integration. It does not block the literal transform-trail tracer, downstream source collection, or other Regrade substrate that does not depend on Warden-authored migration facts.
 
+### Regrade is contract change, not a one-off codemod
+
+Regrade is not a migration utility bolted onto Trails. It is the contract-first model applied to contract change. If Trails makes drift structurally harder while a trail is being authored, the same posture should carry into the moments when a framework contract moves.
+
+The useful invariant is narrower than a generic codemod: Regrade should migrate authored boundaries, then let derivation fan the projections back out. A generic codemod rewrites every surface it can see because it is blind to authored versus derived state. A Trails-aware migration should usually touch less. If Regrade rewrites a projected output, that is a smell; the projection should have re-derived from the updated contract unless the projection itself is the authored artifact.
+
+For Warden-detected migrations, that keeps the ownership line sharp:
+
+- Warden detects the drift and owns the structured migration facts.
+- Regrade collects source, applies safe edits, validates the result, and routes review-required findings.
+- One-time scripts may exist as prototypes or emergency bridges, but they must not become the durable home for framework migration policy.
+
+The external adopter promise is deliberately staged. Internally, the v1 reset should prove the path first against Trails' own dogfood apps and downstream fixtures. A public promise that every breaking framework contract carries its migration path should wait until Regrade can keep that promise across package boundaries and downstream source, not only inside this monorepo.
+
 ### Manifests expose capability, not hidden behavior
 
 Agent-facing guide output and manifests must expose rule-level fix capability when it exists. That lets agents discover which rules can produce fix metadata without manufacturing diagnostics or scraping docs. Concrete edits still appear only in diagnostics from a real run.
@@ -127,6 +141,8 @@ This is the same "one write, many reads" doctrine applied to governance repair: 
 - Guaranteeing every Warden rule has a fix.
 - Claiming review-required fixes are safe to apply automatically.
 - Deciding Regrade package-source modes or the final Regrade ADR shape.
+- Promising external downstream migration support before Regrade has proven
+  package-source modes and adopter-source coverage.
 
 ## Consequences
 

--- a/docs/contributing/script-graduation.md
+++ b/docs/contributing/script-graduation.md
@@ -21,7 +21,9 @@ For newcomers, the ordinary repo heuristic is the toolshed and the house: `scrip
 - **Durable Trails-contract fact** — a concept (trail, surface, error taxonomy, topo, scaffold output, Warden rule set) should own it going forward. Go to Q2.
 - **Transient repo fact** — this repo's state, history, build health, or a one-time migration. No concept should own it. **Transient → tooling**: a script, or a contributor package if shared or large. Stop here **even if it derives**.
 
-The transient branch is the case that makes the model click: "derives a fact" is not what forces graduation. `scripts/vocab-cutover-rewrite.ts` derives rename mappings with real AST analysis, but the truth it derives — a one-time vocabulary migration — is transient, so it stays tooling.
+The transient branch is the case that makes the model click: "derives a fact" is not what forces graduation. A one-off repository cleanup may start as a script even when it uses real AST analysis. The boundary changes when the cleanup becomes a framework contract migration that existing Trails apps should be able to trust. At that point the migration facts must graduate into the Warden/Regrade substrate: Warden detects the contract drift and owns the structured fix metadata; Regrade applies, validates, and routes the change.
+
+That distinction keeps temporary repo tooling from becoming doctrine while still honoring the stable-line promise. A vocabulary cutover script can be a prototype or emergency bridge. A repeatable framework migration path cannot stay there.
 
 ### Q2: What is the relationship to the fact, and who is the audience?
 
@@ -57,11 +59,12 @@ Keep three axes distinct: native vs adapter is the *kind*; subpath/built-in vs e
 | changesets-CLI or foreign registry (TRL-938) | durable | fills seam, foreign boundary | adapter binding, extracted |
 | `.changeset/*.md` as release intent | durable | consumes authored input | neither — an intent source |
 | warden-guide / error-taxonomy doc sync | durable, concept owns it | consumes, renders | thin caller |
-| `vocab-cutover-rewrite` | transient | not applicable | tooling, stays |
+| one-off vocab cleanup prototype | transient | not applicable | tooling, may stay as bridge |
+| framework contract migration | durable | derives/applies authored contract changes | Warden fix metadata + Regrade |
 | trail-input type-cost guard | transient build metric | not applicable | tooling, stays |
 | publish/registry npm mechanics | npm facts, not Trails facts | not applicable | inside the binding, never core |
 
-`release.check` is the derives-and-graduates example: release rules are durable Trails-contract facts, so the script-era checker graduated into the `trails release check` surface, and package scripts became thin callers. `vocab-cutover-rewrite` is the derives-but-stays-tooling example: real derivation over a transient truth.
+`release.check` is the derives-and-graduates example: release rules are durable Trails-contract facts, so the script-era checker graduated into the `trails release check` surface, and package scripts became thin callers. A one-off vocab cleanup prototype is the derives-but-may-stay-tooling example: real derivation over a transient truth. A stable framework contract migration is different; it must become Warden/Regrade work so detection, repair facts, validation, and review routing stay inside Trails.
 
 The native Bun release binding is the fills-a-declared-seam example: `@ontrails/trails/release` owns the binding descriptor plus Bun pack, publish, and registry preflight implementation. Root `publish:*` scripts are compatibility wrappers around that binding. They remain useful named exits, but they do not own the release behavior.
 


### PR DESCRIPTION
## Context

This captures the Regrade framing that was preserved in a local memory note after the drift-hardening stack: framework contract migration should graduate into Warden/Regrade instead of living as a one-off script.

## Changes

- Updates script-graduation doctrine to distinguish one-off repo cleanup scripts from repeatable framework contract migrations.
- Extends the Warden fix-metadata ADR draft with the "Regrade is contract change, not a codemod" framing.
- Records the staged external promise: prove migration internally before promising downstream adopter migration coverage.

## Verification

- `bun run docs:wrap-check`
- `bun scripts/adr.ts check`
- `bun run changeset:check`
- `git diff --check`
- Graphite pre-push stable checks: Warden, ADR, test, typecheck, lint, ast-grep, format, dead-code

## Risks

Docs-only. This does not ratify the external downstream migration promise yet; it explicitly keeps that promise gated on Regrade maturity and package-source coverage.
