### PR TITLE
feat(trails): enrich wayfind outline review text

### DIFF
--- a/.changeset/trl-1030-wayfind-outline-review-text.md
+++ b/.changeset/trl-1030-wayfind-outline-review-text.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Enrich compact `wayfind outline --review` text with existing trail intent, schema, and example-count facts when saved graph artifacts are available.

--- a/apps/trails/src/__tests__/wayfind-cli.test.ts
+++ b/apps/trails/src/__tests__/wayfind-cli.test.ts
@@ -112,8 +112,15 @@ describe('Trails Wayfinder CLI surface', () => {
         },
       ],
       features: {
-        included: ['source', 'trails', 'apps', 'graph', 'diagnostics'],
-        omitted: ['contracts', 'surfaces'],
+        included: [
+          'source',
+          'trails',
+          'apps',
+          'graph',
+          'contracts',
+          'diagnostics',
+        ],
+        omitted: ['surfaces'],
         view: 'review',
       },
       file: 'src/app.ts',
@@ -131,12 +138,21 @@ describe('Trails Wayfinder CLI surface', () => {
         imports: [],
         lineCount: 20,
       },
-      trails: [{ id: 'user.create', line: 10 }],
+      trails: [
+        {
+          contracts: { input: true, output: true },
+          graph: { exampleCount: 1, intent: 'write', surfaces: ['cli'] },
+          id: 'user.create',
+          line: 10,
+        },
+      ],
     });
 
     expect(text).toContain('src/app.ts');
     expect(text).toContain('  graph matches: 1');
-    expect(text).toContain('  10: trail user.create');
+    expect(text).toContain(
+      '  10: trail user.create (write, input+output, 1 example)'
+    );
     expect(text).toContain('  20: app app (topo)');
     expect(text).toContain('  warn: graph.missing: No saved graph.');
   });

--- a/apps/trails/src/run-wayfind-outline.ts
+++ b/apps/trails/src/run-wayfind-outline.ts
@@ -55,6 +55,41 @@ const appendSourceDeclarations = (
   }
 };
 
+type TrailOutline = NonNullable<OutlineOutput['trails']>[number];
+
+const contractFactLabel = (
+  contracts: TrailOutline['contracts']
+): string | undefined => {
+  if (contracts === undefined) {
+    return undefined;
+  }
+  if (contracts.input && contracts.output) {
+    return 'input+output';
+  }
+  if (contracts.input) {
+    return 'input';
+  }
+  if (contracts.output) {
+    return 'output';
+  }
+  return 'no schemas';
+};
+
+const exampleCountLabel = (count: number): string =>
+  `${count.toString()} ${count === 1 ? 'example' : 'examples'}`;
+
+const trailFactSuffix = (trail: TrailOutline): string => {
+  const facts = [
+    trail.graph?.intent,
+    contractFactLabel(trail.contracts),
+    trail.graph === undefined
+      ? undefined
+      : exampleCountLabel(trail.graph.exampleCount),
+  ].filter((fact): fact is string => fact !== undefined);
+
+  return facts.length === 0 ? '' : ` (${facts.join(', ')})`;
+};
+
 const appendTrails = (lines: string[], outline: OutlineOutput): void => {
   if (!includesFeature(outline, 'trails')) {
     return;
@@ -65,7 +100,9 @@ const appendTrails = (lines: string[], outline: OutlineOutput): void => {
   }
   lines.push('');
   for (const trail of trails) {
-    lines.push(formatLine(trail.line, 'trail', trail.id));
+    lines.push(
+      formatLine(trail.line, 'trail', trail.id, trailFactSuffix(trail))
+    );
   }
 };
 


### PR DESCRIPTION
## Context

TRL-1030 improves compact `wayfind outline --review` output by surfacing high-signal graph facts that were already present in the structured JSON result. JSON output remains stable; this only enriches text-mode formatting.

## What Changed

- Enriched trail lines in compact review text with intent, input/output contract presence, and example count when those facts are available.
- Candidate output now reads like `35: trail compile (write, input+output, 1 example)`.
- Kept absent graph/contract facts quiet so the text formatter does not invent unavailable information.
- Added test coverage for the enriched text output and aligned the fixture metadata with included contract facts.
- Added a patch changeset for `@ontrails/trails`.

## Verification

- `bun test packages/wayfinder/src/__tests__/queries.test.ts apps/trails/src/__tests__/wayfind-cli.test.ts apps/trails/src/__tests__/topo-dev.test.ts packages/core/src/__tests__/trails-db.test.ts adapters/commander/src/__tests__/to-commander.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run build`
- `bun run check`
- `bun run changeset:check`
- `bun run wayfinder:dogfood`
- `bun run publish:check`
- `git diff --check`
- Concurrent smoke: 12 `trails compile --json` plus 40 `wayfind outline --review` invocations completed with 0 failures and no `database is locked`, `graph.load`, or generic `Internal server error` signal.
- Graphite pre-push `stable_checks` passed during submit.

## Local Review

In-thread subagent review found no P0/P1/P2 issues. It found one scoped P3: the formatter fixture omitted `contracts` while asserting contract text. Fixed by adding `contracts` to the fixture `included` features and removing it from `omitted`.

## Risks / Notes

- The change is intentionally text-format-only; the JSON result shape is unchanged.
- When graph or contract facts are absent, the formatter leaves the suffix out instead of printing partial guesses.
