### PR TITLE
fix(trails): project compile lock failures clearly

### DIFF
--- a/.changeset/trl-1032-compile-error-projection.md
+++ b/.changeset/trl-1032-compile-error-projection.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/commander": patch
+"@ontrails/trails": patch
+"@ontrails/wayfinder": patch
+---
+
+Emit structured CLI error envelopes for JSON/JSONL command failures and map compile-time Trails DB lock contention to a retryable timeout instead of a generic internal error.

--- a/adapters/commander/src/__tests__/to-commander.test.ts
+++ b/adapters/commander/src/__tests__/to-commander.test.ts
@@ -5,12 +5,13 @@ import {
   NotFoundError,
   PermitError,
   Result,
+  TimeoutError,
   trail,
   topo,
   ValidationError,
 } from '@ontrails/core';
 import type { AnyTrail, CliCommand } from '@ontrails/cli';
-import { deriveCliCommands } from '@ontrails/cli';
+import { deriveCliCommands, outputModePreset } from '@ontrails/cli';
 import { z } from 'zod';
 
 import { toCommander } from '../to-commander.js';
@@ -1282,6 +1283,205 @@ describe('toCommander option wiring', () => {
         'Error: Internal server error\n'
       );
     });
+  });
+
+  test('error handling emits structured stderr under --json', async () => {
+    await withMockedProcess(async () => {
+      const failTrail = trail('fail', {
+        blaze: () => Result.ok('ok'),
+        input: z.object({}),
+      });
+      const program = toCommander([
+        {
+          args: [],
+          execute: () => {
+            throw new TimeoutError(
+              'Timed out waiting for the topo store lock',
+              {
+                context: {
+                  operation: 'write',
+                  reason: 'sqlite-lock-contention',
+                  resource: 'topo-store',
+                },
+              }
+            );
+          },
+          flags: [
+            {
+              name: 'json',
+              required: false,
+              type: 'boolean' as const,
+              variadic: false,
+            },
+          ],
+          intent: 'write' as const,
+          path: ['fail'] as const,
+          trail: failTrail,
+        },
+      ]);
+
+      await expect(
+        program.parseAsync(['node', 'test', 'fail', '--json'], {
+          from: 'node',
+        })
+      ).rejects.toThrow('EXIT 5');
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringContaining('"category": "timeout"')
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringContaining('"code": 5')
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringContaining('"ok": false')
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringContaining('"reason": "sqlite-lock-contention"')
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringContaining('"resource": "topo-store"')
+      );
+    });
+  });
+
+  test('error handling treats value alias output modes as explicit', async () => {
+    await withMockedProcess(async () => {
+      const failTrail = trail('fail', {
+        blaze: () => Result.ok('ok'),
+        input: z.object({}),
+      });
+      const program = toCommander([
+        {
+          args: [],
+          execute: () => {
+            throw new TimeoutError('Timed out waiting for output');
+          },
+          flags: [
+            {
+              choices: ['text', 'json'],
+              default: 'text',
+              name: 'output',
+              required: false,
+              type: 'string' as const,
+              valueAliases: [{ name: 'json', value: 'json' }],
+              variadic: false,
+            },
+          ],
+          intent: 'write' as const,
+          path: ['fail'] as const,
+          trail: failTrail,
+        },
+      ]);
+
+      await expect(
+        program.parseAsync(['node', 'test', 'fail', '--json'], {
+          from: 'node',
+        })
+      ).rejects.toThrow('EXIT 5');
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringContaining('"category": "timeout"')
+      );
+      expect(process.stderr.write).toHaveBeenCalledWith(
+        expect.stringContaining('"ok": false')
+      );
+    });
+  });
+
+  test('error handling honors topo-derived JSON env mode', async () => {
+    const previous = process.env['TEST_APP_JSON'];
+    process.env['TEST_APP_JSON'] = '1';
+
+    try {
+      await withMockedProcess(async () => {
+        const failTrail = trail('fail', {
+          blaze: () => Result.ok('ok'),
+          input: z.object({}),
+        });
+        const program = toCommander(
+          [
+            {
+              args: [],
+              execute: () => {
+                throw new TimeoutError(
+                  'Timed out waiting for the topo store lock'
+                );
+              },
+              flags: outputModePreset(),
+              intent: 'write' as const,
+              path: ['fail'] as const,
+              trail: failTrail,
+            },
+          ],
+          { name: 'demo', topoName: 'test-app' }
+        );
+
+        await expect(
+          program.parseAsync(['node', 'test', 'fail'], {
+            from: 'node',
+          })
+        ).rejects.toThrow('EXIT 5');
+        expect(process.stderr.write).toHaveBeenCalledWith(
+          expect.stringContaining('"category": "timeout"')
+        );
+        expect(process.stderr.write).toHaveBeenCalledWith(
+          expect.stringContaining('"ok": false')
+        );
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env['TEST_APP_JSON'];
+      } else {
+        process.env['TEST_APP_JSON'] = previous;
+      }
+    }
+  });
+
+  test('error handling lets explicit text output override topo env mode', async () => {
+    const previous = process.env['TEST_APP_JSON'];
+    process.env['TEST_APP_JSON'] = '1';
+
+    try {
+      await withMockedProcess(async () => {
+        const failTrail = trail('fail', {
+          blaze: () => Result.ok('ok'),
+          input: z.object({}),
+        });
+        const program = toCommander(
+          [
+            {
+              args: [],
+              execute: () => {
+                throw new TimeoutError(
+                  'Timed out waiting for the topo store lock'
+                );
+              },
+              flags: outputModePreset(),
+              intent: 'write' as const,
+              path: ['fail'] as const,
+              trail: failTrail,
+            },
+          ],
+          { name: 'test-app' }
+        );
+
+        await expect(
+          program.parseAsync(['node', 'test', 'fail', '--output', 'text'], {
+            from: 'node',
+          })
+        ).rejects.toThrow('EXIT 5');
+        expect(process.stderr.write).toHaveBeenCalledWith(
+          'Error: Timed out waiting for the topo store lock\n'
+        );
+        expect(process.stderr.write).not.toHaveBeenCalledWith(
+          expect.stringContaining('"category": "timeout"')
+        );
+      });
+    } finally {
+      if (previous === undefined) {
+        delete process.env['TEST_APP_JSON'];
+      } else {
+        process.env['TEST_APP_JSON'] = previous;
+      }
+    }
   });
 
   test('error handling lists validation issues from error context', async () => {

--- a/adapters/commander/src/surface.ts
+++ b/adapters/commander/src/surface.ts
@@ -62,6 +62,7 @@ const deriveCommanderOptions = (
 ): ToCommanderOptions => {
   const commanderOpts: ToCommanderOptions = {
     name: options.name ?? graph.name,
+    topoName: graph.name,
   };
   if (options.version !== undefined || graph.version !== undefined) {
     commanderOpts.version = options.version ?? graph.version;

--- a/adapters/commander/src/to-commander.ts
+++ b/adapters/commander/src/to-commander.ts
@@ -5,10 +5,16 @@
 import {
   isTrailsError,
   projectPublicSurfaceError,
+  redactErrorContext,
   redactErrorString,
 } from '@ontrails/core';
+import type { SurfaceErrorProjection } from '@ontrails/core';
 import type { CliCommand, CliFlag } from '@ontrails/cli';
-import { applyCliFlagValueAliases, validateCliCommands } from '@ontrails/cli';
+import {
+  applyCliFlagValueAliases,
+  deriveOutputMode,
+  validateCliCommands,
+} from '@ontrails/cli';
 import { Command, InvalidArgumentError, Option } from 'commander';
 
 // ---------------------------------------------------------------------------
@@ -21,6 +27,7 @@ import { Command, InvalidArgumentError, Option } from 'commander';
 export interface ToCommanderOptions {
   description?: string | undefined;
   name?: string | undefined;
+  topoName?: string | undefined;
   version?: string | undefined;
 }
 
@@ -165,19 +172,33 @@ const getActionTarget = (fallbackTarget: Command, actionArgs: unknown[]) => {
 const getParsedFlags = (command: Command): Record<string, unknown> =>
   command.optsWithGlobals() as Record<string, unknown>;
 
+const toOptionKey = (name: string): string =>
+  name.replaceAll(/-([a-zA-Z0-9])/g, (_, ch: string) => ch.toUpperCase());
+
 const getFlagOptionKeys = (flags: readonly CliCommand['flags'][number][]) =>
   new Set(
     flags.flatMap((flag) => [
-      flag.name.replaceAll(/-([a-zA-Z0-9])/g, (_, ch: string) =>
-        ch.toUpperCase()
-      ),
-      ...(flag.valueAliases ?? []).map((alias) =>
-        alias.name.replaceAll(/-([a-zA-Z0-9])/g, (_, ch: string) =>
-          ch.toUpperCase()
-        )
-      ),
+      toOptionKey(flag.name),
+      ...(flag.valueAliases ?? []).map((alias) => toOptionKey(alias.name)),
     ])
   );
+
+const getCanonicalUserSuppliedFlagKeys = (
+  flags: readonly CliCommand['flags'][number][],
+  userSuppliedFlagKeys: ReadonlySet<string>
+): ReadonlySet<string> => {
+  const canonicalKeys = new Set(userSuppliedFlagKeys);
+  for (const flag of flags) {
+    const flagKey = toOptionKey(flag.name);
+    const aliasSelected = (flag.valueAliases ?? []).some((alias) =>
+      userSuppliedFlagKeys.has(toOptionKey(alias.name))
+    );
+    if (aliasSelected) {
+      canonicalKeys.add(flagKey);
+    }
+  }
+  return canonicalKeys;
+};
 
 const getUserSuppliedFlagKeys = (
   command: Command,
@@ -288,13 +309,75 @@ const collectErrorDetailLines = (error: Error): readonly string[] => {
   return [];
 };
 
+const collectErrorContext = (
+  error: Error
+): Record<string, unknown> | undefined => {
+  if (!isTrailsError(error) || error.category === 'internal') {
+    return undefined;
+  }
+  return redactErrorContext(error.context);
+};
+
+interface CliErrorEnvelope {
+  readonly ok: false;
+  readonly context?: Record<string, unknown> | undefined;
+  readonly error: SurfaceErrorProjection;
+  readonly details?: readonly string[] | undefined;
+}
+
+type StructuredErrorMode = 'json' | 'jsonl';
+
+const structuredErrorMode = (
+  flags: Readonly<Record<string, unknown>>,
+  topoName: string,
+  userSuppliedFlagKeys: ReadonlySet<string>
+): StructuredErrorMode | undefined => {
+  const modeFlags = { ...flags };
+  if (!userSuppliedFlagKeys.has('output')) {
+    delete modeFlags['output'];
+  }
+  const { mode } = deriveOutputMode(modeFlags, topoName);
+  return mode === 'text' ? undefined : mode;
+};
+
+const writeStructuredError = (
+  envelope: CliErrorEnvelope,
+  mode: StructuredErrorMode
+): void => {
+  process.stderr.write(
+    mode === 'json'
+      ? `${JSON.stringify(envelope, null, 2)}\n`
+      : `${JSON.stringify(envelope)}\n`
+  );
+};
+
 /** Handle execution errors with appropriate exit codes. */
-const handleError = (error: unknown): void => {
+const handleError = (
+  error: unknown,
+  flags: Readonly<Record<string, unknown>>,
+  topoName: string,
+  userSuppliedFlagKeys: ReadonlySet<string>
+): void => {
   const err = error instanceof Error ? error : new Error(String(error));
   const projection = projectPublicSurfaceError('cli', err);
-  process.stderr.write(`Error: ${projection.message}\n`);
-  for (const line of collectErrorDetailLines(err)) {
-    process.stderr.write(`  ${line}\n`);
+  const context = collectErrorContext(err);
+  const details = collectErrorDetailLines(err);
+  const mode = structuredErrorMode(flags, topoName, userSuppliedFlagKeys);
+  if (mode === undefined) {
+    process.stderr.write(`Error: ${projection.message}\n`);
+    for (const line of details) {
+      process.stderr.write(`  ${line}\n`);
+    }
+  } else {
+    writeStructuredError(
+      {
+        ...(context === undefined ? {} : { context }),
+        error: projection,
+        ...(details.length === 0 ? {} : { details }),
+        ok: false,
+      },
+      mode
+    );
   }
   process.exit(projection.code);
 };
@@ -346,6 +429,7 @@ const maybeUseBareChildFallback = (
 const wireAction = (
   target: Command,
   cmd: CliCommand,
+  topoName: string,
   fallback?: BareChildFallback | undefined
 ): void => {
   target.action(async (...actionArgs: unknown[]) => {
@@ -362,17 +446,24 @@ const wireAction = (
             parentTarget: actionTarget.parent ?? fallback.parentTarget,
           }
     );
+    let { parsedFlags } = action;
     try {
-      await action.command.execute(
-        action.parsedArgs,
-        applyCliFlagValueAliases(
+      parsedFlags = applyCliFlagValueAliases(
+        action.command.flags,
+        action.parsedFlags,
+        action.userSuppliedFlagKeys
+      );
+      await action.command.execute(action.parsedArgs, parsedFlags);
+    } catch (error: unknown) {
+      handleError(
+        error,
+        parsedFlags,
+        topoName,
+        getCanonicalUserSuppliedFlagKeys(
           action.command.flags,
-          action.parsedFlags,
           action.userSuppliedFlagKeys
         )
       );
-    } catch (error: unknown) {
-      handleError(error);
     }
   });
 };
@@ -492,6 +583,7 @@ const applyCliCommand = (
   state: CommandNodeState,
   cmd: CliCommand,
   path: readonly string[],
+  topoName: string,
   fallback?: BareChildFallback | undefined
 ): void => {
   if (state.executable) {
@@ -509,7 +601,7 @@ const applyCliCommand = (
   addArgs(state.command, cmd, {
     forceOptionalFirstArg: fallback !== undefined,
   });
-  wireAction(state.command, cmd, fallback);
+  wireAction(state.command, cmd, topoName, fallback);
   state.cliCommand = cmd;
   state.executable = true;
 };
@@ -540,7 +632,10 @@ const commandRouteEntries = (commands: readonly CliCommand[]) =>
  * const commands = deriveCliCommands(graph);
  * if (commands.isErr()) throw commands.error;
  *
- * const program = toCommander(commands.value, { name: 'demo' });
+ * const program = toCommander(commands.value, {
+ *   name: 'demo',
+ *   topoName: 'demo',
+ * });
  * ```
  */
 export const toCommander = (
@@ -550,6 +645,7 @@ export const toCommander = (
   validateCliCommands(commands);
   const program = new Command();
   applyOptions(program, options);
+  const topoName = options?.topoName ?? options?.name ?? program.name();
   const nodes = new Map<string, CommandNodeState>();
 
   for (const { cmd, path } of commandRouteEntries(commands).toSorted((a, b) =>
@@ -560,7 +656,7 @@ export const toCommander = (
     const state = ensureCommandNode(path, program, nodes);
     const parentKey = pathKey(path.slice(0, -1));
     const fallback = createBareChildFallback(cmd, path, nodes.get(parentKey));
-    applyCliCommand(state, cmd, path, fallback);
+    applyCliCommand(state, cmd, path, topoName, fallback);
   }
 
   return program;

--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -11,7 +11,7 @@ import {
 import { join, resolve } from 'node:path';
 
 import type { Result } from '@ontrails/core';
-import { openReadTrailsDb } from '@ontrails/core';
+import { openReadTrailsDb, TimeoutError } from '@ontrails/core';
 import { createDevStore } from '@ontrails/tracing';
 
 import { devCleanTrail } from '../trails/dev-clean.js';
@@ -29,6 +29,7 @@ import { topoPinTrail } from '../trails/topo-pin.js';
 import { topoTrail } from '../trails/topo.js';
 import { topoUnpinTrail } from '../trails/topo-unpin.js';
 import { validateTrail } from '../trails/validate.js';
+import { mapTopoExportError } from '../trails/topo-store-support.js';
 
 const repoTempDir = (): string =>
   join(
@@ -124,6 +125,24 @@ export const app = topo('fixture-app', { ${topoMembers} });
 };
 
 describe('topo and dev trails', () => {
+  test('maps sqlite lock failures to a retryable compile timeout', () => {
+    const sqliteError = Object.assign(new Error('database is locked'), {
+      code: 'SQLITE_BUSY',
+    });
+
+    const mapped = mapTopoExportError(sqliteError);
+
+    expect(mapped).toBeInstanceOf(TimeoutError);
+    expect(mapped.message).toContain('topo store lock');
+    expect((mapped as TimeoutError).category).toBe('timeout');
+    expect((mapped as TimeoutError).retryable).toBe(true);
+    expect((mapped as TimeoutError).context).toMatchObject({
+      operation: 'compile',
+      reason: 'sqlite-lock-contention',
+      resource: 'trails.db',
+    });
+  });
+
   test('topo surfaces current summary, detail, and compile/verify flow', async () => {
     const dir = repoTempDir();
 

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -14,6 +14,7 @@ import {
   InternalError,
   openWriteTrailsDb,
   Result,
+  TimeoutError,
 } from '@ontrails/core';
 import type {
   LockManifest,
@@ -79,6 +80,44 @@ const persistAndReadStoredExport = (
     snapshot,
     storedExport,
   });
+};
+
+const asError = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+const readErrorCode = (error: unknown): string | undefined => {
+  if (typeof error !== 'object' || error === null || !('code' in error)) {
+    return undefined;
+  }
+  const { code } = error as { readonly code?: unknown };
+  return typeof code === 'string' ? code : undefined;
+};
+
+const isSqliteLockError = (error: unknown): boolean => {
+  const code = readErrorCode(error);
+  if (code === 'SQLITE_BUSY' || code === 'SQLITE_LOCKED') {
+    return true;
+  }
+  return asError(error).message.match(/database is (locked|busy)/i) !== null;
+};
+
+export const mapTopoExportError = (error: unknown): Error => {
+  if (!isSqliteLockError(error)) {
+    return error instanceof Error
+      ? error
+      : new InternalError('Unable to write topo artifacts');
+  }
+  return new TimeoutError(
+    'Timed out waiting for the Trails topo store lock while compiling artifacts. Another topo write may be running; retry after it finishes.',
+    {
+      cause: asError(error),
+      context: {
+        operation: 'compile',
+        reason: 'sqlite-lock-contention',
+        resource: 'trails.db',
+      },
+    }
+  );
 };
 
 export const deriveCurrentTopoExport = (
@@ -159,9 +198,10 @@ export const exportCurrentTopo = async (
   }
 ): Promise<Result<TopoExportReport, Error>> => {
   const rootDir = deriveRootDir(options?.rootDir);
-  const db = openWriteTrailsDb({ rootDir });
+  let db: ReturnType<typeof openWriteTrailsDb> | undefined;
 
   try {
+    db = openWriteTrailsDb({ rootDir });
     const persisted = persistAndReadStoredExport(app, db, rootDir, {
       cliAliases: options?.cliAliases,
     });
@@ -178,14 +218,12 @@ export const exportCurrentTopo = async (
         { force: options?.force }
       );
     } catch (error: unknown) {
-      return Result.err(
-        error instanceof Error
-          ? error
-          : new InternalError('Unable to write topo artifacts')
-      );
+      return Result.err(mapTopoExportError(error));
     }
     return Result.ok({ ...artifacts, snapshot });
+  } catch (error: unknown) {
+    return Result.err(mapTopoExportError(error));
   } finally {
-    db.close();
+    db?.close();
   }
 };

--- a/docs/contributing/codebase-navigation.md
+++ b/docs/contributing/codebase-navigation.md
@@ -32,7 +32,9 @@ bun apps/trails/bin/trails.ts schema wf search
 
 Use `trails schema <command...>` when you need the accepted CLI routes, aliases, flags, and schemas for an operator command before invoking it from a shell.
 
-Use `wayfind outline <file>` before reading a large source file when you need a compact source map. It parses the explicit file path, reports imports, exports, declarations, app declarations, and authored trail IDs, and links those trail IDs to saved graph facts when artifacts exist. Use source search, qmd, or symbol tools when Wayfinder reports missing or stale artifacts, when the task needs implementation text that Topographer does not project, or when the current authority does not allow generating fresh artifacts. If you compile to refresh artifacts, treat the generated `.trails` files as evidence and clean them up unless the branch intentionally owns them.
+Use `wayfind outline <file>` before reading a large source file when you need a compact source map. It parses the explicit file path, reports imports, exports, declarations, app declarations, and authored trail IDs, and links those trail IDs to saved graph facts when artifacts exist. In `--review` text mode, matched trails include compact graph facts such as intent, input/output schema presence, and example count when those facts are available.
+
+Missing graph artifacts are warnings, not hard failures. Follow the diagnostic's `trails compile --module <app-module> --root-dir <workspace-root> --permit '{"id":"operator","scopes":["topo:write"]}'` shape when you are allowed to refresh artifacts; do not silently fall back to stale graph assumptions. Use source search, qmd, or symbol tools when Wayfinder reports missing or stale artifacts, when the task needs implementation text that Topographer does not project, or when the current authority does not allow generating fresh artifacts. If you compile to refresh artifacts, treat the generated `.trails` files as evidence and clean them up unless the branch intentionally owns them.
 
 ## Symbol Navigation
 

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -251,6 +251,33 @@ When a trail returns `Result.err()`, the Commander adapter maps the error catego
 
 The error message is written to stderr. Non-`TrailsError` errors default to exit code 8 (internal).
 
+When the caller requested JSON or JSONL output with `--json`, `--jsonl`, `--output`, or the topo-derived environment variables, failures are also projected through the structured channel on stderr. Stdout stays reserved for successful command output, so agents can read stderr on non-zero exits without parsing text-mode messages.
+
+```json
+{
+  "ok": false,
+  "error": {
+    "category": "timeout",
+    "code": 5,
+    "message": "Timed out waiting for the Trails topo store lock while compiling artifacts. Another topo write may be running; retry after it finishes.",
+    "name": "TimeoutError",
+    "retryable": true,
+    "surface": "cli"
+  },
+  "context": {
+    "operation": "compile",
+    "reason": "sqlite-lock-contention",
+    "resource": "trails.db"
+  }
+}
+```
+
+Text mode remains human-first:
+
+```text
+Error: Timed out waiting for the Trails topo store lock while compiling artifacts. Another topo write may be running; retry after it finishes.
+```
+
 ## Custom Result Handling
 
 Override the default result handler for custom formatting, logging, or metrics:

--- a/packages/wayfinder/README.md
+++ b/packages/wayfinder/README.md
@@ -144,6 +144,25 @@ await wayfindOutlineTrail.blaze(
 
 CLI hosts can expose the same trail as `trails wayfind outline <file>`. Use `--review`, `--source`, `--contracts`, `--surfaces`, or `--all` for blessed views, or `--features source,trails,apps,diagnostics` for an exact feature set. JSON output includes structured counts plus the selected feature list and omitted feature list so agents can distinguish "not requested" from "absent." CLI text output is rendered by the CLI surface from the structured result; the Wayfinder contract does not carry presentation prose.
 
+In text mode, the `--review` view keeps the source map compact while showing graph-backed trail facts when they are available:
+
+```text
+apps/trails/src/trails/compile.ts
+  trails: 1
+  apps: 0
+  declarations: 4
+  graph matches: 1
+
+  13: const compileCurrentTopo
+  24: const compileTrailInputSchema
+  33: type CompileTrailInput
+  35: const compileTrail
+
+  35: trail compile (write, input+output, 1 example)
+```
+
+When saved graph artifacts are missing, `outline` still renders source facts and emits an actionable diagnostic with the compile command shape, including the app module, root directory, and required `topo:write` permit scope. That diagnostic is a prompt to refresh graph evidence; it is not required for source-only navigation.
+
 ## Surfaces, Facets, Versions, And Examples
 
 `wayfind.surfaces` includes both directly projected trail surfaces and facet-projected surfaces. `wayfind.facets` returns facet membership, visibility, and descriptions. `wayfind.versions` returns current and historical trail versions sorted by trail ID and numeric version. `wayfind.examples` lists saved examples without executing any trail.


### PR DESCRIPTION
## Context

TRL-1032 replaces generic `Internal server error` output from `trails compile --json` with structured, agent-usable error facts. The concrete repro shared root cause with TRL-1031: transient SQLite lock contention during concurrent compile/write pressure.

## What Changed

- Commander now emits structured error envelopes to stderr when a failing command was invoked with JSON/JSONL output flags or topo-derived JSON/JSONL env vars.
- Error-mode resolution ignores Commander defaulted `--output text` unless an output mode was actually selected, so env-only structured output and value-alias shorthands still work.
- Commander now keeps the CLI display name separate from the topo name so env vars resolve against the authored topo, matching successful output behavior.
- Value-alias-selected output modes, such as `--json` aliasing `--output json`, count as explicit output selection for failing commands too.
- Structured CLI error envelopes include redacted non-internal `TrailsError.context` when available, preserving retryable facts such as SQLite lock contention reason/resource.
- Text-mode error behavior is preserved, and explicit `--output text` still overrides topo env JSON mode.
- Runtime alias-validation errors remain inside the caught boundary and are projected through the same handler.
- `trails compile` maps precise SQLite busy/locked failures to retryable `TimeoutError` context: `operation: compile`, `reason: sqlite-lock-contention`, `resource: trails.db`.
- Non-lock failures pass through unchanged or remain internal, so corruption/migration issues are not hidden as contention.
- Documented actionable `wayfind outline` graph-prep diagnostics, enriched review text, and structured CLI error stderr output.
- Added patch changesets for `@ontrails/commander`, `@ontrails/trails`, and `@ontrails/wayfinder`.

## Verification

- `bun test adapters/commander/src/__tests__/to-commander.test.ts adapters/commander/src/__tests__/surface.test.ts`
- `bun test packages/wayfinder/src/__tests__/queries.test.ts apps/trails/src/__tests__/wayfind-cli.test.ts apps/trails/src/__tests__/topo-dev.test.ts packages/core/src/__tests__/trails-db.test.ts adapters/commander/src/__tests__/to-commander.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run build`
- `bun run check`
- `bun run changeset:check`
- `bun run docs:wrap-check`
- `bun run wayfinder:dogfood`
- `bun run publish:check`
- `git diff --check`
- Concurrent smoke: 12 `trails compile --json` plus 40 `wayfind outline --review` invocations completed with 0 failures and no `database is locked`, `graph.load`, or generic `Internal server error` signal.
- Manual structured-error smoke: `trails compile --json` without a permit now exits non-zero with `{ ok:false, error:{ category, code, message, name, retryable, surface }, context?, details? }` on stderr.
- Graphite pre-push `stable_checks` passed during submit.

## Local Review

In-thread subagent review found no findings. The reviewer specifically checked structured stderr routing, preserved text mode behavior, alias-validation catching, scoped SQLite lock mapping, non-lock pass-through, and retryable compile-lock context.

## Risks / Notes

- JSON failure envelopes are written to stderr so stdout stays reserved for successful JSON output.
- This branch improves error projection; the underlying transient contention mitigation lives in the downstack TRL-1031 branch.