### PR TITLE
fix(release): allow version pr ci dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     if: github.repository == 'outfitter-dev/trails' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       issues: write
       pull-requests: write

--- a/docs/releases/release-rules-check.md
+++ b/docs/releases/release-rules-check.md
@@ -134,7 +134,7 @@ The release PR labeler fills missing publish/channel/release labels without over
 bun run publish:label-release-pr
 ```
 
-After the labeler updates `changeset-release/main`, the Release workflow checks out that generated branch and validates it with `trails release check`, `release-pack:check --lockfile-only`, and `publish:check`. The workflow also dispatches normal CI for the generated branch because pull request workflows created by `GITHUB_TOKEN` updates do not reliably run from the generated PR event.
+After the labeler updates `changeset-release/main`, the Release workflow checks out that generated branch and validates it with `trails release check`, `release-pack:check --lockfile-only`, and `publish:check`. The workflow also dispatches normal CI for the generated branch because pull request workflows created by `GITHUB_TOKEN` updates do not reliably run from the generated PR event; the version job therefore needs `actions: write` permission in addition to content and pull request permissions.
 
 The policy gate emits machine-readable GitHub Actions outputs and chooses `auto`, `manual`, `none`, or `block`:
 


### PR DESCRIPTION
## Context

The generated release PR validation loop now checks `changeset-release/main` successfully, but the Release workflow still failed when it tried to dispatch normal CI for the generated release branch. GitHub returned `HTTP 403: Resource not accessible by integration` for `gh workflow run CI --ref changeset-release/main`.

## What Changed

- Grant the Release workflow version job `actions: write` so its `GITHUB_TOKEN` can dispatch the CI workflow for the generated release PR branch.
- Document why that permission exists in the release-rules guide so it does not get removed as accidental excess permission.

## Verification

- `bun run format:check`
- `bun run docs:wrap-check`
- `bun run changeset:check`
- `git diff --check`
- Graphite submit pre-push hook passed: warden, ADR check, test, typecheck, lint, lint-ast-grep, format, release-pack, dead-code

## Risk

Low. The permission is scoped to the version job in the Release workflow and is needed only to dispatch CI for the generated release PR branch.