### PR TITLE
fix(config): converge trails substrate loading

### DIFF
--- a/.changeset/project-local-warden-rules.md
+++ b/.changeset/project-local-warden-rules.md
@@ -1,5 +1,0 @@
----
-"@ontrails/warden": patch
----
-
-Load project-local Warden rules from `trails/warden/rules/` by default and expose the loader for embedders.

--- a/.changeset/trl-1013-substrate-first-slice.md
+++ b/.changeset/trl-1013-substrate-first-slice.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/config": patch
+"@ontrails/core": patch
+"@ontrails/trails": patch
+"@ontrails/warden": patch
+---
+
+Centralize Trails config module path conventions, move local config overrides to root `trails.config.local.*`, scaffold the matching gitignore entries, and load project-local Warden rules from `.trails/rules.ts` or `.trails/rules/`.

--- a/.trails/.gitignore
+++ b/.trails/.gitignore
@@ -1,7 +1,3 @@
-# Local config overrides
-config.local.js
-config.local.ts
-
 # Rebuildable cache
 cache/
 

--- a/apps/trails/.trails/.gitignore
+++ b/apps/trails/.trails/.gitignore
@@ -1,7 +1,3 @@
-# Local config overrides
-config.local.js
-config.local.ts
-
 # Rebuildable cache
 cache/
 

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -30,6 +30,7 @@
     "@ontrails/adapter-kit": "workspace:^",
     "@ontrails/cli": "workspace:^",
     "@ontrails/commander": "workspace:^",
+    "@ontrails/config": "workspace:^",
     "@ontrails/core": "workspace:^",
     "@ontrails/http": "workspace:^",
     "@ontrails/mcp": "workspace:^",

--- a/apps/trails/src/release/check.ts
+++ b/apps/trails/src/release/check.ts
@@ -3,6 +3,8 @@ import { readdir } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { findTrailsConfigModulePath } from '@ontrails/config';
+
 import { defaultReleaseConfig, releaseConfigSchema } from './config.js';
 import type { ReleaseConfigInput, ReleaseFactType } from './config.js';
 import { findPublicTrailContractChangeFacts } from './contract-facts.js';
@@ -95,13 +97,6 @@ const VERSION_RELEASE_WORKSPACE_FILES = new Set([
   'CHANGELOG.md',
   'package.json',
 ]);
-const CONFIG_CANDIDATES = [
-  'trails.config.ts',
-  'trails.config.mts',
-  'trails.config.js',
-  'trails.config.mjs',
-] as const;
-
 const normalizePath = (path: string): string =>
   path.replaceAll('\\', '/').replace(/^\.\//u, '');
 
@@ -562,9 +557,7 @@ const findConfigPath = (
     return resolvedPath;
   }
 
-  return CONFIG_CANDIDATES.map((entry) => resolve(repoRoot, entry)).find(
-    (entry) => existsSync(entry)
-  );
+  return findTrailsConfigModulePath({ rootDir: repoRoot });
 };
 
 const extractReleaseConfig = (value: unknown): ReleaseConfigInput | undefined =>

--- a/apps/trails/src/trails/create-scaffold.ts
+++ b/apps/trails/src/trails/create-scaffold.ts
@@ -197,10 +197,12 @@ Keep shared project guidance in \`./AGENTS.md\`. Only Claude-specific bootstrap 
 const GITIGNORE_CONTENT = `node_modules/
 dist/
 *.tsbuildinfo
+trails.config.local.js
+trails.config.local.mjs
+trails.config.local.mts
+trails.config.local.ts
 .trails/cache/
 .trails/state/
-.trails/config.local.js
-.trails/config.local.ts
 `;
 
 const OXLINT_CONFIG_CONTENT = `import { defineConfig } from 'oxlint';

--- a/bun.lock
+++ b/bun.lock
@@ -81,6 +81,7 @@
         "@ontrails/adapter-kit": "workspace:^",
         "@ontrails/cli": "workspace:^",
         "@ontrails/commander": "workspace:^",
+        "@ontrails/config": "workspace:^",
         "@ontrails/core": "workspace:^",
         "@ontrails/http": "workspace:^",
         "@ontrails/mcp": "workspace:^",
