### PR TITLE
feat(regrade): enrich warden review details

### DIFF
--- a/.changeset/regrade-warden-review-details.md
+++ b/.changeset/regrade-warden-review-details.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/regrade": patch
+---
+
+Carry structured review details from Warden-backed term-rewrite diagnostics into Regrade review reports.

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -159,6 +159,91 @@ describe('wardenTermRewriteClasses', () => {
     expect(result?.notes.join('\n')).toContain(
       'Removal has no mechanical replacement'
     );
+    expect(result?.reviewDetails).toEqual([
+      {
+        reason: 'warden-review-required',
+        span: { column: 10, end: 18, line: 1, start: 9 },
+        symbol: 'authLayer',
+      },
+    ]);
+  });
+
+  test('anchors Warden review spans to the diagnostic line', () => {
+    const crossClass = wardenTermRewriteClasses.find(
+      (cls) => cls.id === 'term-rewrite:no-retired-cross-vocabulary'
+    );
+    expect(crossClass).toBeDefined();
+
+    const result = crossClass?.apply(
+      'const crossOne = 1;\nconst crossTwo = 2;\n',
+      { absolutePath: '/repo/src/cross.ts', path: 'src/cross.ts' }
+    );
+
+    expect(result?.kind).toBe('needs-review');
+    expect(result?.reviewDetails).toEqual([
+      {
+        reason: 'warden-review-required',
+        span: { column: 7, end: 11, line: 1, start: 6 },
+        symbol: 'cross',
+      },
+      {
+        reason: 'warden-review-required',
+        span: { column: 7, end: 31, line: 2, start: 26 },
+        symbol: 'cross',
+      },
+    ]);
+  });
+
+  test('omits ambiguous same-line Warden review spans', () => {
+    const crossClass = wardenTermRewriteClasses.find(
+      (cls) => cls.id === 'term-rewrite:no-retired-cross-vocabulary'
+    );
+    expect(crossClass).toBeDefined();
+
+    const result = crossClass?.apply('const crossOne = crossTwo;\n', {
+      absolutePath: '/repo/src/cross.ts',
+      path: 'src/cross.ts',
+    });
+
+    expect(result?.kind).toBe('needs-review');
+    expect(result?.reviewDetails).toEqual([
+      {
+        reason: 'warden-review-required',
+        symbol: 'cross',
+      },
+      {
+        reason: 'warden-review-required',
+        symbol: 'cross',
+      },
+    ]);
+  });
+
+  test('carries Warden review details into report entries', () => {
+    const legacyLayerClass = wardenTermRewriteClasses.find(
+      (cls) => cls.id === 'term-rewrite:no-legacy-layer-imports'
+    );
+    expect(legacyLayerClass).toBeDefined();
+
+    const report = buildRegradeReport({
+      classes: legacyLayerClass ? [legacyLayerClass] : [],
+      files: [
+        {
+          path: 'src/auth.ts',
+          source: "import { authLayer } from '@ontrails/permits';\n",
+        },
+      ],
+      root: '/repo',
+      skipped: [],
+    });
+
+    expect(report.entries[0]?.reviewDetails).toEqual([
+      {
+        classId: 'term-rewrite:no-legacy-layer-imports',
+        reason: 'warden-review-required',
+        span: { column: 10, end: 18, line: 1, start: 9 },
+        symbol: 'authLayer',
+      },
+    ]);
   });
 
   test('reports no-op when Warden finds no term-rewrite diagnostics', () => {

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -203,6 +203,113 @@ const diagnosticNote = (diagnostic: WardenDiagnostic): string => {
   return `${diagnostic.rule}:${diagnostic.line}: ${reason}`;
 };
 
+const firstQuotedValue = (value: string | undefined): string | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  const match = /['"]([^'"]+)['"]/.exec(value);
+  return match?.[1];
+};
+
+const reviewSpanForOffsets = (
+  source: string,
+  start: number,
+  end: number
+): RegradeReviewSpan => {
+  let line = 1;
+  let column = 1;
+  for (let index = 0; index < start; index += 1) {
+    if (source.codePointAt(index) === 10) {
+      line += 1;
+      column = 1;
+    } else {
+      column += 1;
+    }
+  }
+  return { column, end, line, start };
+};
+
+const spanForSymbolOnDiagnosticLine = (
+  source: string,
+  line: number,
+  symbol: string
+): RegradeReviewSpan | undefined => {
+  if (line < 1) {
+    return undefined;
+  }
+  let lineStart = 0;
+  for (let currentLine = 1; currentLine < line; currentLine += 1) {
+    const nextLineStart = source.indexOf('\n', lineStart);
+    if (nextLineStart === -1) {
+      return undefined;
+    }
+    lineStart = nextLineStart + 1;
+  }
+  const nextLineStart = source.indexOf('\n', lineStart);
+  const lineEnd = nextLineStart === -1 ? source.length : nextLineStart;
+  const symbolIndex = source.indexOf(symbol, lineStart);
+  if (symbolIndex === -1 || symbolIndex >= lineEnd) {
+    return undefined;
+  }
+  const nextSymbolIndex = source.indexOf(symbol, symbolIndex + symbol.length);
+  if (nextSymbolIndex !== -1 && nextSymbolIndex < lineEnd) {
+    return undefined;
+  }
+  return reviewSpanForOffsets(source, symbolIndex, symbolIndex + symbol.length);
+};
+
+const diagnosticSpan = (
+  source: string,
+  diagnostic: WardenDiagnostic,
+  symbol: string | undefined
+): RegradeReviewSpan | undefined => {
+  const [edit] = diagnostic.fix?.edits ?? [];
+  if (edit !== undefined) {
+    return reviewSpanForOffsets(source, edit.start, edit.end);
+  }
+  if (symbol === undefined) {
+    return undefined;
+  }
+  return spanForSymbolOnDiagnosticLine(source, diagnostic.line, symbol);
+};
+
+const expectedTarget = (diagnostic: WardenDiagnostic): string | undefined => {
+  const replacements = new Set(
+    (diagnostic.fix?.edits ?? []).map((edit) => edit.replacement)
+  );
+  if (replacements.size !== 1) {
+    return undefined;
+  }
+  const [replacement] = replacements;
+  return replacement === undefined
+    ? undefined
+    : `Replace with "${replacement}".`;
+};
+
+const reviewDetailsFromDiagnostics = (
+  source: string,
+  diagnostics: readonly WardenDiagnostic[],
+  reason: string
+): readonly RegradeReviewDetail[] | undefined => {
+  const details = diagnostics.map((diagnostic) => {
+    const symbol =
+      firstQuotedValue(diagnostic.fix?.reason) ??
+      firstQuotedValue(diagnostic.message);
+    const span = diagnosticSpan(source, diagnostic, symbol);
+    const target = expectedTarget(diagnostic);
+    return {
+      ...(target === undefined ? {} : { expectedTarget: target }),
+      ...(diagnostic.fix?.fixture === undefined
+        ? {}
+        : { fixture: diagnostic.fix.fixture }),
+      reason,
+      ...(span === undefined ? {} : { span }),
+      ...(symbol === undefined ? {} : { symbol }),
+    } satisfies RegradeReviewDetail;
+  });
+  return details.length === 0 ? undefined : details;
+};
+
 const wardenFilePath = (context: RegradeClassContext | undefined): string =>
   context?.absolutePath ?? context?.path ?? '<regrade-source>';
 
@@ -279,10 +386,16 @@ export const createWardenTermRewriteClass = (
         (diagnostic) => diagnostic.fix?.safety !== 'safe'
       );
       if (reviewDiagnostics.length > 0) {
+        const reviewDetails = reviewDetailsFromDiagnostics(
+          source,
+          reviewDiagnostics,
+          'warden-review-required'
+        );
         return {
           kind: 'needs-review',
           notes: reviewDiagnostics.map(diagnosticNote),
           reason: 'warden-review-required',
+          ...(reviewDetails === undefined ? {} : { reviewDetails }),
         };
       }
 
@@ -290,10 +403,16 @@ export const createWardenTermRewriteClass = (
         (diagnostic) => (diagnostic.fix?.edits?.length ?? 0) === 0
       );
       if (diagnosticsMissingEdits.length > 0) {
+        const reviewDetails = reviewDetailsFromDiagnostics(
+          source,
+          diagnosticsMissingEdits,
+          'warden-fix-missing-edits'
+        );
         return {
           kind: 'needs-review',
           notes: diagnostics.map(diagnosticNote),
           reason: 'warden-fix-missing-edits',
+          ...(reviewDetails === undefined ? {} : { reviewDetails }),
         };
       }
 
@@ -302,6 +421,11 @@ export const createWardenTermRewriteClass = (
       );
       const application = applyWardenEdits(source, edits);
       if (!application.ok) {
+        const reviewDetails = reviewDetailsFromDiagnostics(
+          source,
+          diagnostics,
+          'warden-fix-invalid'
+        );
         return {
           kind: 'needs-review',
           notes: [
@@ -309,6 +433,7 @@ export const createWardenTermRewriteClass = (
             `Warden fix edits could not be applied: ${application.reason}.`,
           ],
           reason: 'warden-fix-invalid',
+          ...(reviewDetails === undefined ? {} : { reviewDetails }),
         };
       }
 


### PR DESCRIPTION
## Context

This is the upper branch for the Warden/Regrade hardening slice. It makes Warden-backed Regrade review output useful enough for migration dogfood by carrying structured review details instead of thin route-to-review inventory.

## What changed

- Enriched Warden-backed term-rewrite review entries with structured review details.
- Derives spans from concrete edit offsets when available.
- Falls back to diagnostic-line symbol lookup for review-only Warden diagnostics.
- Omits spans when same-line repeated symbols make the location ambiguous.
- Derives `expectedTarget` when a rewrite class has exactly one replacement.
- Added regressions for repeated symbols across lines and repeated symbols on the same line.

## Verification

- `bun test packages/regrade/src/downstream/__tests__/report.test.ts`
- `bun run typecheck`
- `bun run format:check`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun run changeset:check`
- `git diff --check`
- Graphite pre-push hook passed during submit

## Notes

Local review found and fixed two P2s before submit: cross-line repeated symbols now anchor to the diagnostic line, and same-line repeated symbols omit misleading spans.