### PR TITLE
feat(wayfinder): add source outline navigation

### DIFF
--- a/.changeset/trl-1024-wayfind-outline.md
+++ b/.changeset/trl-1024-wayfind-outline.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/trails": patch
+"@ontrails/wayfinder": patch
+---
+
+Add the `wayfind.outline` source-navigation trail and expose it through the Trails CLI and MCP surfaces.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ The architecture is designed to make consistency easier than drift. Agents build
 
 For Trails graph-navigation questions, use Wayfinder before reconstructing topo facts manually. Start with `trails wayfind overview --root-dir . --json` or the repo-local `bun apps/trails/bin/trails.ts wayfind overview --root-dir . --json` to check artifact source and freshness, then use `wayfind search`, `wayfind trails`, `wayfind contract`, `wayfind describe`, `wayfind nearby`, `wayfind impact`, or `wayfind examples` for saved graph facts.
 
+`wayfind outline <file>` is the source-navigation exception inside Wayfinder: it parses the explicit source file live, then cross-references saved graph artifacts when they are available.
+
 Fall back to `rg`, qmd, source reads, or a fresh compile when Wayfinder reports missing or stale artifacts, when the task needs source text that Topographer does not project, or when writing new artifacts would violate the current work authority. When you fall back, say why so the next agent does not silently repeat the same graph reconstruction.
 
 ## Lexicon

--- a/apps/trails/README.md
+++ b/apps/trails/README.md
@@ -15,7 +15,7 @@ Common workflows:
 - `trails topo` inspects topo state and manages pins/history.
 - `trails compile` writes committed topo artifacts.
 - `trails validate` checks committed topo artifacts for drift.
