### PR TITLE
fix(release): trust graphite release stack proof

### DIFF
--- a/.changeset/release-policy-trusted-stack-proof.md
+++ b/.changeset/release-policy-trusted-stack-proof.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Let generated release PR labeling treat trusted Graphite merge-queue proof with green required CI as source stack evidence for `publish:auto`, alongside explicit `stack:boundary` labels.

--- a/apps/trails/src/__tests__/release-policy.test.ts
+++ b/apps/trails/src/__tests__/release-policy.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   ciStateFromCheckRuns,
   evaluateReleasePolicy,
+  isGraphiteMergeQueueComment,
   labelsForReleasePullRequest,
   releaseIntentForVersionDelta,
   releasePolicyRequiresCiProof,
@@ -175,8 +176,29 @@ describe('evaluateReleasePolicy', () => {
 
     expect(report.decision).toBe('manual');
     expect(report.diagnostics).toContain(
-      'publish:auto requires stack:boundary on every changeset source PR in the release range; missing: #99'
+      'publish:auto requires stack:boundary or trusted Graphite merge evidence on every changeset source PR in the release range; missing: #99'
     );
+  });
+
+  test('allows trusted Graphite source evidence without stack boundary labels', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        sourcePullRequests: [
+          {
+            commitShas: ['abc123'],
+            hasChangeset: true,
+            labels: [],
+            number: 99,
+            title: 'feat: add release fact',
+            trustedStackEvidence:
+              'Graphite merge queue and required CI passed on abc123',
+          },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe('auto');
+    expect(report.diagnostics).toEqual([]);
   });
 
   test('routes unexpected generated release diff entries to manual', () => {
@@ -354,6 +376,54 @@ describe('labelsForReleasePullRequest', () => {
         ],
       })
     ).toEqual(['publish:auto', 'channel:stable', 'release:patch']);
+  });
+
+  test('uses trusted Graphite source evidence to select publish:auto', () => {
+    expect(
+      labelsForReleasePullRequest({
+        currentVersion: '1.0.0-beta.18',
+        existingLabels: [],
+        nextDistTag: 'beta',
+        nextVersion: '1.0.0-beta.19',
+        sourcePullRequests: [
+          {
+            commitShas: ['abc123'],
+            hasChangeset: true,
+            labels: [],
+            number: 99,
+            title: 'feat: release fact',
+            trustedStackEvidence:
+              'Graphite merge queue and required CI passed on abc123',
+          },
+        ],
+      })
+    ).toEqual(['publish:auto', 'channel:beta', 'release:patch']);
+  });
+});
+
+describe('isGraphiteMergeQueueComment', () => {
+  test('recognizes the current Graphite merge queue comment shape', () => {
+    expect(
+      isGraphiteMergeQueueComment({
+        body: 'Merged by the [Graphite merge queue](https://app.graphite.com/queue).',
+        user: { login: 'graphite-app[bot]' },
+      })
+    ).toBe(true);
+  });
+
+  test('rejects non-Graphite comments and unrelated Graphite comments', () => {
+    expect(
+      isGraphiteMergeQueueComment({
+        body: 'Merged by the [Graphite merge queue](https://app.graphite.com/queue).',
+        user: { login: 'github-actions[bot]' },
+      })
+    ).toBe(false);
+    expect(
+      isGraphiteMergeQueueComment({
+        body: 'Graphite stack updated.',
+        user: { login: 'graphite-app[bot]' },
+      })
+    ).toBe(false);
   });
 });
 

--- a/apps/trails/src/release/policy.ts
+++ b/apps/trails/src/release/policy.ts
@@ -44,8 +44,11 @@ export interface ReleasePolicySourcePullRequest {
   readonly commitShas: readonly string[];
   readonly hasChangeset: boolean;
   readonly labels: readonly string[];
+  readonly mergeCommitSha?: string | undefined;
+  readonly mergedAt?: string | null | undefined;
   readonly number: number;
   readonly title: string;
+  readonly trustedStackEvidence?: string | undefined;
 }
 
 export interface ReleasePolicyRegistryPackage {
@@ -676,12 +679,16 @@ const evaluateSourceStackEvidence = (
     ];
   }
 
