### PR TITLE
chore(tsconfig): silence baseurl deprecation

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "baseUrl": ".",
+    "ignoreDeprecations": "5.0",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
## Context

Fresh `main` could not complete the requested baseline because TypeScript 5.9 reports the root `baseUrl` setting as deprecated. The repo still intentionally uses the current config shape, so this branch adds the supported TypeScript deprecation acknowledgement before the AST guard work begins.

## Changes

- Add `ignoreDeprecations: "5.0"` to the root `tsconfig.json`.
- Keep this isolated below TRL-1026 so the functional Warden/Regrade work is reviewable separately.

## Verification

Local baseline and stack verification passed after this branch:

- `bun run oxlint-plugin:build`
- `bun run check`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run build`
- `bun run changeset:check`
- `bun run wayfinder:dogfood`
- `bun run publish:check`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`

The real submit pre-push hook also passed Warden, ADR checks, test, typecheck, lint, ast-grep, format, and dead-code.

## Review

Local Claude Code review found no P0/P1/P2 issues for this branch.

## Risks

Low. This is a TypeScript config acknowledgement only and does not alter runtime code.
