### PR TITLE
fix(release): consolidate registry verdicts behind a phase-aware packageRegistry classifier

### DIFF
--- a/.agents/memory/decisions.md
+++ b/.agents/memory/decisions.md
@@ -176,3 +176,25 @@ Merit aside: a *gate* is a point (binary allow/deny on a path); the job is a *br
 **Follow-up:** If the primitive proceeds, open pathfinding to land the name against the three-neighbor test (must not read as Warden gating, permit/auth gate, release gate, or feature flag) and the bracket/verdict framing. Add a `gate` tombstone to the lexicon Reserved Terms table ("retired Cutover 2 → layer; do not reuse") if the word keeps resurfacing.
 
 **Resolution (same session):** Matt chose the warden family with a literal subcommand: **`trails warden guard`** (`warden guard -- <cmd>`, `warden guard start`, `warden guard verify`). Warden generalizes to "the authority on whether a verdict can be trusted" — drift rules catch contract-trust failures between runs; the guard catches run-trust failures (shifts) during one. Passes the three-neighbor test trivially. CLI/concept family only — no packaging mandate to move the bracket into `@ontrails/warden`. ADR retitled "Verdicts Run on Stable Ground."
+
+### 2026-06-24 `packageRegistry`, not bare `registry`, for the package-registry resource
+
+**Question:** When modeling the npm-protocol package registry as a `resource()` (release reconciliation work), what is the capability's name?
+
+**Decision:** `packageRegistry` (camelCase resource id; `package-registry` in kebab/doc prose). Never bare `registry` as the capability name. Sibling capability stays `release-publication`. GitHub is **not** a resource; its capabilities split into package-registry targets (npmjs and GitHub Packages = instances of one `packageRegistry` resource), a `release-publication` target (GitHub Releases), and the control plane (workflow dispatch / PR-label / check reads) — never one "GitHub adapter" junk drawer.
+
+**Basis:** Hierarchy level 4 (active lexicon) + ADR-0009 (First-Class Resources) + ADR-0029 (adapter packaging). The lexicon already reserves against bare `registry` ("`topo`, not registry or collection"); a `registry` resource would re-muddy that boundary. `packageRegistry` is an unambiguous industry compound that cannot read as a topo, and stays vendor-neutral where `npmRegistry` would re-vendor the abstraction. Asymmetry with `release-publication` is principled: a registry is a *place*, a release is a *record*.
+
+**Confidence:** High on the reject of bare `registry`. Credit Lewis for the catch.
+
+**Related:** decision below on deferring `reconcile` doctrine. Notes: `.agents/notes/2026-06-24-publication-targets-as-resources.md`, `.agents/notes/2026-06-24-release-registry-reconciliation.md`.
+
+### 2026-06-24 Use `reconcile` now; defer cross-substrate doctrine until a second tenant ships
+
+**Question:** Ratify `reconcile` as a broad cross-substrate convergence verb in the lexicon now (store tables + registry + releases = "one verb, three tenants")?
+
+**Decision:** Not yet. `reconcile` is already a recognized operational shape, so *use* it in the release subsystem immediately (no lexicon expansion needed). Defer the doctrine note ("reconcile is *the* cross-substrate convergence operation") until store + release reconcile have both shipped. Use now; ratify doctrine once the second tenant exists.
+
+**Basis:** Gate-on-demonstrated-need applied to vocabulary; tenets "add with intent" + the evaluation hierarchy (codify after the pattern recurs in shipped code). Lewis's discipline.
+
+**Confidence:** High. Low cost to defer; reversible.

--- a/.changeset/packageregistry-classifier.md
+++ b/.changeset/packageregistry-classifier.md
@@ -1,0 +1,9 @@
+---
+'@ontrails/trails': patch
+---
+
+Consolidate registry verdicts behind one shared `packageRegistry` classifier.
+
+`apps/trails/src/release` now derives every package's registry state — `complete`, `needs-publish`, `first-time-package`, `needs-tag-repair`, `tag-points-ahead`, `registry-inaccessible` — from a single `classifyPackageRegistryState` function, fed by an exact-version probe (`npm view <name>@<version>`). The release policy engine and the registry preflight both consume it, so their verdicts can no longer drift, and the missing "is the target version actually published" fact is now first-class.
+
+The preflight check is phase-aware: `publish:registry-check` (ready) treats an unpublished target or a behind dist-tag as expected pre-publish work rather than a failure, while `publish:registry-check:published` still requires every package to be fully published and tagged. This fixes the confusing failure seen when the repo is several releases ahead of the published `beta` tag. Exact-version probes run with bounded concurrency so release checks stay responsive. No publish or dist-tag mutation is performed.

--- a/apps/trails/src/__tests__/release-policy.test.ts
+++ b/apps/trails/src/__tests__/release-policy.test.ts
@@ -301,6 +301,31 @@ describe('evaluateReleasePolicy', () => {
     expect(report.blockers).toEqual([]);
   });
 
