### PR TITLE
test(warden): gate raw ast node field casts

### DIFF
--- a/.agents/skills/clark/references/warden-guide.md
+++ b/.agents/skills/clark/references/warden-guide.md
@@ -51,7 +51,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `unreachable-detour-shadowing` (error, source/source-static, external): Specific detours are not shadowed by earlier broader detours.
 - `valid-describe-refs` (warn, all/project-static, advisory): Describe references point at known Trails concepts.
 - `warden-export-symmetry` (error, source/source-static, repo-local): The Warden package exports trail wrappers, not raw rules.
-- `warden-rules-use-ast` (error, source/source-static, repo-local): Warden source rules use AST helpers instead of ad hoc parsing.
+- `warden-rules-use-ast` (error, source/source-static, repo-local): Warden source rules use AST helpers instead of ad hoc parsing or raw node-field casts.
 
 ### Lifecycle
 

--- a/.changeset/trl-1027-warden-ast-regression-gate.md
+++ b/.changeset/trl-1027-warden-ast-regression-gate.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Warn when Warden rules add raw AST node-field casts where a typed accessor exists.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -51,7 +51,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `unreachable-detour-shadowing` (error, source/source-static, external): Specific detours are not shadowed by earlier broader detours.
 - `valid-describe-refs` (warn, all/project-static, advisory): Describe references point at known Trails concepts.
 - `warden-export-symmetry` (error, source/source-static, repo-local): The Warden package exports trail wrappers, not raw rules.
-- `warden-rules-use-ast` (error, source/source-static, repo-local): Warden source rules use AST helpers instead of ad hoc parsing.
+- `warden-rules-use-ast` (error, source/source-static, repo-local): Warden source rules use AST helpers instead of ad hoc parsing or raw node-field casts.
 
 ### Lifecycle
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,7 +144,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `unreachable-detour-shadowing` (error, source/source-static, external): Specific detours are not shadowed by earlier broader detours.
 - `valid-describe-refs` (warn, all/project-static, advisory): Describe references point at known Trails concepts.
 - `warden-export-symmetry` (error, source/source-static, repo-local): The Warden package exports trail wrappers, not raw rules.
-- `warden-rules-use-ast` (error, source/source-static, repo-local): Warden source rules use AST helpers instead of ad hoc parsing.
+- `warden-rules-use-ast` (error, source/source-static, repo-local): Warden source rules use AST helpers instead of ad hoc parsing or raw node-field casts.
 
 #### Lifecycle
 

--- a/packages/warden/src/__tests__/warden-rules-use-ast.test.ts
+++ b/packages/warden/src/__tests__/warden-rules-use-ast.test.ts
@@ -289,6 +289,46 @@ describe('warden-rules-use-ast', () => {
     });
   });
 
