### PR TITLE
fix(release): verify first-time package tarballs

### DIFF
--- a/.changeset/registry-tarball-proof.md
+++ b/.changeset/registry-tarball-proof.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Teach the registry preflight to verify first-time package publishes when npm's package summary lags behind dist-tags and tarball availability.

--- a/apps/trails/src/__tests__/release-registry-classifier.test.ts
+++ b/apps/trails/src/__tests__/release-registry-classifier.test.ts
@@ -3,9 +3,14 @@ import { describe, expect, test } from 'bun:test';
 import {
   checkRegistryPosture,
   classifyPackageRegistryState,
+  createNpmRegistryVersionView,
+  createNpmRegistryView,
+  parseNpmDistTagListOutput,
+  parseNpmPackDryRunPublishedVersion,
   registryPostureErrors,
 } from '../release/native-bun-registry.js';
 import type {
+  NpmCommandRunner,
   PackageRegistryFacts,
   RegistryResult,
   RegistryVersionView,
@@ -147,6 +152,15 @@ const tagAheadView: RegistryView = async (name) => ({
   version: '1.0.0-beta.29',
 });
 
+const packumentLagView: RegistryView = async (name) => ({
+  'dist-tags': {
+    beta: '1.0.0-beta.29',
+    latest: '1.0.0-beta.29',
+  },
+  name,
+  version: '1.0.0-beta.29',
+});
+
 const targetAbsent: RegistryVersionView = async () => false;
 const targetPublished: RegistryVersionView = async () => true;
 
@@ -222,6 +236,140 @@ describe('registryPostureErrors — phase behavior', () => {
     expect(registryPostureErrors(results, 'beta', 'ready')).toEqual([ahead]);
     expect(registryPostureErrors(results, 'beta', 'published')).toEqual([
       ahead,
+    ]);
+  });
+
+  test('first-time package packument lag can still prove the published target', async () => {
+    const results = await checkRegistryPosture(
+      [
+        {
+          name: '@ontrails/regrade',
+          path: 'packages/regrade',
+          version: '1.0.0-beta.29',
+        },
+      ],
+      packumentLagView,
+      targetPublished,
+      'beta'
+    );
+
+    expect(registryPostureErrors(results, 'beta', 'published')).toEqual([]);
+  });
+});
+
+describe('npm registry fallback parsers', () => {
+  test('parses npm dist-tag ls output into dist-tag facts', () => {
+    expect(
+      parseNpmDistTagListOutput('beta: 1.0.0-beta.29\nlatest: 1.0.0-beta.29\n')
+    ).toEqual({
+      beta: '1.0.0-beta.29',
+      latest: '1.0.0-beta.29',
+    });
+  });
+
+  test('recognizes an npm pack dry-run tarball as exact-version proof', () => {
+    expect(
+      parseNpmPackDryRunPublishedVersion(
+        JSON.stringify([
+          {
+            id: '@ontrails/regrade@1.0.0-beta.29',
+            name: '@ontrails/regrade',
+            version: '1.0.0-beta.29',
+          },
+        ]),
+        '@ontrails/regrade',
+        '1.0.0-beta.29'
+      )
+    ).toBe(true);
+    expect(
+      parseNpmPackDryRunPublishedVersion(
+        JSON.stringify([
+          {
+            id: '@ontrails/regrade@1.0.0-beta.28',
+            name: '@ontrails/regrade',
+            version: '1.0.0-beta.28',
+          },
+        ]),
+        '@ontrails/regrade',
+        '1.0.0-beta.29'
+      )
+    ).toBe(false);
+  });
+});
+
+describe('npm registry fallback wiring', () => {
+  const notFoundResult = {
+    exitCode: 1,
+    stderr:
+      'npm ERR! 404 Not Found - GET https://registry.npmjs.org/@ontrails%2fregrade - Not found',
+    stdout: '',
+  };
+
+  test('falls back from npm view package 404 to npm dist-tag facts', async () => {
+    const commands: string[][] = [];
+    const runNpm: NpmCommandRunner = async (args) => {
+      commands.push([...args]);
+      if (args[0] === 'view') {
+        return notFoundResult;
+      }
+      if (args.join(' ') === 'dist-tag ls @ontrails/regrade') {
+        return {
+          exitCode: 0,
+          stderr: '',
+          stdout: 'beta: 1.0.0-beta.29\nlatest: 1.0.0-beta.29\n',
+        };
+      }
+      throw new Error(`unexpected npm command: ${args.join(' ')}`);
+    };
+
+    await expect(
+      createNpmRegistryView(runNpm)('@ontrails/regrade')
+    ).resolves.toEqual({
+      'dist-tags': {
+        beta: '1.0.0-beta.29',
+        latest: '1.0.0-beta.29',
+      },
+      name: '@ontrails/regrade',
+      version: '1.0.0-beta.29',
+    });
+    expect(commands).toEqual([
+      ['view', '@ontrails/regrade', 'name', 'version', 'dist-tags', '--json'],
+      ['dist-tag', 'ls', '@ontrails/regrade'],
+    ]);
+  });
+
+  test('falls back from npm view exact-version 404 to npm pack proof', async () => {
+    const commands: string[][] = [];
+    const runNpm: NpmCommandRunner = async (args) => {
+      commands.push([...args]);
+      if (args[0] === 'view') {
+        return notFoundResult;
+      }
+      if (
+        args.join(' ') ===
+        'pack @ontrails/regrade@1.0.0-beta.29 --dry-run --json'
+      ) {
+        return {
+          exitCode: 0,
+          stderr: '',
+          stdout: JSON.stringify([
+            {
+              id: '@ontrails/regrade@1.0.0-beta.29',
+              name: '@ontrails/regrade',
+              version: '1.0.0-beta.29',
+            },
+          ]),
+        };
+      }
+      throw new Error(`unexpected npm command: ${args.join(' ')}`);
+    };
+
+    await expect(
+      createNpmRegistryVersionView(runNpm)('@ontrails/regrade', '1.0.0-beta.29')
+    ).resolves.toBe(true);
+    expect(commands).toEqual([
+      ['view', '@ontrails/regrade@1.0.0-beta.29', 'version', '--json'],
+      ['pack', '@ontrails/regrade@1.0.0-beta.29', '--dry-run', '--json'],
     ]);
   });
 });

