### PR TITLE
fix(release): require manual publish dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      publish:
+        description: 'Publish packages when release policy allows manual publication'
+        required: false
+        default: false
+        type: boolean
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -107,7 +113,7 @@ jobs:
   publish:
     name: Publish to npm manually
     needs: publish-policy
-    if: github.repository == 'outfitter-dev/trails' && github.ref == 'refs/heads/main' && needs.publish-policy.outputs.decision == 'manual' && needs.publish-policy.outputs.should_publish == 'true'
+    if: github.repository == 'outfitter-dev/trails' && github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && inputs.publish == true && needs.publish-policy.outputs.decision == 'manual' && needs.publish-policy.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
     environment: npm
     permissions:

--- a/docs/releases/release-rules-check.md
+++ b/docs/releases/release-rules-check.md
@@ -144,6 +144,8 @@ bun run publish:policy
 
 `publish:auto` is available only for the expected generated release PR shape: `changeset-release/main` into `main`, generated-only package version and changelog diffs, exact-SHA CI green, coherent registry/dist-tag state, no unknown or conflicting managed labels, and `stack:boundary` on every source PR that introduced a consumed changeset. Missing source PR evidence or missing `stack:boundary` routes to `publish:manual`; contradictory labels, unknown managed labels, registry contradictions, or `publish:block` block the workflow.
 
+`publish:manual` never publishes from the push event that merges the generated release PR. After the generated PR is merged and the Release workflow policy resolves to `manual`, an operator must dispatch the Release workflow from `main` with `publish=true`. Protected npm environment approval may add another gate, but the workflow does not rely on environment protection as the only manual-publish guard.
+
 ## Warden And Wayfinder
 
 `trails release check` owns branch-local release-rule evaluation. It reads the GitHub or local changed-file list, release config, Changesets intent, and first source-static public trail contract facts. Warden should not duplicate PR file-list logic or own Graphite and GitHub comparison state.


### PR DESCRIPTION
## Context

After the beta.27 generated release PR merged, the Release workflow correctly resolved the policy as `manual`, but the `Publish to npm manually` job started immediately because the `npm` environment did not pause for approval. The publish attempt failed on missing npm auth before publishing anything, but `publish:manual` should be safe even if environment protection is missing or misconfigured.

## What Changed

- Add a `workflow_dispatch` input named `publish`, defaulting to `false`.
- Require `github.event_name == workflow_dispatch` and `inputs.publish == true` before the manual npm publish job can run.
- Document that merging the generated release PR never publishes from the push event; operators must manually dispatch the Release workflow from `main` with `publish=true`.

## Verification

- `bun run format:check`
- `bun run docs:wrap-check`
- `bun run changeset:check`
- `git diff --check`
- Graphite submit pre-push hook passed: warden, ADR check, test, typecheck, lint, lint-ast-grep, format, release-pack, dead-code

## Risk

Low and safety-improving. This keeps automatic publication unchanged for `publish:auto`, while making manual publication require an explicit manual workflow dispatch in addition to any protected environment approval.