### PR TITLE
fix(wayfinder): keep artifact drift scoped to compiled topo

### DIFF
--- a/.changeset/trl-1053-wayfinder-artifact-provenance.md
+++ b/.changeset/trl-1053-wayfinder-artifact-provenance.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/trails": patch
+"@ontrails/wayfinder": patch
+---
+
+Keep Wayfinder artifact drift aligned with rejected and force-annotated topo compiles.

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -14,6 +14,7 @@ import {
   Result,
   SURFACE_LAYER_NAMES_KEY,
   contour,
+  openReadTrailsDb,
   resource,
   schedule,
   signal,
@@ -32,6 +33,7 @@ import {
   writeTopoGraph,
 } from '@ontrails/topographer';
 import type { TopoGraph } from '@ontrails/topographer';
+import { loadWayfinderArtifacts } from '@ontrails/wayfinder';
 import { z } from 'zod';
 
 import {
@@ -153,6 +155,21 @@ const expectOk = <T>(result: Result<T, Error>): T => {
     throw result.error;
   }
   return result.value;
+};
+
+const countTopoSnapshots = (rootDir: string): number => {
+  const db = openReadTrailsDb({ rootDir });
+  try {
+    return (
+      db
+        .query<{ count: number }, []>(
+          'SELECT COUNT(*) as count FROM topo_snapshots'
+        )
+        .get()?.count ?? 0
+    );
+  } finally {
+    db.close();
+  }
 };
 
 const writeSurveyAppFixture = (
@@ -1516,6 +1533,8 @@ describe('trails compile', () => {
         } as never)
       );
       expect(validated.stale).toBe(false);
+      const forcedArtifacts = await loadWayfinderArtifacts({ rootDir: dir });
+      expect(forcedArtifacts.artifactStatus).toEqual({ status: 'fresh' });
       expect(validated.currentHash).toBe(
         deriveTopoGraphHash(stripTopoGraphForces(graph))
       );
@@ -1539,6 +1558,34 @@ describe('trails compile', () => {
         source: 'trails compile --force',
       });
       expect(recompiled.hash).toBe(forced.hash);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('blocked breaking compile keeps saved Wayfinder artifacts fresh', async () => {
+    const dir = repoTempDir();
+
+    try {
+      writeSurveyAppFixture(dir);
+      expectOk(
+        await compileTrail.blaze({ module: './src/app.ts' }, {
+          cwd: dir,
+        } as never)
+      );
+      const snapshotCountAfterExport = countTopoSnapshots(dir);
+
+      writeSurveyAppFixture(dir, { helloNameRequired: true });
+      const blocked = await compileTrail.blaze({ module: './src/app.ts' }, {
+        cwd: dir,
+      } as never);
+      expect(blocked.isErr()).toBe(true);
+      expect(blocked.error).toBeInstanceOf(ConflictError);
+      expect(blocked.error?.message).toContain('breaking change');
+      expect(countTopoSnapshots(dir)).toBe(snapshotCountAfterExport);
+
+      const loaded = await loadWayfinderArtifacts({ rootDir: dir });
+      expect(loaded.artifactStatus).toEqual({ status: 'fresh' });
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -142,11 +142,15 @@ export const deriveCurrentTopoExport = (
   }
 };
 
-const writeStoredExportArtifacts = async (
+const prepareStoredExportArtifacts = async (
   storedExport: StoredTopoExport,
   trailsDir: string,
   options?: { readonly force?: boolean | undefined }
-): Promise<Pick<TopoExportReport, 'hash' | 'lockPath' | 'topoPath'>> => {
+): Promise<{
+  readonly hash: string;
+  readonly lockManifest: LockManifest;
+  readonly topoGraph: TopoGraph;
+}> => {
   const previousTopo = await readTopoGraph({ dir: trailsDir });
   const nextTopo = JSON.parse(storedExport.topoGraphJson) as TopoGraph;
   const diff =
@@ -179,11 +183,31 @@ const writeStoredExportArtifacts = async (
     ],
   } satisfies LockManifest;
 
-  const topoPath = await writeTopoGraph(topoGraph, { dir: trailsDir });
-  const lockPath = await writeLockManifest(lockManifest, { dir: trailsDir });
-
   return {
     hash,
+    lockManifest,
+    topoGraph,
+  };
+};
+
+const writeStoredExportArtifacts = async (
+  storedExport: StoredTopoExport,
+  trailsDir: string,
+  options?: { readonly force?: boolean | undefined }
+): Promise<Pick<TopoExportReport, 'hash' | 'lockPath' | 'topoPath'>> => {
+  const prepared = await prepareStoredExportArtifacts(
+    storedExport,
+    trailsDir,
+    options
+  );
+
+  const topoPath = await writeTopoGraph(prepared.topoGraph, { dir: trailsDir });
+  const lockPath = await writeLockManifest(prepared.lockManifest, {
+    dir: trailsDir,
+  });
+
+  return {
+    hash: prepared.hash,
     lockPath,
     topoPath,
   };
@@ -198,9 +222,26 @@ export const exportCurrentTopo = async (
   }
 ): Promise<Result<TopoExportReport, Error>> => {
   const rootDir = deriveRootDir(options?.rootDir);
+  const trailsDir = deriveTrailsDir({ rootDir });
   let db: ReturnType<typeof openWriteTrailsDb> | undefined;
 
   try {
+    const candidate = deriveCurrentTopoExport(app, {
+      cliAliases: options?.cliAliases,
+      rootDir,
+    });
+    if (candidate.isErr()) {
+      return candidate;
+    }
+
+    try {
+      await prepareStoredExportArtifacts(candidate.value, trailsDir, {
+        force: options?.force,
+      });
+    } catch (error: unknown) {
+      return Result.err(mapTopoExportError(error));
+    }
+
     db = openWriteTrailsDb({ rootDir });
     const persisted = persistAndReadStoredExport(app, db, rootDir, {
       cliAliases: options?.cliAliases,
@@ -212,11 +253,9 @@ export const exportCurrentTopo = async (
     const { snapshot, storedExport } = persisted.value;
     let artifacts: Pick<TopoExportReport, 'hash' | 'lockPath' | 'topoPath'>;
     try {
-      artifacts = await writeStoredExportArtifacts(
-        storedExport,
-        deriveTrailsDir({ rootDir }),
-        { force: options?.force }
-      );
+      artifacts = await writeStoredExportArtifacts(storedExport, trailsDir, {
+        force: options?.force,
+      });
     } catch (error: unknown) {
       return Result.err(mapTopoExportError(error));
     }

--- a/packages/wayfinder/src/loader.ts
+++ b/packages/wayfinder/src/loader.ts
@@ -15,6 +15,7 @@ import {
   isTopoArtifactRegenerationError,
   readLockManifest,
   readTopoGraph,
+  stripTopoGraphForces,
 } from '@ontrails/topographer';
 import type {
   LockManifest,
@@ -262,6 +263,7 @@ const staleReasons = (
 ): readonly WayfinderStaleReason[] => {
   const reasons: WayfinderStaleReason[] = [];
   const actualHash = deriveTopoGraphHash(topoGraph);
+  const contractHash = deriveTopoGraphHash(stripTopoGraphForces(topoGraph));
   const topoArtifact = lockManifest.artifacts.find(
     (artifact) => artifact.role === 'topo' && artifact.path === 'topo.lock'
   );
@@ -279,10 +281,10 @@ const staleReasons = (
   const storeExport = topoStore.export;
   if (storeExport === null) {
     reasons.push({ reason: 'topo-store-export-missing' });
-  } else if (storeExport.topoGraphHash !== actualHash) {
+  } else if (storeExport.topoGraphHash !== contractHash) {
     reasons.push({
       actual: storeExport.topoGraphHash,
-      expected: actualHash,
+      expected: contractHash,
       reason: 'topo-store-hash-mismatch',
       snapshotId: storeExport.snapshot.id,
     });


### PR DESCRIPTION
## Context
Wayfinder artifact drift was using one hash interpretation for both artifact integrity and topo-store contract comparison. Forced topo compiles add audit metadata, and blocked breaking compiles could also advance topo-store snapshots before export conflict handling finished.

## Changes
- Preflight export artifacts before writing topo-store state so rejected compiles do not create new saved snapshots.
- Compare topo.lock/manifest integrity with the full artifact hash, while comparing topo-store exported contract state with force metadata stripped.
- Add regressions for blocked compile no-mutation and forced compile fresh Wayfinder artifacts.
- Add branch-local changeset for @ontrails/trails and @ontrails/wayfinder.

## Verification
- bun test apps/trails/src/__tests__/survey.test.ts packages/wayfinder/src/__tests__/loader.test.ts
- bun run wayfinder:dogfood
- bun run changeset:check
- bun run check
- bun run test
- bun run build
- bun run publish:check
- git diff --check
- gt submit --stack --draft --restack --no-edit --no-interactive --dry-run
- Graphite pre-push hook passed during submit

## Local Review
In-thread local review found no P0-P2 issues. Residual non-blocking note: there is not a dedicated Wayfinder unit test for force annotations plus independent topo-store drift, but loader drift tests plus app-level forced and blocked compile regressions cover the intended split.