@@ -290,6 +291,7 @@
       "dependencies": {
         "@ontrails/adapter-kit": "workspace:^",
         "@ontrails/cli": "workspace:^",
+        "@ontrails/config": "workspace:^",
         "@ontrails/permits": "workspace:^",
         "@ontrails/store": "workspace:^",
         "oxc-parser": "^0.121.0",
@@ -298,7 +300,6 @@
         "zod": "catalog:",
       },
       "devDependencies": {
-        "@ontrails/config": "workspace:^",
         "@ontrails/testing": "workspace:^",
       },
       "peerDependencies": {

--- a/docs/adr/0010-native-infrastructure.md
+++ b/docs/adr/0010-native-infrastructure.md
@@ -80,9 +80,9 @@ Infrastructure has a bootstrap problem. Config resolution runs before `executeTr
 The solution is two phases:
 
 1. **Bootstrap phase.** Config resolves from static sources — TypeScript config
-   files, environment variables, and `.trails/config.local.ts` or
-   `.trails/config.local.js` overrides. No trails involved. This produces the
-   resolved config that resources need to create.
+   files, environment variables, and root `trails.config.local.*` overrides. No
+   trails involved. This produces the resolved config that resources need to
+   create.
 2. **Execution phase.** The topo is built. Resources are registered. Now `config.explain`, `auth.verify`, and other infrastructure trails are available through the normal execution pipeline.
 
 Bootstrap is pure resolution — no side effects, no trail execution, no layers. It runs once at startup. Everything after bootstrap goes through `executeTrail`.
@@ -93,8 +93,6 @@ Trails establishes `.trails/` as the workspace directory for framework state:
 
 ```text
 .trails/
-├── config.local.ts  — local TypeScript overrides (gitignored)
-├── config.local.js  — local JavaScript overrides (gitignored)
 ├── cache/           — rebuildable derived data (gitignored)
 ├── state/           — mutable framework state (gitignored)
 │   └── trails.db    — local framework database
@@ -102,9 +100,9 @@ Trails establishes `.trails/` as the workspace directory for framework state:
 └── trails.lock      — committed v3 lock manifest
 ```
 
-Auto-created on first framework operation. The framework generates a `.gitignore` inside `.trails/` that excludes local mutable state such as `config.local.{ts,js}`, `cache/`, and `state/`. `topo.lock` and `trails.lock` are the committed artifact family that supports inspection and review: `topo.lock` carries the serialized TopoGraph, and `trails.lock` is the compact v3 manifest that points at it.
+Auto-created on first framework operation. The framework generates a `.gitignore` inside `.trails/` that excludes local mutable state such as `cache/` and `state/`. `topo.lock` and `trails.lock` are the committed artifact family that supports inspection and review: `topo.lock` carries the serialized TopoGraph, and `trails.lock` is the compact v3 manifest that points at it.
 
-The workspace gives infrastructure a known home. Config reads overrides from `.trails/config.local.ts` or `.trails/config.local.js`. Local framework state and topo history live in `.trails/state/trails.db`. Derived contract artifacts land alongside them in `.trails/topo.lock` and `.trails/trails.lock`. No more scattering framework files across the project root.
+The workspace gives infrastructure a known home. Config reads local per-developer overrides from root `trails.config.local.*` files. Local framework state and topo history live in `.trails/state/trails.db`. Derived contract artifacts land alongside them in `.trails/topo.lock` and `.trails/trails.lock`.
 
 ### Adapters are the integration point
 

--- a/docs/adr/0011-schema-driven-config.md
+++ b/docs/adr/0011-schema-driven-config.md
@@ -146,7 +146,7 @@ Resolution stack (later overrides earlier):
 
 1. **Schema defaults** — `z.number().default(10)`
 2. **App-authored config** — `base` merged with the selected profile, keyed by `TRAILS_ENV`
-3. **Local overrides** — `.trails/config.local.ts`, gitignored, per-developer
+3. **Local overrides** — root `trails.config.local.*`, gitignored, per-developer
 4. **Environment variables** — auto-mapped from `.env()` bindings on schema fields
 
 Five layers were considered. **CLI flag derivation from config was explicitly rejected.** Config flags would conflict with trail input flags on the same CLI surface. Environment variables are the command-line override mechanism.

--- a/docs/adr/0046-lock-v3-artifact-family.md
+++ b/docs/adr/0046-lock-v3-artifact-family.md
@@ -97,8 +97,7 @@ The topo-store export named `serialized_lock` is not a second graph copy. It is 
   `.trails/topo.lock`;
 - ignored rebuildable cache: `.trails/cache/`;
 - ignored mutable runtime state: `.trails/state/`;
-- ignored local override config: `.trails/config.local.ts` or
-  `.trails/config.local.js`.
+- ignored local override config: root `trails.config.local.*`.
 
 The default local SQLite path is `.trails/state/trails.db`. This is a pre-v1 hard cut from `.trails/trails.db`; runtime and tooling should not silently read fallback data from the legacy root database path.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -423,7 +423,7 @@ SurfaceParityOptions, SurfaceParityComparison
 runWarden(options?), formatWardenReport(report), checkDrift(rootDir, topo?)
 // WardenOptions includes optional tier: source-static | project-static | topo-aware | drift | advisory
 // WardenOptions includes projectRules: false for embedders that opt out of project-local rules
-loadProjectWardenRules(rootDir)    // load rule modules from trails/warden/rules/
+loadProjectWardenRules(rootDir)    // load rule modules from .trails/rules.ts or .trails/rules/
 
 // Built-in registries and wrapped topo
 wardenRules                        // ReadonlyMap<string, WardenRule> — built-in per-file rules (file-scoped and project-aware)

--- a/docs/contributing/warden-rules.md
+++ b/docs/contributing/warden-rules.md
@@ -43,9 +43,9 @@ Owner-first data beats duplicated rule lists. If Warden needs framework facts su
 
 Temporary repo-local rules are allowed when they have a clear lifecycle. TRL-575 is the precedent: a temporary audit scanner needs an owner, reason, baseline count, deletion or promotion trigger, and issue reference. Temporary rules are visible debt; durable framework semantics belong in Warden once the invariant is understood.
 
-Project-local Warden rules live in `trails/warden/rules/` at the project root. Warden loads that directory by default for command and API runs, so an adopting repo can enforce local migration or governance rules without shipping them from `@ontrails/warden`. The location is the ownership signal: a rule in that directory is project-local by placement, not by advisory metadata. Modules may export `rule`, `rules`, `sourceRule`, `sourceRules`, `topoRule`, or `topoRules`; rules without explicit metadata receive repo-local source-static or topo-aware execution metadata so short-lived migration rules do not need ceremony before they can run.
+Project-local Warden rules live in `.trails/rules.ts` or `.trails/rules/` at the project root. Warden loads those files by default for command and API runs, so an adopting repo can enforce local migration or governance rules without shipping them from `@ontrails/warden`. The location is the ownership signal: a rule in that committed-control directory is project-local by placement, not by advisory metadata. Modules may export `rule`, `rules`, `sourceRule`, `sourceRules`, `topoRule`, or `topoRules`; rules without explicit metadata receive repo-local source-static or topo-aware execution metadata so short-lived migration rules do not need ceremony before they can run.
 
-Use `trails/warden/rules/` when the invariant is real for this project but not yet a framework promise. Promote the rule into `@ontrails/warden` only after the survival tests show it belongs to Trails users broadly. Delete it when the migration or temporary hardening window closes.
+Use `.trails/rules.ts` or `.trails/rules/` when the invariant is real for this project but not yet a framework promise. Promote the rule into `@ontrails/warden` only after the survival tests show it belongs to Trails users broadly. Delete it when the migration or temporary hardening window closes.
 
 ## Core Principle
 

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -110,9 +110,9 @@ Ignored mutable runtime state. The default local SQLite database lives at `.trai
 
 Ignored rebuildable cache state. Generated helper artifacts that can be rebuilt from source contracts belong here rather than beside committed lock artifacts.
 
-#### `.trails/config.local.{ts,js}`
+#### `trails.config.local.*`
 
-Ignored per-developer config overrides. Use `.trails/config.local.ts` or `.trails/config.local.js`; do not create nested `.trails/config/local.*` files.
+Ignored per-developer config overrides. Use `trails.config.local.ts`, `trails.config.local.mts`, `trails.config.local.js`, or `trails.config.local.mjs` at the project root; do not create `.trails/config.local.*` or nested `.trails/config/local.*` files.
 
 #### Retired Vocabulary
 
@@ -127,7 +127,8 @@ These names are historical or migration vocabulary, not current target-state lan
 | `cross` / `crosses` | `compose` / `composes` |
 | `crossInput` | `composeInput` |
 | `serialized_lock` | `lock_manifest` when referring to stored manifest export content; `.trails/trails.lock` when referring to the committed manifest file |
-| `.trails/config/local` | `.trails/config.local.{ts,js}` |
+| `.trails/config/local.*` | `trails.config.local.*` |
+| `.trails/config.local.*` | `trails.config.local.*` |
 | `.trails/trails.db` | `.trails/state/trails.db` |
 | `.trails/trails.db-shm` / `.trails/trails.db-wal` | `.trails/state/trails.db-shm` / `.trails/state/trails.db-wal` |
 | `.trails/dev/` | `.trails/state/` for mutable runtime state |

--- a/docs/migration/topograph-artifact-family.md
+++ b/docs/migration/topograph-artifact-family.md
@@ -7,8 +7,7 @@ The v1 topo artifact family uses a compact manifest plus an inspectable graph co
 - `.trails/state/trails.db` is ignored mutable SQLite state for snapshots,
   pins, tracing, and other framework subsystems.
 - `.trails/cache/` is ignored rebuildable cache state.
-- `.trails/config.local.ts` and `.trails/config.local.js` are ignored local
-  override files.
+- `trails.config.local.*` files at the project root are ignored local override files.
 
 Regenerate the current artifact family with:
 
@@ -32,7 +31,8 @@ trails validate
 | `_surface.json` | `.trails/topo.lock` |
 | `surface_map` | `topo_graph` |
 | `serialized_lock` | `lock_manifest` for stored manifest export content; `.trails/trails.lock` for the committed manifest file |
-| `.trails/config/local.*` | `.trails/config.local.ts` or `.trails/config.local.js` |
+| `.trails/config/local.*` | `trails.config.local.*` at the project root |
+| `.trails/config.local.*` | `trails.config.local.*` at the project root |
 | `.trails/trails.db` | `.trails/state/trails.db` |
 | `.trails/dev/` | `.trails/state/` |
 | `.trails/generated/` | `.trails/cache/` |

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -11,8 +11,6 @@ Trails creates a `.trails/` directory in your workspace root on first use:
 ```text
 .trails/
 ├── .gitignore             # Auto-generated gitignore for this directory
-├── config.local.ts        # Local TypeScript config overrides (gitignored)
-├── config.local.js        # Local JavaScript config overrides (gitignored)
 ├── cache/                 # Rebuildable derived data (gitignored)
 ├── state/                 # Mutable framework state (gitignored)
 │   └── trails.db          # SQLite database (topology store)
@@ -23,6 +21,8 @@ Trails creates a `.trails/` directory in your workspace root on first use:
 - **`state/trails.db`** — SQLite database containing topo snapshots, pins, and schema cache. Not git-tracked.
 - **`topo.lock`** — Committed serialized TopoGraph with trail, signal, resource, relation, example, detour, and workspace metadata.
 - **`trails.lock`** — Committed compact v3 manifest that points at `topo.lock` and verifies its hash.
+
+Local per-developer overrides live at the project root as `trails.config.local.*`, not under `.trails/`.
 
 ## What trails.db contains
 

--- a/packages/config/src/__tests__/define-config.test.ts
+++ b/packages/config/src/__tests__/define-config.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { z } from 'zod';
@@ -194,11 +194,9 @@ describe('defineConfig', () => {
       await rm(tempDir, { force: true, recursive: true });
     });
 
-    test('applies local overrides from .trails/config.local.ts', async () => {
-      const configDir = join(tempDir, '.trails');
-      await mkdir(configDir, { recursive: true });
+    test('applies local overrides from trails.config.local.ts', async () => {
       await Bun.write(
-        join(configDir, 'config.local.ts'),
+        join(tempDir, 'trails.config.local.ts'),
         'export default { port: 4444 };'
       );
 
@@ -217,10 +215,8 @@ describe('defineConfig', () => {
     });
 
     test('local overrides applied between profile and env', async () => {
-      const configDir = join(tempDir, '.trails');
-      await mkdir(configDir, { recursive: true });
       await Bun.write(
-        join(configDir, 'config.local.js'),
+        join(tempDir, 'trails.config.local.js'),
         'export default { port: 5555 };'
       );
 
@@ -244,10 +240,8 @@ describe('defineConfig', () => {
     });
 
     test('skips local overrides when TRAILS_ENV=test', async () => {
-      const configDir = join(tempDir, '.trails');
-      await mkdir(configDir, { recursive: true });
       await Bun.write(
-        join(configDir, 'config.local.ts'),
+        join(tempDir, 'trails.config.local.ts'),
         'export default { port: 4444 };'
       );
 

--- a/packages/config/src/define-config.ts
+++ b/packages/config/src/define-config.ts
@@ -3,13 +3,11 @@
  * framework conventions for profile selection and local overrides.
  */
 
-import { existsSync } from 'node:fs';
-import { join } from 'node:path';
-
 import type { z } from 'zod';
 
 import { appConfig } from './app-config.js';
 import { deriveConfig } from './resolve.js';
+import { findTrailsLocalConfigModulePath } from './trails-conventions.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -36,13 +34,8 @@ interface DefineConfigResolveOptions {
 // Local overrides discovery
 // ---------------------------------------------------------------------------
 
-const LOCAL_OVERRIDE_CANDIDATES = [
-  'config.local.ts',
-  'config.local.js',
-] as const;
-
 /**
- * Discover and synchronously import a `.trails/config.local.{ts,js}` file.
+ * Discover and synchronously import a `trails.config.local.*` file.
  *
  * Skipped when `TRAILS_ENV=test` for hermetic test environments.
  */
@@ -54,12 +47,10 @@ const discoverLocalOverrides = async (
     return undefined;
   }
 
-  for (const filename of LOCAL_OVERRIDE_CANDIDATES) {
-    const candidate = join(cwd, '.trails', filename);
-    if (existsSync(candidate)) {
-      const mod: Record<string, unknown> = await import(candidate);
-      return (mod['default'] ?? mod) as Record<string, unknown>;
-    }
+  const candidate = findTrailsLocalConfigModulePath(cwd);
+  if (candidate !== undefined) {
+    const mod: Record<string, unknown> = await import(candidate);
+    return (mod['default'] ?? mod) as Record<string, unknown>;
   }
 
   return undefined;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -9,6 +9,12 @@ export {
 export { collectConfigMeta } from './collect.js';
 export { collectResourceConfigs, type ResourceConfigEntry } from './compose.js';
 export { defineConfig, type DefineConfigOptions } from './define-config.js';
+export {
+  findTrailsConfigModulePath,
+  findTrailsLocalConfigModulePath,
+  trailsConfigModuleCandidates,
+  trailsLocalConfigModuleCandidates,
+} from './trails-conventions.js';
 export { deriveConfigFields, type FieldDescription } from './derive-fields.js';
 export {
   checkConfig,

--- a/packages/config/src/trails-conventions.ts
+++ b/packages/config/src/trails-conventions.ts
@@ -1,0 +1,40 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export const trailsConfigModuleCandidates = [
+  'trails.config.ts',
+  'trails.config.mts',
+  'trails.config.js',
+  'trails.config.mjs',
+] as const;
+
+export const trailsLocalConfigModuleCandidates = [
+  'trails.config.local.ts',
+  'trails.config.local.mts',
+  'trails.config.local.js',
+  'trails.config.local.mjs',
+] as const;
+
+const firstExistingCandidate = (
+  rootDir: string,
+  candidates: readonly string[]
+): string | undefined =>
+  candidates.map((entry) => resolve(rootDir, entry)).find(existsSync);
+
+export const findTrailsConfigModulePath = ({
+  configPath,
+  rootDir,
+}: {
+  readonly configPath?: string | undefined;
+  readonly rootDir: string;
+}): string | undefined => {
+  if (configPath !== undefined) {
+    return resolve(rootDir, configPath);
+  }
+  return firstExistingCandidate(rootDir, trailsConfigModuleCandidates);
+};
+
+export const findTrailsLocalConfigModulePath = (
+  rootDir: string
+): string | undefined =>
+  firstExistingCandidate(rootDir, trailsLocalConfigModuleCandidates);

--- a/packages/core/src/__tests__/trails-db.test.ts
+++ b/packages/core/src/__tests__/trails-db.test.ts
@@ -121,7 +121,6 @@ describe('trails db foundation', () => {
       const content = readFileSync(gitignorePath, 'utf8');
       expect(content).toContain('# custom rule');
       expect(content).toContain('*.local');
-      expect(content).toContain('config.local.ts');
       expect(content).toContain('cache/');
       expect(content).toContain('state/');
     });

--- a/packages/core/src/trails-db.ts
+++ b/packages/core/src/trails-db.ts
@@ -20,10 +20,6 @@ const WORKSPACE_SUBDIRS = [TRAILS_CACHE_DIR, TRAILS_STATE_DIR] as const;
  * @see {@link WORKSPACE_GITIGNORE_CONTENT} for the rendered string form.
  */
 export const WORKSPACE_GITIGNORE_LINES = [
-  '# Local config overrides',
-  'config.local.js',
-  'config.local.ts',
-  '',
   '# Rebuildable cache',
   'cache/',
   '',

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -39,7 +39,7 @@ When adding or auditing rules, follow [Warden Rules](../../docs/contributing/war
 
 ## Project-local rules
 
-Projects can carry local Warden rules in `trails/warden/rules/`. `runWarden()` and `trails warden` load that directory by default for lint runs, then run those rules alongside the built-in registries. Drift-only runs do not import project-local rule modules. Embedders that need only built-in or explicitly provided rules can pass `projectRules: false`.
+Projects can carry local Warden rules in `.trails/rules.ts` or `.trails/rules/`. `runWarden()` and `trails warden` load those files by default for lint runs, then run those rules alongside the built-in registries. Drift-only runs do not import project-local rule modules. Embedders that need only built-in or explicitly provided rules can pass `projectRules: false`.
 
 This is the right home for repo-specific migration checks or governance that has not earned a place in `@ontrails/warden` itself.
 
@@ -153,7 +153,7 @@ This is the same factory used internally to build all built-in rule trails.
 | `wardenTopo` | `Topo` of all built-in rule trails (one per rule) |
 | `runWardenTrails(filePath, sourceCode, options?)` | Dispatch file-scoped rule trails for a file, collect diagnostics |
 | `runTopoAwareWardenTrails(topo)` | Dispatch built-in topo-aware rule trails once for a resolved topo |
-| `loadProjectWardenRules(rootDir)` | Load rule modules from `trails/warden/rules/` |
+| `loadProjectWardenRules(rootDir)` | Load rule modules from `.trails/rules.ts` or `.trails/rules/` |
 | `formatGitHubAnnotations(report)` | GitHub Actions annotation format |
 | `formatJson(report)` | Machine-readable JSON |
 | `formatSummary(report)` | Compact summary line |

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@ontrails/adapter-kit": "workspace:^",
     "@ontrails/cli": "workspace:^",
+    "@ontrails/config": "workspace:^",
     "@ontrails/permits": "workspace:^",
     "@ontrails/store": "workspace:^",
     "oxc-parser": "^0.121.0",
@@ -38,7 +39,6 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@ontrails/config": "workspace:^",
     "@ontrails/testing": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import {
   ConflictError,
@@ -96,14 +96,16 @@ const writeAdapterCheckFixture = (rootDir: string): void => {
 const writeProjectSourceRule = (
   rootDir: string,
   options: {
+    readonly directory?: boolean;
     readonly marker?: string;
     readonly name?: string;
     readonly severity?: 'error' | 'warn';
   } = {}
 ): string => {
-  const ruleDir = join(rootDir, 'trails/warden/rules');
-  mkdirSync(ruleDir, { recursive: true });
-  const rulePath = join(ruleDir, 'project-local-rule.ts');
+  const rulePath = options.directory
+    ? join(rootDir, '.trails', 'rules', 'project-local-rule.ts')
+    : join(rootDir, '.trails', 'rules.ts');
+  mkdirSync(dirname(rulePath), { recursive: true });
   const marker = options.marker ?? 'projectLocalProblem';
   const ruleName = options.name ?? 'project-local-rule';
   const severity = options.severity ?? 'error';
@@ -132,7 +134,7 @@ const writeProjectSourceRule = (
 };
 
 const writeProjectAwareRule = (rootDir: string): string => {
-  const ruleDir = join(rootDir, 'trails/warden/rules');
+  const ruleDir = join(rootDir, '.trails', 'rules');
   mkdirSync(ruleDir, { recursive: true });
   const rulePath = join(ruleDir, 'project-aware-rule.ts');
   writeFileSync(
@@ -1526,10 +1528,36 @@ describe('runWarden --fix wiring', () => {
 });
 
 describe('project-local Warden rules', () => {
-  test('loads source rules from trails/warden/rules by default', async () => {
+  test('loads a source rule from .trails/rules.ts by default', async () => {
     const dir = makeTempDir();
     try {
       writeProjectSourceRule(dir);
+      writeFileSync(join(dir, 'fixture.ts'), 'const projectLocalProblem = 1;');
+
+      const report = await runWarden({
+        lock: 'skip',
+        rootDir: dir,
+        tier: 'source-static',
+      });
+
+      expect(report.diagnostics).toContainEqual(
+        expect.objectContaining({
+          filePath: join(dir, 'fixture.ts'),
+          message: 'Project-local fixture marker found.',
+          rule: 'project-local-rule',
+        })
+      );
+      expect(report.errorCount).toBe(1);
+      expect(report.passed).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('loads source rules from .trails/rules by default', async () => {
+    const dir = makeTempDir();
+    try {
+      writeProjectSourceRule(dir, { directory: true });
       writeFileSync(join(dir, 'fixture.ts'), 'const projectLocalProblem = 1;');
 
       const report = await runWarden({
@@ -1577,7 +1605,7 @@ describe('project-local Warden rules', () => {
   test('does not import project-local rules for drift-only runs', async () => {
     const dir = makeTempDir();
     try {
-      const ruleDir = join(dir, 'trails/warden/rules');
+      const ruleDir = join(dir, '.trails', 'rules');
       mkdirSync(ruleDir, { recursive: true });
       writeFileSync(
         join(ruleDir, 'bad.ts'),
@@ -1634,7 +1662,7 @@ describe('project-local Warden rules', () => {
   test('reports invalid project-local rule modules as Warden diagnostics', async () => {
     const dir = makeTempDir();
     try {
-      const ruleDir = join(dir, 'trails/warden/rules');
+      const ruleDir = join(dir, '.trails', 'rules');
       mkdirSync(ruleDir, { recursive: true });
       const rulePath = join(ruleDir, 'empty.ts');
       writeFileSync(rulePath, 'export const nothing = true;\n');

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -122,7 +122,7 @@ export interface WardenRunOptions {
    */
   readonly tier?: WardenRuleTier | undefined;
   /**
-   * Load project-local Warden rules from `trails/warden/rules/`.
+   * Load project-local Warden rules from `.trails/rules.ts` or `.trails/rules/`.
    *
    * Enabled by default for normal runs so a Trails app can carry migration or
    * repo-local governance with the project instead of shipping it from

--- a/packages/warden/src/command.ts
+++ b/packages/warden/src/command.ts
@@ -14,6 +14,7 @@ import type {
 } from '@ontrails/cli';
 import type { Topo } from '@ontrails/core';
 import { AmbiguousError, NotFoundError } from '@ontrails/core';
+import { findTrailsConfigModulePath } from '@ontrails/config';
 
 import type {
   WardenConfigInput,
@@ -56,13 +57,6 @@ interface MutableWardenConfigLayer {
   lock?: WardenLockMode | undefined;
   noLockMutation?: boolean | undefined;
 }
-
-const CONFIG_CANDIDATES = [
-  'trails.config.ts',
-  'trails.config.mts',
-  'trails.config.js',
-  'trails.config.mjs',
-] as const;
 
 const diagnostic = ({
   filePath = '<warden-cli>',
@@ -491,9 +485,7 @@ const findConfigPath = (
         };
   }
 
-  const candidate = CONFIG_CANDIDATES.map((entry) =>
-    resolve(rootDir, entry)
-  ).find((entry) => existsSync(entry));
+  const candidate = findTrailsConfigModulePath({ rootDir });
   return candidate === undefined
     ? { diagnostics: [] }
     : { configPath: candidate, diagnostics: [] };

--- a/packages/warden/src/project-rules.ts
+++ b/packages/warden/src/project-rules.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { statSync } from 'node:fs';
 import { basename, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -10,7 +10,8 @@ import type {
   WardenRule,
 } from './rules/types.js';
 
-const PROJECT_WARDEN_RULES_DIR = 'trails/warden/rules';
+const PROJECT_WARDEN_RULES_FILE = '.trails/rules.ts';
+const PROJECT_WARDEN_RULES_DIR = '.trails/rules';
 
 export interface ProjectWardenRules {
   readonly diagnostics: readonly WardenDiagnostic[];
@@ -130,18 +131,45 @@ const topoRuleCandidatesFromModule = (
   ...asArray(module.topoRules),
 ];
 
-const collectProjectRuleFiles = (rulesDir: string): readonly string[] => {
-  if (!existsSync(rulesDir)) {
-    return [];
+const isFile = (path: string): boolean => {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+};
+
+const isDirectory = (path: string): boolean => {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+};
+
+const collectProjectRuleFiles = (rootDir: string): readonly string[] => {
+  const files: string[] = [];
+  const rulesFile = join(rootDir, PROJECT_WARDEN_RULES_FILE);
+  const rulesDir = join(rootDir, PROJECT_WARDEN_RULES_DIR);
+
+  if (isFile(rulesFile)) {
+    files.push(rulesFile);
+  }
+
+  if (!isDirectory(rulesDir)) {
+    return files;
   }
 
   const glob = new Bun.Glob('**/*.ts');
-  return [...glob.scanSync({ cwd: rulesDir, onlyFiles: true })]
-    .filter(
-      (entry) => !entry.endsWith('.test.ts') && !basename(entry).startsWith('_')
-    )
-    .map((entry) => join(rulesDir, entry))
-    .toSorted((left, right) => left.localeCompare(right));
+  files.push(
+    ...[...glob.scanSync({ cwd: rulesDir, onlyFiles: true })]
+      .filter(
+        (entry) =>
+          !entry.endsWith('.test.ts') && !basename(entry).startsWith('_')
+      )
+      .map((entry) => join(rulesDir, entry))
+  );
+  return files.toSorted((left, right) => left.localeCompare(right));
 };
 
 const loadRuleFile = async (filePath: string): Promise<ProjectWardenRules> => {
@@ -188,9 +216,7 @@ const loadRuleFile = async (filePath: string): Promise<ProjectWardenRules> => {
 export const loadProjectWardenRules = async (
   rootDir: string
 ): Promise<ProjectWardenRules> => {
-  const files = collectProjectRuleFiles(
-    join(rootDir, PROJECT_WARDEN_RULES_DIR)
-  );
+  const files = collectProjectRuleFiles(rootDir);
   const loaded = await Promise.all(files.map(loadRuleFile));
 
   return {

--- a/scripts/vocab-cutover-map.ts
+++ b/scripts/vocab-cutover-map.ts
@@ -366,7 +366,7 @@ export const auditRules: readonly VocabAuditRule[] = [
       'Retired TopoGraph artifact-family vocabulary still appears outside history, migration notes, and legacy cleanup seams.',
     excludePaths: topographArtifactFamilyRetiredMentionPaths,
     id: 'topograph-artifact-family-retired-term',
-    pattern: String.raw`\bSurfaceMap(?:Entry)?\b|_surface\.json|\bsurface_map\b|\bserialized_lock\b|\.trails/config/local(?:\.[tj]s)?|\.trails/trails\.db(?:-(?:shm|wal))?|\.trails/dev/|\.trails/generated/`,
+    pattern: String.raw`\bSurfaceMap(?:Entry)?\b|_surface\.json|\bsurface_map\b|\bserialized_lock\b|\.trails/config/local(?:\.[cm]?[tj]s)?|\.trails/config\.local(?:\.[cm]?[tj]s)?|\.trails/trails\.db(?:-(?:shm|wal))?|\.trails/dev/|\.trails/generated/`,
   },
   {
     description:


### PR DESCRIPTION
## Summary

- centralize Trails config module path discovery in `@ontrails/config`
- load local config overrides from root `trails.config.local.*` instead of `.trails/config.local.*`
- load project-local Warden rules from `.trails/rules.ts` or `.trails/rules/`
- update scaffold/gitignore behavior plus docs, ADRs, lexicon, migration guidance, and release intent for the substrate cutover

## Verification

- `bun test packages/config/src/__tests__/define-config.test.ts packages/warden/src/__tests__/cli.test.ts packages/warden/src/__tests__/command.test.ts apps/trails/src/__tests__/release-check-trail.test.ts packages/core/src/__tests__/trails-db.test.ts` — 88 pass / 0 fail
- `bun run docs:wrap-check && bun run docs:links`
- `bun run --cwd packages/warden typecheck && bun run --cwd apps/trails typecheck && bun run --cwd packages/config typecheck`
- `bun run vocab:audit`
- `bun run check` — Warden PASS, 0 errors, known pre-existing warnings only
- `bun run test` — 43 Turbo tasks successful
- `bun run build` — 25 Turbo tasks successful
- `bun run wayfinder:dogfood` — 61 trails inspected from saved operator topo artifacts
- `bun run publish:check`
- `bun run changeset:check`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`
- real Graphite submit pre-push hook — Warden, ADR, test, typecheck, lint, ast-grep, format, release-pack, and dead-code passed

## Local Review

- Code/runtime review lane found a P2: `@ontrails/warden` used `@ontrails/config` at runtime but listed it only as a dev dependency. Fixed by moving it to runtime dependencies and refreshing `bun.lock`.
- Docs/release/governance review lane found stale `.trails/config.local.*` guidance. Fixed across docs, ADRs, lexicon, migration notes, and the vocab cutover guard.
- Follow-up review from both lanes reported no open P0/P1/P2 findings.

## Notes

- Known Warden warnings remain outside this branch's scope: internal Wayfinder query trails and existing signal/dead-public-trail backlog depending on the command surface. No Warden errors.
- Goal packet for this run is local-only under `.agents/goals/2026-06-22-substrate-first-slice/` and intentionally not committed.
