### PR TITLE
fix(release): reuse generated release proof

### DIFF
--- a/.changeset/release-policy-proof-reuse.md
+++ b/.changeset/release-policy-proof-reuse.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Make generated release publish policy gather CI proof only for `publish:auto`, reuse generated release PR head proof when it matches the released tree, tolerate duplicate pending checks after a required check has passed, and log registry readiness separately from publish authorization.

--- a/apps/trails/src/__tests__/release-policy.test.ts
+++ b/apps/trails/src/__tests__/release-policy.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  ciStateFromCheckRuns,
   evaluateReleasePolicy,
   labelsForReleasePullRequest,
   releaseIntentForVersionDelta,
+  releasePolicyRequiresCiProof,
+  selectReleasePolicyCiProofTarget,
 } from '../release/policy.js';
-import type { ReleasePolicyInput } from '../release/policy.js';
+import type {
+  ReleasePolicyCheckRun,
+  ReleasePolicyInput,
+} from '../release/policy.js';
 
 const botCommit = {
   authorEmail: '41898282+github-actions[bot]@users.noreply.github.com',
@@ -20,6 +26,7 @@ const releasePr = {
   body: '',
   comments: [],
   headRefName: 'changeset-release/main',
+  headSha: 'release-head-sha',
   labels: ['publish:auto', 'channel:beta', 'release:patch'],
   number: 123,
   title: 'chore(release): version packages',
@@ -66,6 +73,13 @@ const baseInput = (
   ...overrides,
 });
 
+const releasePolicySuccessRun = (name: string): ReleasePolicyCheckRun => ({
+  check_suite: { app: { slug: 'github-actions' } },
+  conclusion: 'success',
+  name,
+  status: 'completed',
+});
+
 describe('evaluateReleasePolicy', () => {
   test('allows publish:auto when generated release and stack evidence are complete', () => {
     const report = evaluateReleasePolicy(baseInput());
@@ -75,6 +89,41 @@ describe('evaluateReleasePolicy', () => {
     expect(report.shouldPublish).toBe(true);
     expect(report.blockers).toEqual([]);
     expect(report.diagnostics).toEqual([]);
+  });
+
+  test('routes publish:auto to manual when CI proof has not been evaluated', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({ ciPassed: undefined, ciProof: undefined })
+    );
+
+    expect(report.decision).toBe('manual');
+    expect(report.diagnostics).toContain('CI proof has not been evaluated');
+  });
+
+  test('keeps manual publish paths independent from CI proof', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        ciPassed: undefined,
+        releasePullRequest: {
+          ...releasePr,
+          labels: ['publish:manual', 'channel:beta', 'release:patch'],
+        },
+      })
+    );
+
+    expect(report.decision).toBe('manual');
+    expect(report.diagnostics).toEqual([]);
+    expect(releasePolicyRequiresCiProof(baseInput())).toBe(true);
+    expect(
+      releasePolicyRequiresCiProof(
+        baseInput({
+          releasePullRequest: {
+            ...releasePr,
+            labels: ['publish:manual', 'channel:beta', 'release:patch'],
+          },
+        })
+      )
+    ).toBe(false);
   });
 
   test('blocks conflicting labels in managed families', () => {
@@ -164,6 +213,9 @@ describe('evaluateReleasePolicy', () => {
     expect(report.decision).toBe('auto');
     expect(report.shouldPublish).toBe(false);
     expect(report.createGitHubRelease).toBe(true);
+    expect(report.reasons).toContain(
+      'Registry package state already matches this release; npm publish will be skipped'
+    );
   });
 
   test('blocks registry drift before publication routing', () => {
@@ -302,6 +354,85 @@ describe('labelsForReleasePullRequest', () => {
         ],
       })
     ).toEqual(['publish:auto', 'channel:stable', 'release:patch']);
+  });
+});
+
+describe('ciStateFromCheckRuns', () => {
+  const requiredNames = [
+    'Build',
+    'Lint & Format',
+    'Dead Code',
+    'Typecheck',
+    'Test',
+    'Governance',
+  ];
+
+  test('passes when every required GitHub Actions check succeeded', () => {
+    expect(
+      ciStateFromCheckRuns(requiredNames.map(releasePolicySuccessRun))
+    ).toBe('passed');
+  });
+
+  test('reuses completed generated-release proof when duplicate checks are pending', () => {
+    const runs = [
+      ...requiredNames.map(
+        (name): ReleasePolicyCheckRun => ({
+          check_suite: { app: { slug: 'github-actions' } },
+          conclusion: null,
+          name,
+          status: 'queued',
+        })
+      ),
+      ...requiredNames.map(releasePolicySuccessRun),
+    ];
+
+    expect(ciStateFromCheckRuns(runs)).toBe('passed');
+  });
+
+  test('blocks when any required check has a completed failure', () => {
+    expect(
+      ciStateFromCheckRuns([
+        ...requiredNames.map(releasePolicySuccessRun),
+        {
+          check_suite: { app: { slug: 'github-actions' } },
+          conclusion: 'failure',
+          name: 'Build',
+          status: 'completed',
+        },
+      ])
+    ).toBe('failed');
+  });
+});
+
+describe('selectReleasePolicyCiProofTarget', () => {
+  test('reuses generated release PR head checks when commit trees match', () => {
+    expect(
+      selectReleasePolicyCiProofTarget({
+        releasePullRequest: releasePr,
+        releasePullRequestHeadTreeSha: 'tree-1',
+        sha: 'main-merge-sha',
+        shaTreeSha: 'tree-1',
+      })
+    ).toEqual({
+      sha: 'release-head-sha',
+      source: 'release-pr-head',
+      summary: 'Generated release PR head CI proof',
+    });
+  });
+
+  test('falls back to exact SHA when generated release PR proof cannot match the tree', () => {
+    expect(
+      selectReleasePolicyCiProofTarget({
+        releasePullRequest: releasePr,
+        releasePullRequestHeadTreeSha: 'tree-2',
+        sha: 'main-merge-sha',
+        shaTreeSha: 'tree-1',
+      })
+    ).toEqual({
+      sha: 'main-merge-sha',
+      source: 'exact-sha',
+      summary: 'Exact-SHA CI proof',
+    });
   });
 });
 

