### PR TITLE
fix(core): wait through trails db lock contention

### DIFF
--- a/.changeset/trl-1031-trails-db-busy-timeout.md
+++ b/.changeset/trl-1031-trails-db-busy-timeout.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/core": patch
+---
+
+Configure Trails SQLite read and write connections with a busy timeout so concurrent artifact readers and writers wait through transient lock contention instead of failing immediately.

--- a/packages/core/src/__tests__/trails-db.test.ts
+++ b/packages/core/src/__tests__/trails-db.test.ts
@@ -60,9 +60,13 @@ describe('trails db foundation', () => {
       const synchronous = db
         .query<{ synchronous: number }, []>('PRAGMA synchronous')
         .get();
+      const busyTimeout = db
+        .query<{ timeout: number }, []>('PRAGMA busy_timeout')
+        .get();
 
       expect(journal?.journal_mode.toLowerCase()).toBe('wal');
       expect(synchronous?.synchronous).toBe(1);
+      expect(busyTimeout?.timeout).toBe(5000);
     } finally {
       db.close();
     }
@@ -76,6 +80,10 @@ describe('trails db foundation', () => {
     const reader = openReadTrailsDb({ rootDir });
 
     try {
+      const busyTimeout = reader
+        .query<{ timeout: number }, []>('PRAGMA busy_timeout')
+        .get();
+      expect(busyTimeout?.timeout).toBe(5000);
       expect(() => reader.run('CREATE TABLE readonly_probe (id TEXT)')).toThrow(
         /readonly|read-only/i
       );

--- a/packages/core/src/trails-db.ts
+++ b/packages/core/src/trails-db.ts
@@ -9,6 +9,7 @@ const TRAILS_DB_FILE = 'trails.db';
 const TRAILS_CACHE_DIR = 'cache';
 const TRAILS_STATE_DIR = 'state';
 const SCHEMA_VERSION_TABLE = 'meta_schema_versions';
+const SQLITE_BUSY_TIMEOUT_MS = 5000;
 const WORKSPACE_SUBDIRS = [TRAILS_CACHE_DIR, TRAILS_STATE_DIR] as const;
 
 /**
@@ -119,8 +120,14 @@ export const ensureTrailsWorkspace = (rootDir: string): void => {
 };
 
 const initializeWritePragmas = (db: Database): void => {
+  db.run(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS.toString()}`);
   db.run('PRAGMA journal_mode = WAL');
   db.run('PRAGMA synchronous = NORMAL');
+  db.run('PRAGMA foreign_keys = ON');
+};
+
+const initializeReadPragmas = (db: Database): void => {
+  db.run(`PRAGMA busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS.toString()}`);
   db.run('PRAGMA foreign_keys = ON');
 };
 
@@ -186,7 +193,7 @@ export const openReadTrailsDb = (
     );
   }
   const db = new Database(dbPath, { readonly: true });
-  db.run('PRAGMA foreign_keys = ON');
+  initializeReadPragmas(db);
   return db;
 };
 


### PR DESCRIPTION
## Context

TRL-1031 investigates `warn: graph.load: database is locked` reports under concurrent outline/artifact reads. The observed reproducible failure was transient SQLite contention during concurrent compile/write pressure, not plain concurrent outline reads.

## What Changed

- Configured Trails SQLite read and write connections with a 5s `PRAGMA busy_timeout`.
- Preserved read-only connection mode for artifact readers.
- Left schema creation and migrations fail-loud; this does not catch or hide corruption/migration errors.
- Added deterministic tests for busy timeout on both read and write connections, plus read-only write rejection.
- Added a patch changeset for `@ontrails/core`.

## Repro Notes

- 40 concurrent outline reads after compile: no `database is locked`, no `graph.load` warning.
- 12 concurrent compiles plus 40 outlines before the fix reproduced generic compile failures under write contention.
- After the busy-timeout change, the same concurrency smoke completed with 0 failures.

## Verification

- `bun test packages/wayfinder/src/__tests__/queries.test.ts apps/trails/src/__tests__/wayfind-cli.test.ts apps/trails/src/__tests__/topo-dev.test.ts packages/core/src/__tests__/trails-db.test.ts adapters/commander/src/__tests__/to-commander.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run build`
- `bun run check`
- `bun run changeset:check`
- `bun run wayfinder:dogfood`
- `bun run publish:check`
- `git diff --check`
- Concurrent smoke: 12 `trails compile --json` plus 40 `wayfind outline --review` invocations completed with 0 failures and no `database is locked`, `graph.load`, or generic `Internal server error` signal.
- Graphite pre-push `stable_checks` passed during submit.

## Local Review

In-thread subagent review found no findings. The reviewer also ran `bun test packages/core/src/__tests__/trails-db.test.ts` and a scratch lock-contention probe where a second write connection waited through transient contention and inserted successfully.

## Risks / Notes

- This addresses transient lock contention by waiting briefly; it intentionally does not retry or mask non-lock failures.
- Plain concurrent outline reads did not reproduce the warning locally, so the fix is scoped to the observed write-contention path.
