### PR TITLE
fix(release): validate generated release prs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: bun run publish:label-release-pr
+      - name: Validate version PR
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        run: |
+          git fetch --no-tags --depth=1 origin changeset-release/main
+          git checkout --force FETCH_HEAD
+          bun run changeset:check
+          bun run release-pack:check -- --lockfile-only
+          bun run publish:check
+      - name: Dispatch version PR CI
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run CI --ref changeset-release/main
 
   publish-policy:
     name: Publish Policy

--- a/docs/releases/release-rules-check.md
+++ b/docs/releases/release-rules-check.md
@@ -134,6 +134,8 @@ The release PR labeler fills missing publish/channel/release labels without over
 bun run publish:label-release-pr
 ```
 
+After the labeler updates `changeset-release/main`, the Release workflow checks out that generated branch and validates it with `trails release check`, `release-pack:check --lockfile-only`, and `publish:check`. The workflow also dispatches normal CI for the generated branch because pull request workflows created by `GITHUB_TOKEN` updates do not reliably run from the generated PR event.
+
 The policy gate emits machine-readable GitHub Actions outputs and chooses `auto`, `manual`, `none`, or `block`:
 
 ```bash


### PR DESCRIPTION
## Context

Generated Changesets release PRs are updated by `GITHUB_TOKEN`, so the normal pull request CI event can be suppressed or left in an action-required state with no jobs. That left the beta.27 release PR needing manual intervention even though the generated branch was locally coherent.

## What Changed

- After `changesets/action` creates or updates `changeset-release/main`, the Release workflow now checks out that generated branch and validates it with `trails release check`, `release-pack:check --lockfile-only`, and `publish:check`.
- The Release workflow then dispatches normal CI for `changeset-release/main` so generated release PRs get build/test/lint/governance proof even when the PR event itself is suppressed.
- Updated the release rules docs to describe the generated-PR validation path.

## Verification

- `bun run format:check`
- `bun run changeset:check`
- `bun run docs:wrap-check`
- `bun run check`
- `git diff --check`
- Graphite pre-push hook: warden, ADR check, test, typecheck, lint, ast-grep, format, release-pack, dead-code
- Manual CI dispatch for #814 on `changeset-release/main` passed: Build, Lint & Format, Dead Code, Typecheck, Test, Governance, CI Gate

## Notes

This PR does not publish packages. It only hardens the generated release PR validation path.