### PR TITLE
fix(wayfinder): make outline graph prep actionable

### DIFF
--- a/.changeset/trl-1033-wayfind-outline-graph-prep.md
+++ b/.changeset/trl-1033-wayfind-outline-graph-prep.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/wayfinder": patch
+---
+
+Make `wayfind outline` missing-graph diagnostics name the compile module, root, and `topo:write` permit requirement while preserving source-first output without graph artifacts.

--- a/packages/wayfinder/src/__tests__/queries.test.ts
+++ b/packages/wayfinder/src/__tests__/queries.test.ts
@@ -473,8 +473,20 @@ describe('wayfinder graph-read query trails', () => {
       );
       expect(result.trails).toBeUndefined();
       expect(result.diagnostics).toEqual([
-        expect.objectContaining({ code: 'graph.missing', severity: 'warn' }),
+        expect.objectContaining({
+          code: 'graph.missing',
+          message: expect.stringContaining('--module <app-module>'),
+          severity: 'warn',
+        }),
       ]);
+      expect(result.diagnostics?.[0]?.message).toContain(
+        '--root-dir <workspace-root>'
+      );
+      expect(result.diagnostics?.[0]?.message).toContain('--permit');
+      expect(result.diagnostics?.[0]?.message).toContain(
+        '"scopes":["topo:write"]'
+      );
+      expect(result.diagnostics?.[0]?.message).toContain('topo:write');
     } finally {
       await rm(sourceRoot, { force: true, recursive: true });
     }

--- a/packages/wayfinder/src/outline.ts
+++ b/packages/wayfinder/src/outline.ts
@@ -647,7 +647,7 @@ const loadGraphSoft = async (
           {
             code: 'graph.missing',
             message:
-              'No saved Wayfinder TopoGraph artifact found. Run `trails compile` for graph reconciliation.',
+              'No saved Wayfinder TopoGraph artifact found. Source outline is still available. To add graph reconciliation, run `trails compile --module <app-module> --root-dir <workspace-root> --permit \'{"id":"operator","scopes":["topo:write"]}\'` with a permit authorized for topo:write.',
             severity: 'warn',
           },
         ],


### PR DESCRIPTION
## Context

TRL-1033 makes first-run `wayfind outline` graph-prep diagnostics actionable while preserving source-first behavior. Missing graph artifacts should not block source outlining, but the warning should tell operators how to compile with an explicit module/root and a real `topo:write` permit instead of vague compile advice.

## What Changed

- Kept missing-graph outline output source-first: source declarations/imports still render when graph artifacts are absent.
- Replaced the generic `Run trails compile` warning with a concrete compile command shape using `--module <app-module>`, `--root-dir <workspace-root>`, and `--permit '{"id":"operator","scopes":["topo:write"]}'`.
- Added test assertions for the actionable permit flag and scoped permit JSON, without introducing the dev-permit shortcut into source.
- Added a patch changeset for `@ontrails/wayfinder`.

## Verification

- `bun test packages/wayfinder/src/__tests__/queries.test.ts apps/trails/src/__tests__/wayfind-cli.test.ts apps/trails/src/__tests__/topo-dev.test.ts packages/core/src/__tests__/trails-db.test.ts adapters/commander/src/__tests__/to-commander.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run build`
- `bun run check`
- `bun run changeset:check`
- `bun run wayfinder:dogfood`
- `bun run publish:check`
- `git diff --check`
- Concurrent smoke: 12 `trails compile --json` plus 40 `wayfind outline --review` invocations completed with 0 failures and no `database is locked`, `graph.load`, or generic `Internal server error` signal.
- Graphite pre-push `stable_checks` passed during submit.

## Local Review

In-thread subagent review found no P0/P1/P2 issues. It found one scoped P3: the test did not lock the `--permit` flag. Fixed by asserting `--permit` and the `"scopes":["topo:write"]` substring.

## Risks / Notes

- This intentionally points at a real `--permit` flow and does not suggest or bypass permit safety.
- Users still need to choose the correct app module; the diagnostic stays placeholder-based because Wayfinder cannot reliably infer that in the missing-artifact path.
