### PR TITLE
feat(warden): load project-local rules

### DIFF
--- a/.changeset/project-local-warden-rules.md
+++ b/.changeset/project-local-warden-rules.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/warden": patch
+---
+
+Load project-local Warden rules from `trails/warden/rules/` by default and expose the loader for embedders.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -422,6 +422,8 @@ SurfaceParityOptions, SurfaceParityComparison
 // Main runtime
 runWarden(options?), formatWardenReport(report), checkDrift(rootDir, topo?)
 // WardenOptions includes optional tier: source-static | project-static | topo-aware | drift | advisory
+// WardenOptions includes projectRules: false for embedders that opt out of project-local rules
+loadProjectWardenRules(rootDir)    // load rule modules from trails/warden/rules/
 
 // Built-in registries and wrapped topo
 wardenRules                        // ReadonlyMap<string, WardenRule> — built-in per-file rules (file-scoped and project-aware)

--- a/docs/contributing/warden-rules.md
+++ b/docs/contributing/warden-rules.md
@@ -43,6 +43,10 @@ Owner-first data beats duplicated rule lists. If Warden needs framework facts su
 
 Temporary repo-local rules are allowed when they have a clear lifecycle. TRL-575 is the precedent: a temporary audit scanner needs an owner, reason, baseline count, deletion or promotion trigger, and issue reference. Temporary rules are visible debt; durable framework semantics belong in Warden once the invariant is understood.
 
+Project-local Warden rules live in `trails/warden/rules/` at the project root. Warden loads that directory by default for command and API runs, so an adopting repo can enforce local migration or governance rules without shipping them from `@ontrails/warden`. The location is the ownership signal: a rule in that directory is project-local by placement, not by advisory metadata. Modules may export `rule`, `rules`, `sourceRule`, `sourceRules`, `topoRule`, or `topoRules`; rules without explicit metadata receive repo-local source-static or topo-aware execution metadata so short-lived migration rules do not need ceremony before they can run.
+
+Use `trails/warden/rules/` when the invariant is real for this project but not yet a framework promise. Promote the rule into `@ontrails/warden` only after the survival tests show it belongs to Trails users broadly. Delete it when the migration or temporary hardening window closes.
+
 ## Core Principle
 
 Express rules as invariants the framework holds, not as instances of bugs found during an audit.

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -37,6 +37,35 @@ Rules cover several families:
 
 When adding or auditing rules, follow [Warden Rules](../../docs/contributing/warden-rules.md): name the invariant, import owner-held framework data, choose the narrowest Warden tier, and collapse families only when the data model, traversal, and diagnostic shape are shared.
 
+## Project-local rules
+
+Projects can carry local Warden rules in `trails/warden/rules/`. `runWarden()` and `trails warden` load that directory by default for lint runs, then run those rules alongside the built-in registries. Drift-only runs do not import project-local rule modules. Embedders that need only built-in or explicitly provided rules can pass `projectRules: false`.
+
+This is the right home for repo-specific migration checks or governance that has not earned a place in `@ontrails/warden` itself.
+
+A rule module may export `rule`, `rules`, `sourceRule`, `sourceRules`, `topoRule`, or `topoRules`. Rules without explicit metadata receive default repo-local source-static or topo-aware metadata so short migration rules can run without extra ceremony. Project-aware source rules that provide `checkWithContext()` default to repo-local project-static metadata.
+
+```typescript
+export const rule = {
+  name: 'local-contract-check',
+  severity: 'error',
+  description: 'Local contract examples keep their migration marker.',
+  check(sourceCode, filePath) {
+    return sourceCode.includes('deprecatedMarker')
+      ? [
+          {
+            filePath,
+            line: 1,
+            message: 'Replace deprecatedMarker before release.',
+            rule: 'local-contract-check',
+            severity: 'error',
+          },
+        ]
+      : [];
+  },
+};
+```
+
 ## Drift detection
 
 Warden integrates with `@ontrails/topographer` to detect when the topo has changed without updating the lock file:
@@ -124,6 +153,7 @@ This is the same factory used internally to build all built-in rule trails.
 | `wardenTopo` | `Topo` of all built-in rule trails (one per rule) |
 | `runWardenTrails(filePath, sourceCode, options?)` | Dispatch file-scoped rule trails for a file, collect diagnostics |
 | `runTopoAwareWardenTrails(topo)` | Dispatch built-in topo-aware rule trails once for a resolved topo |