+  test('does not block when the target version is unpublished and the tag is behind', () => {
+    // The live beta.28 incident: repo target is ahead of the published beta
+    // dist-tag, but the target tarball does not exist yet. This must stay a
+    // publish-pending state, never a registry blocker.
+    const report = evaluateReleasePolicy(
+      baseInput({
+        previousVersion: '1.0.0-beta.24',
+        registryPackages: [
+          {
+            expectedTagVersion: '1.0.0-beta.24',
+            name: '@ontrails/core',
+            status: 'published',
+            version: '1.0.0-beta.28',
+            versionPublished: false,
+          },
+        ],
+        version: '1.0.0-beta.28',
+      })
+    );
+
+    expect(report.blockers).toEqual([]);
+    expect(report.shouldPublish).toBe(true);
+    expect(report.decision).not.toBe('block');
+  });
+
   test('requires publish:none audit reason', () => {
     const blocked = evaluateReleasePolicy(
       baseInput({

--- a/apps/trails/src/__tests__/release-registry-classifier.test.ts
+++ b/apps/trails/src/__tests__/release-registry-classifier.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  checkRegistryPosture,
+  classifyPackageRegistryState,
+  registryPostureErrors,
+} from '../release/native-bun-registry.js';
+import type {
+  PackageRegistryFacts,
+  RegistryResult,
+  RegistryVersionView,
+  RegistryView,
+  RegistryWorkspace,
+} from '../release/native-bun-registry.js';
+
+const acceptsLegacyCheckRegistryPostureSignature: (
+  workspaces: readonly RegistryWorkspace[],
+  view: RegistryView,
+  expectedTag: string
+) => Promise<RegistryResult[]> = checkRegistryPosture;
+
+const acceptsLegacyRegistryPostureErrorsSignature: (
+  results: readonly RegistryResult[],
+  expectedTag: string,
+  requirePublished: boolean
+) => string[] = registryPostureErrors;
+
+const publishedFacts = (
+  overrides: Partial<PackageRegistryFacts> = {}
+): PackageRegistryFacts => ({
+  expectedTagVersion: '1.0.0-beta.28',
+  status: 'published',
+  targetVersion: '1.0.0-beta.28',
+  versionPublished: true,
+  ...overrides,
+});
+
+describe('classifyPackageRegistryState', () => {
+  test('complete when target is published and the tag points at it', () => {
+    expect(classifyPackageRegistryState(publishedFacts()).kind).toBe(
+      'complete'
+    );
+  });
+
+  test('complete when publish state is unknown but the tag is at target', () => {
+    // Preserves the policy `versionPublished ?? true` default.
+    expect(
+      classifyPackageRegistryState(
+        publishedFacts({ versionPublished: undefined })
+      ).kind
+    ).toBe('complete');
+  });
+
+  test('first-time-package when the package is missing entirely', () => {
+    expect(
+      classifyPackageRegistryState({
+        expectedTagVersion: undefined,
+        status: 'missing',
+        targetVersion: '1.0.0-beta.28',
+        versionPublished: false,
+      }).kind
+    ).toBe('first-time-package');
+  });
+
+  test('needs-publish when the target version is absent and the tag is behind', () => {
+    // The live beta.28 incident shape.
+    expect(
+      classifyPackageRegistryState(
+        publishedFacts({
+          expectedTagVersion: '1.0.0-beta.24',
+          versionPublished: false,
+        })
+      ).kind
+    ).toBe('needs-publish');
+  });
+
+  test('needs-publish (not tag-repair) when the tag is behind but publish state is unknown', () => {
+    // Preserves conservative policy behavior: an unprobed behind-tag must not
+    // be promoted to a tag repair (which policy treats as a blocker).
+    expect(
+      classifyPackageRegistryState(
+        publishedFacts({
+          expectedTagVersion: '1.0.0-beta.24',
+          versionPublished: undefined,
+        })
+      ).kind
+    ).toBe('needs-publish');
+  });
+
+  test('needs-tag-repair when the target is published but the tag is behind', () => {
+    const state = classifyPackageRegistryState(
+      publishedFacts({
+        expectedTagVersion: '1.0.0-beta.24',
+        versionPublished: true,
+      })
+    );
+    expect(state.kind).toBe('needs-tag-repair');
+    expect(state).toMatchObject({ currentTagVersion: '1.0.0-beta.24' });
+  });
+
+  test('tag-points-ahead when the dist-tag is newer than the target', () => {
+    const state = classifyPackageRegistryState(
+      publishedFacts({
+        expectedTagVersion: '1.0.0-beta.29',
+        versionPublished: true,
+      })
+    );
+    expect(state.kind).toBe('tag-points-ahead');
+    expect(state).toMatchObject({ currentTagVersion: '1.0.0-beta.29' });
+  });
+
+  test('registry-inaccessible when the probe failed', () => {
+    expect(
+      classifyPackageRegistryState({
+        error: 'boom',
+        expectedTagVersion: undefined,
+        status: 'inaccessible',
+        targetVersion: '1.0.0-beta.28',
+        versionPublished: false,
+      }).kind
+    ).toBe('registry-inaccessible');
+  });
+});
+
+const incidentWorkspaces: readonly RegistryWorkspace[] = [
+  { name: '@ontrails/core', path: 'packages/core', version: '1.0.0-beta.28' },
+];
+
+// Repo target beta.28; beta tag at beta.24; beta.28 tarball absent.
+const behindTagView: RegistryView = async (name) => ({
+  'dist-tags': { beta: '1.0.0-beta.24' },
+  name,
+  version: '1.0.0-beta.24',
+});
+
+// Target beta.28 is published, but the beta tag still points at beta.24.
+const publishedStaleTagView: RegistryView = async (name) => ({
+  'dist-tags': { beta: '1.0.0-beta.24' },
+  name,
+  version: '1.0.0-beta.28',
+});
+
+// The beta tag points one release ahead of the repo target.
+const tagAheadView: RegistryView = async (name) => ({
+  'dist-tags': { beta: '1.0.0-beta.29' },
+  name,
+  version: '1.0.0-beta.29',
+});
+
+const targetAbsent: RegistryVersionView = async () => false;
+const targetPublished: RegistryVersionView = async () => true;
+
+describe('registryPostureErrors — live beta.28 incident', () => {
+  test('ready phase passes (publish pending); published phase fails', async () => {
+    const results = await checkRegistryPosture(
+      incidentWorkspaces,
+      behindTagView,
+      targetAbsent,
+      'beta'
+    );
+
+    expect(registryPostureErrors(results, 'beta', 'ready')).toEqual([]);
+    expect(registryPostureErrors(results, 'beta', 'published')).toEqual([
+      '@ontrails/core: target version 1.0.0-beta.28 is not published',
+    ]);
+  });
+
+  test('preserves the legacy exported helper signatures', async () => {
+    const results = await acceptsLegacyCheckRegistryPostureSignature(
+      incidentWorkspaces,
+      behindTagView,
+      'beta'
+    );
+
+    expect(results).toEqual([
+      {
+        distTags: { beta: '1.0.0-beta.24' },
+        expectedTagVersion: '1.0.0-beta.24',
+        name: '@ontrails/core',
+        status: 'published',
+        version: '1.0.0-beta.24',
+        versionPublished: undefined,
+        workspaceVersion: '1.0.0-beta.28',
+      },
+    ]);
+    expect(
+      acceptsLegacyRegistryPostureErrorsSignature(results, 'beta', false)
+    ).toEqual([]);
+    expect(
+      acceptsLegacyRegistryPostureErrorsSignature(results, 'beta', true)
+    ).toEqual([
+      '@ontrails/core: target version 1.0.0-beta.28 publish state was not probed',
+    ]);
+  });
+});
+
+describe('registryPostureErrors — phase behavior', () => {
+  test('a published target with a stale tag only fails in published phase', async () => {
+    const results = await checkRegistryPosture(
+      incidentWorkspaces,
+      publishedStaleTagView,
+      targetPublished,
+      'beta'
+    );
+
+    expect(registryPostureErrors(results, 'beta', 'ready')).toEqual([]);
+    expect(registryPostureErrors(results, 'beta', 'published')).toEqual([
+      '@ontrails/core: needs dist-tag update — beta points to 1.0.0-beta.24, target 1.0.0-beta.28',
+    ]);
+  });
+
+  test('a tag ahead of the target blocks in both phases', async () => {
+    const results = await checkRegistryPosture(
+      incidentWorkspaces,
+      tagAheadView,
+      targetPublished,
+      'beta'
+    );
+    const ahead =
+      '@ontrails/core: dist-tag beta points to 1.0.0-beta.29, which is newer than target 1.0.0-beta.28';
+
+    expect(registryPostureErrors(results, 'beta', 'ready')).toEqual([ahead]);
+    expect(registryPostureErrors(results, 'beta', 'published')).toEqual([
+      ahead,
+    ]);
+  });
+});

--- a/apps/trails/src/release/index.ts
+++ b/apps/trails/src/release/index.ts
@@ -72,14 +72,20 @@ export {
 } from './pack-coherence.js';
 export {
   checkRegistryPosture,
+  classifyPackageRegistryState,
   discoverRegistryWorkspaces,
   formatDistTagSummary,
+  npmRegistryVersionView,
   npmRegistryView,
   registryPostureErrors,
   runRegistryPreflight,
   runRegistryPreflightCli,
+  type PackageRegistryFacts,
+  type PackageRegistryState,
+  type RegistryCheckPhase,
   type RegistryPreflightOptions,
   type RegistryResult,
+  type RegistryVersionView,
   type RegistryView,
   type RegistryWorkspace,
 } from './native-bun-registry.js';

--- a/apps/trails/src/release/native-bun-registry.ts
+++ b/apps/trails/src/release/native-bun-registry.ts
@@ -2,8 +2,15 @@
 import { readdir } from 'node:fs/promises';
 import { join, relative, resolve } from 'node:path';
 
+import { compareSemver } from './semver.js';
+
 const REPO_ROOT = resolve(process.cwd());
 const SUMMARY_DIST_TAGS = ['latest', 'beta'] as const;
+/** Bound concurrent npm probes so release checks stay responsive on large workspaces. */
+const PROBE_CONCURRENCY = 8;
+
+/** Phase of a registry check: pre-publish readiness vs post-publish verification. */
+export type RegistryCheckPhase = 'published' | 'ready';
 
 export interface RegistryPreflightOptions {
   readonly requirePublished: boolean;
@@ -35,6 +42,7 @@ export type RegistryResult =
       readonly name: string;
       readonly status: 'published';
       readonly version: string;
+      readonly versionPublished: boolean | undefined;
       readonly workspaceVersion: string;
     }
   | {
@@ -48,6 +56,106 @@ export type RegistryResult =
       readonly status: 'inaccessible';
       readonly workspaceVersion: string;
     };
+
+/**
+ * The single source of truth for what a package's registry state means for a
+ * release. Both the release policy engine and the registry preflight derive
+ * verdicts from this, so they cannot drift.
+ */
+export type PackageRegistryState =
+  | { readonly kind: 'complete' }
+  | { readonly kind: 'needs-publish' }
+  | { readonly kind: 'first-time-package' }
+  | {
+      readonly kind: 'needs-tag-repair';
+      readonly currentTagVersion: string | undefined;
+    }
+  | { readonly kind: 'tag-points-ahead'; readonly currentTagVersion: string }
+  | { readonly kind: 'registry-inaccessible'; readonly error: string };
+
+/** Minimal facts the classifier needs, mappable from any registry probe shape. */
+export interface PackageRegistryFacts {
+  readonly status: 'inaccessible' | 'missing' | 'published';
+  readonly targetVersion: string;
+  readonly expectedTagVersion: string | undefined;
+  readonly versionPublished: boolean | undefined;
+  readonly error?: string | undefined;
+}
+
+/**
+ * Classify a package's registry state from two orthogonal facts — whether the
+ * target version is published, and where the dist-tag points relative to it —
+ * plus reachability. Members are mutually exclusive by construction.
+ *
+ * `versionPublished` is read strictly only in the behind-tag case: a behind tag
+ * becomes a `needs-tag-repair` only when the target is known published (`true`);
+ * `undefined` or `false` route to `needs-publish`, preserving the conservative
+ * release-policy behavior. When the tag already points at the target, an
+ * unprobed (`undefined`) state counts as published and yields `complete`, which
+ * matches the policy `versionPublished ?? true` default. `undefined` means the
+ * exact-version probe was not run, including policy inputs and compatibility
+ * callers that supply an injected registry view without a version probe.
+ */
+export const classifyPackageRegistryState = (
+  facts: PackageRegistryFacts
+): PackageRegistryState => {
+  if (facts.status === 'inaccessible') {
+    return {
+      error: facts.error ?? 'registry probe failed',
+      kind: 'registry-inaccessible',
+    };
+  }
+  if (facts.status === 'missing') {
+    return { kind: 'first-time-package' };
+  }
+
+  const { expectedTagVersion, targetVersion, versionPublished } = facts;
+  const tagAtTarget = expectedTagVersion === targetVersion;
+  const tagAhead =
+    expectedTagVersion !== undefined &&
+    !tagAtTarget &&
+    compareSemver(expectedTagVersion, targetVersion) > 0;
+
+  if (tagAhead) {
+    return { currentTagVersion: expectedTagVersion, kind: 'tag-points-ahead' };
+  }
+  if (tagAtTarget) {
+    return versionPublished === false
+      ? { kind: 'needs-publish' }
+      : { kind: 'complete' };
+  }
+  if (versionPublished === true) {
+    return { currentTagVersion: expectedTagVersion, kind: 'needs-tag-repair' };
+  }
+  return { kind: 'needs-publish' };
+};
+
+/** Map a registry probe result into the classifier's fact shape. */
+const factsFromResult = (result: RegistryResult): PackageRegistryFacts => {
+  if (result.status === 'published') {
+    return {
+      expectedTagVersion: result.expectedTagVersion,
+      status: 'published',
+      targetVersion: result.workspaceVersion,
+      versionPublished: result.versionPublished,
+    };
+  }
+  if (result.status === 'inaccessible') {
+    return {
+      error: result.error,
+      expectedTagVersion: undefined,
+      status: 'inaccessible',
+      targetVersion: result.workspaceVersion,
+      versionPublished: false,
+    };
+  }
+  return {
+    expectedTagVersion: undefined,
+    status: 'missing',
+    targetVersion: result.workspaceVersion,
+    versionPublished: false,
+  };
+};
 
 const USAGE = `Usage: bun scripts/check-registry-preflight.ts [options]
 
@@ -217,9 +325,66 @@ export const npmRegistryView: RegistryView = async (name) => {
   throw new Error(stderr.trim() || `npm view failed for ${name}`);
 };
 
+/** Probe whether an exact `name@version` is published. The missing fact that
+ * a tag/version summary alone cannot answer. */
+export type RegistryVersionView = (
+  name: string,
+  version: string
+) => Promise<boolean | undefined>;
+
+const UNKNOWN_REGISTRY_VERSION_STATE: { readonly published?: boolean } = {};
+const unknownRegistryVersionView: RegistryVersionView = async () =>
+  UNKNOWN_REGISTRY_VERSION_STATE.published;
+
+export const npmRegistryVersionView: RegistryVersionView = async (
+  name,
+  version
+) => {
+  const proc = Bun.spawn(
+    ['npm', 'view', `${name}@${version}`, 'version', '--json'],
+    { stderr: 'pipe', stdin: 'ignore', stdout: 'pipe' }
+  );
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  if (exitCode === 0) {
+    return JSON.parse(stdout.trim()) === version;
+  }
+  const combined = `${stdout}\n${stderr}`;
+  if (combined.includes('E404') || combined.includes('404 Not Found')) {
+    return false;
+  }
+  throw new Error(stderr.trim() || `npm view failed for ${name}@${version}`);
+};
+
+/** Run async tasks with a bounded number in flight, preserving input order. */
+const mapBounded = async <T, R>(
+  items: readonly T[],
+  limit: number,
+  task: (item: T) => Promise<R>
+): Promise<R[]> => {
+  const results: R[] = [];
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await task(items[index] as T);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, worker)
+  );
+  return results;
+};
+
 const checkWorkspaceRegistryPosture = async (
   workspace: RegistryWorkspace,
   view: RegistryView,
+  versionView: RegistryVersionView,
   expectedTag: string
 ): Promise<RegistryResult> => {
   try {
@@ -238,6 +403,7 @@ const checkWorkspaceRegistryPosture = async (
       name: workspace.name,
       status: 'published',
       version: registry.version ?? '(unknown)',
+      versionPublished: await versionView(workspace.name, workspace.version),
       workspaceVersion: workspace.version,
     };
   } catch (error) {
@@ -250,33 +416,97 @@ const checkWorkspaceRegistryPosture = async (
   }
 };
 
-export const checkRegistryPosture = async (
+type CheckRegistryPostureArgs =
+  | readonly [versionView: RegistryVersionView, expectedTag: string]
+  | readonly [expectedTag: string];
+
+const normalizeCheckRegistryPostureArgs = (
+  args: CheckRegistryPostureArgs
+): {
+  readonly expectedTag: string;
+  readonly versionView: RegistryVersionView;
+} => {
+  if (args.length === 1) {
+    return { expectedTag: args[0], versionView: unknownRegistryVersionView };
+  }
+  return { expectedTag: args[1], versionView: args[0] };
+};
+
+export function checkRegistryPosture(
   workspaces: readonly RegistryWorkspace[],
   view: RegistryView,
   expectedTag: string
-): Promise<RegistryResult[]> =>
-  Promise.all(
-    workspaces.map((workspace) =>
-      checkWorkspaceRegistryPosture(workspace, view, expectedTag)
-    )
+): Promise<RegistryResult[]>;
+export function checkRegistryPosture(
+  workspaces: readonly RegistryWorkspace[],
+  view: RegistryView,
+  versionView: RegistryVersionView,
+  expectedTag: string
+): Promise<RegistryResult[]>;
+export async function checkRegistryPosture(
+  workspaces: readonly RegistryWorkspace[],
+  view: RegistryView,
+  ...args: CheckRegistryPostureArgs
+): Promise<RegistryResult[]> {
+  const { expectedTag, versionView } = normalizeCheckRegistryPostureArgs(args);
+  return mapBounded(workspaces, PROBE_CONCURRENCY, (workspace) =>
+    checkWorkspaceRegistryPosture(workspace, view, versionView, expectedTag)
   );
+}
+
+/**
+ * Phase-aware registry errors, derived from the shared classifier.
+ *
+ * `ready` (pre-publish): only a tag pointing *ahead* of the target or an
+ * inaccessible registry is an error. A behind tag or an unpublished target is
+ * the expected state before publish runs, not a failure.
+ *
+ * `published` (post-publish): every package must be `complete`.
+ */
+const normalizeRegistryCheckPhase = (
+  phaseOrRequirePublished: boolean | RegistryCheckPhase
+): RegistryCheckPhase => {
+  if (typeof phaseOrRequirePublished !== 'boolean') {
+    return phaseOrRequirePublished;
+  }
+  return phaseOrRequirePublished ? 'published' : 'ready';
+};
 
 export const registryPostureErrors = (
   results: readonly RegistryResult[],
   expectedTag: string,
-  requirePublished: boolean
+  phaseOrRequirePublished: boolean | RegistryCheckPhase
 ): string[] => {
+  const phase = normalizeRegistryCheckPhase(phaseOrRequirePublished);
   const errors: string[] = [];
   for (const result of results) {
-    if (result.status === 'inaccessible') {
-      errors.push(`${result.name}: registry probe failed: ${result.error}`);
-    } else if (result.status === 'missing') {
-      if (requirePublished) {
-        errors.push(`${result.name}: package is missing from the registry`);
-      }
-    } else if (result.expectedTagVersion !== result.workspaceVersion) {
+    const state = classifyPackageRegistryState(factsFromResult(result));
+    if (state.kind === 'registry-inaccessible') {
+      errors.push(`${result.name}: registry probe failed: ${state.error}`);
+      continue;
+    }
+    if (state.kind === 'tag-points-ahead') {
       errors.push(
-        `${result.name}: dist-tag ${expectedTag} points to ${result.expectedTagVersion ?? '(missing)'}, expected ${result.workspaceVersion}`
+        `${result.name}: dist-tag ${expectedTag} points to ${state.currentTagVersion}, which is newer than target ${result.workspaceVersion}`
+      );
+      continue;
+    }
+    if (phase === 'ready' || state.kind === 'complete') {
+      continue;
+    }
+    if (state.kind === 'first-time-package') {
+      errors.push(`${result.name}: package is missing from the registry`);
+    } else if (state.kind === 'needs-publish') {
+      const targetState =
+        result.status === 'published' && result.versionPublished === undefined
+          ? 'publish state was not probed'
+          : 'is not published';
+      errors.push(
+        `${result.name}: target version ${result.workspaceVersion} ${targetState}`
+      );
+    } else if (state.kind === 'needs-tag-repair') {
+      errors.push(
+        `${result.name}: needs dist-tag update — ${expectedTag} points to ${state.currentTagVersion ?? '(missing)'}, target ${result.workspaceVersion}`
       );
     }
   }
@@ -290,6 +520,18 @@ export const formatDistTagSummary = (
     ', '
   );
 
+const formatTargetVersionStatus = (
+  versionPublished: boolean | undefined
+): string => {
+  if (versionPublished === true) {
+    return 'target version published';
+  }
+  if (versionPublished === false) {
+    return 'target version not published yet';
+  }
+  return 'target version publish state unknown';
+};
+
 const printResults = (
   results: readonly RegistryResult[],
   expectedTag: string
@@ -297,8 +539,9 @@ const printResults = (
   console.log(`Registry preflight for dist-tag "${expectedTag}"`);
   for (const result of results) {
     if (result.status === 'published') {
+      const targetStatus = formatTargetVersionStatus(result.versionPublished);
       console.log(
-        `✓ ${result.name}@${result.workspaceVersion}: published (registry version ${result.version}, expected ${expectedTag}=${result.expectedTagVersion ?? 'missing'}, tags ${formatDistTagSummary(result.distTags)})`
+        `✓ ${result.name}@${result.workspaceVersion}: package exists, ${targetStatus} (registry version ${result.version}, expected ${expectedTag}=${result.expectedTagVersion ?? 'missing'}, tags ${formatDistTagSummary(result.distTags)})`
       );
     } else if (result.status === 'missing') {
       console.log(
@@ -310,18 +553,38 @@ const printResults = (
   }
 };
 
+const normalizeRegistryPreflightViews = (
+  view: RegistryView | undefined,
+  versionView: RegistryVersionView | undefined
+): {
+  readonly versionView: RegistryVersionView;
+  readonly view: RegistryView;
+} => {
+  if (view === undefined) {
+    return { versionView: npmRegistryVersionView, view: npmRegistryView };
+  }
+  return { versionView: versionView ?? unknownRegistryVersionView, view };
+};
+
 export const runRegistryPreflight = async (
   options: RegistryPreflightOptions,
-  view: RegistryView = npmRegistryView
+  view?: RegistryView,
+  versionView?: RegistryVersionView
 ): Promise<number> => {
+  const registryViews = normalizeRegistryPreflightViews(view, versionView);
   const expectedTag = options.tag ?? (await resolveDefaultTag());
   const workspaces = await discoverRegistryWorkspaces();
-  const results = await checkRegistryPosture(workspaces, view, expectedTag);
+  const results = await checkRegistryPosture(
+    workspaces,
+    registryViews.view,
+    registryViews.versionView,
+    expectedTag
+  );
   printResults(results, expectedTag);
   const errors = registryPostureErrors(
     results,
     expectedTag,
-    options.requirePublished
+    options.requirePublished ? 'published' : 'ready'
   );
   if (errors.length > 0) {
     console.error('\nRegistry preflight failed:');

--- a/apps/trails/src/release/policy.ts
+++ b/apps/trails/src/release/policy.ts
@@ -2,8 +2,15 @@
 import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
-import { discoverRegistryWorkspaces } from './native-bun-registry.js';
-import type { RegistryResult } from './native-bun-registry.js';
+import {
+  classifyPackageRegistryState,
+  discoverRegistryWorkspaces,
+} from './native-bun-registry.js';
+import type {
+  PackageRegistryFacts,
+  RegistryResult,
+} from './native-bun-registry.js';
+import { compareSemver, parseSemver } from './semver.js';
 
 export type PublishIntent =
   | 'publish:auto'
@@ -452,15 +459,23 @@ const readLabelFamily = <T extends string>(
   return result;
 };
 
+const factsFromPolicyPackage = (
+  entry: ReleasePolicyRegistryPackage
+): PackageRegistryFacts => ({
+  expectedTagVersion: entry.expectedTagVersion,
+  status: entry.status,
+  targetVersion: entry.version,
+  versionPublished: entry.versionPublished,
+});
+
 const registryComplete = (
   packages: readonly ReleasePolicyRegistryPackage[]
 ): boolean =>
   packages.length > 0 &&
   packages.every(
     (entry) =>
-      entry.status === 'published' &&
-      entry.expectedTagVersion === entry.version &&
-      (entry.versionPublished ?? true)
+      classifyPackageRegistryState(factsFromPolicyPackage(entry)).kind ===
+      'complete'
   );
 
 const registryBlockers = (
@@ -468,31 +483,20 @@ const registryBlockers = (
   distTag: string
 ): readonly string[] =>
   packages.flatMap((entry) => {
-    if (entry.status === 'inaccessible') {
+    const state = classifyPackageRegistryState(factsFromPolicyPackage(entry));
+    if (state.kind === 'registry-inaccessible') {
       return [`${entry.name}: registry state is inaccessible`];
     }
-
-    if (
-      entry.status === 'published' &&
-      entry.expectedTagVersion !== undefined &&
-      entry.expectedTagVersion !== entry.version &&
-      compareSemver(entry.expectedTagVersion, entry.version) > 0
-    ) {
+    if (state.kind === 'tag-points-ahead') {
       return [
-        `${entry.name}: dist-tag ${distTag} points to ${entry.expectedTagVersion}, expected ${entry.version}`,
+        `${entry.name}: dist-tag ${distTag} points to ${state.currentTagVersion}, expected ${entry.version}`,
       ];
     }
-
-    if (
-      entry.status === 'published' &&
-      entry.versionPublished === true &&
-      entry.expectedTagVersion !== entry.version
-    ) {
+    if (state.kind === 'needs-tag-repair') {
       return [
-        `${entry.name}: version ${entry.version} is already published but dist-tag ${distTag} points to ${entry.expectedTagVersion ?? '(missing)'}`,
+        `${entry.name}: version ${entry.version} is already published but dist-tag ${distTag} points to ${state.currentTagVersion ?? '(missing)'}`,
       ];
     }
-
     return [];
   });
 
@@ -823,89 +827,6 @@ export const releaseIntentForVersionDelta = (
   return undefined;
 };
 
-const compareSemver = (leftVersion: string, rightVersion: string): number => {
-  const left = parseSemver(leftVersion);
-  const right = parseSemver(rightVersion);
-  if (!left || !right) {
-    return leftVersion.localeCompare(rightVersion);
-  }
-
-  for (const key of ['major', 'minor', 'patch'] as const) {
-    const delta = left[key] - right[key];
-    if (delta !== 0) {
-      return delta;
-    }
-  }
-
-  if (left.prerelease === right.prerelease) {
-    return 0;
-  }
-  if (!left.prerelease) {
-    return 1;
-  }
-  if (!right.prerelease) {
-    return -1;
-  }
-  return comparePrerelease(left.prerelease, right.prerelease);
-};
-
-const comparePrerelease = (leftValue: string, rightValue: string): number => {
-  const left = parsePrerelease(leftValue);
-  const right = parsePrerelease(rightValue);
-  const length = Math.max(left.length, right.length);
-
-  for (let index = 0; index < length; index += 1) {
-    const leftPart = left[index];
-    const rightPart = right[index];
-    if (leftPart === undefined) {
-      return -1;
-    }
-    if (rightPart === undefined) {
-      return 1;
-    }
-    if (leftPart === rightPart) {
-      continue;
-    }
-    if (typeof leftPart === 'number' && typeof rightPart === 'number') {
-      return leftPart - rightPart;
-    }
-    if (typeof leftPart === 'number') {
-      return -1;
-    }
-    if (typeof rightPart === 'number') {
-      return 1;
-    }
-    const delta = leftPart.localeCompare(rightPart);
-    if (delta !== 0) {
-      return delta;
-    }
-  }
-
-  return 0;
-};
-
-const parsePrerelease = (value: string): (number | string)[] =>
-  value
-    .split('.')
-    .map((part) => (/^[0-9]+$/u.test(part) ? Number.parseInt(part, 10) : part));
-
-const parseSemver = (version: string) => {
-  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/u);
-  if (!match) {
-    return;
-  }
-  const [, major, minor, patch, prerelease] = match;
-  if (!major || !minor || !patch) {
-    return;
-  }
-  return {
-    major: Number.parseInt(major, 10),
-    minor: Number.parseInt(minor, 10),
-    patch: Number.parseInt(patch, 10),
-    prerelease,
-  };
-};
-
 const writeGitHubOutput = async (
   values: Record<string, boolean | number | string | undefined>
 ): Promise<void> => {
@@ -1051,77 +972,37 @@ const distTagForVersion = async (version: string): Promise<string> => {
     : 'latest';
 };
 
-const registryPackagesFromResults = async (
+const registryPackagesFromResults = (
   results: readonly RegistryResult[]
-): Promise<readonly ReleasePolicyRegistryPackage[]> =>
-  Promise.all(
-    results.map(async (result) => {
-      const versionPublished =
-        result.status === 'published'
-          ? await readPackageVersionPublished(
-              result.name,
-              result.workspaceVersion
-            )
-          : false;
-
-      if (result.status === 'published') {
-        return {
-          expectedTagVersion: result.expectedTagVersion,
-          name: result.name,
-          status: 'published',
-          version: result.workspaceVersion,
-          versionPublished,
-        };
-      }
+): readonly ReleasePolicyRegistryPackage[] =>
+  results.map((result) => {
+    if (result.status === 'published') {
       return {
+        expectedTagVersion: result.expectedTagVersion,
         name: result.name,
-        status: result.status,
+        status: 'published',
         version: result.workspaceVersion,
-        versionPublished,
+        versionPublished: result.versionPublished,
       };
-    })
-  );
-
-const readPackageVersionPublished = async (
-  name: string,
-  version: string
-): Promise<boolean> => {
-  const subprocess = Bun.spawn(
-    ['npm', 'view', `${name}@${version}`, 'version', '--json'],
-    {
-      cwd: repoRoot,
-      stderr: 'pipe',
-      stdin: 'ignore',
-      stdout: 'pipe',
     }
-  );
-  const [exitCode, stdout, stderr] = await Promise.all([
-    subprocess.exited,
-    new Response(subprocess.stdout).text(),
-    new Response(subprocess.stderr).text(),
-  ]);
-
-  if (exitCode === 0) {
-    return JSON.parse(stdout.trim()) === version;
-  }
-
-  const combined = `${stdout}\n${stderr}`;
-  if (combined.includes('E404') || combined.includes('404 Not Found')) {
-    return false;
-  }
-
-  throw new Error(stderr.trim() || `npm view failed for ${name}@${version}`);
-};
+    return {
+      name: result.name,
+      status: result.status,
+      version: result.workspaceVersion,
+      versionPublished: false,
+    };
+  });
 
 const readRegistryPackages = async (
   distTag: string
 ): Promise<readonly ReleasePolicyRegistryPackage[]> => {
-  const { checkRegistryPosture, npmRegistryView } =
+  const { checkRegistryPosture, npmRegistryView, npmRegistryVersionView } =
     await import('./native-bun-registry.js');
   const workspaces = await discoverRegistryWorkspaces(repoRoot);
   const results = await checkRegistryPosture(
     workspaces,
     npmRegistryView,
+    npmRegistryVersionView,
     distTag
   );
   return registryPackagesFromResults(results);

--- a/apps/trails/src/release/semver.ts
+++ b/apps/trails/src/release/semver.ts
@@ -1,0 +1,104 @@
+/**
+ * Minimal semver comparison shared across release tooling.
+ *
+ * Extracted from `policy.ts` so the release policy engine and the registry
+ * classifier compare versions through one implementation instead of two.
+ */
+
+interface ParsedSemver {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+  readonly prerelease: string | undefined;
+}
+
+export const parseSemver = (version: string): ParsedSemver | undefined => {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/u);
+  if (!match) {
+    return;
+  }
+  const [, major, minor, patch, prerelease] = match;
+  if (!major || !minor || !patch) {
+    return;
+  }
+  return {
+    major: Number.parseInt(major, 10),
+    minor: Number.parseInt(minor, 10),
+    patch: Number.parseInt(patch, 10),
+    prerelease,
+  };
+};
+
+const parsePrerelease = (value: string): (number | string)[] =>
+  value
+    .split('.')
+    .map((part) => (/^[0-9]+$/u.test(part) ? Number.parseInt(part, 10) : part));
+
+const comparePrerelease = (leftValue: string, rightValue: string): number => {
+  const left = parsePrerelease(leftValue);
+  const right = parsePrerelease(rightValue);
+  const length = Math.max(left.length, right.length);
+
+  for (let index = 0; index < length; index += 1) {
+    const leftPart = left[index];
+    const rightPart = right[index];
+    if (leftPart === undefined) {
+      return -1;
+    }
+    if (rightPart === undefined) {
+      return 1;
+    }
+    if (leftPart === rightPart) {
+      continue;
+    }
+    if (typeof leftPart === 'number' && typeof rightPart === 'number') {
+      return leftPart - rightPart;
+    }
+    if (typeof leftPart === 'number') {
+      return -1;
+    }
+    if (typeof rightPart === 'number') {
+      return 1;
+    }
+    const delta = leftPart.localeCompare(rightPart);
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+
+  return 0;
+};
+
+/**
+ * Compare two semver strings. Returns a negative number when `leftVersion`
+ * sorts before `rightVersion`, a positive number when it sorts after, and 0
+ * when equal. Unparseable inputs fall back to a locale comparison.
+ */
+export const compareSemver = (
+  leftVersion: string,
+  rightVersion: string
+): number => {
+  const left = parseSemver(leftVersion);
+  const right = parseSemver(rightVersion);
+  if (!left || !right) {
+    return leftVersion.localeCompare(rightVersion);
+  }
+
+  for (const key of ['major', 'minor', 'patch'] as const) {
+    const delta = left[key] - right[key];
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+
+  if (left.prerelease === right.prerelease) {
+    return 0;
+  }
+  if (!left.prerelease) {
+    return 1;
+  }
+  if (!right.prerelease) {
+    return -1;
+  }
+  return comparePrerelease(left.prerelease, right.prerelease);
+};

--- a/docs/adr/0047-stable-release-line-discipline.md
+++ b/docs/adr/0047-stable-release-line-discipline.md
@@ -36,8 +36,11 @@ The repo already has a workable release mechanism:
 - `bun run publish:packages` publishes through Bun and derives the dist-tag
   from `.changeset/pre.json`.
 - `bun run publish:registry-check` and
-  `bun run publish:registry-check:published` verify registry availability and
-  dist-tag posture without mutating the registry.
+  `bun run publish:registry-check:published` verify registry posture without
+  mutating the registry. The first command is the pre-publish readiness check:
+  it proves the registry is reachable and the expected tag is not ahead of the
+  repo target, but it may pass while the target version is still unpublished.
+  The `:published` variant is the post-publish equality gate.
 
 What was missing was the stable-line decision those tools enforce. Without an ADR, release docs can drift back toward operator memory: "run the right thing, publish the right packages, recover carefully." Stable needs that memory turned into a contract.
 
@@ -170,7 +173,8 @@ A release PR that changes package versions or prepares a stable cutover should c
 
 - `bunx changeset status --verbose`;
 - `bun run publish:check`;
-- `bun run publish:registry-check`;
+- `bun run publish:registry-check` before publication, and
+  `bun run publish:registry-check:published` after publication;
 - fresh-start generated app smoke when scaffolds or generated dependencies are
   in scope;
 - ADR and runbook checks when release doctrine or procedure changes.

--- a/docs/releases/beta-channel-policy.md
+++ b/docs/releases/beta-channel-policy.md
@@ -48,11 +48,15 @@ The native Bun release binding follows that source. The package scripts below ar
 
 - `bun run publish:check` is local and read-only.
 - `bun run publish:registry-check` defaults to `.changeset/pre.json`'s tag in
-  prerelease mode, so it checks `beta` today.
+  prerelease mode, so it checks `beta` today. This is the pre-publish
+  readiness check: it proves the registry is reachable and the expected tag is
+  not ahead of the repo target. It may pass while the tag still points at the
+  previous published beta.
 - `bun run publish:packages` publishes with Bun and uses the same prerelease tag
   by default.
 - `bun run publish:registry-check:published` verifies the expected dist-tag
-  after publication.
+  after publication and requires every public package to exist at the repo
+  target version.
 
 During the beta line, `latest` may intentionally lag behind `beta`. Operators should not advance `latest` after every beta publication. Move `latest` only when leaving prerelease mode for the stable 1.x line, or after a separate explicit release decision that says a beta should become the unqualified default.
 
@@ -70,7 +74,15 @@ The standard beta posture check is:
 bun run publish:registry-check
 ```
 
-Its output validates the expected tag and prints both `latest` and `beta` for each published public workspace package, making tag lag visible.
+Its output validates registry readiness and prints both `latest` and `beta` for each published public workspace package, making tag lag visible. A behind tag is expected before the current beta has been published; the check fails when the registry is inaccessible or the tag points ahead of the repo target.
+
+After publishing, use the strict equality gate:
+
+```bash
+bun run publish:registry-check:published
+```
+
+That check requires every public workspace package to exist at the repo target version and the expected dist-tag to point at that version.
 
 For a small representative spot check:
 
@@ -118,7 +130,9 @@ After substantial stacks merge to `main`:
 5. Review package versions, changelogs, generated lockfile changes, and
    generated-app dependency ranges.
 6. Run the version-branch gates, including `bun run publish:check` and
-   `bun run publish:registry-check`.
+   `bun run publish:registry-check`. The registry check is a pre-publish
+   readiness gate, so it may pass while the current release is still unpublished
+   and the channel tag points at the previous beta.
 7. Submit and merge the version PR only after CI and review are clean. The
    GitHub release workflow creates or updates the generated
    `changeset-release/main` PR, applies missing `publish:*`, `channel:*`, and

--- a/docs/releases/stable-cutover.md
+++ b/docs/releases/stable-cutover.md
@@ -79,10 +79,12 @@ Before creating the version PR:
    bun run publish:registry-check
    ```
 
-   First-time public packages can be reported as first-time package
-   candidates during this read-only probe. That is expected before their first
-   publication; after publishing, use `bun run publish:registry-check:published`
-   to require every package and dist-tag to exist.
+   This is the pre-publish readiness probe. It proves the registry is reachable
+   and the expected dist-tag is not ahead of the repo target. It can pass while
+   the tag still points at the previous published version, and first-time public
+   packages can be reported as first-time package candidates. After publishing,
+   use `bun run publish:registry-check:published` to require every package and
+   dist-tag to match the repo target.
 
 7. The local package tarballs are clean:
 
@@ -301,6 +303,8 @@ Run final local pre-publish checks:
 bun run publish:check
 bun run publish:registry-check
 ```
+
+`publish:registry-check` is the readiness check before mutation. It should make registry drift visible, but it does not require the target version to be published yet. The strict equality check is the post-publish gate below.
 
 Publish with the repo script:
 

--- a/scripts/__tests__/check-registry-preflight.test.ts
+++ b/scripts/__tests__/check-registry-preflight.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 import { mkdtemp, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -8,11 +8,26 @@ import {
   discoverRegistryWorkspaces,
   formatDistTagSummary,
   registryPostureErrors,
+  runRegistryPreflight,
 } from '../check-registry-preflight.ts';
 import type {
+  RegistryResult,
+  RegistryVersionView,
   RegistryView,
   RegistryWorkspace,
 } from '../check-registry-preflight.ts';
+
+const acceptsLegacyCheckRegistryPostureSignature: (
+  workspaces: readonly RegistryWorkspace[],
+  view: RegistryView,
+  expectedTag: string
+) => Promise<RegistryResult[]> = checkRegistryPosture;
+
+const acceptsLegacyRegistryPostureErrorsSignature: (
+  results: readonly RegistryResult[],
+  expectedTag: string,
+  requirePublished: boolean
+) => string[] = registryPostureErrors;
 
 const workspaces: readonly RegistryWorkspace[] = [
   {
@@ -53,6 +68,38 @@ const failingRegistryView: RegistryView = async () => {
   throw new Error('registry unavailable');
 };
 
+const publishedVersionView: RegistryVersionView = async () => true;
+const unpublishedVersionView: RegistryVersionView = async () => false;
+
+const withConsoleOutput = async (
+  invoke: () => Promise<number>
+): Promise<{
+  readonly code: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}> => {
+  const originalConsoleError = console.error;
+  const originalConsoleLog = console.log;
+  const stderr: string[] = [];
+  const stdout: string[] = [];
+  console.error = mock((...args: unknown[]) => {
+    stderr.push(args.map(String).join(' '));
+  }) as typeof console.error;
+  console.log = mock((...args: unknown[]) => {
+    stdout.push(args.map(String).join(' '));
+  }) as typeof console.log;
+  try {
+    return {
+      code: await invoke(),
+      stderr: stderr.join('\n'),
+      stdout: stdout.join('\n'),
+    };
+  } finally {
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+  }
+};
+
 describe('formatDistTagSummary', () => {
   test('formats latest and beta dist-tags together for beta-channel audits', () => {
     expect(
@@ -72,6 +119,7 @@ describe('checkRegistryPosture', () => {
     const results = await checkRegistryPosture(
       workspaces,
       mixedRegistryView,
+      publishedVersionView,
       'beta'
     );
 
@@ -80,21 +128,23 @@ describe('checkRegistryPosture', () => {
       ['@ontrails/commander', 'missing'],
       ['@ontrails/http', 'published'],
     ]);
-    expect(registryPostureErrors(results, 'beta', false)).toEqual([]);
-    expect(registryPostureErrors(results, 'beta', true)).toEqual([
+    expect(registryPostureErrors(results, 'beta', 'ready')).toEqual([]);
+    expect(registryPostureErrors(results, 'beta', 'published')).toEqual([
       '@ontrails/commander: package is missing from the registry',
     ]);
   });
 
-  test('fails when the expected dist-tag points at a different version', async () => {
+  test('treats a behind dist-tag with an unpublished target as pending in ready phase', async () => {
     const results = await checkRegistryPosture(
       [workspaces[0]],
       staleTagRegistryView,
+      unpublishedVersionView,
       'beta'
     );
 
-    expect(registryPostureErrors(results, 'beta', false)).toEqual([
-      '@ontrails/core: dist-tag beta points to 1.0.0-beta.14, expected 1.0.0-beta.15',
+    expect(registryPostureErrors(results, 'beta', 'ready')).toEqual([]);
+    expect(registryPostureErrors(results, 'beta', 'published')).toEqual([
+      '@ontrails/core: target version 1.0.0-beta.15 is not published',
     ]);
   });
 
@@ -102,11 +152,40 @@ describe('checkRegistryPosture', () => {
     const results = await checkRegistryPosture(
       [workspaces[0]],
       failingRegistryView,
+      publishedVersionView,
       'beta'
     );
 
-    expect(registryPostureErrors(results, 'beta', false)).toEqual([
+    expect(registryPostureErrors(results, 'beta', 'ready')).toEqual([
       '@ontrails/core: registry probe failed: registry unavailable',
+    ]);
+  });
+
+  test('keeps the exported legacy helper call shapes working', async () => {
+    const results = await acceptsLegacyCheckRegistryPostureSignature(
+      [workspaces[0]],
+      staleTagRegistryView,
+      'beta'
+    );
+
+    expect(results).toEqual([
+      {
+        distTags: { beta: '1.0.0-beta.14' },
+        expectedTagVersion: '1.0.0-beta.14',
+        name: '@ontrails/core',
+        status: 'published',
+        version: '1.0.0-beta.14',
+        versionPublished: undefined,
+        workspaceVersion: '1.0.0-beta.15',
+      },
+    ]);
+    expect(
+      acceptsLegacyRegistryPostureErrorsSignature(results, 'beta', false)
+    ).toEqual([]);
+    expect(
+      acceptsLegacyRegistryPostureErrorsSignature(results, 'beta', true)
+    ).toEqual([
+      '@ontrails/core: target version 1.0.0-beta.15 publish state was not probed',
     ]);
   });
 
@@ -125,6 +204,7 @@ describe('checkRegistryPosture', () => {
     const resultsPromise = checkRegistryPosture(
       workspaces,
       concurrentRegistryView,
+      publishedVersionView,
       'beta'
     );
     await Bun.sleep(0);
@@ -134,6 +214,34 @@ describe('checkRegistryPosture', () => {
     expect(results.map((result) => result.name)).toEqual(
       workspaces.map((workspace) => workspace.name)
     );
+  });
+});
+
+describe('runRegistryPreflight', () => {
+  test('keeps injected registry views no-network unless a version view is supplied', async () => {
+    const output = await withConsoleOutput(() =>
+      runRegistryPreflight(
+        { requirePublished: false, tag: 'beta' },
+        staleTagRegistryView
+      )
+    );
+
+    expect(output.code).toBe(0);
+    expect(output.stdout).toContain('target version publish state unknown');
+    expect(output.stdout).not.toContain('target version not published yet');
+  });
+
+  test('reports unpublished targets when callers explicitly pass a version view', async () => {
+    const output = await withConsoleOutput(() =>
+      runRegistryPreflight(
+        { requirePublished: false, tag: 'beta' },
+        staleTagRegistryView,
+        unpublishedVersionView
+      )
+    );
+
+    expect(output.code).toBe(0);
+    expect(output.stdout).toContain('target version not published yet');
   });
 });
 

--- a/scripts/check-registry-preflight.ts
+++ b/scripts/check-registry-preflight.ts
@@ -7,10 +7,16 @@ if (import.meta.main) {
 
 export {
   checkRegistryPosture,
+  classifyPackageRegistryState,
   discoverRegistryWorkspaces,
   formatDistTagSummary,
   registryPostureErrors,
   runRegistryPreflight,
+  type PackageRegistryFacts,
+  type PackageRegistryState,
+  type RegistryCheckPhase,
+  type RegistryResult,
+  type RegistryVersionView,
   type RegistryView,
   type RegistryWorkspace,
 } from '@ontrails/trails/release';


### PR DESCRIPTION
## What

Consolidate registry verdicts behind one shared `packageRegistry` classifier, and make the registry preflight phase-aware. First PR in the release-reconciliation ladder (classifier + drift guard → planner → apply).

## Why

`policy.ts` and the preflight (`native-bun-registry.ts`) encoded registry verdicts **twice** over the same `RegistryResult` type and had drifted. The preflight flagged a behind dist-tag as a failure regardless of phase — producing the confusing beta.28 readiness failure even though the target version simply wasn't published yet. (Live: every `@ontrails/*` package is `beta → 1.0.0-beta.24` while the repo is at `1.0.0-beta.28`, and `beta.28` tarballs are absent.)

## What changed

- **One classifier** — `classifyPackageRegistryState` derives a mutually-exclusive state (`complete`, `needs-publish`, `first-time-package`, `needs-tag-repair`, `tag-points-ahead`, `registry-inaccessible`) from two orthogonal facts (target published? × dist-tag relation) + reachability. Both `policy.ts` and the preflight consume it — no twin semantics.
- **Exact-version probe** relocated into the shared module (`npmRegistryVersionView`) and surfaced as `versionPublished` on every result — the missing fact a tag/version summary cannot answer.
- **Phase-aware preflight** — `ready` treats an unpublished target / behind tag as expected pre-publish work; `published` requires every package complete. Fixes the beta.28 false failure.
- **`release/semver.ts`** — shared semver compare/parse (one implementation, not two).
- **Bounded probe concurrency** so release checks stay responsive.

## Guardrails honored

- **Behavior-preserving:** existing release-policy registry tests pass unchanged, including the `versionPublished === true` vs `undefined` distinction; added a beta.28-state policy test proving it stays non-blocking.
- **Live-incident fixture:** target `beta.28`, tag `beta.24`, `beta.28` absent → ready passes, published fails.
- **No mutation** — classifier/probe/check only; no publish, dist-tag, or reconcile apply.
- **User-facing wording:** "needs dist-tag update".

## Size note

616+/183− but mostly tests (~190) + a mechanical `semver.ts` extraction (~110, moved not new) + changeset/decision-log. The logic delta in `policy.ts` / `native-bun-registry.ts` is moderate.

## Distribution-ready

- **Changeset:** `@ontrails/trails` patch ✓
- **Docs:** AGENTS.md release description still accurate (registry-check = readiness; published = strict); the fix makes the check match its documented intent. No doc change needed.
- **Warden / Wayfinder dogfood:** N/A — no framework surface, Topographer, or graph change.
- **Tests/gates:** 90 release + scripts tests pass; typecheck, lint, ast-grep, format all green.

## Verification (post-merge)

Stays draft until CI is green. After merge we publish `beta.28`; `publish:registry-check:published` flipping green is the end-to-end proof of the readiness/post-publish split.

https://claude.ai/code/session_011qvb3z4BKCqxyUKJnpdPqw