--- a/apps/trails/src/release/native-bun-registry.ts
+++ b/apps/trails/src/release/native-bun-registry.ts
@@ -304,26 +304,131 @@ export const discoverRegistryWorkspaces = async (
 
 export type RegistryView = (name: string) => Promise<NpmView | null>;
 
-export const npmRegistryView: RegistryView = async (name) => {
-  const proc = Bun.spawn(
-    ['npm', 'view', name, 'name', 'version', 'dist-tags', '--json'],
-    { stderr: 'pipe', stdin: 'ignore', stdout: 'pipe' }
-  );
+export interface NpmCommandResult {
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+export type NpmCommandRunner = (
+  args: readonly string[]
+) => Promise<NpmCommandResult>;
+
+const readSpawnResult = async (
+  proc: Bun.Subprocess<'ignore', 'pipe', 'pipe'>
+): Promise<NpmCommandResult> => {
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
     new Response(proc.stderr).text(),
     proc.exited,
   ]);
+  return { exitCode, stderr, stdout };
+};
 
-  if (exitCode === 0) {
-    return JSON.parse(stdout) as NpmView;
-  }
+const runNpmCommand: NpmCommandRunner = async (args) =>
+  readSpawnResult(
+    Bun.spawn(['npm', ...args], {
+      stderr: 'pipe',
+      stdin: 'ignore',
+      stdout: 'pipe',
+    })
+  );
+
+const isNpmNotFoundOutput = (stdout: string, stderr: string): boolean => {
   const combined = `${stdout}\n${stderr}`;
-  if (combined.includes('E404') || combined.includes('404 Not Found')) {
+  return combined.includes('E404') || combined.includes('404 Not Found');
+};
+
+export const parseNpmDistTagListOutput = (
+  stdout: string
+): Record<string, string> => {
+  const distTags: Record<string, string> = {};
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    const separator = trimmed.indexOf(':');
+    if (separator < 1) {
+      continue;
+    }
+    const tag = trimmed.slice(0, separator).trim();
+    const version = trimmed.slice(separator + 1).trim();
+    if (tag.length > 0 && version.length > 0) {
+      distTags[tag] = version;
+    }
+  }
+  return distTags;
+};
+
+export const parseNpmPackDryRunPublishedVersion = (
+  stdout: string,
+  name: string,
+  version: string
+): boolean => {
+  const parsed = JSON.parse(stdout.trim()) as unknown;
+  if (!Array.isArray(parsed)) {
+    return false;
+  }
+  return parsed.some((entry) => {
+    if (typeof entry !== 'object' || entry === null) {
+      return false;
+    }
+    const candidate = entry as {
+      readonly id?: unknown;
+      readonly name?: unknown;
+      readonly version?: unknown;
+    };
+    return (
+      candidate.id === `${name}@${version}` ||
+      (candidate.name === name && candidate.version === version)
+    );
+  });
+};
+
+const npmDistTagRegistryView = async (
+  name: string,
+  runNpm: NpmCommandRunner
+): Promise<NpmView | null> => {
+  const { exitCode, stderr, stdout } = await runNpm(['dist-tag', 'ls', name]);
+  if (exitCode !== 0) {
+    if (isNpmNotFoundOutput(stdout, stderr)) {
+      return null;
+    }
+    throw new Error(stderr.trim() || `npm dist-tag ls failed for ${name}`);
+  }
+
+  const distTags = parseNpmDistTagListOutput(stdout);
+  const version =
+    distTags['latest'] ?? distTags['beta'] ?? Object.values(distTags)[0];
+  if (version === undefined) {
     return null;
   }
-  throw new Error(stderr.trim() || `npm view failed for ${name}`);
+  return { 'dist-tags': distTags, name, version };
 };
+
+export const createNpmRegistryView =
+  (runNpm: NpmCommandRunner = runNpmCommand): RegistryView =>
+  async (name) => {
+    const { exitCode, stderr, stdout } = await runNpm([
+      'view',
+      name,
+      'name',
+      'version',
+      'dist-tags',
+      '--json',
+    ]);
+
+    if (exitCode === 0) {
+      return JSON.parse(stdout) as NpmView;
+    }
+    if (isNpmNotFoundOutput(stdout, stderr)) {
+      return npmDistTagRegistryView(name, runNpm);
+    }
+    throw new Error(stderr.trim() || `npm view failed for ${name}`);
+  };
+
+export const npmRegistryView: RegistryView = createNpmRegistryView();
 
 /** Probe whether an exact `name@version` is published. The missing fact that
  * a tag/version summary alone cannot answer. */
@@ -336,29 +441,48 @@ const UNKNOWN_REGISTRY_VERSION_STATE: { readonly published?: boolean } = {};
 const unknownRegistryVersionView: RegistryVersionView = async () =>
   UNKNOWN_REGISTRY_VERSION_STATE.published;
 
-export const npmRegistryVersionView: RegistryVersionView = async (
-  name,
-  version
-) => {
-  const proc = Bun.spawn(
-    ['npm', 'view', `${name}@${version}`, 'version', '--json'],
-    { stderr: 'pipe', stdin: 'ignore', stdout: 'pipe' }
-  );
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
+export const createNpmRegistryVersionView =
+  (runNpm: NpmCommandRunner = runNpmCommand): RegistryVersionView =>
+  async (name, version) => {
+    const { exitCode, stderr, stdout } = await runNpm([
+      'view',
+      `${name}@${version}`,
+      'version',
+      '--json',
+    ]);
 
-  if (exitCode === 0) {
-    return JSON.parse(stdout.trim()) === version;
-  }
-  const combined = `${stdout}\n${stderr}`;
-  if (combined.includes('E404') || combined.includes('404 Not Found')) {
-    return false;
-  }
-  throw new Error(stderr.trim() || `npm view failed for ${name}@${version}`);
-};
+    if (exitCode === 0) {
+      return JSON.parse(stdout.trim()) === version;
+    }
+    if (!isNpmNotFoundOutput(stdout, stderr)) {
+      throw new Error(
+        stderr.trim() || `npm view failed for ${name}@${version}`
+      );
+    }
+
+    const packResult = await runNpm([
+      'pack',
+      `${name}@${version}`,
+      '--dry-run',
+      '--json',
+    ]);
+    if (packResult.exitCode === 0) {
+      return parseNpmPackDryRunPublishedVersion(
+        packResult.stdout,
+        name,
+        version
+      );
+    }
+    if (isNpmNotFoundOutput(packResult.stdout, packResult.stderr)) {
+      return false;
+    }
+    throw new Error(
+      packResult.stderr.trim() || `npm pack failed for ${name}@${version}`
+    );
+  };
+
+export const npmRegistryVersionView: RegistryVersionView =
+  createNpmRegistryVersionView();
 
 /** Run async tasks with a bounded number in flight, preserving input order. */
 const mapBounded = async <T, R>(


### PR DESCRIPTION
## Context

Beta.29 published successfully, including the first-time `@ontrails/regrade` package, but the strict post-publish registry check initially failed because npm's package summary endpoint could still 404 while `npm dist-tag ls` and `npm pack --dry-run` could already prove the package/version.

## What Changed

- Add npm registry fallback wiring for first-time package visibility lag.
- Fall back from `npm view <pkg>` 404s to `npm dist-tag ls <pkg>` for package/tag facts.
- Fall back from `npm view <pkg>@<version>` 404s to `npm pack <pkg>@<version> --dry-run --json` for exact target-version proof.
- Preserve injected registry view compatibility: fake/custom views remain no-network unless callers explicitly provide a version view.
- Add focused parser and command-wiring tests for the beta.29 failure mode.

## Verification

- `bun test apps/trails/src/__tests__/release-registry-classifier.test.ts scripts/__tests__/check-registry-preflight.test.ts apps/trails/src/__tests__/release-policy.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run changeset:check`
- `bun run publish:registry-check:published`
- `bun run publish:check`
- `git diff --check`
- `bun run check`
- `bun run test`
- `bun run build`
- Graphite pre-push hook

## Local Review

- In-thread subagent review, exported helper compatibility/offline behavior: 5/5 clean, 0 P0-P2.
- In-thread subagent review, npm runtime semantics/operator DX: first pass found a P2 test gap, fixed with command-level fallback tests; second pass 5/5 clean, 0 P0-P2.

## Release Notes

Includes a patch changeset for `@ontrails/trails`. This should ship in the next beta so future first-time package publishes can be verified without waiting for npm packument consistency.