--- a/apps/trails/src/release/policy.ts
+++ b/apps/trails/src/release/policy.ts
@@ -33,6 +33,7 @@ export interface ReleasePolicyPullRequest {
   readonly body: string;
   readonly comments: readonly string[];
   readonly headRefName: string;
+  readonly headSha?: string | undefined;
   readonly labels: readonly string[];
   readonly number: number;
   readonly title: string;
@@ -55,9 +56,29 @@ export interface ReleasePolicyRegistryPackage {
   readonly versionPublished?: boolean | undefined;
 }
 
+export type ReleasePolicyCiProofSource =
+  | 'assumed'
+  | 'exact-sha'
+  | 'missing'
+  | 'release-pr-head';
+
+export interface ReleasePolicyCiProof {
+  readonly passed: boolean;
+  readonly source: ReleasePolicyCiProofSource;
+  readonly summary: string;
+}
+
+export interface ReleasePolicyCheckRun {
+  readonly check_suite?: { readonly app?: { readonly slug?: string } };
+  readonly conclusion?: string | null;
+  readonly name: string;
+  readonly status: string;
+}
+
 export interface ReleasePolicyInput {
   readonly changedFiles: readonly ReleasePolicyChangedFile[];
-  readonly ciPassed: boolean;
+  readonly ciPassed?: boolean | undefined;
+  readonly ciProof?: ReleasePolicyCiProof | undefined;
   readonly commit: ReleasePolicyCommit;
   readonly distTag: string;
   readonly previousVersion?: string | undefined;
@@ -74,6 +95,7 @@ export interface ReleasePolicyReport {
   readonly autoEligible: boolean;
   readonly blockers: readonly string[];
   readonly channel: ChannelIntent | undefined;
+  readonly ciProof?: ReleasePolicyCiProof | undefined;
   readonly createGitHubRelease: boolean;
   readonly decision: ReleasePolicyDecision;
   readonly diagnostics: readonly string[];
@@ -88,6 +110,12 @@ interface FamilyResult<T extends string> {
   readonly conflicts: readonly string[];
   readonly unknown: readonly string[];
   readonly value?: T;
+}
+
+interface ReleasePolicyCiProofTarget {
+  readonly sha: string;
+  readonly source: Exclude<ReleasePolicyCiProofSource, 'assumed' | 'missing'>;
+  readonly summary: string;
 }
 
 const repoRoot = resolve(process.cwd());
@@ -241,6 +269,10 @@ export const evaluateReleasePolicy = (
     });
   }
 
+  const proof = readCiProofFromInput(input);
+  if (proof) {
+    reasons.push(`${proof.summary} passed`);
+  }
   reasons.push(
     'publish:auto is set and low-risk release checks passed for the generated release'
   );
@@ -303,6 +335,52 @@ export const labelsForReleasePullRequest = ({
   return labelsToAdd;
 };
 
+export const releasePolicyRequiresCiProof = (
+  input: ReleasePolicyInput
+): boolean => {
+  const publish = readLabelFamily(
+    input.releasePullRequest?.labels ?? [],
+    'publish:',
+    publishIntents
+  );
+  return (
+    publish.value === 'publish:auto' &&
+    publish.conflicts.length === 0 &&
+    publish.unknown.length === 0
+  );
+};
+
+export const selectReleasePolicyCiProofTarget = ({
+  releasePullRequest,
+  releasePullRequestHeadTreeSha,
+  sha,
+  shaTreeSha,
+}: {
+  readonly releasePullRequest?: ReleasePolicyPullRequest | undefined;
+  readonly releasePullRequestHeadTreeSha?: string | undefined;
+  readonly sha: string;
+  readonly shaTreeSha?: string | undefined;
+}): ReleasePolicyCiProofTarget => {
+  if (
+    releasePullRequest?.headSha &&
+    shaTreeSha &&
+    releasePullRequestHeadTreeSha &&
+    shaTreeSha === releasePullRequestHeadTreeSha
+  ) {
+    return {
+      sha: releasePullRequest.headSha,
+      source: 'release-pr-head',
+      summary: 'Generated release PR head CI proof',
+    };
+  }
+
+  return {
+    sha,
+    source: 'exact-sha',
+    summary: 'Exact-SHA CI proof',
+  };
+};
+
 const makeReport = (
   input: ReleasePolicyInput,
   options: {
@@ -319,17 +397,27 @@ const makeReport = (
 ): ReleasePolicyReport => {
   const canPublish =
     options.decision === 'auto' || options.decision === 'manual';
+  const packagesPublished = registryComplete(input.registryPackages);
+  const reasons = [...options.reasons];
+  if (canPublish) {
+    reasons.push(
+      packagesPublished
+        ? 'Registry package state already matches this release; npm publish will be skipped'
+        : 'Registry package state is incomplete for this release; npm publish remains required'
+    );
+  }
   return {
     autoEligible: options.autoEligible ?? false,
     blockers: options.blockers,
     channel: options.channel,
+    ciProof: readCiProofFromInput(input),
     createGitHubRelease: canPublish,
     decision: options.decision,
     diagnostics: options.diagnostics,
     publish: options.publish,
-    reasons: options.reasons,
+    reasons,
     release: options.release,
-    shouldPublish: canPublish && !registryComplete(input.registryPackages),
+    shouldPublish: canPublish && !packagesPublished,
     stack: options.stack,
   };
 };
@@ -507,11 +595,39 @@ const evaluateAutoChecks = (
     );
   }
 
-  if (!input.ciPassed) {
-    diagnostics.push('Exact-SHA CI checks have not passed');
-  }
+  diagnostics.push(...evaluateCiProofEvidence(input));
 
   return { diagnostics, ok: diagnostics.length === 0 };
+};
+
+const evaluateCiProofEvidence = (
+  input: ReleasePolicyInput
+): readonly string[] => {
+  const proof = readCiProofFromInput(input);
+  if (proof?.passed) {
+    return [];
+  }
+  return [
+    proof
+      ? `${proof.summary} has not passed`
+      : 'CI proof has not been evaluated',
+  ];
+};
+
+const readCiProofFromInput = (
+  input: ReleasePolicyInput
+): ReleasePolicyCiProof | undefined => {
+  if (input.ciProof) {
+    return input.ciProof;
+  }
+  if (input.ciPassed === undefined) {
+    return undefined;
+  }
+  return {
+    passed: input.ciPassed,
+    source: 'exact-sha',
+    summary: 'Exact-SHA CI proof',
+  };
 };
 
 const readSourceStackLabels = (
@@ -1023,7 +1139,7 @@ const githubJson = async <T>(repository: string, path: string): Promise<T> => {
 interface GitHubPullRequest {
   readonly base: { readonly ref: string };
   readonly body?: string | null;
-  readonly head: { readonly ref: string };
+  readonly head: { readonly ref: string; readonly sha?: string };
   readonly labels: readonly { readonly name: string }[];
   readonly number: number;
   readonly title: string;
@@ -1038,13 +1154,12 @@ interface GitHubContentFile {
   readonly content: string;
 }
 
+interface GitHubCommitResponse {
+  readonly commit: { readonly tree?: { readonly sha?: string } };
+}
+
 interface GitHubCheckRunsResponse {
-  readonly check_runs: readonly {
-    readonly check_suite?: { readonly app?: { readonly slug?: string } };
-    readonly conclusion?: string | null;
-    readonly name: string;
-    readonly status: string;
-  }[];
+  readonly check_runs: readonly ReleasePolicyCheckRun[];
 }
 
 const managedGitHubLabels = [
@@ -1130,6 +1245,7 @@ const readReleasePullRequest = async (
     body: pull.body ?? '',
     comments: comments.map((comment) => comment.body ?? ''),
     headRefName: pull.head.ref,
+    ...(pull.head.sha === undefined ? {} : { headSha: pull.head.sha }),
     labels: pull.labels.map((label) => label.name),
     number: pull.number,
     title: pull.title,
@@ -1155,6 +1271,7 @@ const readOpenReleasePullRequest = async (
     body: pull.body ?? '',
     comments: [],
     headRefName: pull.head.ref,
+    ...(pull.head.sha === undefined ? {} : { headSha: pull.head.sha }),
     labels: pull.labels.map((label) => label.name),
     number: pull.number,
     title: pull.title,
@@ -1299,14 +1416,31 @@ const readSourcePullRequests = async (
   return [...byNumber.values()];
 };
 
-const readCiPassed = async (
+const readCiProof = async (
   repository: string,
-  sha: string
-): Promise<boolean> => {
+  sha: string,
+  releasePullRequest: ReleasePolicyPullRequest | undefined
+): Promise<ReleasePolicyCiProof> => {
   if (process.env['TRAILS_RELEASE_POLICY_ASSUME_CI_PASSED'] === '1') {
-    return true;
+    return {
+      passed: true,
+      source: 'assumed',
+      summary: 'Assumed CI proof',
+    };
   }
 
+  const [shaTreeSha, releasePullRequestHeadTreeSha] = await Promise.all([
+    readCommitTreeSha(repository, sha),
+    releasePullRequest?.headSha
+      ? readCommitTreeSha(repository, releasePullRequest.headSha)
+      : undefined,
+  ]);
+  const target = selectReleasePolicyCiProofTarget({
+    releasePullRequest,
+    releasePullRequestHeadTreeSha,
+    sha,
+    shaTreeSha,
+  });
   const attempts = Number.parseInt(
     process.env['TRAILS_RELEASE_POLICY_CI_ATTEMPTS'] ?? '1',
     10
@@ -1317,22 +1451,49 @@ const readCiPassed = async (
   );
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    const state = await readCiState(repository, sha);
+    const state = await readCiState(repository, target.sha);
     if (state === 'passed') {
-      return true;
+      return {
+        passed: true,
+        source: target.source,
+        summary: target.summary,
+      };
     }
     if (state === 'failed') {
-      return false;
+      return {
+        passed: false,
+        source: target.source,
+        summary: target.summary,
+      };
     }
     if (attempt < attempts && waitMs > 0) {
       console.error(
-        `trails: waiting for exact-SHA CI checks (${attempt}/${attempts})`
+        `trails: waiting for ${target.summary.toLowerCase()} (${attempt}/${attempts})`
       );
       await Bun.sleep(waitMs);
     }
   }
 
-  return false;
+  return {
+    passed: false,
+    source: target.source,
+    summary: target.summary,
+  };
+};
+
+const readCommitTreeSha = async (
+  repository: string,
+  sha: string
+): Promise<string | undefined> => {
+  try {
+    const response = await githubJson<GitHubCommitResponse>(
+      repository,
+      `/commits/${sha}`
+    );
+    return response.commit.tree?.sha;
+  } catch {
+    return undefined;
+  }
 };
 
 const readCiState = async (
@@ -1343,35 +1504,45 @@ const readCiState = async (
     repository,
     `/commits/${sha}/check-runs?per_page=100`
   );
-  const requiredRuns = new Map(
-    response.check_runs
-      .filter((run) => run.check_suite?.app?.slug === 'github-actions')
-      .filter((run) =>
-        [
-          'Build',
-          'Lint & Format',
-          'Dead Code',
-          'Typecheck',
-          'Test',
-          'Governance',
-        ].includes(run.name)
-      )
-      .map((run) => [run.name, run])
-  );
-  const relevantRuns = [
+  return ciStateFromCheckRuns(response.check_runs);
+};
+
+export const ciStateFromCheckRuns = (
+  runs: readonly ReleasePolicyCheckRun[]
+): 'failed' | 'passed' | 'pending' => {
+  const requiredNames = [
     'Build',
     'Lint & Format',
     'Dead Code',
     'Typecheck',
     'Test',
     'Governance',
-  ].map((name) => requiredRuns.get(name));
+  ] as const;
+  const relevantRuns = runs
+    .filter((run) => run.check_suite?.app?.slug === 'github-actions')
+    .filter((run) =>
+      requiredNames.includes(run.name as (typeof requiredNames)[number])
+    );
 
-  if (relevantRuns.some((run) => !run || run.status !== 'completed')) {
-    return 'pending';
-  }
-  if (relevantRuns.some((run) => run?.conclusion !== 'success')) {
-    return 'failed';
+  for (const name of requiredNames) {
+    const namedRuns = relevantRuns.filter((run) => run.name === name);
+    if (namedRuns.length === 0) {
+      return 'pending';
+    }
+    if (
+      namedRuns.some(
+        (run) => run.status === 'completed' && run.conclusion !== 'success'
+      )
+    ) {
+      return 'failed';
+    }
+    if (
+      !namedRuns.some(
+        (run) => run.status === 'completed' && run.conclusion === 'success'
+      )
+    ) {
+      return 'pending';
+    }
   }
   return 'passed';
 };
@@ -1397,20 +1568,17 @@ const readPolicyInput = async (): Promise<ReleasePolicyInput> => {
     process.env['GITHUB_SHA'] ?? (await runText(['git', 'rev-parse', 'HEAD']));
   const previousVersion = await readPreviousVersion();
   const registryPackages = await readRegistryPackages(distTag);
-  const [releasePullRequest, commit, changedFiles, ciPassed] =
-    await Promise.all([
-      readReleasePullRequest(repository, sha),
-      readCommitInfo(),
-      readChangedFiles(),
-      readCiPassed(repository, sha),
-    ]);
+  const [releasePullRequest, commit, changedFiles] = await Promise.all([
+    readReleasePullRequest(repository, sha),
+    readCommitInfo(),
+    readChangedFiles(),
+  ]);
   const sourcePullRequests = previousVersion
     ? await readSourcePullRequests(repository, previousVersion)
     : undefined;
 
   return {
     changedFiles,
-    ciPassed,
     commit,
     distTag,
     ...(previousVersion === undefined ? {} : { previousVersion }),
@@ -1425,8 +1593,30 @@ const readPolicyInput = async (): Promise<ReleasePolicyInput> => {
 };
 
 const commandPolicy = async (): Promise<void> => {
-  const input = await readPolicyInput();
-  const report = evaluateReleasePolicy(input);
+  let input = await readPolicyInput();
+  let report = releasePolicyRequiresCiProof(input)
+    ? evaluateReleasePolicy({
+        ...input,
+        ciProof: {
+          passed: true,
+          source: 'missing',
+          summary: 'Deferred CI proof',
+        },
+      })
+    : evaluateReleasePolicy(input);
+
+  if (report.decision === 'auto') {
+    input = {
+      ...input,
+      ciProof: await readCiProof(
+        input.repository,
+        input.sha,
+        input.releasePullRequest
+      ),
+    };
+    report = evaluateReleasePolicy(input);
+  }
+
   printReport(report);
   await writeGitHubOutput({
     channel: report.channel ?? '',

--- a/docs/releases/release-rules-check.md
+++ b/docs/releases/release-rules-check.md
@@ -142,7 +142,15 @@ The policy gate emits machine-readable GitHub Actions outputs and chooses `auto`
 bun run publish:policy
 ```
 
-`publish:auto` is available only for the expected generated release PR shape: `changeset-release/main` into `main`, generated-only package version and changelog diffs, exact-SHA CI green, coherent registry/dist-tag state, no unknown or conflicting managed labels, and `stack:boundary` on every source PR that introduced a consumed changeset. Missing source PR evidence or missing `stack:boundary` routes to `publish:manual`; contradictory labels, unknown managed labels, registry contradictions, or `publish:block` block the workflow.
+`publish:auto` is available only for the expected generated release PR shape: `changeset-release/main` into `main`, generated-only package version and changelog diffs, CI proof green, coherent registry/dist-tag state, no unknown or conflicting managed labels, and `stack:boundary` on every source PR that introduced a consumed changeset. Missing source PR evidence or missing `stack:boundary` routes to `publish:manual`; contradictory labels, unknown managed labels, registry contradictions, or `publish:block` block the workflow.
+
+CI proof is gathered only when a generated release PR requests `publish:auto`. Manual, no-label, `publish:none`, and blocked paths do not wait on CI checks before routing to their decision. When auto proof is needed, the policy first reuses the generated release PR head checks if the current release commit and PR head commit resolve to the same Git tree. If that proof cannot be established, it falls back to exact-SHA checks on the current commit. Both paths read the required GitHub Actions checks (`Build`, `Lint & Format`, `Dead Code`, `Typecheck`, `Test`, and `Governance`). Duplicate pending checks do not mask an already-completed success for the same required check, but any completed failure still blocks automation.
+
+The policy log separates three facts:
+
+- **Publish authorization:** whether labels and generated-release evidence permit `auto`, require `manual`, select `none`, or `block`.
+- **Package readiness:** whether registry state already matches the generated package version and dist-tag.
+- **Publish necessity:** whether npm publication still needs to run after authorization.
 
 `publish:manual` never publishes from the push event that merges the generated release PR. After the generated PR is merged and the Release workflow policy resolves to `manual`, an operator must dispatch the Release workflow from `main` with `publish=true`. Protected npm environment approval may add another gate, but the workflow does not rely on environment protection as the only manual-publish guard.
 


### PR DESCRIPTION
## Context
Generated release publish policy was still too literal about CI proof: it could wait on exact-SHA checks even when the generated release PR had already proven the identical tree, and it fetched CI proof before knowing whether the path even wanted `publish:auto`.

## What Changed
- Added structured CI proof sources for assumed, exact-SHA, missing/deferred, and generated release PR head proof.
- Reuse generated release PR head checks when the release commit and PR head commit resolve to the same Git tree; fall back to exact-SHA checks otherwise.
- Fetch CI proof lazily only when the release policy can otherwise resolve to `auto`.
- Treat duplicate pending check runs as non-blocking once a required GitHub Actions check has a completed success, while preserving completed failures as blockers.
- Separate publish authorization, registry readiness, and publish necessity in the policy reasons.
- Document the updated policy behavior and add a patch changeset for `@ontrails/trails`.

## Verification
- `bun test apps/trails/src/__tests__/release-policy.test.ts`
- `bun run --cwd apps/trails typecheck`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun run changeset:check`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`
- Real `gt submit --stack --draft --restack --no-edit --no-interactive` pre-push gate passed: Warden, ADR, test, typecheck, lint, lint-ast-grep, format, release-pack, dead-code.

## Local Review
- Correctness review loop: 5/5 clean, no P0/P1/P2 findings.
- DX review loop round 1 found a P2 that the first implementation only reused duplicate check proof, not generated PR head proof. Fixed with tree-equivalent PR-head proof reuse.
- DX review loop round 2: 5/5 clean, no P0/P1/P2 findings.

## Notes
No package publishing was run. Registry readiness is now reported separately from whether publish is authorized.