### PR TITLE
fix(core): move trails db state to xdg store

### DIFF
--- a/.changeset/trl-1057-xdg-state-store.md
+++ b/.changeset/trl-1057-xdg-state-store.md
@@ -1,0 +1,9 @@
+---
+"@ontrails/core": patch
+"@ontrails/trails": patch
+"@ontrails/tracing": patch
+"@ontrails/topographer": patch
+"@ontrails/wayfinder": patch
+---
+
+Move the default `trails.db` location to the per-user Trails state store, expose deterministic state-store path helpers, stop scaffolding disposable `.trails/cache` and `.trails/state` directories, and update topo-store documentation for the global-state substrate.

--- a/apps/trails/.trails/.gitignore
+++ b/apps/trails/.trails/.gitignore
@@ -1,5 +1,0 @@
-# Rebuildable cache
-cache/
-
-# Mutable runtime state
-state/

--- a/apps/trails/__tests__/examples.test.ts
+++ b/apps/trails/__tests__/examples.test.ts
@@ -1,25 +1,19 @@
 /* oxlint-disable eslint-plugin-jest/require-hook -- testExamples registers tests at module scope */
 import { afterAll, beforeAll } from 'bun:test';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { mkdirSync, rmSync } from 'node:fs';
+import { resolve } from 'node:path';
 
-import { WORKSPACE_GITIGNORE_CONTENT, topo } from '@ontrails/core';
+import { topo } from '@ontrails/core';
 import { testExamples } from '@ontrails/testing';
 
 import { operatorApp } from '../src/app.js';
 
 const trailsWorkspaceDir = resolve(import.meta.dir, '..', '.trails');
-const trailsGitignorePath = join(trailsWorkspaceDir, '.gitignore');
-const trailsWorkspaceSubdirs = ['cache', 'state'] as const;
 const repoRoot = resolve(import.meta.dir, '..', '..', '..');
 
 const resetTrailsWorkspace = (): void => {
   rmSync(trailsWorkspaceDir, { force: true, recursive: true });
   mkdirSync(trailsWorkspaceDir, { recursive: true });
-  for (const subdir of trailsWorkspaceSubdirs) {
-    mkdirSync(join(trailsWorkspaceDir, subdir), { recursive: true });
-  }
-  writeFileSync(trailsGitignorePath, WORKSPACE_GITIGNORE_CONTENT);
 };
 
 beforeAll(() => {

--- a/apps/trails/src/__tests__/create.test.ts
+++ b/apps/trails/src/__tests__/create.test.ts
@@ -207,6 +207,30 @@ const assertDefaultProjectFiles = (dir: string): void => {
   );
 };
 
+const assertGitignore = (dir: string): void => {
+  expectContainsAll(readText(dir, '.gitignore'), [
+    'node_modules/',
+    '.trails/cache/',
+    '.trails/state/',
+    '.trails/trails.db*',
+    'trails.config.local.ts',
+  ]);
+};
+
+const assertNoDisposableTrailsState = (dir: string): void => {
+  expectPaths(
+    dir,
+    [
+      '.trails/cache',
+      '.trails/state',
+      '.trails/trails.db',
+      '.trails/trails.db-shm',
+      '.trails/trails.db-wal',
+    ],
+    false
+  );
+};
+
 const assertTsconfigTests = (dir: string): void => {
   const tsconfig = readJson(dir, 'tsconfig.tests.json');
   expect(tsconfig['extends']).toBe('./tsconfig.json');
@@ -535,6 +559,8 @@ describe('trails create', () => {
           'tsconfig.tests.json',
         ]);
         assertDefaultProjectFiles(dir);
+        assertGitignore(dir);
+        assertNoDisposableTrailsState(dir);
         assertAgentGuidance(dir);
         assertReadme(dir);
         assertScaffoldProvenance(dir);
@@ -570,7 +596,6 @@ describe('trails create', () => {
             { kind: 'write', path: 'AGENTS.md' },
             { kind: 'write', path: 'CLAUDE.md' },
             { kind: 'write', path: 'src/app.ts' },
-            { kind: 'write', path: '.trails/.gitignore' },
             { kind: 'write', path: '.trails/scaffold.json' },
             { kind: 'write', path: 'tsconfig.tests.json' },
           ])
@@ -608,6 +633,7 @@ describe('trails create', () => {
           ],
           true
         );
+        assertNoDisposableTrailsState(dir);
       });
     });
 

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
   existsSync,
   mkdirSync,
@@ -306,6 +306,27 @@ const repoTempDir = (): string =>
     '.tmp-tests',
     `trails-survey-${Date.now()}-${Math.random().toString(36).slice(2)}`
   );