+| `loadProjectWardenRules(rootDir)` | Load rule modules from `trails/warden/rules/` |
 | `formatGitHubAnnotations(report)` | GitHub Actions annotation format |
 | `formatJson(report)` | Machine-readable JSON |
 | `formatSummary(report)` | Compact summary line |

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -93,6 +93,74 @@ const writeAdapterCheckFixture = (rootDir: string): void => {
   );
 };
 
+const writeProjectSourceRule = (
+  rootDir: string,
+  options: {
+    readonly marker?: string;
+    readonly name?: string;
+    readonly severity?: 'error' | 'warn';
+  } = {}
+): string => {
+  const ruleDir = join(rootDir, 'trails/warden/rules');
+  mkdirSync(ruleDir, { recursive: true });
+  const rulePath = join(ruleDir, 'project-local-rule.ts');
+  const marker = options.marker ?? 'projectLocalProblem';
+  const ruleName = options.name ?? 'project-local-rule';
+  const severity = options.severity ?? 'error';
+  writeFileSync(
+    rulePath,
+    `export const rule = {
+  name: '${ruleName}',
+  severity: '${severity}',
+  description: 'Project-local fixture rule.',
+  check(sourceCode, filePath) {
+    const marker = ${JSON.stringify(marker.split(/(?=[A-Z])/))}.join('');
+    return sourceCode.includes(marker)
+      ? [{
+          filePath,
+          line: 1,
+          message: 'Project-local fixture marker found.',
+          rule: '${ruleName}',
+          severity: '${severity}',
+        }]
+      : [];
+  },
+};
+`
+  );
+  return rulePath;
+};
+
+const writeProjectAwareRule = (rootDir: string): string => {
+  const ruleDir = join(rootDir, 'trails/warden/rules');
+  mkdirSync(ruleDir, { recursive: true });
+  const rulePath = join(ruleDir, 'project-aware-rule.ts');
+  writeFileSync(
+    rulePath,
+    `export const rule = {
+  name: 'project-aware-rule',
+  severity: 'error',
+  description: 'Project-aware fixture rule.',
+  check() {
+    return [];
+  },
+  checkWithContext(sourceCode, filePath) {
+    return sourceCode.includes('projectAwareProblem')
+      ? [{
+          filePath,
+          line: 1,
+          message: 'Project-aware fixture marker found.',
+          rule: 'project-aware-rule',
+          severity: 'error',
+        }]
+      : [];
+  },
+};
+`
+  );
+  return rulePath;
+};
+
 const writeManifest = (rootDir: string, hash: string): Promise<string> =>
   writeLockManifest(
     {
@@ -1451,6 +1519,142 @@ describe('runWarden --fix wiring', () => {
       expect(report.fixes?.skipped).toBeGreaterThanOrEqual(1);
       // Review-only fixes never rewrite source.
       expect(readFileSync(filePath, 'utf8')).toBe(source);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('project-local Warden rules', () => {
+  test('loads source rules from trails/warden/rules by default', async () => {
+    const dir = makeTempDir();
+    try {
+      writeProjectSourceRule(dir);
+      writeFileSync(join(dir, 'fixture.ts'), 'const projectLocalProblem = 1;');
+
+      const report = await runWarden({
+        lock: 'skip',
+        rootDir: dir,
+        tier: 'source-static',
+      });
+
+      expect(report.diagnostics).toContainEqual(
+        expect.objectContaining({
+          filePath: join(dir, 'fixture.ts'),
+          message: 'Project-local fixture marker found.',
+          rule: 'project-local-rule',
+        })
+      );
+      expect(report.errorCount).toBe(1);
+      expect(report.passed).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('can disable project-local rule loading for narrow embedders', async () => {
+    const dir = makeTempDir();
+    try {
+      writeProjectSourceRule(dir);
+      writeFileSync(join(dir, 'fixture.ts'), 'const projectLocalProblem = 1;');
+
+      const report = await runWarden({
+        lock: 'skip',
+        projectRules: false,
+        rootDir: dir,
+        tier: 'source-static',
+      });
+
+      expect(report.diagnostics.map((entry) => entry.rule)).not.toContain(
+        'project-local-rule'
+      );
+      expect(report.passed).toBe(true);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('does not import project-local rules for drift-only runs', async () => {
+    const dir = makeTempDir();
+    try {
+      const ruleDir = join(dir, 'trails/warden/rules');
+      mkdirSync(ruleDir, { recursive: true });
+      writeFileSync(
+        join(ruleDir, 'bad.ts'),
+        "throw new Error('drift should not import me');\n"
+      );
+
+      const report = await runWarden({
+        lock: 'skip',
+        rootDir: dir,
+        tier: 'drift',
+      });
+
+      expect(report.diagnostics.map((entry) => entry.rule)).not.toContain(
+        'project-warden-rules'
+      );
+      expect(report.passed).toBe(true);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('defaults project-aware local rules to project-static metadata', async () => {
+    const dir = makeTempDir();
+    try {
+      writeProjectAwareRule(dir);
+      writeFileSync(join(dir, 'fixture.ts'), 'const projectAwareProblem = 1;');
+
+      const sourceReport = await runWarden({
+        lock: 'skip',
+        rootDir: dir,
+        tier: 'source-static',
+      });
+      expect(sourceReport.diagnostics.map((entry) => entry.rule)).not.toContain(
+        'project-aware-rule'
+      );
+
+      const projectReport = await runWarden({
+        lock: 'skip',
+        rootDir: dir,
+        tier: 'project-static',
+      });
+      expect(projectReport.diagnostics).toContainEqual(
+        expect.objectContaining({
+          filePath: join(dir, 'fixture.ts'),
+          message: 'Project-aware fixture marker found.',
+          rule: 'project-aware-rule',
+        })
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('reports invalid project-local rule modules as Warden diagnostics', async () => {
+    const dir = makeTempDir();
+    try {
+      const ruleDir = join(dir, 'trails/warden/rules');
+      mkdirSync(ruleDir, { recursive: true });
+      const rulePath = join(ruleDir, 'empty.ts');
+      writeFileSync(rulePath, 'export const nothing = true;\n');
+
+      const report = await runWarden({
+        lock: 'skip',
+        rootDir: dir,
+        tier: 'source-static',
+      });
+
+      expect(report.diagnostics).toContainEqual(
+        expect.objectContaining({
+          filePath: rulePath,
+          message:
+            'Project Warden rule module must export a WardenRule or TopoAwareWardenRule.',
+          rule: 'project-warden-rules',
+          severity: 'error',
+        })
+      );
+      expect(report.passed).toBe(false);
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/warden/src/__tests__/public-api.test.ts
+++ b/packages/warden/src/__tests__/public-api.test.ts
@@ -44,6 +44,7 @@ describe('@ontrails/warden public API', () => {
     expect(warden.listWardenRuleMetadata().length).toBeGreaterThan(0);
     expect(warden.adapterCheckRuleName).toBe('adapter-check');
     expect(typeof warden.runWardenAdapterChecks).toBe('function');
+    expect(typeof warden.loadProjectWardenRules).toBe('function');
   });
 
   test('exports the composable Warden config schema from the root entrypoint', () => {

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -27,6 +27,8 @@ import { isDraftMarkedFile } from './draft.js';
 import { applySafeFixesToSource, hasSafeFixEdits } from './fix.js';
 import type { DriftResult } from './drift.js';
 import { checkDrift } from './drift.js';
+import { loadProjectWardenRules } from './project-rules.js';
+import type { ProjectWardenRules } from './project-rules.js';
 import {
   collectProjectDocumentationImportResolutions,
   collectProjectImportResolutions,
@@ -119,6 +121,15 @@ export interface WardenRunOptions {
    * lint rule dispatch. `lintOnly` and `driftOnly` remain compatibility shims.
    */
   readonly tier?: WardenRuleTier | undefined;
+  /**
+   * Load project-local Warden rules from `trails/warden/rules/`.
+   *
+   * Enabled by default for normal runs so a Trails app can carry migration or
+   * repo-local governance with the project instead of shipping it from
+   * `@ontrails/warden`. Set to `false` for narrow tests or embedders that need
+   * only built-in and explicitly provided rules.
+   */
+  readonly projectRules?: boolean | undefined;
   /**
    * App topology for drift detection. When provided, enables real topology
    * drift comparison and unlocks the topo-aware rule dispatch path.
@@ -860,6 +871,23 @@ const createOptionsDiagnostic = (message: string): WardenDiagnostic => ({
   severity: 'error',
 });
 
+const emptyProjectWardenRules = (): ProjectWardenRules => ({
+  diagnostics: [],
+  sourceRules: [],
+  topoRules: [],
+});
+
+const loadProjectRulesForRun = async (
+  rootDir: string,
+  options: WardenRunOptions,
+  runLint: boolean
+): Promise<ProjectWardenRules> => {
+  if (!runLint || options.projectRules === false) {
+    return emptyProjectWardenRules();
+  }
+  return loadProjectWardenRules(rootDir);
+};
+
 interface WardenRuleSelector {
   readonly depth?: WardenDepth | undefined;
   readonly tier?: WardenRuleTier | undefined;
@@ -1439,13 +1467,14 @@ export const runWarden = async (
   } satisfies WardenRuleSelector;
   const runLint = shouldRunLint(options);
   const runDrift = shouldRunDrift(options, effectiveConfig);
+  const projectRules = await loadProjectRulesForRun(rootDir, options, runLint);
   const lintResult = runLint
     ? await lintFiles(
         rootDir,
         effectiveConfig.drafts,
         topoTargets,
-        options.extraTopoRules ?? [],
-        options.extraSourceRules ?? [],
+        [...projectRules.topoRules, ...(options.extraTopoRules ?? [])],
+        [...projectRules.sourceRules, ...(options.extraSourceRules ?? [])],
         selector
       )
     : { diagnostics: [], sourceFiles: [] };
@@ -1453,6 +1482,7 @@ export const runWarden = async (
 
   const rawDiagnostics = [
     ...configDiagnostics,
+    ...projectRules.diagnostics,
     ...optionDiagnostics,
     ...lintResult.diagnostics,
     ...adapterDiagnostics,

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -119,6 +119,10 @@ export {
 export type { DriftResult } from './drift.js';
 export { checkDrift } from './drift.js';
 
+// Project-local rule loading
+export type { ProjectWardenRules } from './project-rules.js';
+export { loadProjectWardenRules } from './project-rules.js';
+
 // Guide projection
 export type {
   WardenGuideFormat,

--- a/packages/warden/src/project-rules.ts
+++ b/packages/warden/src/project-rules.ts
@@ -1,0 +1,201 @@
+import { existsSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import type {
+  ProjectAwareWardenRule,
+  TopoAwareWardenRule,
+  WardenDiagnostic,
+  WardenRuleMetadata,
+  WardenRule,
+} from './rules/types.js';
+
+const PROJECT_WARDEN_RULES_DIR = 'trails/warden/rules';
+
+export interface ProjectWardenRules {
+  readonly diagnostics: readonly WardenDiagnostic[];
+  readonly sourceRules: readonly WardenRule[];
+  readonly topoRules: readonly TopoAwareWardenRule[];
+}
+
+interface RuleModule {
+  readonly default?: unknown;
+  readonly rule?: unknown;
+  readonly rules?: unknown;
+  readonly sourceRule?: unknown;
+  readonly sourceRules?: unknown;
+  readonly topoRule?: unknown;
+  readonly topoRules?: unknown;
+}
+
+const diagnostic = (message: string, filePath: string): WardenDiagnostic => ({
+  filePath,
+  line: 1,
+  message,
+  rule: 'project-warden-rules',
+  severity: 'error',
+});
+
+const asArray = (value: unknown): readonly unknown[] => {
+  if (value === undefined) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+};
+
+const isSourceRule = (value: unknown): value is WardenRule => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const maybe = value as Partial<WardenRule>;
+  return (
+    typeof maybe.name === 'string' &&
+    typeof maybe.description === 'string' &&
+    (maybe.severity === 'error' || maybe.severity === 'warn') &&
+    typeof maybe.check === 'function'
+  );
+};
+
+const isTopoRule = (value: unknown): value is TopoAwareWardenRule => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const maybe = value as Partial<TopoAwareWardenRule>;
+  return (
+    typeof maybe.name === 'string' &&
+    typeof maybe.description === 'string' &&
+    (maybe.severity === 'error' || maybe.severity === 'warn') &&
+    typeof maybe.checkTopo === 'function'
+  );
+};
+
+const defaultProjectRuleDepth = (
+  tier: WardenRuleMetadata['tier']
+): WardenRuleMetadata['depth'] => {
+  if (tier === 'topo-aware') {
+    return 'topo';
+  }
+  if (tier === 'project-static') {
+    return 'project';
+  }
+  return 'source';
+};
+
+const defaultProjectRuleMetadata = (
+  rule: { readonly description: string },
+  tier: WardenRuleMetadata['tier']
+): WardenRuleMetadata => ({
+  concern: 'general',
+  depth: defaultProjectRuleDepth(tier),
+  invariant: rule.description,
+  lifecycle: { state: 'durable' },
+  scope: 'repo-local',
+  tier,
+});
+
+const isProjectAwareSourceRule = (
+  rule: WardenRule
+): rule is ProjectAwareWardenRule =>
+  'checkWithContext' in rule && typeof rule.checkWithContext === 'function';
+
+const withSourceRuleMetadata = (rule: WardenRule): WardenRule => ({
+  ...rule,
+  metadata:
+    rule.metadata ??
+    defaultProjectRuleMetadata(
+      rule,
+      isProjectAwareSourceRule(rule) ? 'project-static' : 'source-static'
+    ),
+});
+
+const withTopoRuleMetadata = (
+  rule: TopoAwareWardenRule
+): TopoAwareWardenRule => ({
+  ...rule,
+  metadata: rule.metadata ?? defaultProjectRuleMetadata(rule, 'topo-aware'),
+});
+
+const ruleCandidatesFromModule = (module: RuleModule): readonly unknown[] => [
+  ...asArray(module.default),
+  ...asArray(module.rule),
+  ...asArray(module.rules),
+  ...asArray(module.sourceRule),
+  ...asArray(module.sourceRules),
+];
+
+const topoRuleCandidatesFromModule = (
+  module: RuleModule
+): readonly unknown[] => [
+  ...asArray(module.topoRule),
+  ...asArray(module.topoRules),
+];
+
+const collectProjectRuleFiles = (rulesDir: string): readonly string[] => {
+  if (!existsSync(rulesDir)) {
+    return [];
+  }
+
+  const glob = new Bun.Glob('**/*.ts');
+  return [...glob.scanSync({ cwd: rulesDir, onlyFiles: true })]
+    .filter(
+      (entry) => !entry.endsWith('.test.ts') && !basename(entry).startsWith('_')
+    )
+    .map((entry) => join(rulesDir, entry))
+    .toSorted((left, right) => left.localeCompare(right));
+};
+
+const loadRuleFile = async (filePath: string): Promise<ProjectWardenRules> => {
+  let module: RuleModule;
+  try {
+    module = (await import(pathToFileURL(filePath).href)) as RuleModule;
+  } catch (error) {
+    return {
+      diagnostics: [
+        diagnostic(
+          error instanceof Error
+            ? `Failed to load project Warden rule module: ${error.message}`
+            : 'Failed to load project Warden rule module.',
+          filePath
+        ),
+      ],
+      sourceRules: [],
+      topoRules: [],
+    };
+  }
+
+  const sourceRules = ruleCandidatesFromModule(module)
+    .filter(isSourceRule)
+    .map(withSourceRuleMetadata);
+  const topoRules = topoRuleCandidatesFromModule(module)
+    .filter(isTopoRule)
+    .map(withTopoRuleMetadata);
+  if (sourceRules.length === 0 && topoRules.length === 0) {
+    return {
+      diagnostics: [
+        diagnostic(
+          'Project Warden rule module must export a WardenRule or TopoAwareWardenRule.',
+          filePath
+        ),
+      ],
+      sourceRules: [],
+      topoRules: [],
+    };
+  }
+
+  return { diagnostics: [], sourceRules, topoRules };
+};
+
+export const loadProjectWardenRules = async (
+  rootDir: string
+): Promise<ProjectWardenRules> => {
+  const files = collectProjectRuleFiles(
+    join(rootDir, PROJECT_WARDEN_RULES_DIR)
+  );
+  const loaded = await Promise.all(files.map(loadRuleFile));
+
+  return {
+    diagnostics: loaded.flatMap((result) => result.diagnostics),
+    sourceRules: loaded.flatMap((result) => result.sourceRules),
+    topoRules: loaded.flatMap((result) => result.topoRules),
+  };
+};


### PR DESCRIPTION
## Context

This is the lower branch for the Warden/Regrade hardening slice. It makes project-local Warden rules a first-class repo convention so Trails can dogfood migration/governance rules from `trails/warden/rules/` without shipping those rules from `@ontrails/warden`.

## What changed

- Added project-local Warden rule loading from `trails/warden/rules/`.
- Supports default/rule/rules/sourceRule/sourceRules/topoRule/topoRules exports.
- Defaults local source, project-aware, and topo rules to repo-local metadata when omitted.
- Keeps project-local rule imports out of drift-only runs and adds `projectRules: false` opt-out.
- Documents the convention and public API surface.

## Verification

- `bun test packages/warden/src/__tests__/cli.test.ts -t "project-local Warden rules"`
- `bun run typecheck`
- `bun run format:check`
- `bun run docs:wrap-check`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun run changeset:check`
- `git diff --check`
- Graphite pre-push hook passed during submit

## Notes

Local review found and fixed two P2s before submit: drift-only runs no longer import project rules, and metadata-less project-aware local rules now default to project-static metadata.