### PR TITLE
fix(release): fetch generated release history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Validate version PR
         if: steps.changesets.outputs.hasChangesets == 'true'
         run: |
-          git fetch --no-tags --depth=1 origin changeset-release/main
+          git fetch --no-tags origin changeset-release/main
           git checkout --force FETCH_HEAD
           bun run changeset:check
           bun run release-pack:check -- --lockfile-only


### PR DESCRIPTION
## Context

The first generated-release validation patch (#815) correctly added a Release workflow self-check for `changeset-release/main`, but the workflow fetched that branch with `--depth=1`. The generated release PR then failed validation because `changeset:check` could not derive a merge base against `origin/main`.

## What Changed

- Fetch `changeset-release/main` without shallow depth before validating the generated release PR branch.
- Keep the rest of the generated-release validation sequence unchanged: changeset check, lockfile release-pack check, publish check, and CI dispatch.

## Verification

- `bun run format:check`
- `bun run changeset:check`
- `git diff --check`
- Graphite submit pre-push hook passed: dead-code, format, lint, lint-ast-grep, test, typecheck, warden

## Risk

Low. This only changes fetch history depth inside the Release workflow so the existing release-rule checks can compare the generated release branch against `main`.