+
+let testStateHome: string | undefined;
+let originalTrailsStateHome: string | undefined;
+
+beforeEach(() => {
+  originalTrailsStateHome = process.env.TRAILS_STATE_HOME;
+  testStateHome = repoTempDir();
+  process.env.TRAILS_STATE_HOME = testStateHome;
+});
+
+afterEach(() => {
+  if (originalTrailsStateHome === undefined) {
+    delete process.env.TRAILS_STATE_HOME;
+  } else {
+    process.env.TRAILS_STATE_HOME = originalTrailsStateHome;
+  }
+  if (testStateHome !== undefined) {
+    rmSync(testStateHome, { force: true, recursive: true });
+    testStateHome = undefined;
+  }
+});
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/apps/trails/src/__tests__/topo-dev.test.ts
+++ b/apps/trails/src/__tests__/topo-dev.test.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable max-statements */
 
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import {
   existsSync,
   mkdirSync,
@@ -11,7 +11,11 @@ import {
 import { join, resolve } from 'node:path';
 
 import type { Result } from '@ontrails/core';
-import { openReadTrailsDb, TimeoutError } from '@ontrails/core';
+import {
+  deriveTrailsDbPath,
+  openReadTrailsDb,
+  TimeoutError,
+} from '@ontrails/core';
 import { createDevStore } from '@ontrails/tracing';
 
 import { devCleanTrail } from '../trails/dev-clean.js';
@@ -37,6 +41,31 @@ const repoTempDir = (): string =>
     '.tmp-tests',
     `topo-dev-${Date.now()}-${Math.random().toString(36).slice(2)}`
   );
+
+let testStateHome: string | undefined;
+let originalTrailsStateHome: string | undefined;
+
+const restoreTrailsStateHome = (value: string | undefined): void => {
+  if (value === undefined) {
+    delete process.env.TRAILS_STATE_HOME;
+    return;
+  }
+  process.env.TRAILS_STATE_HOME = value;
+};
+
+beforeEach(() => {
+  originalTrailsStateHome = process.env.TRAILS_STATE_HOME;
+  testStateHome = repoTempDir();
+  process.env.TRAILS_STATE_HOME = testStateHome;
+});
+
+afterEach(() => {
+  restoreTrailsStateHome(originalTrailsStateHome);
+  if (testStateHome !== undefined) {
+    rmSync(testStateHome, { force: true, recursive: true });
+  }
+  testStateHome = undefined;
+});
 
 const expectOk = <T>(result: Result<T, Error>): T => {
   if (result.isErr()) {
@@ -508,18 +537,17 @@ describe('topo and dev trails', () => {
       const resetPreview = expectOk(
         await devResetTrail.blaze({ dryRun: true }, { cwd: dir } as never)
       );
+      const dbPath = deriveTrailsDbPath({ rootDir: dir });
       expect(resetPreview.dryRun).toBe(true);
-      expect(resetPreview.removedFiles).toContain('.trails/state/trails.db');
+      expect(resetPreview.removedFiles).toContain(dbPath);
 
       const resetResult = expectOk(
         await devResetTrail.blaze({ dryRun: false, yes: true }, {
           cwd: dir,
         } as never)
       );
-      expect(resetResult.removedFiles).toContain('.trails/state/trails.db');
-      expect(existsSync(join(dir, '.trails', 'state', 'trails.db'))).toBe(
-        false
-      );
+      expect(resetResult.removedFiles).toContain(dbPath);
+      expect(existsSync(dbPath)).toBe(false);
       expect(
         readFileSync(join(dir, '.trails', 'trails.lock'), 'utf8').length
       ).toBeGreaterThan(0);
@@ -540,9 +568,7 @@ describe('topo and dev trails', () => {
       expect(preview.dryRun).toBe(true);
       expect(preview.removed.topoSnapshots).toBe(0);
       expect(preview.removed.traceRecords).toBe(0);
-      expect(existsSync(join(dir, '.trails', 'state', 'trails.db'))).toBe(
-        false
-      );
+      expect(existsSync(deriveTrailsDbPath({ rootDir: dir }))).toBe(false);
 
       const applied = expectOk(
         await devCleanTrail.blaze({ dryRun: false, yes: true }, {
@@ -552,9 +578,7 @@ describe('topo and dev trails', () => {
       expect(applied.dryRun).toBe(false);
       expect(applied.removed.topoSnapshots).toBe(0);
       expect(applied.removed.traceRecords).toBe(0);
-      expect(existsSync(join(dir, '.trails', 'state', 'trails.db'))).toBe(
-        false
-      );
+      expect(existsSync(deriveTrailsDbPath({ rootDir: dir }))).toBe(false);
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/apps/trails/src/local-state-io.ts
+++ b/apps/trails/src/local-state-io.ts
@@ -151,3 +151,23 @@ export const removeRootRelativeFileIfPresent = (
     );
   }
 };
+
+export const removeFileIfPresent = (
+  path: string
+): TrailsResult<boolean, Error> => {
+  if (!existsSync(path)) {
+    return Result.ok(false);
+  }
+
+  try {
+    rmSync(path, { force: true });
+    return Result.ok(true);
+  } catch (error) {
+    return Result.err(
+      new InternalError(`Failed to remove local state file "${path}"`, {
+        cause: asError(error),
+        context: { path },
+      })
+    );
+  }
+};

--- a/apps/trails/src/trails/create-scaffold.ts
+++ b/apps/trails/src/trails/create-scaffold.ts
@@ -1,12 +1,12 @@
 /**
  * `create.scaffold` trail -- Creates base project structure.
  *
- * Generates package.json, tsconfig, app.ts, starter trails, and .trails/ directory.
+ * Generates package.json, tsconfig, app.ts, starter trails, and scaffold provenance.
  */
 
 import { resolve } from 'node:path';
 
-import { Result, trail, WORKSPACE_GITIGNORE_CONTENT } from '@ontrails/core';
+import { Result, trail } from '@ontrails/core';
 import type { Result as TrailsResult } from '@ontrails/core';
 import { z } from 'zod';
 
@@ -197,12 +197,13 @@ Keep shared project guidance in \`./AGENTS.md\`. Only Claude-specific bootstrap 
 const GITIGNORE_CONTENT = `node_modules/
 dist/
 *.tsbuildinfo
+.trails/cache/
+.trails/state/
+.trails/trails.db*
 trails.config.local.js
 trails.config.local.mjs
 trails.config.local.mts
 trails.config.local.ts
-.trails/cache/
-.trails/state/
 `;
 
 const OXLINT_CONFIG_CONTENT = `import { defineConfig } from 'oxlint';
@@ -555,7 +556,6 @@ const collectScaffoldFiles = (
     ['.gitignore', GITIGNORE_CONTENT],
     ['oxlint.config.ts', OXLINT_CONFIG_CONTENT],
     ['.oxfmtrc.jsonc', OXFMTRC_CONTENT],
-    ['.trails/.gitignore', WORKSPACE_GITIGNORE_CONTENT],
     ['.trails/scaffold.json', generateScaffoldProvenance(starter)],
     ['src/app.ts', generateAppTs(name, starter)],
     ...starterFileGenerators[starter](),

--- a/apps/trails/src/trails/dev-support.ts
+++ b/apps/trails/src/trails/dev-support.ts
@@ -1,5 +1,5 @@
 import { existsSync, statSync } from 'node:fs';
-import { join } from 'node:path';
+import { isAbsolute, join } from 'node:path';
 
 import {
   openReadTrailsDb,
@@ -21,7 +21,10 @@ import {
   previewTraceCleanup,
 } from '@ontrails/tracing';
 
-import { removeRootRelativeFileIfPresent } from '../local-state-io.js';
+import {
+  removeFileIfPresent,
+  removeRootRelativeFileIfPresent,
+} from '../local-state-io.js';
 
 import { requireTrailRootDir } from './root-dir.js';
 
@@ -31,9 +34,17 @@ const deriveRootDir = (cwd?: string): string => requireTrailRootDir(cwd);
 
 const removeResetFileIfPresent = (
   rootDir: string,
-  relativePath: string
+  resetPath: string
 ): boolean => {
-  const removed = removeRootRelativeFileIfPresent(rootDir, relativePath);
+  if (isAbsolute(resetPath)) {
+    const removed = removeFileIfPresent(resetPath);
+    if (removed.isErr()) {
+      throw removed.error;
+    }
+    return removed.value;
+  }
+
+  const removed = removeRootRelativeFileIfPresent(rootDir, resetPath);
   if (removed.isErr()) {
     throw removed.error;
   }
@@ -139,7 +150,7 @@ const buildDbStats = (
 ): DevStatsReport['db'] => ({
   exists,
   fileSizeBytes: exists ? statSync(dbPath).size : 0,
-  path: '.trails/state/trails.db',
+  path: dbPath,
 });
 
 const emptyDevStats = (
@@ -256,12 +267,12 @@ const buildCleanReport = (
   };
 };
 
-const RESET_FILES = [
+const legacyResetFiles = [
+  // Legacy paths (pre-state migration) — cleaned for one cycle so upgrading
+  // workspaces do not leave stale DB sidecars at old locations.
   '.trails/state/trails.db',
   '.trails/state/trails.db-shm',
   '.trails/state/trails.db-wal',
-  // Legacy paths (pre-state migration) — cleaned for one cycle so upgrading
-  // workspaces do not leave stale DB sidecars at old locations.
   '.trails/trails.db',
   '.trails/trails.db-shm',
   '.trails/trails.db-wal',
@@ -270,10 +281,18 @@ const RESET_FILES = [
   '.trails/dev/tracing.db-wal',
 ] as const;
 
-const presentResetFiles = (
-  rootDir: string
-): readonly (typeof RESET_FILES)[number][] =>
-  RESET_FILES.filter((relativePath) => existsSync(join(rootDir, relativePath)));
+const currentResetFiles = (rootDir: string): readonly string[] => {
+  const dbPath = deriveTrailsDbPath({ rootDir });
+  return [dbPath, `${dbPath}-shm`, `${dbPath}-wal`];
+};
+
+const resetFileExists = (rootDir: string, resetPath: string): boolean =>
+  existsSync(isAbsolute(resetPath) ? resetPath : join(rootDir, resetPath));
+
+const presentResetFiles = (rootDir: string): readonly string[] =>
+  [...currentResetFiles(rootDir), ...legacyResetFiles].filter((resetPath) =>
+    resetFileExists(rootDir, resetPath)
+  );
 
 export const buildDevStats = (
   options?: DevRetentionOptions

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,7 +23,8 @@ blobRefSchema, createBlobRef(...)  // declare and create binary output reference
 //               .getContour(name), .hasContour(name), .listContours(), .contourIds(), .contourCount
 //               .getResource(id), .hasResource(id), .listResources(), .resourceIds(), .resourceCount
 openReadTrailsDb(options?), openWriteTrailsDb(options?), ensureSubsystemSchema(db, options)
-deriveTrailsDir(options?), deriveTrailsDbPath(options?)
+deriveTrailsDir(options?), deriveTrailsDbPath(options?), deriveTrailsStateDir(options?)
+deriveTrailsStateHome(options?), deriveTrailsProjectKey(options?)
 // topo-store API (createTopoStore, createMockTopoStore, topoStore, snapshot helpers, etc.)
 // has moved to @ontrails/topographer per ADR-0042. See that section below.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,7 +163,7 @@ Overrides are escape hatches. They're visible in the TopoGraph as explicit devia
 | `@ontrails/store` | Backend-agnostic schema-derived store definitions | None beyond core |
 | `@ontrails/drizzle` | Drizzle SQLite adapter, typed store bindings, read-only bindings | `drizzle-orm` |
 | `@ontrails/observe` | Production log and trace sink contracts, composition, and built-in sinks | None beyond core |
-| `@ontrails/tracing` | Tracing compatibility, query/status trails, `.trails/state/trails.db` dev-state storage, sampling helpers, OTel adapter | None beyond core |
+| `@ontrails/tracing` | Tracing compatibility, query/status trails, Trails state-store dev storage, sampling helpers, OTel adapter | None beyond core |
 | `@ontrails/logtape` | LogTape sink adapter for `@ontrails/observe` | None (accepts any LogTape-shaped logger via a structural interface) |
 | `@ontrails/pino` | Pino sink adapter for `@ontrails/observe` | None (accepts any Pino-shaped logger via a structural interface) |
 

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -102,13 +102,13 @@ The SQL/storage spelling for serialized TopoGraph content. In the topo store, `t
 
 The SQL/storage spelling for the stored lock manifest export. The manifest is the compact `.trails/trails.lock` artifact that points at `topo.lock` and verifies the TopoGraph hash; it is not a second copy of the graph.
 
-#### `.trails/state/`
+#### Trails state store
 
-Ignored mutable runtime state. The default local SQLite database lives at `.trails/state/trails.db`; its `-wal` and `-shm` sidecars are transient local state and must not be committed.
+Per-user mutable runtime state. The default local SQLite database lives under `$TRAILS_STATE_HOME/trails/projects/<project-key>/trails.db`, then `$XDG_STATE_HOME`, then `~/.local/state`. Its `-wal` and `-shm` sidecars are transient local state and must not be committed.
 
-#### `.trails/cache/`
+#### Trails cache store
 
-Ignored rebuildable cache state. Generated helper artifacts that can be rebuilt from source contracts belong here rather than beside committed lock artifacts.
+Per-user rebuildable cache state. Cache artifacts that can be rebuilt from source contracts belong in the global Trails cache tier, not beside committed lock artifacts or under `.trails/`.
 
 #### `trails.config.local.*`
 
@@ -129,10 +129,10 @@ These names are historical or migration vocabulary, not current target-state lan
 | `serialized_lock` | `lock_manifest` when referring to stored manifest export content; `.trails/trails.lock` when referring to the committed manifest file |
 | `.trails/config/local.*` | `trails.config.local.*` |
 | `.trails/config.local.*` | `trails.config.local.*` |
-| `.trails/trails.db` | `.trails/state/trails.db` |
-| `.trails/trails.db-shm` / `.trails/trails.db-wal` | `.trails/state/trails.db-shm` / `.trails/state/trails.db-wal` |
-| `.trails/dev/` | `.trails/state/` for mutable runtime state |
-| `.trails/generated/` | `.trails/cache/` for rebuildable generated state |
+| `.trails/trails.db` | Trails state store `trails.db` |
+| `.trails/trails.db-shm` / `.trails/trails.db-wal` | Trails state store SQLite sidecars |
+| `.trails/state/` / `.trails/dev/` | Trails state store for mutable runtime state |
+| `.trails/cache/` / `.trails/generated/` | Trails cache store for rebuildable generated state |
 
 Historical release notes, old migrations, accepted ADR history, and explicitly superseded planning archives may mention retired names when the surrounding text clearly marks them as legacy. Active guidance should teach the current names.
 
@@ -261,7 +261,7 @@ Trails signals are authored, typed notifications in the contract graph. Schedule
 
 ### `pin`
 
-A named snapshot of the graph state at a point in time. Pins are stored in the shared `trails.db` at `.trails/state/trails.db` and enable comparison between the current resolved graph and a previous known-good state.
+A named snapshot of the graph state at a point in time. Pins are stored in the shared local `trails.db` in the Trails state store and enable comparison between the current resolved graph and a previous known-good state.
 
 ```bash
 trails topo pin --name v1.0

--- a/docs/migration/topograph-artifact-family.md
+++ b/docs/migration/topograph-artifact-family.md
@@ -4,9 +4,9 @@ The v1 topo artifact family uses a compact manifest plus an inspectable graph co
 
 - `.trails/trails.lock` is the committed lock v3 manifest.
 - `.trails/topo.lock` is the committed serialized `TopoGraph` content artifact.
-- `.trails/state/trails.db` is ignored mutable SQLite state for snapshots,
-  pins, tracing, and other framework subsystems.
-- `.trails/cache/` is ignored rebuildable cache state.
+- `trails.db` lives in the per-user Trails state store for snapshots, pins,
+  tracing, and other framework subsystems.
+- Rebuildable cache state lives outside the repo in the Trails cache store.
 - `trails.config.local.*` files at the project root are ignored local override files.
 
 Regenerate the current artifact family with:
@@ -33,19 +33,19 @@ trails validate
 | `serialized_lock` | `lock_manifest` for stored manifest export content; `.trails/trails.lock` for the committed manifest file |
 | `.trails/config/local.*` | `trails.config.local.*` at the project root |
 | `.trails/config.local.*` | `trails.config.local.*` at the project root |
-| `.trails/trails.db` | `.trails/state/trails.db` |
-| `.trails/dev/` | `.trails/state/` |
-| `.trails/generated/` | `.trails/cache/` |
+| `.trails/trails.db` | Trails state store `trails.db` |
+| `.trails/dev/` | Trails state store |
+| `.trails/generated/` | Trails cache store |
 
 ## Local Cleanup
 
-Current builds create the shared database under `.trails/state/`. If an old workspace still has untracked root SQLite sidecars, remove only the legacy root files:
+Current builds create the shared database under the per-user Trails state store. If an old workspace still has untracked root SQLite sidecars, remove only the legacy root files:
 
 ```bash
 rm -f .trails/trails.db .trails/trails.db-shm .trails/trails.db-wal
 ```
 
-Do not commit any `.trails/state/trails.db*` files. They are local runtime state and are ignored by the workspace `.trails/.gitignore`.
+Do not commit any `.trails/state/trails.db*` files if they exist from older builds. They are legacy local runtime state; current builds use the per-user state store.
 
 ## Consumer Updates
 

--- a/docs/migration/trailhead-to-surface.md
+++ b/docs/migration/trailhead-to-surface.md
@@ -95,7 +95,7 @@ Reset local Trails state before upgrading:
 trails dev reset --yes
 ```
 
-If you manage the database manually on current builds, delete `.trails/state/trails.db` and its SQLite sidecar files (`.trails/state/trails.db-wal`, `.trails/state/trails.db-shm`) before recreating local state. Very old beta workspaces may also have legacy root files at `.trails/trails.db*`; remove those only as migration cleanup.
+If you manage the database manually on current builds, prefer `trails dev reset --yes` so the CLI removes the derived Trails state-store database and legacy repo-local SQLite sidecars together. Very old beta workspaces may also have legacy root files at `.trails/trails.db*`; remove those only as migration cleanup.
 
 ## Query Trail
 

--- a/docs/releases/stable-cutover.md
+++ b/docs/releases/stable-cutover.md
@@ -111,8 +111,13 @@ Before creating the version PR:
 
     ```bash
     git status --short -- .trails .trails-tmp
-    git status --short -- .trails/state/trails.db .trails/state/trails.db-shm .trails/state/trails.db-wal
+    git status --short -- .trails/state .trails/cache '.trails/trails.db*'
     ```
+
+    Current `trails.db` state lives in the per-user Trails state store and
+    cannot be staged from the repo. Treat `.trails/state`, `.trails/cache`, or
+    `.trails/trails.db*` as legacy repo-local residue; clean it with
+    `trails dev reset --yes` before release.
 
 11. The ADR and docs checks pass:
 

--- a/docs/topo-store.md
+++ b/docs/topo-store.md
@@ -1,26 +1,22 @@
 # Topo Store
 
-The topo store is Trails' queryable database of your application's topology — every trail, signal, resource, and their relationships. It lives in `.trails/state/trails.db` and is created automatically when you run topo commands.
+The topo store is Trails' queryable database of your application's topology — every trail, signal, resource, and their relationships. Its default `trails.db` lives in the per-user Trails state store (`$TRAILS_STATE_HOME`, `$XDG_STATE_HOME`, then `~/.local/state`) and is created automatically when you run topo commands.
 
 For the full SQLite schema and programmatic query API, see the [Topo Store Reference](./topo-store-reference.md). If you are migrating from the old surface-map or root database layout, see the [TopoGraph Artifact Family Migration](./migration/topograph-artifact-family.md).
 
-## The `.trails/` directory
+## Project files and local state
 
-Trails creates a `.trails/` directory in your workspace root on first use:
+Current v1 builds still write the committed topo artifact family under `.trails/`:
 
 ```text
 .trails/
-├── .gitignore             # Auto-generated gitignore for this directory
-├── cache/                 # Rebuildable derived data (gitignored)
-├── state/                 # Mutable framework state (gitignored)
-│   └── trails.db          # SQLite database (topology store)
 ├── topo.lock              # Serialized TopoGraph (git-tracked)
 └── trails.lock            # Lock v3 manifest (text, git-tracked)
 ```
 
-- **`state/trails.db`** — SQLite database containing topo snapshots, pins, and schema cache. Not git-tracked.
 - **`topo.lock`** — Committed serialized TopoGraph with trail, signal, resource, relation, example, detour, and workspace metadata.
 - **`trails.lock`** — Committed compact v3 manifest that points at `topo.lock` and verifies its hash.
+- **`trails.db`** — SQLite database containing topo snapshots, pins, and schema cache. It is local state under the per-user Trails state store, not a repo file.
 
 Local per-developer overrides live at the project root as `trails.config.local.*`, not under `.trails/`.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -162,14 +162,14 @@ The developer returns `Result.err(new NotFoundError(...))`. The framework maps i
 The root package also exposes a few low-level contracts that other framework packages build on:
 
 - **Intrinsic tracing** -- `TraceRecord`, `TraceSink`, `TraceContext`, and the sink registry helpers are the core-owned execution record shape shared by `@ontrails/observe`, `@ontrails/tracing`, and adapters.
-- **Trails DB** -- `deriveTrailsDbPath`, `deriveTrailsDir`, `ensureSubsystemSchema`, `openReadTrailsDb`, and `openWriteTrailsDb` are the generic database primitive used by framework subsystems.
+- **Trails DB** -- `deriveTrailsDbPath`, `deriveTrailsStateDir`, `deriveTrailsStateHome`, `deriveTrailsProjectKey`, `deriveTrailsDir`, `ensureSubsystemSchema`, `openReadTrailsDb`, and `openWriteTrailsDb` are the generic database primitive used by framework subsystems.
 - **Surface projection helpers** -- safe error projection, layer field projection, compose-batch validation, late-bound signal references, and Zod default-wrapper stripping are stable root exports for first-party surfaces, store helpers, and tests.
 
 See the [API Reference](../../docs/api-reference.md) for the full list.
 
 ## Migration: topo-store moved to `@ontrails/topographer`
 
-Per [ADR-0042](../../docs/adr/0042-core-topographer-boundary-doctrine.md), the topo-store public API previously exported from `@ontrails/core` now lives in `@ontrails/topographer`. Generic `trails-db` helpers (`openReadTrailsDb`, `openWriteTrailsDb`, `ensureSubsystemSchema`, `deriveTrailsDbPath`, `deriveTrailsDir`) stay in core because tracing and other subsystems share them.
+Per [ADR-0042](../../docs/adr/0042-core-topographer-boundary-doctrine.md), the topo-store public API previously exported from `@ontrails/core` now lives in `@ontrails/topographer`. Generic `trails-db` helpers (`openReadTrailsDb`, `openWriteTrailsDb`, `ensureSubsystemSchema`, `deriveTrailsDbPath`, `deriveTrailsStateDir`, `deriveTrailsStateHome`, `deriveTrailsProjectKey`, `deriveTrailsDir`) stay in core because tracing and other subsystems share them.
 
 Update consumer imports:
 

--- a/packages/core/src/__tests__/trails-db.test.ts
+++ b/packages/core/src/__tests__/trails-db.test.ts
@@ -1,20 +1,17 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
+  deriveTrailsProjectKey,
   ensureSubsystemSchema,
   ensureTrailsWorkspace,
   openReadTrailsDb,
   openWriteTrailsDb,
   deriveTrailsDbPath,
+  deriveTrailsStateDir,
+  deriveTrailsStateHome,
   WORKSPACE_GITIGNORE_CONTENT,
 } from '../trails-db.js';
 
@@ -33,26 +30,64 @@ describe('trails db foundation', () => {
     return tmpRoot;
   };
 
-  const expectWorkspaceLayout = (rootDir: string): void => {
-    expect(existsSync(join(rootDir, '.trails', '.gitignore'))).toBe(true);
-    expect(existsSync(join(rootDir, '.trails', 'cache'))).toBe(true);
-    expect(existsSync(join(rootDir, '.trails', 'state'))).toBe(true);
+  const expectNoDisposableWorkspaceLayout = (rootDir: string): void => {
+    expect(existsSync(join(rootDir, '.trails', '.gitignore'))).toBe(false);
+    expect(existsSync(join(rootDir, '.trails', 'cache'))).toBe(false);
+    expect(existsSync(join(rootDir, '.trails', 'state'))).toBe(false);
   };
 
-  test('deriveTrailsDbPath places the database in .trails/state/trails.db', () => {
+  test('deriveTrailsDbPath places the database in the XDG state store', () => {
     const rootDir = '/tmp/example-app';
-    expect(deriveTrailsDbPath({ rootDir })).toBe(
-      '/tmp/example-app/.trails/state/trails.db'
+    const env = { XDG_STATE_HOME: '/tmp/trails-state' };
+    const projectKey = deriveTrailsProjectKey({ rootDir });
+
+    expect(projectKey).toMatch(/^example-app-[a-f0-9]{16}$/);
+    expect(deriveTrailsStateHome({ env, rootDir })).toBe('/tmp/trails-state');
+    expect(deriveTrailsStateDir({ env, rootDir })).toBe(
+      `/tmp/trails-state/trails/projects/${projectKey}`
     );
+    expect(deriveTrailsDbPath({ env, rootDir })).toBe(
+      `/tmp/trails-state/trails/projects/${projectKey}/trails.db`
+    );
+  });
+
+  test('TRAILS_STATE_HOME overrides XDG_STATE_HOME', () => {
+    expect(
+      deriveTrailsStateHome({
+        env: {
+          TRAILS_STATE_HOME: '/tmp/trails-explicit-state',
+          XDG_STATE_HOME: '/tmp/xdg-state',
+        },
+        rootDir: '/tmp/example-app',
+      })
+    ).toBe('/tmp/trails-explicit-state');
+  });
+
+  test('deriveTrailsDbPath preserves explicit path overrides', () => {
+    expect(
+      deriveTrailsDbPath({
+        env: { XDG_STATE_HOME: '/tmp/ignored-state' },
+        path: '/tmp/custom/trails.db',
+        rootDir: '/tmp/example-app',
+      })
+    ).toBe('/tmp/custom/trails.db');
   });
 
   test('openWriteTrailsDb creates the database with WAL and NORMAL defaults', () => {
     const rootDir = makeRoot();
-    const db = openWriteTrailsDb({ rootDir });
+    const stateHome = join(rootDir, 'state-home');
+    const db = openWriteTrailsDb({
+      env: { XDG_STATE_HOME: stateHome },
+      rootDir,
+    });
 
     try {
-      expect(existsSync(deriveTrailsDbPath({ rootDir }))).toBe(true);
-      expectWorkspaceLayout(rootDir);
+      expect(
+        existsSync(
+          deriveTrailsDbPath({ env: { XDG_STATE_HOME: stateHome }, rootDir })
+        )
+      ).toBe(true);
+      expectNoDisposableWorkspaceLayout(rootDir);
 
       const journal = db
         .query<{ journal_mode: string }, []>('PRAGMA journal_mode')
@@ -74,10 +109,11 @@ describe('trails db foundation', () => {
 
   test('openReadTrailsDb blocks writes at the SQLite connection level', () => {
     const rootDir = makeRoot();
-    const writer = openWriteTrailsDb({ rootDir });
+    const env = { XDG_STATE_HOME: join(rootDir, 'state-home') };
+    const writer = openWriteTrailsDb({ env, rootDir });
     writer.close();
 
-    const reader = openReadTrailsDb({ rootDir });
+    const reader = openReadTrailsDb({ env, rootDir });
 
     try {
       const busyTimeout = reader
@@ -93,57 +129,32 @@ describe('trails db foundation', () => {
   });
 
   describe('ensureTrailsWorkspace', () => {
-    test('creates the canonical cache/state subdirectories', () => {
+    test('creates only the committed-control directory', () => {
       const rootDir = makeRoot();
       ensureTrailsWorkspace(rootDir);
-      expectWorkspaceLayout(rootDir);
+      expect(existsSync(join(rootDir, '.trails'))).toBe(true);
+      expectNoDisposableWorkspaceLayout(rootDir);
     });
 
-    test('writes the canonical gitignore content on first run', () => {
+    test('is idempotent without writing a workspace gitignore', () => {
       const rootDir = makeRoot();
       ensureTrailsWorkspace(rootDir);
-      const content = readFileSync(
-        join(rootDir, '.trails', '.gitignore'),
-        'utf8'
-      );
-      expect(content).toBe(WORKSPACE_GITIGNORE_CONTENT);
+      ensureTrailsWorkspace(rootDir);
+      expect(existsSync(join(rootDir, '.trails'))).toBe(true);
+      expectNoDisposableWorkspaceLayout(rootDir);
     });
 
-    test('appends missing canonical lines to an existing gitignore', () => {
-      const rootDir = makeRoot();
-      ensureTrailsWorkspace(rootDir);
-      const gitignorePath = join(rootDir, '.trails', '.gitignore');
-
-      // Simulate a user who removed two canonical lines and added their own.
-      writeFileSync(gitignorePath, '# custom rule\n*.local\n');
-      ensureTrailsWorkspace(rootDir);
-
-      const content = readFileSync(gitignorePath, 'utf8');
-      expect(content).toContain('# custom rule');
-      expect(content).toContain('*.local');
-      expect(content).toContain('cache/');
-      expect(content).toContain('state/');
-    });
-
-    test('leaves an up-to-date gitignore untouched on repeat runs', () => {
-      const rootDir = makeRoot();
-      ensureTrailsWorkspace(rootDir);
-      const first = readFileSync(
-        join(rootDir, '.trails', '.gitignore'),
-        'utf8'
-      );
-      ensureTrailsWorkspace(rootDir);
-      const second = readFileSync(
-        join(rootDir, '.trails', '.gitignore'),
-        'utf8'
-      );
-      expect(second).toBe(first);
+    test('keeps legacy gitignore compatibility content empty', () => {
+      expect(WORKSPACE_GITIGNORE_CONTENT).toBe('');
     });
   });
 
   test('ensureSubsystemSchema only migrates when the subsystem version changes', () => {
     const rootDir = makeRoot();
-    const db = openWriteTrailsDb({ rootDir });
+    const db = openWriteTrailsDb({
+      env: { XDG_STATE_HOME: join(rootDir, 'state-home') },
+      rootDir,
+    });
     let calls = 0;
 
     try {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -392,6 +392,9 @@ export type { Topo, TopoIdentity } from './topo.js';
 export {
   deriveTrailsDbPath,
   deriveTrailsDir,
+  deriveTrailsProjectKey,
+  deriveTrailsStateDir,
+  deriveTrailsStateHome,
   ensureSubsystemSchema,
   ensureTrailsWorkspace,
   openReadTrailsDb,

--- a/packages/core/src/trails-db.ts
+++ b/packages/core/src/trails-db.ts
@@ -1,41 +1,36 @@
 import { Database } from 'bun:sqlite';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
 
 import { NotFoundError } from './errors.js';
 
 const TRAILS_DIR = '.trails';
 const TRAILS_DB_FILE = 'trails.db';
-const TRAILS_CACHE_DIR = 'cache';
-const TRAILS_STATE_DIR = 'state';
+const TRAILS_STORE_DIR = 'trails';
+const TRAILS_PROJECTS_DIR = 'projects';
 const SCHEMA_VERSION_TABLE = 'meta_schema_versions';
 const SQLITE_BUSY_TIMEOUT_MS = 5000;
-const WORKSPACE_SUBDIRS = [TRAILS_CACHE_DIR, TRAILS_STATE_DIR] as const;
+const PROJECT_KEY_HASH_LENGTH = 16;
+const PROJECT_KEY_NAME_FALLBACK = 'project';
 
 /**
- * The canonical lines written to a freshly-bootstrapped
- * `.trails/.gitignore`. Kept as the source of truth for every consumer that
- * needs to either write the file (scaffold) or audit its content (tests).
+ * Legacy no-op compatibility export.
  *
- * @see {@link WORKSPACE_GITIGNORE_CONTENT} for the rendered string form.
+ * `.trails/` is committed project control, not disposable cache/state. New
+ * code should not write a `.trails/.gitignore`; keep this export available for
+ * older callers during the pre-1.0 cutover.
  */
-export const WORKSPACE_GITIGNORE_LINES = [
-  '# Rebuildable cache',
-  'cache/',
-  '',
-  '# Mutable runtime state',
-  'state/',
-  '',
-] as const;
+export const WORKSPACE_GITIGNORE_LINES = [] as const;
 
 /**
- * The canonical rendered `.trails/.gitignore` content. Use this when writing
- * the file eagerly (e.g. during `trails create` scaffolding) or when asserting
- * on the workspace bootstrap output.
+ * Legacy no-op compatibility export. See {@link WORKSPACE_GITIGNORE_LINES}.
  */
-export const WORKSPACE_GITIGNORE_CONTENT = `${WORKSPACE_GITIGNORE_LINES.join('\n').trimEnd()}\n`;
+export const WORKSPACE_GITIGNORE_CONTENT = '';
 
 export interface TrailsDbLocationOptions {
+  readonly env?: Record<string, string | undefined>;
   readonly path?: string;
   readonly rootDir?: string;
 }
@@ -53,66 +48,67 @@ interface SchemaVersionRow {
 const deriveRootDir = (rootDir?: string): string =>
   resolve(rootDir ?? process.cwd());
 
+const sanitizeProjectKeyName = (name: string): string => {
+  const normalized = name.replaceAll(/[^a-zA-Z0-9._-]+/g, '-');
+  return normalized.length > 0 ? normalized : PROJECT_KEY_NAME_FALLBACK;
+};
+
+const projectHash = (rootDir: string): string =>
+  createHash('sha256')
+    .update(rootDir)
+    .digest('hex')
+    .slice(0, PROJECT_KEY_HASH_LENGTH);
+
+export const deriveTrailsProjectKey = (
+  options?: TrailsDbLocationOptions
+): string => {
+  const rootDir = deriveRootDir(options?.rootDir);
+  return `${sanitizeProjectKeyName(basename(rootDir))}-${projectHash(rootDir)}`;
+};
+
+export const deriveTrailsStateHome = (
+  options?: TrailsDbLocationOptions
+): string => {
+  const env = options?.env ?? process.env;
+  return resolve(
+    env['TRAILS_STATE_HOME'] ??
+      env['XDG_STATE_HOME'] ??
+      join(homedir(), '.local', 'state')
+  );
+};
+
+export const deriveTrailsStateDir = (
+  options?: TrailsDbLocationOptions
+): string =>
+  join(
+    deriveTrailsStateHome(options),
+    TRAILS_STORE_DIR,
+    TRAILS_PROJECTS_DIR,
+    deriveTrailsProjectKey(options)
+  );
+
 export const deriveTrailsDir = (options?: TrailsDbLocationOptions): string =>
   join(deriveRootDir(options?.rootDir), TRAILS_DIR);
 
 export const deriveTrailsDbPath = (options?: TrailsDbLocationOptions): string =>
   options?.path
     ? resolve(options.path)
-    : join(deriveTrailsDir(options), TRAILS_STATE_DIR, TRAILS_DB_FILE);
+    : join(deriveTrailsStateDir(options), TRAILS_DB_FILE);
 
 const ensureDbParentDir = (dbPath: string): void => {
   mkdirSync(dirname(dbPath), { recursive: true });
 };
 
-const appendMissingGitignoreLines = (
-  gitignorePath: string,
-  content: string
-): void => {
-  const existingLines = new Set(content.split('\n').map((l) => l.trim()));
-  const missing = WORKSPACE_GITIGNORE_LINES.filter(
-    (line) => line !== '' && !existingLines.has(line)
-  );
-
-  if (missing.length === 0) {
-    return;
-  }
-
-  const next = `${content.trimEnd()}\n\n${missing.join('\n')}`;
-  writeFileSync(gitignorePath, `${next.trimEnd()}\n`);
-};
-
-const ensureWorkspaceGitignore = (trailsDir: string): void => {
-  const gitignorePath = join(trailsDir, '.gitignore');
-
-  if (!existsSync(gitignorePath)) {
-    writeFileSync(gitignorePath, WORKSPACE_GITIGNORE_CONTENT);
-    return;
-  }
-
-  appendMissingGitignoreLines(
-    gitignorePath,
-    readFileSync(gitignorePath, 'utf8')
-  );
-};
-
 /**
  * Bootstrap the `.trails/` workspace at `rootDir`.
  *
- * Creates the workspace directory plus the canonical `cache/` and `state/`
- * subdirectories, then either writes a fresh `.gitignore` matching
- * {@link WORKSPACE_GITIGNORE_CONTENT} or appends any missing canonical lines
- * to an existing one. Safe to call repeatedly. This is the single canonical
- * source of truth for workspace layout — scaffolding, configuration loading,
- * and runtime DB initialization all flow through here.
+ * Creates only the committed-control directory. Derived cache and observed
+ * state live in the per-user Trails store, so this helper intentionally does
+ * not create `.trails/cache`, `.trails/state`, or `.trails/.gitignore`.
  */
 export const ensureTrailsWorkspace = (rootDir: string): void => {
   const trailsDir = deriveTrailsDir({ rootDir });
   mkdirSync(trailsDir, { recursive: true });
-  for (const subdir of WORKSPACE_SUBDIRS) {
-    mkdirSync(join(trailsDir, subdir), { recursive: true });
-  }
-  ensureWorkspaceGitignore(trailsDir);
 };
 
 const initializeWritePragmas = (db: Database): void => {
@@ -163,15 +159,14 @@ export const openWriteTrailsDb = (
   options?: TrailsDbLocationOptions
 ): Database => {
   const rootDir = deriveRootDir(options?.rootDir);
-  const dbPath = deriveTrailsDbPath(
-    options?.path ? { path: options.path, rootDir } : { rootDir }
-  );
+  const locationOptions: TrailsDbLocationOptions = {
+    ...(options?.env === undefined ? {} : { env: options.env }),
+    ...(options?.path === undefined ? {} : { path: options.path }),
+    rootDir,
+  };
+  const dbPath = deriveTrailsDbPath(locationOptions);
 
-  if (options?.path === undefined) {
-    ensureTrailsWorkspace(rootDir);
-  } else {
-    ensureDbParentDir(dbPath);
-  }
+  ensureDbParentDir(dbPath);
 
   const db = new Database(dbPath, { create: true });
   initializeWritePragmas(db);

--- a/packages/topographer/README.md
+++ b/packages/topographer/README.md
@@ -12,7 +12,7 @@ Most applications reach this package through top-level `trails compile`, `trails
 - semantic diffing between two TopoGraphs
 - file I/O helpers for `.trails/topo.lock` and `.trails/trails.lock`
 - the topo-store: queryable persistence of the resolved topo graph in the shared
-  `trails.db` at `.trails/state/trails.db`, including snapshots, pinning,
+  `trails.db` in the per-user Trails state store, including snapshots, pinning,
   history, and read-only query accessors (relocated from `@ontrails/core` per
   ADR-0042)
 
@@ -71,7 +71,7 @@ The typical exported artifact pair is:
 | `readTopoGraph(options?)` | Read `.trails/topo.lock` |
 | `writeLockManifest(manifest, options?)` | Write `.trails/trails.lock` as a v3 manifest |
 | `readLockManifest(options?)` | Read the v3 manifest from `.trails/trails.lock` |
-| `createTopoStore(options?)` | Read-only query interface over the persisted topo state in `.trails/state/trails.db` |
+| `createTopoStore(options?)` | Read-only query interface over the persisted topo state in the Trails state-store `trails.db` |
 | `createMockTopoStore(seed?)` | Seeded in-memory mock for tests that need a `ReadOnlyTopoStore` |
 | `topoStore` | Read-only `resource()` wrapper around `createTopoStore`, suitable for `resources: [...]` |
 | `createTopoSnapshot(topo, options?)` | Persist a new topo snapshot row plus its denormalized projections |

--- a/packages/topographer/src/__tests__/topo-snapshots.test.ts
+++ b/packages/topographer/src/__tests__/topo-snapshots.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -15,11 +15,28 @@ import {
 
 describe('topo snapshot primitives', () => {
   let tmpRoot: string | undefined;
+  let testStateHome: string | undefined;
+  let originalTrailsStateHome: string | undefined;
+
+  beforeEach(() => {
+    originalTrailsStateHome = process.env.TRAILS_STATE_HOME;
+    testStateHome = mkdtempSync(join(tmpdir(), 'topo-snapshots-state-'));
+    process.env.TRAILS_STATE_HOME = testStateHome;
+  });
 
   afterEach(() => {
+    if (originalTrailsStateHome === undefined) {
+      delete process.env.TRAILS_STATE_HOME;
+    } else {
+      process.env.TRAILS_STATE_HOME = originalTrailsStateHome;
+    }
     if (tmpRoot) {
       rmSync(tmpRoot, { force: true, recursive: true });
       tmpRoot = undefined;
+    }
+    if (testStateHome) {
+      rmSync(testStateHome, { force: true, recursive: true });
+      testStateHome = undefined;
     }
   });
 

--- a/packages/topographer/src/__tests__/topo-store-read.test.ts
+++ b/packages/topographer/src/__tests__/topo-store-read.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import type { Database } from 'bun:sqlite';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -295,11 +295,28 @@ const graphAttachmentApp = () => {
 
 describe('read-only topo store', () => {
   let tmpRoot: string | undefined;
+  let testStateHome: string | undefined;
+  let originalTrailsStateHome: string | undefined;
+
+  beforeEach(() => {
+    originalTrailsStateHome = process.env.TRAILS_STATE_HOME;
+    testStateHome = mkdtempSync(join(tmpdir(), 'topo-store-read-state-'));
+    process.env.TRAILS_STATE_HOME = testStateHome;
+  });
 
   afterEach(() => {
+    if (originalTrailsStateHome === undefined) {
+      delete process.env.TRAILS_STATE_HOME;
+    } else {
+      process.env.TRAILS_STATE_HOME = originalTrailsStateHome;
+    }
     if (tmpRoot) {
       rmSync(tmpRoot, { force: true, recursive: true });
       tmpRoot = undefined;
+    }
+    if (testStateHome) {
+      rmSync(testStateHome, { force: true, recursive: true });
+      testStateHome = undefined;
     }
   });
 

--- a/packages/topographer/src/__tests__/topo-store.test.ts
+++ b/packages/topographer/src/__tests__/topo-store.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -16,6 +16,7 @@ import {
   topo,
   trail,
   webhook,
+  deriveTrailsDbPath,
   openWriteTrailsDb,
 } from '@ontrails/core';
 import type { Layer } from '@ontrails/core';
@@ -609,7 +610,7 @@ const replaceStoreWithHistoryOnlyStore = async (
 ): Promise<void> => {
   // Ensure mtime/size differs so the cached identity is invalidated even on
   // filesystems with coarse mtime granularity.
-  const dbPath = join(rootDir, '.trails', 'state', 'trails.db');
+  const dbPath = deriveTrailsDbPath({ rootDir });
   rmSync(dbPath, { force: true });
   rmSync(`${dbPath}-shm`, { force: true });
   rmSync(`${dbPath}-wal`, { force: true });
@@ -624,11 +625,28 @@ const replaceStoreWithHistoryOnlyStore = async (
 
 describe('topo store projection', () => {
   let tmpRoot: string | undefined;
+  let testStateHome: string | undefined;
+  let originalTrailsStateHome: string | undefined;
+
+  beforeEach(() => {
+    originalTrailsStateHome = process.env.TRAILS_STATE_HOME;
+    testStateHome = mkdtempSync(join(tmpdir(), 'topo-store-state-'));
+    process.env.TRAILS_STATE_HOME = testStateHome;
+  });
 
   afterEach(() => {
+    if (originalTrailsStateHome === undefined) {
+      delete process.env.TRAILS_STATE_HOME;
+    } else {
+      process.env.TRAILS_STATE_HOME = originalTrailsStateHome;
+    }
     if (tmpRoot) {
       rmSync(tmpRoot, { force: true, recursive: true });
       tmpRoot = undefined;
+    }
+    if (testStateHome) {
+      rmSync(testStateHome, { force: true, recursive: true });
+      testStateHome = undefined;
     }
   });
 

--- a/packages/tracing/src/__tests__/dev-store.test.ts
+++ b/packages/tracing/src/__tests__/dev-store.test.ts
@@ -3,6 +3,8 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { deriveTrailsDbPath } from '@ontrails/core';
+
 import type { TraceRecord } from '../trace-record.js';
 import type { DevStore } from '../stores/dev.js';
 import { createDevStore } from '../stores/dev.js';
@@ -73,13 +75,17 @@ describe('createDevStore', () => {
   });
 
   describe('lifecycle', () => {
-    test('defaults to the shared .trails/state/trails.db path under rootDir', () => {
+    test('defaults to the shared XDG state path under rootDir', () => {
       const dir = makeTmpDir();
+      const env = { XDG_STATE_HOME: join(dir, 'state-home') };
 
-      store = createDevStore({ rootDir: dir });
+      store = createDevStore({ env, rootDir: dir });
       store.write(makeRecord());
 
-      expect(existsSync(join(dir, '.trails', 'state', 'trails.db'))).toBe(true);
+      expect(existsSync(deriveTrailsDbPath({ env, rootDir: dir }))).toBe(true);
+      expect(existsSync(join(dir, '.trails', 'state', 'trails.db'))).toBe(
+        false
+      );
     });
 
     test('creates a database file at the specified path', () => {

--- a/packages/tracing/src/stores/dev.ts
+++ b/packages/tracing/src/stores/dev.ts
@@ -15,9 +15,11 @@ import type { TraceRecord, TraceSink } from '@ontrails/core';
 
 /** Configuration for the SQLite dev store. */
 export interface DevStoreOptions {
-  /** Path to the SQLite database file. Defaults to `.trails/state/trails.db`. */
+  /** Environment used for state-store discovery. Defaults to `process.env`. */
+  readonly env?: Record<string, string | undefined>;
+  /** Path to the SQLite database file. Overrides state-store discovery. */
   readonly path?: string;
-  /** Root directory used when resolving the default `.trails/state/trails.db` path. */
+  /** Root directory used when deriving the default per-project state path. */
   readonly rootDir?: string;
   /** Maximum number of records to retain. Defaults to 10000. */
   readonly maxRecords?: number;
@@ -233,6 +235,7 @@ export const createDevStore = (options?: DevStoreOptions): DevStore => {
   const maxRecords = options?.maxRecords ?? DEFAULT_MAX_RECORDS;
   const maxAge = options?.maxAge ?? DEFAULT_MAX_AGE;
   const db = openWriteTrailsDb({
+    ...(options?.env === undefined ? {} : { env: options.env }),
     ...(options?.path === undefined ? {} : { path: options.path }),
     ...(options?.rootDir === undefined ? {} : { rootDir: options.rootDir }),
   });

--- a/packages/warden/src/__tests__/drift.test.ts
+++ b/packages/warden/src/__tests__/drift.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -83,6 +83,28 @@ const seedSavedTopo = (dir: string): string => {
 };
 
 describe('checkDrift', () => {
+  let testStateHome: string | undefined;
+  let originalTrailsStateHome: string | undefined;
+
+  beforeEach(() => {
+    originalTrailsStateHome = process.env.TRAILS_STATE_HOME;
+    testStateHome = join(tmpdir(), `drift-state-${Date.now()}`);
+    mkdirSync(testStateHome, { recursive: true });
+    process.env.TRAILS_STATE_HOME = testStateHome;
+  });
+
+  afterEach(() => {
+    if (originalTrailsStateHome === undefined) {
+      delete process.env.TRAILS_STATE_HOME;
+    } else {
+      process.env.TRAILS_STATE_HOME = originalTrailsStateHome;
+    }
+    if (testStateHome) {
+      rmSync(testStateHome, { force: true, recursive: true });
+      testStateHome = undefined;
+    }
+  });
+
   test('returns stale: false when no topo is provided', async () => {
     const result = await checkDrift('/tmp');
     expect(result.stale).toBe(false);

--- a/packages/wayfinder/src/__tests__/loader.test.ts
+++ b/packages/wayfinder/src/__tests__/loader.test.ts
@@ -7,6 +7,7 @@ import { z } from 'zod';
 
 import {
   Result,
+  deriveTrailsDbPath,
   openReadTrailsDb,
   openWriteTrailsDb,
   topo,
@@ -31,6 +32,15 @@ import {
 } from '../index.js';
 
 let tempDir: string;
+let originalTrailsStateHome: string | undefined;
+
+const restoreTrailsStateHome = (value: string | undefined): void => {
+  if (value === undefined) {
+    delete process.env.TRAILS_STATE_HOME;
+    return;
+  }
+  process.env.TRAILS_STATE_HOME = value;
+};
 
 const userShowTrail = trail('user.show', {
   blaze: () => Result.ok({ ok: true }),
@@ -119,9 +129,12 @@ const seedTopoStore = (graph = makeTopo()) => {
 
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), 'wayfinder-loader-test-'));
+  originalTrailsStateHome = process.env.TRAILS_STATE_HOME;
+  process.env.TRAILS_STATE_HOME = join(tempDir, '.test-state');
 });
 
 afterEach(async () => {
+  restoreTrailsStateHome(originalTrailsStateHome);
   await rm(tempDir, { force: true, recursive: true });
 });
 
@@ -143,6 +156,32 @@ describe('loadWayfinderArtifacts', () => {
     expect(loaded.topoStore?.trails.map((entry) => entry.id)).toEqual([
       'user.show',
     ]);
+  });
+
+  test('does not infer topo-store state from an artifact directory alone', async () => {
+    await writeFreshArtifacts();
+    const legacyDbPath = join(artifactsDir(), 'state', 'trails.db');
+    const legacySnapshot = createTopoSnapshot(makeTopo({ accountListTrail }), {
+      createdAt: '2026-06-04T00:00:00.000Z',
+      gitSha: 'abc123',
+      path: legacyDbPath,
+      rootDir: tempDir,
+    });
+    if (legacySnapshot.isErr()) {
+      throw legacySnapshot.error;
+    }
+
+    const loaded = await loadWayfinderArtifacts({ dir: artifactsDir() });
+
+    expect(loaded.topoGraph?.entries.map((entry) => entry.id)).toEqual([
+      'user.show',
+    ]);
+    expect(loaded.lockManifest?.version).toBe(3);
+    expect(loaded.topoStore).toBeNull();
+    expect(loaded.artifactStatus).toEqual({
+      artifacts: ['topoStore'],
+      status: 'missing',
+    });
   });
 
   test('materializes topo-store records at load time', async () => {
@@ -335,7 +374,7 @@ describe('wayfinderFact', () => {
       drift: { status: 'aligned' },
       source: {
         kind: 'topoStore',
-        path: `${tempDir}/.trails/state/trails.db`,
+        path: deriveTrailsDbPath({ rootDir: tempDir }),
         schemaVersion: TOPO_STORE_SCHEMA_VERSION,
       },
       value: { hasOutput: true },

--- a/packages/wayfinder/src/__tests__/queries.test.ts
+++ b/packages/wayfinder/src/__tests__/queries.test.ts
@@ -9,6 +9,7 @@ import {
   ConflictError,
   Result,
   createTrailContext,
+  deriveTrailsDbPath,
   resource,
   signal,
   topo,
@@ -622,7 +623,7 @@ describe('wayfinder graph-read query trails', () => {
     });
   });
 
-  test('keeps explicit artifact directories isolated from context cwd', async () => {
+  test('keeps explicit artifact directories isolated from mutable state', async () => {
     const artifactRoot = join(tempDir, 'artifact-root');
     const cwdRoot = join(tempDir, 'cwd-root');
     await mkdir(artifactRoot, { recursive: true });
@@ -636,7 +637,22 @@ describe('wayfinder graph-read query trails', () => {
       )
     );
 
-    expect(overview.drift).toEqual({ status: 'aligned' });
+    expect(overview.drift).toEqual({
+      artifacts: ['topoStore'],
+      status: 'absent',
+    });
+
+    const overviewWithStateStore = await expectOk(
+      wayfindOverviewTrail.blaze(
+        {
+          dir: artifactsDirFor(artifactRoot),
+          trailsDbPath: deriveTrailsDbPath({ rootDir: artifactRoot }),
+        },
+        createTrailContext({ cwd: cwdRoot, workspaceRoot: cwdRoot })
+      )
+    );
+
+    expect(overviewWithStateStore.drift).toEqual({ status: 'aligned' });
   });
 
   test('finds entities with typed filters', async () => {

--- a/packages/wayfinder/src/loader.ts
+++ b/packages/wayfinder/src/loader.ts
@@ -95,7 +95,7 @@ const resolveArtifactReadOptions = (
 
 const resolveTopoStoreLocation = (
   options?: WayfinderArtifactLoaderOptions
-): TrailsDbLocationOptions => {
+): TrailsDbLocationOptions | undefined => {
   if (options?.path !== undefined) {
     return options.rootDir === undefined
       ? { path: options.path }
@@ -105,7 +105,7 @@ const resolveTopoStoreLocation = (
     return { rootDir: options.rootDir };
   }
   if (options?.dir !== undefined) {
-    return { path: join(options.dir, 'state', 'trails.db') };
+    return undefined;
   }
   return {};
 };
@@ -154,6 +154,9 @@ const readTopoStoreArtifact = (
   options?: WayfinderArtifactLoaderOptions
 ): ArtifactRead<WayfinderTopoStoreLoad> => {
   const location = resolveTopoStoreLocation(options);
+  if (location === undefined) {
+    return { kind: 'ok', value: null };
+  }
   const path = deriveTrailsDbPath(location);
   if (!existsSync(path)) {
     return { kind: 'ok', value: null };
@@ -393,8 +396,11 @@ export const wayfinderTopoGraphSource = (
 
 export const wayfinderTopoStoreSource = (
   options?: WayfinderArtifactLoaderOptions
-) => ({
-  kind: 'topoStore' as const,
-  path: deriveTrailsDbPath(resolveTopoStoreLocation(options)),
-  schemaVersion: TOPO_STORE_SCHEMA_VERSION,
-});
+) => {
+  const location = resolveTopoStoreLocation(options);
+  return {
+    kind: 'topoStore' as const,
+    ...(location === undefined ? {} : { path: deriveTrailsDbPath(location) }),
+    schemaVersion: TOPO_STORE_SCHEMA_VERSION,
+  };
+};

--- a/scripts/vocab-cutover-map.ts
+++ b/scripts/vocab-cutover-map.ts
@@ -181,12 +181,18 @@ const topographArtifactFamilyRetiredMatches = [
   ...legacyBootstrapCleanupMatches,
   // Legacy root DB and dev-state sidecars are still removed by dev.reset/dev.clean
   // so upgraded workspaces do not leave stale local files behind.
-  { line: 265, path: 'apps/trails/src/trails/dev-support.ts' },
-  { line: 266, path: 'apps/trails/src/trails/dev-support.ts' },
-  { line: 267, path: 'apps/trails/src/trails/dev-support.ts' },
-  { line: 268, path: 'apps/trails/src/trails/dev-support.ts' },
-  { line: 269, path: 'apps/trails/src/trails/dev-support.ts' },
-  { line: 270, path: 'apps/trails/src/trails/dev-support.ts' },
+  { line: 276, path: 'apps/trails/src/trails/dev-support.ts' },
+  { line: 277, path: 'apps/trails/src/trails/dev-support.ts' },
+  { line: 278, path: 'apps/trails/src/trails/dev-support.ts' },
+  { line: 279, path: 'apps/trails/src/trails/dev-support.ts' },
+  { line: 280, path: 'apps/trails/src/trails/dev-support.ts' },
+  { line: 281, path: 'apps/trails/src/trails/dev-support.ts' },
+  // Fresh scaffolds ignore legacy repo-local DB residue without creating it.
+  { line: 202, path: 'apps/trails/src/trails/create-scaffold.ts' },
+  { line: 215, path: 'apps/trails/src/__tests__/create.test.ts' },
+  { line: 226, path: 'apps/trails/src/__tests__/create.test.ts' },
+  { line: 227, path: 'apps/trails/src/__tests__/create.test.ts' },
+  { line: 228, path: 'apps/trails/src/__tests__/create.test.ts' },
   // The topo-store migration and fixture must name pre-v12 columns exactly.
   {
     line: 345,
@@ -210,6 +216,18 @@ const topographArtifactFamilyRetiredMatches = [
   },
   {
     line: 1441,
+    path: 'packages/topographer/src/__tests__/topo-store.test.ts',
+  },
+  {
+    line: 1443,
+    path: 'packages/topographer/src/__tests__/topo-store.test.ts',
+  },
+  {
+    line: 1457,
+    path: 'packages/topographer/src/__tests__/topo-store.test.ts',
+  },
+  {
+    line: 1459,
     path: 'packages/topographer/src/__tests__/topo-store.test.ts',
   },
 ] as const;


### PR DESCRIPTION
## Summary

- Move the default generic `trails.db` path out of repo-local `.trails/state` into a deterministic per-user XDG state store.
- Stop bootstrapping disposable `.trails/cache`, `.trails/state`, and `.trails/.gitignore` paths during workspace/scaffold setup.
- Update Wayfinder, Topographer, tracing, dev reset/status, scaffold behavior, docs, tests, and vocab audit allowlists for the new state-store boundary.

## Local Review

- Round 1 found P2 test-state leaks into real `~/.local/state` and stale Wayfinder `dir` semantics. Fixed with isolated `TRAILS_STATE_HOME` fixtures and artifact-dir-only loader behavior.
- Round 1 docs/scaffold review found missing legacy ignore coverage and stale release docs. Fixed.
- Round 2 implementation review: 5/5, no P0-P2 findings.
- Round 2 docs/scaffold review found scaffold tests needed negative assertions for disposable `.trails` state. Fixed.
- Final targeted review: 5/5, no P0-P2 findings.

## Verification

- `bun test packages/wayfinder/src/__tests__/queries.test.ts`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run lint:ast-grep`
- `bun run test`
- `bun run vocab:audit`
- `bun run check`
- `bun run build`
- `bun run changeset:check`
- `bun run wayfinder:dogfood`
- `bun run publish:check`
- `git diff --check`

## Notes

- `bun run check` still reports existing Warden warnings for unrelated dead public trails and demo signal graph coaching, with 0 errors.
- Removed leaked test-state directories from earlier failing runs under `~/.local/state/trails/projects/` for known test prefixes only.