### PR TITLE
fix(release): classify unpublished target versions

### DIFF
--- a/.changeset/registry-etarget-prepublish.md
+++ b/.changeset/registry-etarget-prepublish.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Treat npm `ETARGET` exact-version probes as unpublished target versions during registry readiness checks.

--- a/apps/trails/src/__tests__/release-registry-classifier.test.ts
+++ b/apps/trails/src/__tests__/release-registry-classifier.test.ts
@@ -304,6 +304,12 @@ describe('npm registry fallback wiring', () => {
       'npm ERR! 404 Not Found - GET https://registry.npmjs.org/@ontrails%2fregrade - Not found',
     stdout: '',
   };
+  const noMatchingVersionResult = {
+    exitCode: 1,
+    stderr:
+      'npm error code ETARGET\nnpm error notarget No matching version found for @ontrails/core@1.0.0-beta.30.',
+    stdout: '',
+  };
 
   test('falls back from npm view package 404 to npm dist-tag facts', async () => {
     const commands: string[][] = [];
@@ -370,6 +376,24 @@ describe('npm registry fallback wiring', () => {
     expect(commands).toEqual([
       ['view', '@ontrails/regrade@1.0.0-beta.29', 'version', '--json'],
       ['pack', '@ontrails/regrade@1.0.0-beta.29', '--dry-run', '--json'],
+    ]);
+  });
+
+  test('treats npm exact-version ETARGET as an unpublished target', async () => {
+    const commands: string[][] = [];
+    const runNpm: NpmCommandRunner = async (args) => {
+      commands.push([...args]);
+      if (args[0] === 'view') {
+        return noMatchingVersionResult;
+      }
+      throw new Error(`unexpected npm command: ${args.join(' ')}`);
+    };
+
+    await expect(
+      createNpmRegistryVersionView(runNpm)('@ontrails/core', '1.0.0-beta.30')
+    ).resolves.toBe(false);
+    expect(commands).toEqual([
+      ['view', '@ontrails/core@1.0.0-beta.30', 'version', '--json'],
     ]);
   });
 });

--- a/apps/trails/src/release/native-bun-registry.ts
+++ b/apps/trails/src/release/native-bun-registry.ts
@@ -339,6 +339,17 @@ const isNpmNotFoundOutput = (stdout: string, stderr: string): boolean => {
   return combined.includes('E404') || combined.includes('404 Not Found');
 };
 
+const isNpmExactVersionMissingOutput = (
+  stdout: string,
+  stderr: string
+): boolean => {
+  const combined = `${stdout}\n${stderr}`;
+  return (
+    combined.includes('ETARGET') ||
+    combined.includes('No matching version found')
+  );
+};
+
 export const parseNpmDistTagListOutput = (
   stdout: string
 ): Record<string, string> => {
@@ -454,6 +465,9 @@ export const createNpmRegistryVersionView =
     if (exitCode === 0) {
       return JSON.parse(stdout.trim()) === version;
     }
+    if (isNpmExactVersionMissingOutput(stdout, stderr)) {
+      return false;
+    }
     if (!isNpmNotFoundOutput(stdout, stderr)) {
       throw new Error(
         stderr.trim() || `npm view failed for ${name}@${version}`
@@ -472,6 +486,9 @@ export const createNpmRegistryVersionView =
         name,
         version
       );
+    }
+    if (isNpmExactVersionMissingOutput(packResult.stdout, packResult.stderr)) {
+      return false;
     }
     if (isNpmNotFoundOutput(packResult.stdout, packResult.stderr)) {
       return false;


### PR DESCRIPTION
## Context

The generated beta.30 release PR exposed one more registry edge after #824: for an existing package with an unpublished target version, `npm view <pkg>@<version> version --json` returns `ETARGET` / `No matching version found`. That should be classified as “target not published yet” in the ready phase, not as registry inaccessible.

## What Changed

- Treat exact-version `ETARGET` / `No matching version found` output as `versionPublished: false`.
- Preserve the package-summary-lag fallback: `E404` still tries `npm pack <pkg>@<version> --dry-run --json` as tarball proof.
- Add a focused regression test for the beta.30 `ETARGET` shape.
- Add a patch changeset for `@ontrails/trails`.

## Verification

- `bun test apps/trails/src/__tests__/release-registry-classifier.test.ts scripts/__tests__/check-registry-preflight.test.ts apps/trails/src/__tests__/release-policy.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run changeset:check`
- `bun run publish:registry-check`
- `bun run publish:check`
- `bun run build`
- `bun run format:check`
- `git diff --check`
- Graphite pre-push hook: passed (`warden`, ADR check, tests, typecheck, lint, ast-grep, format, release-pack, dead-code)

## Local Review

In-thread review agent: 5/5 confidence, no P0-P3 findings. It specifically checked E404 fallback preservation, ETARGET classification, no hidden injected-view network probes, and strict published-phase behavior.