-  const missingBoundary = changesetPulls.filter(
-    (pull) => !pull.labels.includes('stack:boundary')
+  const missingEvidence = changesetPulls.filter(
+    (pull) => !hasSourceStackEvidence(pull)
   );
-  if (stack !== 'stack:boundary' || missingBoundary.length > 0) {
+  if (
+    (stack !== 'stack:boundary' &&
+      !changesetPulls.every((pull) => pull.trustedStackEvidence)) ||
+    missingEvidence.length > 0
+  ) {
     return [
-      `publish:auto requires stack:boundary on every changeset source PR in the release range; missing: ${missingBoundary
+      `publish:auto requires stack:boundary or trusted Graphite merge evidence on every changeset source PR in the release range; missing: ${missingEvidence
         .map((pull) => `#${pull.number}`)
         .join(', ')}`,
     ];
@@ -689,6 +696,12 @@ const evaluateSourceStackEvidence = (
 
   return [];
 };
+
+const hasSourceStackEvidence = (
+  pull: ReleasePolicySourcePullRequest
+): boolean =>
+  pull.labels.includes('stack:boundary') ||
+  pull.trustedStackEvidence !== undefined;
 
 const evaluateGeneratedReleaseDiff = (
   changedFiles: readonly ReleasePolicyChangedFile[]
@@ -1141,13 +1154,17 @@ interface GitHubPullRequest {
   readonly body?: string | null;
   readonly head: { readonly ref: string; readonly sha?: string };
   readonly labels: readonly { readonly name: string }[];
+  readonly merge_commit_sha?: string | null;
+  readonly merged_at?: string | null;
   readonly number: number;
   readonly title: string;
   readonly user: { readonly login: string };
 }
 
-interface GitHubComment {
+export interface ReleasePolicyGitHubComment {
+  readonly author?: { readonly login?: string | null } | null;
   readonly body?: string | null;
+  readonly user?: { readonly login?: string | null } | null;
 }
 
 interface GitHubContentFile {
@@ -1236,7 +1253,7 @@ const readReleasePullRequest = async (
   if (!pull) {
     return undefined;
   }
-  const comments = await githubJson<GitHubComment[]>(
+  const comments = await githubJson<ReleasePolicyGitHubComment[]>(
     repository,
     `/issues/${pull.number}/comments`
   );
@@ -1408,12 +1425,73 @@ const readSourcePullRequests = async (
       commitShas: [commitSha],
       hasChangeset,
       labels: pull.labels.map((label) => label.name),
+      ...(pull.merge_commit_sha === undefined || pull.merge_commit_sha === null
+        ? {}
+        : { mergeCommitSha: pull.merge_commit_sha }),
+      ...(pull.merged_at === undefined ? {} : { mergedAt: pull.merged_at }),
       number: pull.number,
       title: pull.title,
     });
   }
 
-  return [...byNumber.values()];
+  return Promise.all(
+    [...byNumber.values()].map((pull) =>
+      enrichSourcePullRequestStackEvidence(repository, pull)
+    )
+  );
+};
+
+const enrichSourcePullRequestStackEvidence = async (
+  repository: string,
+  pull: ReleasePolicySourcePullRequest
+): Promise<ReleasePolicySourcePullRequest> => {
+  if (!pull.hasChangeset || pull.number <= 0 || hasSourceStackEvidence(pull)) {
+    return pull;
+  }
+
+  if (!pull.mergedAt) {
+    return pull;
+  }
+
+  try {
+    const comments = await githubJson<ReleasePolicyGitHubComment[]>(
+      repository,
+      `/issues/${pull.number}/comments`
+    );
+    if (!comments.some(isGraphiteMergeQueueComment)) {
+      return pull;
+    }
+
+    const proofSha = pull.mergeCommitSha ?? pull.commitShas.at(-1);
+    if (!proofSha) {
+      return pull;
+    }
+
+    const ciState = await readCiState(repository, proofSha);
+    if (ciState !== 'passed') {
+      return pull;
+    }
+
+    return {
+      ...pull,
+      trustedStackEvidence: `Graphite merge queue and required CI passed on ${proofSha.slice(0, 7)}`,
+    };
+  } catch {
+    // Optional trust enrichment must fail closed into publish:manual, not abort release labeling.
+    return pull;
+  }
+};
+
+export const isGraphiteMergeQueueComment = (
+  comment: ReleasePolicyGitHubComment
+): boolean => {
+  const login = comment.user?.login ?? comment.author?.login;
+  if (login !== 'graphite-app[bot]' && login !== 'graphite-app') {
+    return false;
+  }
+  return /\bMerged by the\s+\[?Graphite merge queue\b/u.test(
+    comment.body ?? ''
+  );
 };
 
 const readCiProof = async (

--- a/docs/releases/release-rules-check.md
+++ b/docs/releases/release-rules-check.md
@@ -121,7 +121,7 @@ Managed release PR labels:
 
 | Family | Labels | Meaning |
 | --- | --- | --- |
-| Source evidence | `stack:boundary` | Applied to source PRs whose consumed changesets are complete enough for automatic publication. |
+| Source evidence | `stack:boundary` | Applied to source PRs whose consumed changesets are complete enough for automatic publication. Trusted Graphite merge-queue proof may satisfy the same source-evidence requirement without the label. |
 | Publish intent | `publish:auto`, `publish:manual`, `publish:none`, `publish:block` | Select automatic publish, protected manual publish, intentional no-publish, or hard block. |
 | Channel intent | `channel:beta`, `channel:stable` | Declares the intended npm dist-tag family. `beta` maps to prerelease beta publication; `stable` maps to `latest`. |
 | Release size | `release:patch`, `release:minor`, `release:major` | Declares the semver movement expected on the generated release PR. |
@@ -142,7 +142,7 @@ The policy gate emits machine-readable GitHub Actions outputs and chooses `auto`
 bun run publish:policy
 ```
 
-`publish:auto` is available only for the expected generated release PR shape: `changeset-release/main` into `main`, generated-only package version and changelog diffs, CI proof green, coherent registry/dist-tag state, no unknown or conflicting managed labels, and `stack:boundary` on every source PR that introduced a consumed changeset. Missing source PR evidence or missing `stack:boundary` routes to `publish:manual`; contradictory labels, unknown managed labels, registry contradictions, or `publish:block` block the workflow.
+`publish:auto` is available only for the expected generated release PR shape: `changeset-release/main` into `main`, generated-only package version and changelog diffs, CI proof green, coherent registry/dist-tag state, no unknown or conflicting managed labels, and source evidence on every source PR that introduced a consumed changeset. Source evidence can come from an explicit `stack:boundary` label, or from trusted Graphite merge-queue evidence: the source PR was merged by the Graphite merge queue and the required GitHub Actions checks passed on the source PR merge/head SHA. Missing source PR evidence routes to `publish:manual`; contradictory labels, unknown managed labels, registry contradictions, or `publish:block` block the workflow.
 
 CI proof is gathered only when a generated release PR requests `publish:auto`. Manual, no-label, `publish:none`, and blocked paths do not wait on CI checks before routing to their decision. When auto proof is needed, the policy first reuses the generated release PR head checks if the current release commit and PR head commit resolve to the same Git tree. If that proof cannot be established, it falls back to exact-SHA checks on the current commit. Both paths read the required GitHub Actions checks (`Build`, `Lint & Format`, `Dead Code`, `Typecheck`, `Test`, and `Governance`). Duplicate pending checks do not mask an already-completed success for the same required check, but any completed failure still blocks automation.
 


### PR DESCRIPTION
## Context

TRL-1061 follows the release-policy proof reuse work from #819. The generated release PR created from #819 still landed as `publish:manual` because the old source-evidence model only trusted explicit `stack:boundary` labels. This branch lets the release labeler recognize trusted Graphite merge-queue evidence instead: a source PR merged by Graphite with required CI passing can now satisfy the source stack evidence requirement for `publish:auto`.

## What Changed

- Added source PR metadata for merge commit, merge time, and derived trusted stack evidence.
- Enriched source PRs by looking for Graphite merge-queue comments and required CI on the proof SHA.
- Matched the real Graphite comment shape observed in this repo: `graphite-app[bot]` plus Markdown-linked `Merged by the [Graphite merge queue](...)`.
- Made optional trust enrichment fail closed: GitHub comment/check lookup failures leave the PR without trusted evidence so the generated release routes to manual rather than aborting or over-trusting.
- Updated release-policy tests, release docs, and added a branch-local `@ontrails/trails` changeset.

## Local Review

- Correctness round 1: found P1 real Graphite comment mismatch; fixed.
- DX round 1: found P2 enrichment failure should fail closed; fixed.
- Correctness round 2: caught stale `GitHubComment` type reference; fixed.
- DX round 2: approved 5/5, no P0/P1/P2.
- Correctness round 3: approved 5/5, no P0/P1/P2.

## Verification

- `bun test apps/trails/src/__tests__/release-policy.test.ts` passed: 24 pass / 0 fail.
- `bun run --cwd apps/trails typecheck` passed.
- `bun run format:check` passed.
- `bun run lint` passed.
- `bun run typecheck` passed.
- `bun run check` passed.
- `bun run test` passed.
- `bun run build` passed.
- `bun run publish:check` passed.
- `bun run wayfinder:dogfood` passed: 61 trails inspected.
- `bun run changeset:check` passed.
- `git diff --check` passed.
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run` passed.
- Real Graphite submit pre-push hook passed.

## Notes

This does not publish packages. It makes future generated release PR labeling smarter when source PRs have trusted Graphite merge-queue proof and green required CI. Existing manually labeled release PRs remain manual unless someone intentionally relabels them.