### PR TITLE
fix(config): add shared trails project root discovery

### DIFF
--- a/.changeset/trl-1021-shared-root-discovery.md
+++ b/.changeset/trl-1021-shared-root-discovery.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/config": patch
+"@ontrails/warden": patch
+---
+
+Add shared Trails project-root discovery helpers and use them in Warden so nested
+cwd invocations still load root `trails.config.*` and project-local
+`.trails/rules*` governance.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -514,6 +514,12 @@ RegradeReviewDetail, RegradeReviewSpan, RegradeScanTargets, RegradeSelection
 defineConfig(options)                // define a config schema with base, profiles, and extensions
 appConfig(name, options)             // lower-level config factory without Trails conventions
 
+// Trails conventions
+findTrailsConfigModulePath(options)  // locate root trails.config.*
+findTrailsLocalConfigModulePath(rootDir) // locate root trails.config.local.*
+findTrailsProjectRoot(options?)      // walk upward to a project root marker
+resolveTrailsProjectRoot(options?)   // explicit root or discovered/fallback root
+
 // Extensions
 env(schema, envVar)                  // bind a schema field to an environment variable
 secret(schema)                       // mark a field as sensitive (redacted in output)

--- a/docs/contributing/warden-rules.md
+++ b/docs/contributing/warden-rules.md
@@ -45,6 +45,8 @@ Temporary repo-local rules are allowed when they have a clear lifecycle. TRL-575
 
 Project-local Warden rules live in `.trails/rules.ts` or `.trails/rules/` at the project root. Warden loads those files by default for command and API runs, so an adopting repo can enforce local migration or governance rules without shipping them from `@ontrails/warden`. The location is the ownership signal: a rule in that committed-control directory is project-local by placement, not by advisory metadata. Modules may export `rule`, `rules`, `sourceRule`, `sourceRules`, `topoRule`, or `topoRules`; rules without explicit metadata receive repo-local source-static or topo-aware execution metadata so short-lived migration rules do not need ceremony before they can run.
 
+Project-root discovery uses committed project markers such as `trails.config.*` or `trails.lock`, with source-shaped projects as fallback when no committed marker exists above them. A bare `.trails/` directory is not a root marker by itself. This lets Warden find root-local rules from nested cwd invocations without making every incidental `.trails/` folder look like a project boundary.
+
 Use `.trails/rules.ts` or `.trails/rules/` when the invariant is real for this project but not yet a framework promise. Promote the rule into `@ontrails/warden` only after the survival tests show it belongs to Trails users broadly. Delete it when the migration or temporary hardening window closes.
 
 ## Core Principle

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -90,6 +90,16 @@ Each layer overrides the previous. Environment variables always win.
 
 `appConfig()` discovers `*.config.toml`, `*.config.json`, `*.config.jsonc`, and `*.config.yaml` by default, plus dotfile equivalents when `dotfile: true`.
 
+## Trails project roots
+
+`@ontrails/config` owns the shared project-root convention helpers used by framework tools. `resolveTrailsProjectRoot()` honors an explicit root first, then walks upward from a start directory looking for committed project markers:
+
+- `trails.config.ts`, `.mts`, `.js`, or `.mjs`
+- `trails.lock`
+- source-shaped projects with `src/trails/` or `trails/` when no committed marker exists above them
+
+`trails.config.local.*` is a per-developer override and does not mark a project root by itself. A bare `.trails/` directory also does not mark a root; it is the committed-control home for project-local sections after a project root is known.
+
 ## Extensions
 
 ### `env()`