+  describe('positive fixtures: raw AST node-field casts', () => {
+    const targetFile = ruleFilePath('fake-rule.ts');
+
+    test('warns when a rule hand-casts a known AST node field', () => {
+      const source = `export const r = { check() { const callee = (node as unknown as { callee?: AstNode }).callee; return callee ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.rule).toBe('warden-rules-use-ast');
+      expect(diagnostics[0]?.severity).toBe('warn');
+      expect(diagnostics[0]?.message).toContain('callee -> getNodeCallee');
+      expect(diagnostics[0]?.message).toContain('raw AST node-field cast');
+    });
+
+    test('warns once for destructured casts with multiple known fields', () => {
+      const source = `export const r = { check() { const { id, init } = node as unknown as { id?: AstNode; init?: AstNode }; return id && init ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('warn');
+      expect(diagnostics[0]?.message).toContain('id -> getNodeId');
+      expect(diagnostics[0]?.message).toContain('init -> getNodeInit');
+    });
+
+    test('warns outside check methods because node-field casts are rule-local API drift', () => {
+      const source = `const callee = (node as unknown as { callee?: AstNode }).callee;\nexport const r = { check() { return callee ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.severity).toBe('warn');
+      expect(diagnostics[0]?.message).toContain('callee -> getNodeCallee');
+    });
+
+    test('suggests the discriminant accessor for switch-like node casts', () => {
+      const source = `export const r = { check() { const discriminant = (node as unknown as { discriminant?: AstNode }).discriminant; return discriminant ? [] : []; } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics.length).toBe(1);
+      expect(diagnostics[0]?.message).toContain(
+        'discriminant -> getNodeDiscriminant'
+      );
+    });
+  });
+
   describe('parameter-origin tracking (TRL-346 / Option A)', () => {
     // The pre-TRL-346 detectors gated on identifier spelling alone (a fixed
     // set of raw-source names). That over-fired on unrelated locals whose
@@ -441,6 +481,12 @@ export const r = { check(sourceCode: string, filePath: string) { const defs = fi
     test('does not flag computed member access', () => {
       // Defensive: computed member access is too ambiguous to flag reliably.
       const source = `export const r = { check(sourceCode: string) { const m = 'split'; return (sourceCode as unknown as { [k: string]: Function })[m]('\\n'); } };\n`;
+      const diagnostics = wardenRulesUseAst.check(source, targetFile);
+      expect(diagnostics).toEqual([]);
+    });
+
+    test('does not flag unrecognized type-literal casts', () => {
+      const source = `export const r = { check() { const state = node as unknown as { reason?: string }; return state.reason ? [] : []; } };\n`;
       const diagnostics = wardenRulesUseAst.check(source, targetFile);
       expect(diagnostics).toEqual([]);
     });

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -701,7 +701,8 @@ const builtinWardenRuleMetadataInput = {
   },
   'warden-rules-use-ast': {
     ...durableRepoLocal,
-    invariant: 'Warden source rules use AST helpers instead of ad hoc parsing.',
+    invariant:
+      'Warden source rules use AST helpers instead of ad hoc parsing or raw node-field casts.',
     tier: 'source-static',
   },
   'webhook-route-collision': {

--- a/packages/warden/src/rules/warden-rules-use-ast.ts
+++ b/packages/warden/src/rules/warden-rules-use-ast.ts
@@ -14,6 +14,9 @@
  *    source identifier, e.g. `new RegExp(sourceCode)`, `RegExp(rawText, 'g')`.
  *    Interpolating raw source into a regex constructor is the same class of
  *    bug as scanning with one — see TRL-345.
+ * 4. `rawNodeFieldCastSite` — asserting AST nodes through
+ *    `as unknown as { field?: ... }` where a typed accessor exists on
+ *    `./ast.ts`.
  *
  * This rule is path-anchored to this package's own `src/rules/` directory so
  * it never fires against a consumer repo that happens to share the same
@@ -33,6 +36,7 @@ import {
   getNodeComputed,
   getNodeDeclarations,
   getNodeElements,
+  getNodeExpression,
   getNodeId,
   getNodeKey,
   getNodeKind,
@@ -43,8 +47,10 @@ import {
   getNodeParams,
   getNodeProperties,
   getNodeProperty,
+  getNodeTypeAnnotation,
   getNodeValueNode,
   getStringValue,
+  isAstNode,
   offsetToLine,
   parse,
   walk,
@@ -375,6 +381,7 @@ const DIAGNOSTIC_ADVICE =
 interface DetectedSite {
   readonly identifier: AstNode;
   readonly message: string;
+  readonly severity: 'error' | 'warn';
   readonly start: number;
 }
 
@@ -386,6 +393,7 @@ const detectRawScan = (node: AstNode): DetectedSite | null => {
   return {
     identifier: scan.identifier,
     message: `${RULE_NAME}: ${scan.identifierName}.${scan.methodName}(...) treats source text as a string. ${DIAGNOSTIC_ADVICE}`,
+    severity: 'error',
     start: scan.start,
   };
 };
@@ -398,6 +406,7 @@ const detectRegexScan = (node: AstNode): DetectedSite | null => {
   return {
     identifier: regex.identifier,
     message: `${RULE_NAME}: regex.${regex.methodName}(${regex.identifierName}) scans raw source text. ${DIAGNOSTIC_ADVICE}`,
+    severity: 'error',
     start: regex.start,
   };
 };
@@ -411,7 +420,103 @@ const detectRegexConstruction = (node: AstNode): DetectedSite | null => {
   return {
     identifier: construction.identifier,
     message: `${RULE_NAME}: ${prefix}(${construction.identifierName}) constructs a regex from raw source text. ${DIAGNOSTIC_ADVICE}`,
+    severity: 'error',
     start: construction.start,
+  };
+};
+
+const AST_FIELD_ACCESSORS: ReadonlyMap<string, string> = new Map([
+  ['alternate', 'getNodeAlternate'],
+  ['argument', 'getNodeArgument'],
+  ['arguments', 'getNodeArguments'],
+  ['body', 'getNodeBodyNode or getNodeBodyStatements'],
+  ['callee', 'getNodeCallee'],
+  ['cases', 'getNodeCases'],
+  ['computed', 'getNodeComputed'],
+  ['consequent', 'getNodeConsequent'],
+  ['declaration', 'getNodeDeclaration'],
+  ['declarations', 'getNodeDeclarations'],
+  ['discriminant', 'getNodeDiscriminant'],
+  ['elements', 'getNodeElements'],
+  ['exportKind', 'getNodeExportKind'],
+  ['exported', 'getNodeExported'],
+  ['expression', 'getNodeExpression'],
+  ['id', 'getNodeId'],
+  ['imported', 'getNodeImported'],
+  ['init', 'getNodeInit'],
+  ['key', 'getNodeKey'],
+  ['kind', 'getNodeKind'],
+  ['left', 'getNodeLeft'],
+  ['local', 'getNodeLocal'],
+  ['name', 'getNodeName'],
+  ['object', 'getNodeObject'],
+  ['operator', 'getNodeOperator'],
+  ['param', 'getNodeParam'],
+  ['params', 'getNodeParams'],
+  ['properties', 'getNodeProperties'],
+  ['property', 'getNodeProperty'],
+  ['returnType', 'getNodeReturnType'],
+  ['right', 'getNodeRight'],
+  ['source', 'getNodeSource'],
+  ['specifiers', 'getNodeSpecifiers'],
+  ['superClass', 'getNodeSuperClass'],
+  ['test', 'getNodeTest'],
+  ['typeAnnotation', 'getNodeTypeAnnotation'],
+  ['value', 'getNodeValue or getNodeValueNode'],
+]);
+
+const typeLiteralMembers = (
+  annotation: AstNode | undefined
+): readonly AstNode[] => {
+  if (annotation?.type !== 'TSTypeLiteral') {
+    return [];
+  }
+  const { members } = annotation;
+  return Array.isArray(members) ? members.filter(isAstNode) : [];
+};
+
+const typePropertyName = (member: AstNode): string | null => {
+  if (member.type !== 'TSPropertySignature' || getNodeComputed(member)) {
+    return null;
+  }
+  const key = getNodeKey(member);
+  if (key?.type === 'Identifier') {
+    return getNodeName(key) ?? null;
+  }
+  return key ? getStringValue(key) : null;
+};
+
+const knownAccessorEntries = (
+  annotation: AstNode | undefined
+): readonly [string, string][] =>
+  typeLiteralMembers(annotation).flatMap((member) => {
+    const field = typePropertyName(member);
+    const accessor = field ? AST_FIELD_ACCESSORS.get(field) : undefined;
+    return field && accessor ? [[field, accessor] as const] : [];
+  });
+
+const isUnknownAssertion = (node: AstNode | undefined): node is AstNode =>
+  node?.type === 'TSAsExpression' &&
+  getNodeTypeAnnotation(node)?.type === 'TSUnknownKeyword';
+
+const detectRawNodeFieldCast = (node: AstNode): DetectedSite | null => {
+  if (node.type !== 'TSAsExpression') {
+    return null;
+  }
+  const expression = getNodeExpression(node);
+  if (!isUnknownAssertion(expression)) {
+    return null;
+  }
+  const entries = knownAccessorEntries(getNodeTypeAnnotation(node));
+  if (entries.length === 0) {
+    return null;
+  }
+  const fields = entries.map(([field, accessor]) => `${field} -> ${accessor}`);
+  return {
+    identifier: expression,
+    message: `${RULE_NAME}: raw AST node-field cast should use typed helpers from ./ast.js (${fields.join(', ')}). Raw node-field casts drift from the curated @ontrails/warden/ast guard surface.`,
+    severity: 'warn',
+    start: node.start,
   };
 };
 
@@ -425,6 +530,7 @@ const DETECTORS: readonly ((node: AstNode) => DetectedSite | null)[] = [
   detectRawScan,
   detectRegexScan,
   detectRegexConstruction,
+  detectRawNodeFieldCast,
 ];
 
 const detectSite = (node: AstNode): DetectedSite | null => {
@@ -819,7 +925,7 @@ const recordDiagnostic = (ctx: ScopeWalkContext, site: DetectedSite): void => {
     line: offsetToLine(ctx.sourceCode, site.start),
     message: site.message,
     rule: RULE_NAME,
-    severity: 'error' as const,
+    severity: site.severity,
   });
 };
 
@@ -834,6 +940,10 @@ const maybeRecordDetection = (
 ): void => {
   const site = detectSite(node);
   if (!site) {
+    return;
+  }
+  if (site.severity === 'warn') {
+    recordDiagnostic(ctx, site);
     return;
   }
   const name = getIdentifierName(site.identifier);
@@ -984,7 +1094,7 @@ const analyze = (
 
 /**
  * Warden rule enforcing that warden rules themselves walk the AST rather than
- * regex-scan raw source text.
+ * regex-scan raw source text or hand-cast recurring AST node fields.
  */
 export const wardenRulesUseAst: WardenRule = {
   check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
@@ -998,7 +1108,7 @@ export const wardenRulesUseAst: WardenRule = {
     return analyze(sourceCode, filePath, ast);
   },
   description:
-    'Enforces that warden rules inspect the AST via packages/warden/src/rules/ast.ts helpers rather than regex-scanning raw source text.',
+    'Enforces that warden rules inspect the AST via packages/warden/src/rules/ast.ts helpers rather than regex-scanning raw source text or hand-casting node fields.',
   name: RULE_NAME,
   severity: 'error',
 };

--- a/packages/warden/src/trails/warden-rules-use-ast.trail.ts
+++ b/packages/warden/src/trails/warden-rules-use-ast.trail.ts
@@ -40,6 +40,25 @@ export const wardenRulesUseAstTrail = wrapRule({
       },
       name: 'Flags sourceCode.split(...) in a rule file',
     },
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: fakeRulePath,
+            line: 1,
+            message:
+              'warden-rules-use-ast: raw AST node-field cast should use typed helpers from ./ast.js (callee -> getNodeCallee). Raw node-field casts drift from the curated @ontrails/warden/ast guard surface.',
+            rule: 'warden-rules-use-ast',
+            severity: 'warn',
+          },
+        ],
+      },
+      input: {
+        filePath: fakeRulePath,
+        sourceCode: `export const r = { check() { const callee = (node as unknown as { callee?: AstNode }).callee; return callee ? [] : []; } };\n`,
+      },
+      name: 'Warns on hand-cast AST node fields',
+    },
   ],
   rule: wardenRulesUseAst,
 });

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -51,7 +51,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `unreachable-detour-shadowing` (error, source/source-static, external): Specific detours are not shadowed by earlier broader detours.
 - `valid-describe-refs` (warn, all/project-static, advisory): Describe references point at known Trails concepts.
 - `warden-export-symmetry` (error, source/source-static, repo-local): The Warden package exports trail wrappers, not raw rules.
-- `warden-rules-use-ast` (error, source/source-static, repo-local): Warden source rules use AST helpers instead of ad hoc parsing.
+- `warden-rules-use-ast` (error, source/source-static, repo-local): Warden source rules use AST helpers instead of ad hoc parsing or raw node-field casts.
 
 ### Lifecycle
 


### PR DESCRIPTION
## Context

TRL-1027 prevents the TRL-1026 cast backlog from returning. The gate stays warn-level for now, with error promotion left as the follow-up once it has soaked.

## Changes

- Extend `warden-rules-use-ast` to detect raw `as unknown as { field?: ... }` AST node-field casts when a typed accessor exists.
- Keep existing Warden AST/source rule violations at error severity while reporting this new regression family at warn severity.
- Add tests for direct access, destructuring, discriminant coverage, detection outside check methods, and negative cases for unrecognized/computed fields.
- Add a Warden trail example for the new warning.
- Regenerate Warden guidance in `AGENTS.md` and skill/plugin guide mirrors.

## Verification

Local verification passed:

- `bun run typecheck`
- `bun run test`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run build`
- `bun run check` with Warden PASS, 0 errors, known unrelated warnings
- `bun run changeset:check`
- `bun run wayfinder:dogfood` with 50 trails inspected
- `bun run publish:check`
- `bun run warden:agents:sync`
- `bun run warden:agents:check`
- `bun run warden:skills:sync`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`

The real submit pre-push hook also passed Warden, ADR checks, test, typecheck, lint, ast-grep, format, and dead-code.

## Review

Local Claude Code review found no P0/P1/P2 issues. Relevant P3s were fixed before submit: added `discriminant` mapping, made the trail example use actual newline source text, and added an outside-check-method regression test.

## Follow-Up

Promote the raw node-field cast diagnostic from warn to error after the gate has soaked and any future false positives are resolved.

## Risks

Low to moderate. This is governance only, but it intentionally watches rule implementation patterns, so any future false positives should be handled by tightening the field-to-accessor map rather than bypassing the rule.