-- `trails wayfind overview`, `trails wayfind find`, `trails wf search`, and adjacent `trails wayfind ...` commands read saved topo artifacts through Wayfinder for local graph navigation.
+- `trails wayfind overview`, `trails wayfind find`, `trails wf search`, `trails wayfind outline <file>`, and adjacent `trails wayfind ...` commands read saved topo artifacts and source outlines through Wayfinder for local navigation.
 - `trails schema <command...>` shows accepted CLI routes, aliases, flags, and schemas for an operator command.
 - `trails warden` runs Trails governance checks for contract and architecture drift.
 - `trails regrade --root-dir <path> --json` dry-runs downstream migration checks; add `--apply` only to write safe rewrites.

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -72,6 +72,7 @@ describe('Trails MCP surface shaping', () => {
       'trails_wayfind_examples',
       'trails_wayfind_impact',
       'trails_wayfind_nearby',
+      'trails_wayfind_outline',
       'trails_wayfind_overview',
       'trails_wayfind_search',
       'trails_wayfind_trails',
@@ -110,6 +111,7 @@ describe('Trails MCP surface shaping', () => {
     const tools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
     const wayfindAdapters = requireTool(tools, 'trails_wayfind_adapters');
     const wayfindErrors = requireTool(tools, 'trails_wayfind_errors');
+    const wayfindOutline = requireTool(tools, 'trails_wayfind_outline');
     const wayfindSearch = requireTool(tools, 'trails_wayfind_search');
     const warden = requireTool(tools, 'trails_warden');
     const devClean = requireTool(tools, 'trails_dev_clean');
@@ -130,6 +132,15 @@ describe('Trails MCP surface shaping', () => {
     expect(wayfindErrors.annotations).toMatchObject({
       readOnlyHint: true,
       title: 'List saved trail error facts with provenance',
+    });
+
+    expect(wayfindOutline.description).toBe(
+      'Outline one source file and connect source structure to saved Trails graph facts'
+    );
+    expect(wayfindOutline.annotations).toMatchObject({
+      readOnlyHint: true,
+      title:
+        'Outline one source file and connect source structure to saved Trails graph facts',
     });
 
     expect(wayfindSearch.description).toBe(
@@ -178,6 +189,7 @@ describe('Trails MCP surface shaping', () => {
     expect(shapedTrailIds).not.toContain('completions.__complete');
     expect(shapedTrailIds).toContain('wayfind.adapters');
     expect(shapedTrailIds).toContain('wayfind.errors');
+    expect(shapedTrailIds).toContain('wayfind.outline');
     expect(shapedTrailIds).not.toContain('wayfind.query');
   });
 
@@ -190,6 +202,7 @@ describe('Trails MCP surface shaping', () => {
     expect(trailsMcpIncludedTrails).toContain('warden');
     expect(trailsMcpIncludedTrails).toContain('wayfind.adapters');
     expect(trailsMcpIncludedTrails).toContain('wayfind.errors');
+    expect(trailsMcpIncludedTrails).toContain('wayfind.outline');
     expect(trailsMcpIncludedTrails).toContain('wayfind.search');
   });
 

--- a/apps/trails/src/__tests__/wayfind-cli.test.ts
+++ b/apps/trails/src/__tests__/wayfind-cli.test.ts
@@ -7,6 +7,7 @@ import {
   trailsCliAliases,
   trailsCliIncludedTrails,
 } from '../app.js';
+import { formatWayfindOutlineText } from '../run-wayfind-outline.js';
 
 const unwrapCommands = () => {
   const result = deriveCliCommands(app, {
@@ -35,6 +36,7 @@ describe('Trails Wayfinder CLI surface', () => {
     expect(commandPaths).toContain('wayfind nearby');
     expect(commandPaths).toContain('wayfind impact');
     expect(commandPaths).toContain('wayfind examples');
+    expect(commandPaths).toContain('wayfind outline');
 
     expect(trailIds).toContain('wayfind.overview');
     expect(trailIds).toContain('wayfind.adapters');
@@ -46,6 +48,12 @@ describe('Trails Wayfinder CLI surface', () => {
     expect(trailIds).toContain('wayfind.nearby');
     expect(trailIds).toContain('wayfind.impact');
     expect(trailIds).toContain('wayfind.examples');
+    expect(trailIds).toContain('wayfind.outline');
+
+    const outline = commands.find(
+      (command) => command.trail.id === 'wayfind.outline'
+    );
+    expect(outline?.args.map((arg) => arg.name)).toEqual(['file']);
 
     const search = commands.find(
       (command) => command.trail.id === 'wayfind.search'
@@ -84,5 +92,52 @@ describe('Trails Wayfinder CLI surface', () => {
   test('keeps the base operator topo separate from CLI Wayfinder exposure', () => {
     expect(operatorApp.get('wayfind.overview')).toBeUndefined();
     expect(app.get('wayfind.overview')).toBeDefined();
+  });
+
+  test('renders outline text from structured fields', () => {
+    const text = formatWayfindOutlineText({
+      apps: [{ callee: 'topo', line: 20, name: 'app' }],
+      counts: {
+        apps: 1,
+        declarations: 2,
+        diagnostics: 1,
+        graphMatches: 1,
+        trails: 1,
+      },
+      diagnostics: [
+        {
+          code: 'graph.missing',
+          message: 'No saved graph.',
+          severity: 'warn',
+        },
+      ],
+      features: {
+        included: ['source', 'trails', 'apps', 'graph', 'diagnostics'],
+        omitted: ['contracts', 'surfaces'],
+        view: 'review',
+      },
+      file: 'src/app.ts',
+      graph: {
+        matchedTrailIds: ['user.create'],
+        source: null,
+      },
+      rootDir: '/repo',
+      source: {
+        declarations: [
+          { kind: 'const', line: 10, name: 'userCreateTrail' },
+          { kind: 'const', line: 20, name: 'app' },
+        ],
+        exports: [],
+        imports: [],
+        lineCount: 20,
+      },
+      trails: [{ id: 'user.create', line: 10 }],
+    });
+
+    expect(text).toContain('src/app.ts');
+    expect(text).toContain('  graph matches: 1');
+    expect(text).toContain('  10: trail user.create');
+    expect(text).toContain('  20: app app (topo)');
+    expect(text).toContain('  warn: graph.missing: No saved graph.');
   });
 });

--- a/apps/trails/src/app.ts
+++ b/apps/trails/src/app.ts
@@ -8,6 +8,7 @@ import {
   wayfindImpactTrail,
   wayfindNearbyTrail,
   wayfindOverviewTrail,
+  wayfindOutlineTrail,
   wayfindSearchTrail,
   wayfindTrailsTrail,
 } from '@ontrails/wayfinder';
@@ -95,6 +96,7 @@ const cliWayfinderTrails = {
   wayfindExamplesTrail,
   wayfindImpactTrail,
   wayfindNearbyTrail,
+  wayfindOutlineTrail,
   wayfindOverviewTrail,
   wayfindSearchTrail,
   wayfindTrailsTrail,

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -52,6 +52,7 @@ import {
   runWatchLoop,
 } from './run-watch.js';
 import { tryWardenOutput } from './run-warden.js';
+import { tryWayfindOutlineOutput } from './run-wayfind-outline.js';
 import { tryLoadFreshAppLease } from './trails/load-app.js';
 import { resolveRunModulePath } from './trails/run.js';
 import { resolveTrailRootDir } from './trails/root-dir.js';
@@ -98,6 +99,9 @@ const buildOnResult =
       return;
     }
     if (tryReleaseCheckOutput(resolvedCtx)) {
+      return;
+    }
+    if (tryWayfindOutlineOutput(resolvedCtx)) {
       return;
     }
     await defaultOnResult(resolvedCtx);

--- a/apps/trails/src/mcp-app.ts
+++ b/apps/trails/src/mcp-app.ts
@@ -7,6 +7,7 @@ import {
   wayfindImpactTrail,
   wayfindNearbyTrail,
   wayfindOverviewTrail,
+  wayfindOutlineTrail,
   wayfindSearchTrail,
   wayfindTrailsTrail,
 } from '@ontrails/wayfinder';
@@ -24,6 +25,7 @@ export const trailsMcpApp = topo('trails', operatorTrails, {
   wayfindExamplesTrail,
   wayfindImpactTrail,
   wayfindNearbyTrail,
+  wayfindOutlineTrail,
   wayfindOverviewTrail,
   wayfindSearchTrail,
   wayfindTrailsTrail,

--- a/apps/trails/src/mcp-options.ts
+++ b/apps/trails/src/mcp-options.ts
@@ -41,6 +41,7 @@ export const trailsMcpIncludedTrails = [
   'wayfind.impact',
   'wayfind.nearby',
   'wayfind.overview',
+  'wayfind.outline',
   'wayfind.search',
   'wayfind.trails',
 ] as const;

--- a/apps/trails/src/release/wayfinder-dogfood-smoke.ts
+++ b/apps/trails/src/release/wayfinder-dogfood-smoke.ts
@@ -202,6 +202,33 @@ const assertResolvedTarget = (value: JsonObject, label: string): void => {
   }
 };
 
+const assertOutlineFindsOperatorApp = (outline: JsonObject): void => {
+  const features = assertObject(
+    outline['features'],
+    'wayfind outline features'
+  );
+  if (features['view'] !== 'custom') {
+    throw new Error('wayfind outline did not echo the custom feature view');
+  }
+  const { apps } = outline;
+  if (!Array.isArray(apps)) {
+    throw new TypeError('wayfind outline did not return app facts');
+  }
+  const appNames = apps
+    .map((entry) => assertObject(entry, 'wayfind outline app')['name'])
+    .filter((name): name is string => typeof name === 'string');
+  if (!appNames.includes('operatorApp')) {
+    throw new Error('wayfind outline did not find the operator app export');
+  }
+  if (outline['file'] !== 'apps/trails/src/app.ts') {
+    throw new Error('wayfind outline did not preserve the source file path');
+  }
+  const counts = assertObject(outline['counts'], 'wayfind outline counts');
+  if (counts['apps'] !== apps.length) {
+    throw new Error('wayfind outline counts diverged from app facts');
+  }
+};
+
 export const runWayfinderDogfoodSmoke =
   async (): Promise<WayfinderDogfoodSmokeResult> => {
     const tempRoot = await mkdtemp(join(tmpdir(), 'trails-wayfinder-dogfood-'));
@@ -276,6 +303,23 @@ export const runWayfinderDogfoodSmoke =
       const impact = runWayfind(tempRoot, ['impact', 'wayfind.search']);
       assertFreshSource(impact, 'wayfind impact');
       assertResolvedTarget(impact, 'wayfind impact');
+
+      const outline = runCommand(
+        [
+          process.execPath,
+          trailsBin,
+          'wayfind',
+          'outline',
+          'apps/trails/src/app.ts',
+          '--root-dir',
+          repoRoot,
+          '--features',
+          'source,apps,diagnostics',
+          '--json',
+        ],
+        'trails wayfind outline'
+      );
+      assertOutlineFindsOperatorApp(outline);
 
       return {
         check: 'wayfinder-dogfood',

--- a/apps/trails/src/run-wayfind-outline.ts
+++ b/apps/trails/src/run-wayfind-outline.ts
@@ -1,0 +1,129 @@
+import { deriveOutputMode, output } from '@ontrails/cli';
+import type { ActionResultContext } from '@ontrails/cli';
+import { outlineOutputSchema } from '@ontrails/wayfinder';
+import type { OutlineFeature, OutlineOutput } from '@ontrails/wayfinder';
+
+const includesFeature = (
+  outline: OutlineOutput,
+  feature: OutlineFeature
+): boolean => outline.features.included.includes(feature);
+
+const formatLine = (
+  line: number,
+  kind: string,
+  name: string,
+  suffix = ''
+): string => `${line.toString().padStart(4, ' ')}: ${kind} ${name}${suffix}`;
+
+const appendGraphCount = (lines: string[], outline: OutlineOutput): void => {
+  if (
+    includesFeature(outline, 'graph') &&
+    outline.counts.graphMatches !== undefined
+  ) {
+    lines.push(`  graph matches: ${outline.counts.graphMatches.toString()}`);
+  }
+};
+
+const appendDiagnosticCount = (
+  lines: string[],
+  outline: OutlineOutput
+): void => {
+  if (
+    includesFeature(outline, 'diagnostics') &&
+    outline.counts.diagnostics > 0
+  ) {
+    lines.push(`  diagnostics: ${outline.counts.diagnostics.toString()}`);
+  }
+};
+
+const appendSourceDeclarations = (
+  lines: string[],
+  outline: OutlineOutput
+): void => {
+  if (!includesFeature(outline, 'source')) {
+    return;
+  }
+  const declarations = outline.source?.declarations ?? [];
+  if (declarations.length === 0) {
+    return;
+  }
+  lines.push('');
+  for (const declaration of declarations.slice(0, 40)) {
+    lines.push(
+      formatLine(declaration.line, declaration.kind, declaration.name)
+    );
+  }
+};
+
+const appendTrails = (lines: string[], outline: OutlineOutput): void => {
+  if (!includesFeature(outline, 'trails')) {
+    return;
+  }
+  const trails = outline.trails ?? [];
+  if (trails.length === 0) {
+    return;
+  }
+  lines.push('');
+  for (const trail of trails) {
+    lines.push(formatLine(trail.line, 'trail', trail.id));
+  }
+};
+
+const appendApps = (lines: string[], outline: OutlineOutput): void => {
+  if (!includesFeature(outline, 'apps')) {
+    return;
+  }
+  const apps = outline.apps ?? [];
+  if (apps.length === 0) {
+    return;
+  }
+  lines.push('');
+  for (const app of apps) {
+    lines.push(formatLine(app.line, 'app', app.name, ` (${app.callee})`));
+  }
+};
+
+const appendDiagnostics = (lines: string[], outline: OutlineOutput): void => {
+  if (!includesFeature(outline, 'diagnostics')) {
+    return;
+  }
+  for (const diagnostic of outline.diagnostics ?? []) {
+    lines.push(
+      `  ${diagnostic.severity}: ${diagnostic.code}: ${diagnostic.message}`
+    );
+  }
+};
+
+export const formatWayfindOutlineText = (outline: OutlineOutput): string => {
+  const lines = [
+    outline.file,
+    `  trails: ${outline.counts.trails.toString()}`,
+    `  apps: ${outline.counts.apps.toString()}`,
+    `  declarations: ${outline.counts.declarations.toString()}`,
+  ];
+
+  appendGraphCount(lines, outline);
+  appendDiagnosticCount(lines, outline);
+  appendSourceDeclarations(lines, outline);
+  appendTrails(lines, outline);
+  appendApps(lines, outline);
+  appendDiagnostics(lines, outline);
+
+  return lines.join('\n');
+};
+
+export const tryWayfindOutlineOutput = (ctx: ActionResultContext): boolean => {
+  if (ctx.trail.id !== 'wayfind.outline' || ctx.result.isErr()) {
+    return false;
+  }
+  const { mode } = deriveOutputMode(ctx.flags, ctx.topoName);
+  if (mode !== 'text') {
+    return false;
+  }
+  const parsed = outlineOutputSchema.safeParse(ctx.result.value);
+  if (!parsed.success) {
+    return false;
+  }
+  output(formatWayfindOutlineText(parsed.data), mode);
+  return true;
+};

--- a/bun.lock
+++ b/bun.lock
@@ -311,6 +311,7 @@
       "version": "1.0.0-beta.24",
       "dependencies": {
         "@ontrails/adapter-kit": "workspace:^",
+        "@ontrails/warden": "workspace:^",
       },
       "peerDependencies": {
         "@ontrails/core": "workspace:^",

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -279,7 +279,7 @@ wayfindTrailsTrail, wayfindContoursTrail, wayfindResourcesTrail, wayfindSignalsT
 wayfindSurfacesTrail, wayfindFacetsTrail, wayfindVersionsTrail, wayfindExamplesTrail
 wayfindErrorsTrail, wayfindAdaptersTrail
 wayfindDescribeTrail, wayfindContractTrail, wayfindNearbyTrail, wayfindImpactTrail
-wayfindDiffTrail
+wayfindOutlineTrail, wayfindDiffTrail
 
 // Artifact loading, provenance, and typed filters
 loadWayfinderArtifacts, wayfinderTopoGraphSource, wayfinderTopoStoreSource
@@ -295,6 +295,7 @@ WayfinderFreshnessFresh, WayfinderFreshnessMissing
 WayfinderFreshnessSchemaVersionDrift, WayfinderFreshnessStale, WayfinderStaleReason
 WayfinderEntityFilters, WayfinderEntityFilterInput, WayfinderEntityKind
 WayfinderEntityRef, WayfinderFilterContext, WayfinderIntent
+OutlineFeature, OutlineInput, OutlineOutput, OutlineView
 ```
 
 Wayfinder trails are internal by default. Surface hosts expose selected query trails deliberately, usually by exact trail ID for operator tooling.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,7 +174,7 @@ Overrides are escape hatches. They're visible in the TopoGraph as explicit devia
 | `@ontrails/testing` | `testAll()`, `testExamples()`, `testTrail()`, contract testing, surface harnesses |
 | `@ontrails/topographer` | TopoGraphs, semantic diffing, lock manifest and `topo.lock` helpers, topo-store persistence (relocated from `@ontrails/core` per ADR-0042) |
 | `@ontrails/warden` | Lint rules, drift detection, CI gating |
-| `@ontrails/wayfinder` | Graph-read query trails over saved Topographer artifacts for agent navigation |
+| `@ontrails/wayfinder` | Graph-read query trails and source outlines over saved Topographer artifacts for agent navigation |
 
 ### Apps
 
@@ -200,14 +200,13 @@ Overrides are escape hatches. They're visible in the TopoGraph as explicit devia
 @ontrails/tracing (core)
 @ontrails/testing (core, cli, mcp, observe)
 @ontrails/topographer (core)
-@ontrails/wayfinder (core, topographer)
+@ontrails/warden (core, topographer)
+@ontrails/wayfinder (core, topographer, warden)
      ^
 @ontrails/commander (cli, commander)
 @ontrails/hono (http, hono)
 @ontrails/vite (node:stream only, no workspace deps)
 @ontrails/logtape (observe)
-@ontrails/warden (core, topographer)
-     ^
 apps/trails (cli/commander, http, topographer, tracing, wayfinder)
 ```
 

--- a/docs/contributing/codebase-navigation.md
+++ b/docs/contributing/codebase-navigation.md
@@ -25,12 +25,14 @@ bun apps/trails/bin/trails.ts wayfind errors --root-dir . --input-json '{"filter
 bun apps/trails/bin/trails.ts wayfind adapters --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind nearby wayfind.search --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind impact wayfind.search --root-dir . --json
+bun apps/trails/bin/trails.ts wayfind outline apps/trails/src/app.ts --root-dir . --review
+bun apps/trails/bin/trails.ts wayfind outline apps/trails/src/app.ts --root-dir . --features source,apps,diagnostics --json
 bun apps/trails/bin/trails.ts schema wf search
 ```
 
 Use `trails schema <command...>` when you need the accepted CLI routes, aliases, flags, and schemas for an operator command before invoking it from a shell.
 
-Use source search, qmd, or symbol tools when Wayfinder reports missing or stale artifacts, when the task needs implementation text that Topographer does not project, or when the current authority does not allow generating fresh artifacts. If you compile to refresh artifacts, treat the generated `.trails` files as evidence and clean them up unless the branch intentionally owns them.
+Use `wayfind outline <file>` before reading a large source file when you need a compact source map. It parses the explicit file path, reports imports, exports, declarations, app declarations, and authored trail IDs, and links those trail IDs to saved graph facts when artifacts exist. Use source search, qmd, or symbol tools when Wayfinder reports missing or stale artifacts, when the task needs implementation text that Topographer does not project, or when the current authority does not allow generating fresh artifacts. If you compile to refresh artifacts, treat the generated `.trails` files as evidence and clean them up unless the branch intentionally owns them.
 
 ## Symbol Navigation
 

--- a/docs/releases/wayfinder-v0.md
+++ b/docs/releases/wayfinder-v0.md
@@ -4,7 +4,7 @@ Wayfinder is now a real graph-read package, not just a reserved shell. The v0 ca
 
 ## What Ships
 
-- `@ontrails/wayfinder` exports `wayfinderTopo` and the v0 `wayfind.*` query trails for overview, typed search/listing, describe/contract inspection, examples, error facts, adapter facts, nearby relation reads, impact traversal, and explicit saved-baseline diffing.
+- `@ontrails/wayfinder` exports `wayfinderTopo` and the v0 `wayfind.*` query trails for overview, typed search/listing, describe/contract inspection, source-file outlines, examples, error facts, adapter facts, nearby relation reads, impact traversal, and explicit saved-baseline diffing.
 - Graph queries read existing Topographer artifacts or topo-store records. Adapter facts read package and conformance evidence through `@ontrails/adapter-kit`. V0 does not boot apps, resolve resources, reach the network, or mutate local state.
 - Query results include source and freshness metadata so agents can distinguish fresh artifacts from missing, stale, or schema-drifted artifacts.
 - Version and example listings preserve trail-version semantics: version records sort numerically, parent trail example filters include current and historical version examples, and `exampleCoverage: false` stays scoped to uncovered entities.
@@ -14,7 +14,7 @@ Wayfinder is now a real graph-read package, not just a reserved shell. The v0 ca
 
 Existing apps do not expose Wayfinder automatically. Wayfinder trails are internal by default, and MCP/HTTP hosts must opt in with exact trail IDs behind their own authorization boundary.
 
-Agents should try Wayfinder first when the question is about saved graph facts: which trails exist, what a contract looks like, which resources/signals/surfaces touch a trail, what is nearby, and what changed between two saved TopoGraphs. Raw file search remains the fallback when artifacts are missing, stale beyond the task's tolerance, or when the question is about source code that Topographer does not yet project.
+Agents should try Wayfinder first when the question is about saved graph facts: which trails exist, what a contract looks like, which resources/signals/surfaces touch a trail, what is nearby, and what changed between two saved TopoGraphs. Use `wayfind outline <file>` before reading a large source file when a compact AST-backed source map would answer the first navigation question. Raw file search remains the fallback when artifacts are missing, stale beyond the task's tolerance, or when the question is about source code that Topographer does not yet project.
 
 ## Dogfood Release Gate
 

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -227,7 +227,7 @@ await surface(graph, {
 
 Wayfinder trails are internal read tools over saved graph artifacts and package evidence. Expose them on MCP only when the host operator wants agents to inspect facts directly, and include explicit trail IDs instead of widening the whole `wayfind.*` namespace.
 
-The Trails operator MCP surface starts with selected first-class Wayfinder tools: `wayfind.overview`, `wayfind.search`, `wayfind.trails`, `wayfind.contract`, `wayfind.examples`, `wayfind.errors`, `wayfind.adapters`, `wayfind.nearby`, and `wayfind.impact`. They remain direct tools rather than one broad Wayfinder facet so agents can see read-only annotations, descriptions, and output schemas at the tool boundary. Adjacent saved-topo inspection stays grouped in the operator's existing `inspect` facet; unselected Wayfinder queries are not exposed by default.
+The Trails operator MCP surface starts with selected first-class Wayfinder tools: `wayfind.overview`, `wayfind.search`, `wayfind.trails`, `wayfind.contract`, `wayfind.examples`, `wayfind.errors`, `wayfind.adapters`, `wayfind.nearby`, `wayfind.impact`, and `wayfind.outline`. They remain direct tools rather than one broad Wayfinder facet so agents can see read-only annotations, descriptions, and output schemas at the tool boundary. Adjacent saved-topo inspection stays grouped in the operator's existing `inspect` facet; unselected Wayfinder queries are not exposed by default.
 
 Do not document or expose deferred Wayfinder ideas as if they exist. V0 has no generic `wayfind.query`, semantic search, signposts, or `wayfind.implications`.
 

--- a/packages/wayfinder/README.md
+++ b/packages/wayfinder/README.md
@@ -2,7 +2,7 @@
 
 Agent-shaped wayfinding query trails over saved graph and package evidence.
 
-`@ontrails/wayfinder` lets agents query a Trails app's resolved topo and package-level authoring facts without re-deriving the graph from `grep` plus file reads. The v0 catalog is cold and deterministic: graph queries read existing Topographer artifacts (`topo.lock`, `trails.lock`, and materialized current `trails.db` topo-store records), while adapter queries read `@ontrails/adapter-kit` package and conformance evidence. Wayfinder does not start apps, boot resources, reach the network, or mutate local state.
+`@ontrails/wayfinder` lets agents query a Trails app's resolved topo, source outline, and package-level authoring facts without re-deriving the graph from `grep` plus file reads. The v0 catalog is cold and deterministic: graph queries read existing Topographer artifacts (`topo.lock`, `trails.lock`, and materialized current `trails.db` topo-store records), source outline queries parse explicit files with OXC, and adapter queries read `@ontrails/adapter-kit` package and conformance evidence. Wayfinder does not start apps, boot resources, reach the network, or mutate local state.
 
 The package exports `wayfinderTopo` plus individual graph-read trails.
 
@@ -26,6 +26,7 @@ The package exports `wayfinderTopo` plus individual graph-read trails.
 | `wayfind.contract` | Inspect the input/output/intent contract for one trail or version. |
 | `wayfind.nearby` | Return direct typed relation edges around one entity. |
 | `wayfind.impact` | Walk upstream, downstream, or both relation directions. |
+| `wayfind.outline` | Outline one source file and connect it to saved graph facts when available. |
 | `wayfind.diff` | Compare two explicit saved TopoGraph baselines. |
 
 Each graph-read trail is internal by default and returns provenance and freshness metadata with its result so callers can tell whether the answer came from fresh artifacts, stale artifacts, missing artifacts, or schema-version drift. Adapter facts carry package and conformance provenance instead. Public surface exposure must be a deliberate host decision.
@@ -126,6 +127,22 @@ await wayfindContractTrail.blaze(
 ```
 
 Missing IDs return `Result.err(new NotFoundError(...))`, preserving Trails' surface error mapping instead of returning ambiguous empty objects.
+
+## Outline
+
+Use `wayfind.outline` when an agent needs to inspect a file's shape before reading the whole source. The query parses the explicit file path, returns imports, exports, declarations, app/topo declarations, and authored trail IDs, then reconciles trail IDs with saved Topographer artifacts when they are available. Missing artifacts are diagnostics, not hard failures, so `outline` remains useful in a fresh checkout or during repair work.
+
+```ts
+import { createTrailContext } from '@ontrails/core';
+import { wayfindOutlineTrail } from '@ontrails/wayfinder';
+
+await wayfindOutlineTrail.blaze(
+  { file: 'apps/trails/src/app.ts', rootDir: process.cwd(), review: true },
+  createTrailContext()
+);
+```
+
+CLI hosts can expose the same trail as `trails wayfind outline <file>`. Use `--review`, `--source`, `--contracts`, `--surfaces`, or `--all` for blessed views, or `--features source,trails,apps,diagnostics` for an exact feature set. JSON output includes structured counts plus the selected feature list and omitted feature list so agents can distinguish "not requested" from "absent." CLI text output is rendered by the CLI surface from the structured result; the Wayfinder contract does not carry presentation prose.
 
 ## Surfaces, Facets, Versions, And Examples
 

--- a/packages/wayfinder/package.json
+++ b/packages/wayfinder/package.json
@@ -23,7 +23,8 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@ontrails/adapter-kit": "workspace:^"
+    "@ontrails/adapter-kit": "workspace:^",
+    "@ontrails/warden": "workspace:^"
   },
   "peerDependencies": {
     "@ontrails/core": "workspace:^",

--- a/packages/wayfinder/src/__tests__/queries.test.ts
+++ b/packages/wayfinder/src/__tests__/queries.test.ts
@@ -37,6 +37,7 @@ import {
   wayfindImpactTrail,
   wayfindNearbyTrail,
   wayfindOverviewTrail,
+  wayfindOutlineTrail,
   wayfindSearchTrail,
   wayfindSurfacesTrail,
   wayfindTrailsTrail,
@@ -342,6 +343,7 @@ describe('wayfinder graph-read query trails', () => {
       'wayfind.facets',
       'wayfind.impact',
       'wayfind.nearby',
+      'wayfind.outline',
       'wayfind.overview',
       'wayfind.resources',
       'wayfind.search',
@@ -350,6 +352,132 @@ describe('wayfinder graph-read query trails', () => {
       'wayfind.trails',
       'wayfind.versions',
     ]);
+  });
+
+  test('outlines a source file and reconciles trail ids to saved graph facts', async () => {
+    await writeFile(
+      tempDir,
+      'src/app.ts',
+      [
+        "import { Result, topo, trail } from '@ontrails/core';",
+        "export const userCreateTrail = trail('user.create', {",
+        '  blaze: () => Result.ok({ id: "u1" }),',
+        '  input: z.object({ name: z.string() }),',
+        '  output: z.object({ id: z.string() }),',
+        '});',
+        'export const app = topo("demo", { userCreateTrail });',
+        '',
+      ].join('\n')
+    );
+
+    const result = await expectOk(
+      wayfindOutlineTrail.blaze({ file: 'src/app.ts' }, ctx())
+    );
+
+    expect(result.features).toMatchObject({
+      included: ['trails', 'apps', 'surfaces', 'graph', 'diagnostics'],
+      view: 'default',
+    });
+    expect(result.file).toBe('src/app.ts');
+    expect(result.trails).toEqual([
+      expect.objectContaining({
+        graph: expect.objectContaining({
+          exampleCount: 0,
+          intent: 'write',
+          surfaces: ['cli'],
+        }),
+        id: 'user.create',
+      }),
+    ]);
+    expect(result.apps).toEqual([
+      expect.objectContaining({ callee: 'topo', name: 'app' }),
+    ]);
+    expect(result.graph?.matchedTrailIds).toEqual(['user.create']);
+    expect(result.surfaces).toEqual(['cli']);
+    expect(result.counts).toMatchObject({
+      apps: 1,
+      declarations: 2,
+      diagnostics: result.diagnostics?.length ?? 0,
+      graphMatches: 1,
+      trails: 1,
+    });
+    expect(result).not.toHaveProperty('summary');
+  });
+
+  test('outlines graph surfaces without requiring graph feature output', async () => {
+    await writeFile(
+      tempDir,
+      'src/app.ts',
+      [
+        "import { Result, topo, trail } from '@ontrails/core';",
+        "export const userCreateTrail = trail('user.create', {",
+        '  blaze: () => Result.ok({ id: "u1" }),',
+        '});',
+        'export const app = topo("demo", { userCreateTrail });',
+        '',
+      ].join('\n')
+    );
+
+    const result = await expectOk(
+      wayfindOutlineTrail.blaze(
+        { features: 'surfaces', file: 'src/app.ts' },
+        ctx()
+      )
+    );
+
+    expect(result.features.included).toEqual(['surfaces']);
+    expect(result.surfaces).toEqual(['cli']);
+    expect(result.trails).toBeUndefined();
+    expect(result.graph).toBeUndefined();
+  });
+
+  test('outlines source-only facts when graph artifacts are unavailable', async () => {
+    const sourceRoot = await mkdtemp(join(tmpdir(), 'wayfinder-outline-test-'));
+    try {
+      await writeFile(
+        sourceRoot,
+        'src/source.ts',
+        [
+          "import { Result, trail } from '@ontrails/core';",
+          "import { sourceName as localName } from './dependency';",
+          "export function helper() { return 'ok'; }",
+          "export const localTrail = trail('local.read', {",
+          '  blaze: () => Result.ok({ ok: true }),',
+          '  input: z.object({}),',
+          '});',
+          '',
+        ].join('\n')
+      );
+
+      const result = await expectOk(
+        wayfindOutlineTrail.blaze(
+          { file: 'src/source.ts', rootDir: sourceRoot, source: true },
+          ctx()
+        )
+      );
+
+      expect(result.features.view).toBe('source');
+      expect(result.source?.declarations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ kind: 'function', name: 'helper' }),
+          expect.objectContaining({ kind: 'const', name: 'localTrail' }),
+        ])
+      );
+      expect(result.source?.imports).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            names: ['localName'],
+            source: './dependency',
+          }),
+        ])
+      );
+      expect(result.trails).toBeUndefined();
+      expect(result.diagnostics).toEqual([
+        expect.objectContaining({ code: 'graph.missing', severity: 'warn' }),
+      ]);
+    } finally {
+      await rm(sourceRoot, { force: true, recursive: true });
+    }
   });
 
   test('lists adapter facts from workspace package evidence', async () => {

--- a/packages/wayfinder/src/index.ts
+++ b/packages/wayfinder/src/index.ts
@@ -62,6 +62,7 @@ export {
   wayfindImpactTrail,
   wayfindNearbyTrail,
   wayfindOverviewTrail,
+  wayfindOutlineTrail,
   wayfindResourcesTrail,
   wayfindSearchTrail,
   wayfindSignalsTrail,
@@ -70,6 +71,13 @@ export {
   wayfindVersionsTrail,
   wayfinderTopo,
 } from './queries.js';
+export type {
+  OutlineFeature,
+  OutlineInput,
+  OutlineOutput,
+  OutlineView,
+} from './outline.js';
+export { outlineInputSchema, outlineOutputSchema } from './outline.js';
 export { wayfinderFact } from './provenance.js';
 export type {
   WayfinderArtifactKind,

--- a/packages/wayfinder/src/outline.ts
+++ b/packages/wayfinder/src/outline.ts
@@ -1,0 +1,884 @@
+import { readFile } from 'node:fs/promises';
+import { relative, resolve } from 'node:path';
+
+import {
+  DerivationError,
+  NotFoundError,
+  Result,
+  ValidationError,
+  securePath,
+  trail,
+} from '@ontrails/core';
+import type { TrailsError } from '@ontrails/core';
+import type { TopoGraph, TopoGraphEntry } from '@ontrails/topographer';
+import {
+  findTrailDefinitions,
+  getStringValue,
+  identifierName,
+  offsetToLineColumn,
+  parseWithDiagnostics,
+  walkWithParents,
+} from '@ontrails/warden/ast';
+import type { AstNode, AstParentContext } from '@ontrails/warden/ast';
+import { z } from 'zod';
+
+import { loadWayfinderArtifacts } from './loader.js';
+import type { WayfinderArtifactLoad } from './loader.js';
+
+const outlineFeatureNames = [
+  'source',
+  'trails',
+  'apps',
+  'contracts',
+  'surfaces',
+  'graph',
+  'diagnostics',
+] as const;
+
+const defaultOutlineFeatures = [
+  'trails',
+  'apps',
+  'surfaces',
+  'graph',
+  'diagnostics',
+] as const;
+
+const outlineViewFeatures = {
+  all: outlineFeatureNames,
+  contracts: ['trails', 'contracts', 'graph', 'diagnostics'],
+  default: defaultOutlineFeatures,
+  review: ['source', 'trails', 'contracts', 'graph', 'diagnostics'],
+  source: ['source', 'diagnostics'],
+  surfaces: ['trails', 'apps', 'surfaces', 'graph', 'diagnostics'],
+} as const satisfies Record<string, readonly OutlineFeature[]>;
+
+const outlineFeatureSchema = z.enum(outlineFeatureNames);
+const outlineViewSchema = z.enum([
+  'all',
+  'contracts',
+  'custom',
+  'default',
+  'review',
+  'source',
+  'surfaces',
+]);
+
+export type OutlineFeature = z.infer<typeof outlineFeatureSchema>;
+export type OutlineView = z.infer<typeof outlineViewSchema>;
+
+export const outlineInputSchema = z
+  .object({
+    all: z
+      .boolean()
+      .default(false)
+      .describe('Show every outline feature family'),
+    contracts: z
+      .boolean()
+      .default(false)
+      .describe('Show trail contract and schema facts'),
+    features: z
+      .string()
+      .optional()
+      .describe('Comma-separated feature families to include'),
+    file: z.string().min(1).describe('Source file to outline'),
+    review: z
+      .boolean()
+      .default(false)
+      .describe('Show the source and contract facts most useful for review'),
+    rootDir: z.string().optional().describe('Workspace root directory'),
+    source: z
+      .boolean()
+      .default(false)
+      .describe('Show source-level imports, exports, and declarations'),
+    surfaces: z
+      .boolean()
+      .default(false)
+      .describe('Show surface and app membership facts'),
+  })
+  .strict();
+
+export type OutlineInput = z.output<typeof outlineInputSchema>;
+
+const sourceImportSchema = z.object({
+  names: z.array(z.string()).readonly(),
+  source: z.string(),
+});
+
+const sourceExportSchema = z.object({
+  line: z.number().int().positive(),
+  names: z.array(z.string()).readonly(),
+  source: z.string().optional(),
+});
+
+const sourceDeclarationSchema = z.object({
+  kind: z.enum([
+    'class',
+    'class-member',
+    'const',
+    'function',
+    'interface',
+    'type',
+    'variable',
+  ]),
+  line: z.number().int().positive(),
+  name: z.string(),
+});
+
+const sourceAppSchema = z.object({
+  callee: z.string(),
+  line: z.number().int().positive(),
+  name: z.string(),
+});
+
+const sourceOutlineSchema = z.object({
+  declarations: z.array(sourceDeclarationSchema).readonly(),
+  exports: z.array(sourceExportSchema).readonly(),
+  imports: z.array(sourceImportSchema).readonly(),
+  lineCount: z.number().int().nonnegative(),
+});
+
+const trailOutlineSchema = z.object({
+  contracts: z
+    .object({
+      input: z.boolean(),
+      output: z.boolean(),
+    })
+    .optional(),
+  graph: z
+    .object({
+      exampleCount: z.number().int().nonnegative(),
+      intent: z.enum(['destroy', 'read', 'write']),
+      surfaces: z.array(z.string()).readonly(),
+    })
+    .optional(),
+  id: z.string(),
+  line: z.number().int().positive(),
+});
+
+const graphOutlineSchema = z.object({
+  matchedTrailIds: z.array(z.string()).readonly(),
+  source: z
+    .object({
+      freshness: z.string(),
+      kind: z.string(),
+      path: z.string().optional(),
+    })
+    .nullable(),
+});
+
+const outlineDiagnosticSchema = z.object({
+  code: z.string(),
+  line: z.number().int().positive().optional(),
+  message: z.string(),
+  severity: z.enum(['error', 'info', 'warn']),
+});
+
+const outlineCountsSchema = z.object({
+  apps: z.number().int().nonnegative(),
+  declarations: z.number().int().nonnegative(),
+  diagnostics: z.number().int().nonnegative(),
+  graphMatches: z.number().int().nonnegative().optional(),
+  trails: z.number().int().nonnegative(),
+});
+
+export const outlineOutputSchema = z.object({
+  apps: z.array(sourceAppSchema).readonly().optional(),
+  counts: outlineCountsSchema,
+  diagnostics: z.array(outlineDiagnosticSchema).readonly().optional(),
+  features: z.object({
+    included: z.array(outlineFeatureSchema).readonly(),
+    omitted: z.array(outlineFeatureSchema).readonly(),
+    view: outlineViewSchema,
+  }),
+  file: z.string(),
+  graph: graphOutlineSchema.optional(),
+  rootDir: z.string(),
+  source: sourceOutlineSchema.optional(),
+  surfaces: z.array(z.string()).readonly().optional(),
+  trails: z.array(trailOutlineSchema).readonly().optional(),
+});
+
+export type OutlineOutput = z.output<typeof outlineOutputSchema>;
+
+interface OutlineDiagnostic {
+  readonly code: string;
+  readonly line?: number | undefined;
+  readonly message: string;
+  readonly severity: 'error' | 'info' | 'warn';
+}
+
+interface SourceImport {
+  readonly names: readonly string[];
+  readonly source: string;
+}
+
+interface SourceExport {
+  readonly line: number;
+  readonly names: readonly string[];
+  readonly source?: string | undefined;
+}
+
+interface SourceDeclaration {
+  readonly kind:
+    | 'class'
+    | 'class-member'
+    | 'const'
+    | 'function'
+    | 'interface'
+    | 'type'
+    | 'variable';
+  readonly line: number;
+  readonly name: string;
+}
+
+interface SourceTrail {
+  readonly id: string;
+  readonly line: number;
+}
+
+interface SourceApp {
+  readonly callee: string;
+  readonly line: number;
+  readonly name: string;
+}
+
+interface ParsedSourceOutline {
+  readonly apps: readonly SourceApp[];
+  readonly declarations: readonly SourceDeclaration[];
+  readonly diagnostics: readonly OutlineDiagnostic[];
+  readonly exports: readonly SourceExport[];
+  readonly imports: readonly SourceImport[];
+  readonly lineCount: number;
+  readonly trails: readonly SourceTrail[];
+}
+
+const uniqueSorted = (values: readonly string[]): readonly string[] =>
+  [...new Set(values)].toSorted();
+
+const lineFor = (sourceCode: string, node: AstNode): number =>
+  offsetToLineColumn(sourceCode, node.start).line;
+
+const stringLiteralValue = (node: AstNode | undefined): string | undefined => {
+  if (!node) {
+    return undefined;
+  }
+  return getStringValue(node) ?? undefined;
+};
+
+const propertyName = (node: AstNode | undefined): string | undefined => {
+  if (!node) {
+    return undefined;
+  }
+  if (node.type === 'Identifier') {
+    return identifierName(node) ?? undefined;
+  }
+  return stringLiteralValue(node);
+};
+
+const staticCalleeName = (node: AstNode | undefined): string | undefined => {
+  if (!node) {
+    return undefined;
+  }
+  if (node.type === 'Identifier') {
+    return identifierName(node) ?? undefined;
+  }
+  if (
+    node.type === 'MemberExpression' ||
+    node.type === 'StaticMemberExpression'
+  ) {
+    const { object } = node as unknown as { object?: AstNode };
+    const { property } = node as unknown as { property?: AstNode };
+    const receiver = identifierName(object);
+    const member = propertyName(property);
+    return receiver && member ? `${receiver}.${member}` : member;
+  }
+  return undefined;
+};
+
+const localImportName = (specifier: AstNode): string | undefined => {
+  const { local } = specifier as unknown as { local?: AstNode };
+  const { imported } = specifier as unknown as { imported?: AstNode };
+  if (specifier.type === 'ImportSpecifier') {
+    return (
+      identifierName(local) ??
+      identifierName(imported) ??
+      stringLiteralValue(imported) ??
+      undefined
+    );
+  }
+  return identifierName(local) ?? undefined;
+};
+
+const collectImports = (ast: AstNode): readonly SourceImport[] => {
+  const imports: SourceImport[] = [];
+  for (const node of (ast.body as readonly AstNode[] | undefined) ?? []) {
+    if (node.type !== 'ImportDeclaration') {
+      continue;
+    }
+    const { source: sourceNode } = node as unknown as { source?: AstNode };
+    const source = stringLiteralValue(sourceNode);
+    if (source === undefined) {
+      continue;
+    }
+    const { specifiers = [] } = node as unknown as {
+      specifiers?: readonly AstNode[];
+    };
+    imports.push({
+      names: uniqueSorted(
+        specifiers.flatMap((specifier) => {
+          const name = localImportName(specifier);
+          return name === undefined ? [] : [name];
+        })
+      ),
+      source,
+    });
+  }
+  return imports;
+};
+
+const declarationName = (node: AstNode | undefined): string | undefined => {
+  if (!node) {
+    return undefined;
+  }
+  const { id } = node as unknown as { id?: AstNode };
+  return identifierName(id) ?? undefined;
+};
+
+const variableKind = (declaration: AstNode): SourceDeclaration['kind'] => {
+  const { kind } = declaration as unknown as { kind?: unknown };
+  return kind === 'const' ? 'const' : 'variable';
+};
+
+const collectVariableDeclarations = (
+  node: AstNode,
+  kind: SourceDeclaration['kind'],
+  sourceCode: string
+): SourceDeclaration[] => {
+  const declarations =
+    (node as unknown as { declarations?: readonly AstNode[] }).declarations ??
+    [];
+  return declarations.flatMap((declarator) => {
+    const { id } = declarator as unknown as { id?: AstNode };
+    const name = identifierName(id);
+    return name === null
+      ? []
+      : [{ kind, line: lineFor(sourceCode, declarator), name }];
+  });
+};
+
+const isTopLevelStatement = (context: AstParentContext): boolean => {
+  if (context.parent?.type === 'Program') {
+    return true;
+  }
+  if (
+    context.parent?.type !== 'ExportNamedDeclaration' &&
+    context.parent?.type !== 'ExportDefaultDeclaration'
+  ) {
+    return false;
+  }
+  const grandparent = (context.parent as unknown as { parent?: AstNode })
+    .parent;
+  return grandparent === undefined || grandparent.type === 'Program';
+};
+
+const collectDeclarations = (
+  ast: AstNode,
+  sourceCode: string
+): readonly SourceDeclaration[] => {
+  const declarations: SourceDeclaration[] = [];
+
+  walkWithParents(ast, (node, context) => {
+    if (
+      node.type === 'MethodDefinition' ||
+      node.type === 'PropertyDefinition'
+    ) {
+      const name = propertyName((node as unknown as { key?: AstNode }).key);
+      if (name !== undefined) {
+        declarations.push({
+          kind: 'class-member',
+          line: lineFor(sourceCode, node),
+          name,
+        });
+      }
+      return;
+    }
+
+    if (!isTopLevelStatement(context)) {
+      return;
+    }
+
+    if (node.type === 'FunctionDeclaration') {
+      const name = declarationName(node);
+      if (name !== undefined) {
+        declarations.push({
+          kind: 'function',
+          line: lineFor(sourceCode, node),
+          name,
+        });
+      }
+      return;
+    }
+
+    if (node.type === 'ClassDeclaration') {
+      const name = declarationName(node);
+      if (name !== undefined) {
+        declarations.push({
+          kind: 'class',
+          line: lineFor(sourceCode, node),
+          name,
+        });
+      }
+      return;
+    }
+
+    if (
+      node.type === 'TSInterfaceDeclaration' ||
+      node.type === 'InterfaceDeclaration'
+    ) {
+      const name = declarationName(node);
+      if (name !== undefined) {
+        declarations.push({
+          kind: 'interface',
+          line: lineFor(sourceCode, node),
+          name,
+        });
+      }
+      return;
+    }
+
+    if (node.type === 'TSTypeAliasDeclaration') {
+      const name = declarationName(node);
+      if (name !== undefined) {
+        declarations.push({
+          kind: 'type',
+          line: lineFor(sourceCode, node),
+          name,
+        });
+      }
+      return;
+    }
+
+    if (node.type === 'VariableDeclaration') {
+      declarations.push(
+        ...collectVariableDeclarations(node, variableKind(node), sourceCode)
+      );
+    }
+  });
+
+  return declarations.toSorted(
+    (a, b) => a.line - b.line || a.name.localeCompare(b.name)
+  );
+};
+
+const exportNamesFromDeclaration = (
+  declaration: AstNode
+): readonly string[] => {
+  if (declaration.type === 'VariableDeclaration') {
+    return collectVariableDeclarations(declaration, 'variable', '').map(
+      (entry) => entry.name
+    );
+  }
+  const name = declarationName(declaration);
+  return name === undefined ? [] : [name];
+};
+
+const collectExports = (
+  ast: AstNode,
+  sourceCode: string
+): readonly SourceExport[] => {
+  const exports: SourceExport[] = [];
+  for (const node of (ast.body as readonly AstNode[] | undefined) ?? []) {
+    if (
+      node.type !== 'ExportNamedDeclaration' &&
+      node.type !== 'ExportDefaultDeclaration' &&
+      node.type !== 'ExportAllDeclaration'
+    ) {
+      continue;
+    }
+    const {
+      declaration,
+      source: sourceNode,
+      specifiers = [],
+    } = node as unknown as {
+      declaration?: AstNode;
+      source?: AstNode;
+      specifiers?: readonly AstNode[];
+    };
+    const exportSource = stringLiteralValue(sourceNode);
+    const names = uniqueSorted([
+      ...(declaration === undefined
+        ? []
+        : exportNamesFromDeclaration(declaration)),
+      ...specifiers.flatMap((specifier) => {
+        const { exported } = specifier as unknown as { exported?: AstNode };
+        const { local } = specifier as unknown as { local?: AstNode };
+        return [propertyName(exported) ?? propertyName(local)].filter(
+          (name): name is string => name !== undefined
+        );
+      }),
+      ...(node.type === 'ExportDefaultDeclaration' ? ['default'] : []),
+      ...(node.type === 'ExportAllDeclaration' ? ['*'] : []),
+    ]);
+    exports.push({
+      line: lineFor(sourceCode, node),
+      names,
+      ...(exportSource === undefined ? {} : { source: exportSource }),
+    });
+  }
+  return exports;
+};
+
+const collectApps = (
+  ast: AstNode,
+  sourceCode: string
+): readonly SourceApp[] => {
+  const apps: SourceApp[] = [];
+  walkWithParents(ast, (node, context) => {
+    if (node.type !== 'VariableDeclarator') {
+      return;
+    }
+    const { init } = node as unknown as { init?: AstNode };
+    if (init?.type !== 'CallExpression') {
+      return;
+    }
+    const { callee: calleeNode } = init as unknown as { callee?: AstNode };
+    const callee = staticCalleeName(calleeNode);
+    if (callee !== 'topo' && callee !== 'createTrailsApp') {
+      return;
+    }
+    const { id } = node as unknown as { id?: AstNode };
+    const name = identifierName(id);
+    if (name === null) {
+      return;
+    }
+    const lineSource = context.parent ?? node;
+    apps.push({ callee, line: lineFor(sourceCode, lineSource), name });
+  });
+  return apps;
+};
+
+const parseSourceOutline = (
+  filePath: string,
+  sourceCode: string
+): ParsedSourceOutline | null => {
+  const parsed = parseWithDiagnostics(filePath, sourceCode);
+  if (parsed.ast === null) {
+    return null;
+  }
+
+  return {
+    apps: collectApps(parsed.ast, sourceCode),
+    declarations: collectDeclarations(parsed.ast, sourceCode),
+    diagnostics: parsed.diagnostics.map((diagnostic) => {
+      const [label] = diagnostic.labels;
+      return {
+        code: 'source.parse',
+        ...(label === undefined
+          ? {}
+          : { line: offsetToLineColumn(sourceCode, label.start).line }),
+        message: diagnostic.message,
+        severity:
+          diagnostic.severity.toLowerCase() === 'error' ? 'error' : 'warn',
+      };
+    }),
+    exports: collectExports(parsed.ast, sourceCode),
+    imports: collectImports(parsed.ast),
+    lineCount: sourceCode.length === 0 ? 0 : sourceCode.split('\n').length,
+    trails: findTrailDefinitions(parsed.ast).map((definition) => ({
+      id: definition.id,
+      line: offsetToLineColumn(sourceCode, definition.start).line,
+    })),
+  };
+};
+
+const selectedView = (
+  input: OutlineInput
+): Result<
+  { readonly features: readonly OutlineFeature[]; readonly view: OutlineView },
+  ValidationError
+> => {
+  const selected = [
+    input.all ? 'all' : undefined,
+    input.contracts ? 'contracts' : undefined,
+    input.review ? 'review' : undefined,
+    input.source ? 'source' : undefined,
+    input.surfaces ? 'surfaces' : undefined,
+    input.features === undefined ? undefined : 'custom',
+  ].filter((value): value is OutlineView => value !== undefined);
+
+  if (selected.length > 1) {
+    return Result.err(
+      new ValidationError(
+        'Choose only one outline view: --review, --source, --contracts, --surfaces, --all, or --features.'
+      )
+    );
+  }
+
+  const view = selected[0] ?? 'default';
+  if (view !== 'custom') {
+    return Result.ok({ features: outlineViewFeatures[view], view });
+  }
+
+  const values = (input.features ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  const parsed = z.array(outlineFeatureSchema).safeParse(values);
+  if (!parsed.success || values.length === 0) {
+    return Result.err(
+      new ValidationError(
+        `--features must be a comma-separated list drawn from: ${outlineFeatureNames.join(', ')}.`
+      )
+    );
+  }
+  return Result.ok({
+    features: uniqueSorted(parsed.data) as OutlineFeature[],
+    view,
+  });
+};
+
+const hasFeature = (
+  features: readonly OutlineFeature[],
+  feature: OutlineFeature
+): boolean => features.includes(feature);
+
+const loadGraphSoft = async (
+  rootDir: string
+): Promise<{
+  readonly diagnostics: readonly OutlineDiagnostic[];
+  readonly graph: TopoGraph | null;
+  readonly load: WayfinderArtifactLoad | null;
+}> => {
+  try {
+    const load = await loadWayfinderArtifacts({ rootDir });
+    if (load.topoGraph === null) {
+      return {
+        diagnostics: [
+          {
+            code: 'graph.missing',
+            message:
+              'No saved Wayfinder TopoGraph artifact found. Run `trails compile` for graph reconciliation.',
+            severity: 'warn',
+          },
+        ],
+        graph: null,
+        load,
+      };
+    }
+    return {
+      diagnostics:
+        load.freshness.status === 'fresh'
+          ? []
+          : [
+              {
+                code: 'graph.freshness',
+                message: `Saved Wayfinder artifacts are ${load.freshness.status}.`,
+                severity: 'warn',
+              },
+            ],
+      graph: load.topoGraph,
+      load,
+    };
+  } catch (error) {
+    return {
+      diagnostics: [
+        {
+          code: 'graph.load',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Unable to load Wayfinder artifacts.',
+          severity: 'warn',
+        },
+      ],
+      graph: null,
+      load: null,
+    };
+  }
+};
+
+const trailGraphFacts = (
+  graph: TopoGraph | null,
+  id: string
+):
+  | {
+      readonly exampleCount: number;
+      readonly intent: 'destroy' | 'read' | 'write';
+      readonly surfaces: readonly string[];
+    }
+  | undefined => {
+  const entry = graph?.entries.find(
+    (candidate): candidate is TopoGraphEntry =>
+      candidate.kind === 'trail' && candidate.id === id
+  );
+  if (entry === undefined) {
+    return undefined;
+  }
+  return {
+    exampleCount: entry.exampleCount,
+    intent: entry.intent ?? 'write',
+    surfaces: entry.surfaces,
+  };
+};
+
+const contractFacts = (
+  graph: TopoGraph | null,
+  id: string
+): { readonly input: boolean; readonly output: boolean } | undefined => {
+  const entry = graph?.entries.find(
+    (candidate) => candidate.kind === 'trail' && candidate.id === id
+  );
+  return entry === undefined
+    ? undefined
+    : { input: entry.input !== undefined, output: entry.output !== undefined };
+};
+
+const graphSourcePath = (rootDir: string): string =>
+  resolve(rootDir, '.trails', 'topo.lock');
+
+const graphOutline = (
+  rootDir: string,
+  graph: TopoGraph | null,
+  load: WayfinderArtifactLoad | null,
+  sourceTrails: readonly SourceTrail[]
+): z.output<typeof graphOutlineSchema> => ({
+  matchedTrailIds: sourceTrails
+    .map((sourceTrail) => sourceTrail.id)
+    .filter((id) =>
+      graph?.entries.some((entry) => entry.kind === 'trail' && entry.id === id)
+    )
+    .toSorted(),
+  source:
+    graph === null || load === null
+      ? null
+      : {
+          freshness: load.freshness.status,
+          kind: 'topoGraph',
+          path: graphSourcePath(rootDir),
+        },
+});
+
+const buildOutline = async (
+  input: OutlineInput,
+  cwd: string | undefined
+): Promise<Result<OutlineOutput, TrailsError>> => {
+  const view = selectedView(input);
+  if (view.isErr()) {
+    return view;
+  }
+
+  const rootDir = resolve(input.rootDir ?? cwd ?? process.cwd());
+  const safeFile = securePath(rootDir, input.file);
+  if (safeFile.isErr()) {
+    return safeFile;
+  }
+
+  let sourceCode: string;
+  try {
+    sourceCode = await readFile(safeFile.value, 'utf8');
+  } catch (error) {
+    const cause = error instanceof Error ? error : new Error(String(error));
+    return Result.err(
+      new NotFoundError(`Unable to read source file "${input.file}".`, {
+        cause,
+        context: { file: safeFile.value },
+      })
+    );
+  }
+
+  const parsed = parseSourceOutline(safeFile.value, sourceCode);
+  if (parsed === null) {
+    return Result.err(
+      new DerivationError(`Unable to parse source file "${input.file}".`, {
+        context: { file: safeFile.value },
+      })
+    );
+  }
+
+  const graphLoad = await loadGraphSoft(rootDir);
+  const diagnostics = [...parsed.diagnostics, ...graphLoad.diagnostics];
+  const { features } = view.value;
+  const omitted = outlineFeatureNames.filter(
+    (feature) => !features.includes(feature)
+  );
+  const relativeFile = relative(rootDir, safeFile.value) || input.file;
+  const trails = parsed.trails.map((sourceTrail) => ({
+    ...(hasFeature(features, 'contracts')
+      ? { contracts: contractFacts(graphLoad.graph, sourceTrail.id) }
+      : {}),
+    id: sourceTrail.id,
+    line: sourceTrail.line,
+    ...(hasFeature(features, 'graph')
+      ? { graph: trailGraphFacts(graphLoad.graph, sourceTrail.id) }
+      : {}),
+  }));
+  const surfaces = uniqueSorted(
+    parsed.trails.flatMap(
+      (sourceTrail) =>
+        trailGraphFacts(graphLoad.graph, sourceTrail.id)?.surfaces ?? []
+    )
+  );
+  const graphMatches = parsed.trails.filter((sourceTrail) =>
+    graphLoad.graph?.entries.some(
+      (entry) => entry.kind === 'trail' && entry.id === sourceTrail.id
+    )
+  ).length;
+
+  return Result.ok({
+    ...(hasFeature(features, 'apps') ? { apps: parsed.apps } : {}),
+    counts: {
+      apps: parsed.apps.length,
+      declarations: parsed.declarations.length,
+      diagnostics: diagnostics.length,
+      ...(hasFeature(features, 'graph') ? { graphMatches } : {}),
+      trails: parsed.trails.length,
+    },
+    ...(hasFeature(features, 'diagnostics') ? { diagnostics } : {}),
+    features: {
+      included: features,
+      omitted,
+      view: view.value.view,
+    },
+    file: relativeFile,
+    ...(hasFeature(features, 'graph')
+      ? {
+          graph: graphOutline(
+            rootDir,
+            graphLoad.graph,
+            graphLoad.load,
+            parsed.trails
+          ),
+        }
+      : {}),
+    rootDir,
+    ...(hasFeature(features, 'source')
+      ? {
+          source: {
+            declarations: parsed.declarations,
+            exports: parsed.exports,
+            imports: parsed.imports,
+            lineCount: parsed.lineCount,
+          },
+        }
+      : {}),
+    ...(hasFeature(features, 'surfaces') ? { surfaces } : {}),
+    ...(hasFeature(features, 'trails') ? { trails } : {}),
+  });
+};
+
+export const wayfindOutlineTrail = trail('wayfind.outline', {
+  args: ['file'],
+  blaze: async (input, ctx) => buildOutline(input, ctx.cwd),
+  description:
+    'Outline one source file and connect source structure to saved Trails graph facts',
+  examples: [
+    {
+      input: { file: 'apps/trails/src/app.ts', rootDir: '.' },
+      name: 'Outline a Trails source file',
+    },
+  ],
+  input: outlineInputSchema,
+  intent: 'read',
+  output: outlineOutputSchema,
+  visibility: 'internal',
+});

--- a/packages/wayfinder/src/queries.ts
+++ b/packages/wayfinder/src/queries.ts
@@ -32,6 +32,7 @@ import type {
   WayfinderArtifactLoaderOptions,
 } from './loader.js';
 import { deriveTrailErrorFacts } from './error-facts.js';
+import { wayfindOutlineTrail } from './outline.js';
 import {
   diffResult,
   edgeTouches,
@@ -44,6 +45,8 @@ import {
   relationGroupSchema,
   resolveEntityRef,
 } from './relations.js';
+
+export { wayfindOutlineTrail } from './outline.js';
 
 const artifactSourceSchema = z.object({
   kind: z.enum(['lockManifest', 'topoGraph', 'topoStore']),
@@ -1588,6 +1591,7 @@ export const wayfinderTopo = topo('wayfinder', {
   wayfindFacetsTrail,
   wayfindImpactTrail,
   wayfindNearbyTrail,
+  wayfindOutlineTrail,
   wayfindOverviewTrail,
   wayfindResourcesTrail,
   wayfindSearchTrail,

--- a/scripts/check-readme-snippets.ts
+++ b/scripts/check-readme-snippets.ts
@@ -233,6 +233,7 @@ export const wayfindDescribeTrail: any;
 export const wayfindDiffTrail: any;
 export const wayfindImpactTrail: any;
 export const wayfindNearbyTrail: any;
+export const wayfindOutlineTrail: any;
 export const wayfindOverviewTrail: any;
 export const wayfinderTopo: any;
 export const wayfindSearchTrail: any;


### PR DESCRIPTION
## Context

Adds `wayfind.outline` as the source-navigation slice for Wayfinder: parse an explicit source file live, then cross-reference saved topo graph facts when available. This gives agents a compact file outline without forcing them to read the whole file first.

## What Changed

- Added `@ontrails/wayfinder` outline derivation with selectable feature sets and blessed CLI views (`--source`, `--review`, `--contracts`, `--surfaces`, `--all`, `--features`).
- Exposed `trails wayfind outline <file>` through CLI and MCP, including README/API/docs updates and a release smoke check.
- Kept the Wayfinder contract structured: JSON/MCP output carries counts, source facts, graph matches, trails, apps, diagnostics, contracts, and surfaces; CLI text is rendered by the Trails CLI surface instead of carrying presentation prose in the contract.
- Documented that `wayfind outline` is Wayfinder's live-source exception: it derives source shape from the requested file and only consumes saved graph artifacts for graph/context facts.

## Verification

- `bun test packages/wayfinder/src/__tests__/queries.test.ts apps/trails/src/__tests__/wayfind-cli.test.ts apps/trails/src/__tests__/mcp.test.ts`
- `bun run typecheck --filter=@ontrails/wayfinder`
- `bun run typecheck --filter=@ontrails/trails`
- `bun run docs:snippets`
- `bun run wayfinder:dogfood`
- `bun run check`
- `bun run build`
- `bun run publish:check`
- `bun run changeset:check`
- `git diff --check`
- Graphite pre-push hook passed: Warden, ADR, test, typecheck, lint, ast-grep, format, dead-code

## Notes

Warden still reports the existing `dead-internal-trail` warning family for internal Wayfinder query trails, now including `wayfind.outline`; there are no Warden errors.