--- a/packages/config/src/__tests__/trails-conventions.test.ts
+++ b/packages/config/src/__tests__/trails-conventions.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import {
+  findTrailsProjectRoot,
+  resolveTrailsProjectRoot,
+} from '../trails-conventions.js';
+
+const makeTempDir = (): string =>
+  mkdtempSync(join(tmpdir(), 'trails-conventions-'));
+
+describe('Trails project root conventions', () => {
+  test('walks up from nested cwd to the nearest root config marker', () => {
+    const root = makeTempDir();
+    try {
+      const nested = join(root, 'packages', 'app', 'src');
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(join(root, 'trails.config.ts'), 'export default {};\n');
+
+      expect(findTrailsProjectRoot({ startDir: nested })).toMatchObject({
+        marker: 'config',
+        markerPath: join(root, 'trails.config.ts'),
+        rootDir: root,
+      });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('prefers the nearest committed project marker in nested projects', () => {
+    const workspace = makeTempDir();
+    try {
+      const member = join(workspace, 'packages', 'app');
+      const nested = join(member, 'src', 'feature');
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(
+        join(workspace, 'trails.config.ts'),
+        'export default {};\n'
+      );
+      writeFileSync(join(member, 'trails.lock'), '{}\n');
+
+      expect(findTrailsProjectRoot({ startDir: nested })).toMatchObject({
+        marker: 'lock',
+        markerPath: join(member, 'trails.lock'),
+        rootDir: member,
+      });
+    } finally {
+      rmSync(workspace, { force: true, recursive: true });
+    }
+  });
+
+  test('does not treat a bare .trails directory as a root marker', () => {
+    const root = makeTempDir();
+    try {
+      const nested = join(root, 'src');
+      mkdirSync(join(root, '.trails', 'rules'), { recursive: true });
+      mkdirSync(nested, { recursive: true });
+
+      expect(findTrailsProjectRoot({ startDir: nested })).toBeUndefined();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('does not treat a local override alone as a root marker', () => {
+    const root = makeTempDir();
+    try {
+      const nested = join(root, 'packages', 'app');
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(
+        join(root, 'trails.config.local.ts'),
+        'export default {};\n'
+      );
+
+      expect(findTrailsProjectRoot({ startDir: nested })).toBeUndefined();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('recognizes source-shaped projects without requiring control files', () => {
+    const root = makeTempDir();
+    try {
+      const sourceRoot = join(root, 'src', 'trails');
+      const nested = join(sourceRoot, 'features');
+      mkdirSync(nested, { recursive: true });
+
+      expect(findTrailsProjectRoot({ startDir: nested })).toMatchObject({
+        marker: 'source',
+        markerPath: sourceRoot,
+        rootDir: root,
+      });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('treats source-shaped projects as fallback below committed workspace markers', () => {
+    const workspace = makeTempDir();
+    try {
+      const member = join(workspace, 'packages', 'app');
+      const sourceRoot = join(member, 'src', 'trails');
+      const nested = join(sourceRoot, 'features');
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(
+        join(workspace, 'trails.config.ts'),
+        'export default {};\n'
+      );
+
+      expect(findTrailsProjectRoot({ startDir: nested })).toMatchObject({
+        marker: 'config',
+        markerPath: join(workspace, 'trails.config.ts'),
+        rootDir: workspace,
+      });
+    } finally {
+      rmSync(workspace, { force: true, recursive: true });
+    }
+  });
+
+  test('ignores directory-shaped config and lock marker lookalikes', () => {
+    const root = makeTempDir();
+    try {
+      const nested = join(root, 'src');
+      mkdirSync(join(root, 'trails.config.ts'), { recursive: true });
+      mkdirSync(join(root, 'trails.lock'), { recursive: true });
+      mkdirSync(nested, { recursive: true });
+
+      expect(findTrailsProjectRoot({ startDir: nested })).toBeUndefined();
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('explicit roots win over discovered parent markers', () => {
+    const root = makeTempDir();
+    try {
+      const explicit = join(root, 'scratch');
+      const nested = join(root, 'packages', 'app', 'src');
+      mkdirSync(explicit, { recursive: true });
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(join(root, 'trails.config.ts'), 'export default {};\n');
+
+      expect(
+        resolveTrailsProjectRoot({
+          explicitRootDir: explicit,
+          startDir: nested,
+        })
+      ).toMatchObject({
+        marker: 'explicit',
+        rootDir: explicit,
+      });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('falls back to the resolved start directory when no marker exists', () => {
+    const root = makeTempDir();
+    try {
+      const nested = join(root, 'loose');
+      mkdirSync(nested, { recursive: true });
+
+      expect(resolveTrailsProjectRoot({ startDir: nested })).toMatchObject({
+        marker: 'fallback',
+        rootDir: resolve(nested),
+      });
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -12,8 +12,14 @@ export { defineConfig, type DefineConfigOptions } from './define-config.js';
 export {
   findTrailsConfigModulePath,
   findTrailsLocalConfigModulePath,
+  findTrailsProjectRoot,
+  resolveTrailsProjectRoot,
   trailsConfigModuleCandidates,
+  trailsLockFileName,
   trailsLocalConfigModuleCandidates,
+  trailsSourceRootCandidates,
+  type TrailsProjectRootMarker,
+  type TrailsProjectRootResolution,
 } from './trails-conventions.js';
 export { deriveConfigFields, type FieldDescription } from './derive-fields.js';
 export {

--- a/packages/config/src/trails-conventions.ts
+++ b/packages/config/src/trails-conventions.ts
@@ -1,5 +1,5 @@
-import { existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 
 export const trailsConfigModuleCandidates = [
   'trails.config.ts',
@@ -15,11 +15,52 @@ export const trailsLocalConfigModuleCandidates = [
   'trails.config.local.mjs',
 ] as const;
 
+export const trailsLockFileName = 'trails.lock' as const;
+
+export const trailsSourceRootCandidates = ['src/trails', 'trails'] as const;
+
+export type TrailsProjectRootMarker =
+  | 'config'
+  | 'explicit'
+  | 'fallback'
+  | 'lock'
+  | 'source';
+
+export interface TrailsProjectRootResolution {
+  readonly marker: TrailsProjectRootMarker;
+  readonly markerPath?: string | undefined;
+  readonly rootDir: string;
+}
+
+export interface FindTrailsProjectRootOptions {
+  readonly startDir?: string | undefined;
+}
+
+export interface ResolveTrailsProjectRootOptions extends FindTrailsProjectRootOptions {
+  readonly explicitRootDir?: string | undefined;
+}
+
+const isFile = (path: string): boolean => {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+};
+
+const isDirectory = (path: string): boolean => {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+};
+
 const firstExistingCandidate = (
   rootDir: string,
   candidates: readonly string[]
 ): string | undefined =>
-  candidates.map((entry) => resolve(rootDir, entry)).find(existsSync);
+  candidates.map((entry) => resolve(rootDir, entry)).find(isFile);
 
 export const findTrailsConfigModulePath = ({
   configPath,
@@ -38,3 +79,81 @@ export const findTrailsLocalConfigModulePath = (
   rootDir: string
 ): string | undefined =>
   firstExistingCandidate(rootDir, trailsLocalConfigModuleCandidates);
+
+const firstExistingSourceRoot = (rootDir: string): string | undefined =>
+  trailsSourceRootCandidates
+    .map((entry) => join(rootDir, entry))
+    .find(isDirectory);
+
+const findProjectRootMarkerIn = (
+  rootDir: string
+): Omit<TrailsProjectRootResolution, 'rootDir'> | undefined => {
+  const configPath = findTrailsConfigModulePath({ rootDir });
+  if (configPath !== undefined) {
+    return { marker: 'config', markerPath: configPath };
+  }
+
+  const lockPath = join(rootDir, trailsLockFileName);
+  if (isFile(lockPath)) {
+    return { marker: 'lock', markerPath: lockPath };
+  }
+
+  return undefined;
+};
+
+const findSourceRootMarkerIn = (
+  rootDir: string
+): Omit<TrailsProjectRootResolution, 'rootDir'> | undefined => {
+  const sourcePath = firstExistingSourceRoot(rootDir);
+  if (sourcePath !== undefined) {
+    return { marker: 'source', markerPath: sourcePath };
+  }
+
+  return undefined;
+};
+
+export const findTrailsProjectRoot = ({
+  startDir = process.cwd(),
+}: FindTrailsProjectRootOptions = {}):
+  | TrailsProjectRootResolution
+  | undefined => {
+  let current = resolve(startDir);
+  let sourceFallback: TrailsProjectRootResolution | undefined;
+
+  while (true) {
+    const marker = findProjectRootMarkerIn(current);
+    if (marker !== undefined) {
+      return { ...marker, rootDir: current };
+    }
+
+    const sourceMarker = findSourceRootMarkerIn(current);
+    if (sourceMarker !== undefined) {
+      sourceFallback = { ...sourceMarker, rootDir: current };
+    }
+
+    const parent = dirname(current);
+    if (parent === current) {
+      return sourceFallback;
+    }
+    current = parent;
+  }
+};
+
+export const resolveTrailsProjectRoot = ({
+  explicitRootDir,
+  startDir = process.cwd(),
+}: ResolveTrailsProjectRootOptions = {}): TrailsProjectRootResolution => {
+  if (explicitRootDir !== undefined) {
+    return {
+      marker: 'explicit',
+      rootDir: resolve(startDir, explicitRootDir),
+    };
+  }
+
+  return (
+    findTrailsProjectRoot({ startDir }) ?? {
+      marker: 'fallback',
+      rootDir: resolve(startDir),
+    }
+  );
+};

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -41,6 +41,8 @@ When adding or auditing rules, follow [Warden Rules](../../docs/contributing/war
 
 Projects can carry local Warden rules in `.trails/rules.ts` or `.trails/rules/`. `runWarden()` and `trails warden` load those files by default for lint runs, then run those rules alongside the built-in registries. Drift-only runs do not import project-local rule modules. Embedders that need only built-in or explicitly provided rules can pass `projectRules: false`.
 
+Warden uses the shared Trails project-root resolver when a caller does not pass `rootDir` or `--root-dir`, so commands launched from nested directories still load the nearest root `trails.config.*` and its `.trails/rules*` files. An explicit root always wins over discovery.
+
 This is the right home for repo-specific migration checks or governance that has not earned a place in `@ontrails/warden` itself.
 
 A rule module may export `rule`, `rules`, `sourceRule`, `sourceRules`, `topoRule`, or `topoRules`. Rules without explicit metadata receive default repo-local source-static or topo-aware metadata so short migration rules can run without extra ceremony. Project-aware source rules that provide `checkWithContext()` default to repo-local project-static metadata.

--- a/packages/warden/src/__tests__/command.test.ts
+++ b/packages/warden/src/__tests__/command.test.ts
@@ -257,4 +257,80 @@ describe('runWardenCommand', () => {
       rmSync(dir, { force: true, recursive: true });
     }
   });
+
+  test('discovers root config and project-local rules from nested cwd', async () => {
+    const dir = makeTempDir();
+    try {
+      const nested = join(dir, 'packages', 'app', 'src');
+      mkdirSync(join(dir, '.trails'), { recursive: true });
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(
+        join(dir, 'trails.config.ts'),
+        `export default { warden: { depth: 'source', lock: 'skip' } };\n`
+      );
+      writeFileSync(
+        join(dir, '.trails', 'rules.ts'),
+        `export const rule = {
+  name: 'nested-root-project-rule',
+  severity: 'error',
+  description: 'Nested cwd fixture rule.',
+  check(sourceCode, filePath) {
+    return sourceCode.includes('nestedRootProblem')
+      ? [{ filePath, line: 1, message: 'Nested root fixture marker found.', rule: 'nested-root-project-rule', severity: 'error' }]
+      : [];
+  },
+};\n`
+      );
+      const sourcePath = join(dir, 'fixture.ts');
+      writeFileSync(sourcePath, 'const nestedRootProblem = 1;\n');
+
+      const result = await runWardenCommand({ cwd: nested, env: {} });
+
+      expect(result.report.effectiveConfig).toMatchObject({
+        depth: 'source',
+        lock: 'skip',
+      });
+      expect(result.report.diagnostics).toContainEqual(
+        expect.objectContaining({
+          filePath: sourcePath,
+          message: 'Nested root fixture marker found.',
+          rule: 'nested-root-project-rule',
+        })
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('explicit --root-dir wins over nested cwd discovery', async () => {
+    const dir = makeTempDir();
+    try {
+      const explicitRoot = join(dir, 'explicit');
+      const discoveredRoot = join(dir, 'discovered');
+      const nested = join(discoveredRoot, 'packages', 'app', 'src');
+      mkdirSync(explicitRoot, { recursive: true });
+      mkdirSync(nested, { recursive: true });
+      writeFileSync(
+        join(explicitRoot, 'trails.config.ts'),
+        `export default { warden: { depth: 'source', lock: 'skip' } };\n`
+      );
+      writeFileSync(
+        join(discoveredRoot, 'trails.config.ts'),
+        `export default { warden: { depth: 'project', lock: 'skip' } };\n`
+      );
+
+      const result = await runWardenCommand({
+        args: ['--root-dir', explicitRoot],
+        cwd: nested,
+        env: {},
+      });
+
+      expect(result.report.effectiveConfig).toMatchObject({
+        depth: 'source',
+        lock: 'skip',
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
 });

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -7,6 +7,7 @@
 
 import { isAbsolute, relative, resolve } from 'node:path';
 
+import { resolveTrailsProjectRoot } from '@ontrails/config';
 import type { Topo } from '@ontrails/core';
 import { deriveTopoGraph } from '@ontrails/topographer';
 import type { TopoGraph } from '@ontrails/topographer';
@@ -1445,7 +1446,10 @@ export const applySafeFixesToFiles = async (
 export const runWarden = async (
   options: WardenRunOptions = {}
 ): Promise<WardenReport> => {
-  const rootDir = resolve(options.rootDir ?? process.cwd());
+  const { rootDir } = resolveTrailsProjectRoot({
+    explicitRootDir: options.rootDir,
+    startDir: process.cwd(),
+  });
   const { diagnostics: configDiagnostics, effectiveConfig } =
     resolveWardenConfig({
       cli: buildCliConfigLayer(options),

--- a/packages/warden/src/command.ts
+++ b/packages/warden/src/command.ts
@@ -14,7 +14,10 @@ import type {
 } from '@ontrails/cli';
 import type { Topo } from '@ontrails/core';
 import { AmbiguousError, NotFoundError } from '@ontrails/core';
-import { findTrailsConfigModulePath } from '@ontrails/config';
+import {
+  findTrailsConfigModulePath,
+  resolveTrailsProjectRoot,
+} from '@ontrails/config';
 
 import type {
   WardenConfigInput,
@@ -898,7 +901,10 @@ export const runWardenCommand = async ({
   env = {},
 }: RunWardenCommandOptions): Promise<WardenCommandResult> => {
   const parsed = parseWardenCommandArgs(args);
-  const rootDir = resolve(cwd, parsed.rootDir ?? '.');
+  const { rootDir } = resolveTrailsProjectRoot({
+    explicitRootDir: parsed.rootDir,
+    startDir: cwd,
+  });
   const loadedConfig = await loadWardenConfig({
     configPath: parsed.configPath,
     env,


### PR DESCRIPTION
## Context

TRL-1021 adds the shared Trails project-root discovery slice for the substrate cutover. The goal is to give config and Warden one exact resolver for explicit roots, committed project markers, and source-shaped fallback projects instead of each surface guessing from cwd.

## What changed

- Added `findTrailsProjectRoot()` and `resolveTrailsProjectRoot()` to `@ontrails/config`.
- Treats `trails.config.*` and `trails.lock` as committed file markers.
- Treats `src/trails` or `trails` as fallback source-shaped roots only when no committed marker exists above.
- Ignores bare `.trails/` and `trails.config.local.*` as root markers.
- Wires Warden CLI and command execution through the shared resolver when `--root-dir` is not explicit.
- Adds temp-fixture tests for nested cwd discovery, explicit root precedence, source fallback, local override non-markers, and directory-shaped marker lookalikes.
- Updates config/Warden docs and API reference, plus a branch-local changeset for `@ontrails/config` and `@ontrails/warden`.

## Local review

Two in-thread local review rounds completed. Round 1 found one P2 around source-shaped package roots under a committed workspace marker. The fix makes source-shaped roots fallback-only under committed markers and proves/docs that contract. Round 2 reported no remaining P0-P2 findings.

## Verification

- `bun test packages/config/src/__tests__/trails-conventions.test.ts packages/warden/src/__tests__/command.test.ts`
- `bun run --cwd packages/config test`
- `bun run --cwd packages/warden test`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun run changeset:check`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`

Pre-push also passed during real Graphite submit.

## Notes

This slice does not introduce or move XDG/global cache/state paths. The proof is focused on project-root detection and Warden consuming project-local config/rules from nested cwd. XDG-specific env-isolated fixtures belong with the later global cache/state migration slice.