### PR TITLE
chore: tune codex agent concurrency

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,3 @@
 [agents]
-max_threads = 6
-max_depth = 1
+max_threads = 10
+max_depth = 2


### PR DESCRIPTION
## Context

Repo-local Codex agent settings were too conservative for the current review and subagent loops.

## Changes

- Increase `.codex` agent concurrency from 6 threads / depth 1 to 10 threads / depth 2.

## Verification

- pre-commit hook passed during `gt create`
- `git diff --check HEAD~1..HEAD`

## Release

- No package release impact. Configuration-only repo-local change.