### PR TITLE
fix(regrade): shape actionable report entries

### DIFF
--- a/.changeset/regrade-actionable-report-entries.md
+++ b/.changeset/regrade-actionable-report-entries.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/regrade": patch
+"@ontrails/trails": patch
+---
+
+Default Regrade reports to actionable entries, add skip counts grouped by
+reason, and expose an `includeEntries` option for full report inventories.

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -23,6 +23,12 @@ const regradeInputSchema = z.object({
     .array(z.string())
     .optional()
     .describe('Regrade class ids to run (defaults to all built-in classes)'),
+  includeEntries: z
+    .enum(['actionable', 'all'])
+    .default('actionable')
+    .describe(
+      'Report entry detail to include; counts always cover the full run'
+    ),
   rootDir: z.string().optional().describe('Workspace root directory'),
 });
 
@@ -36,6 +42,7 @@ export const regradeTrail = trail('regrade', {
     const reportResult: TrailsResult<RegradeReport | null, Error> = runRegrade({
       apply: input.apply,
       classes: wardenTermRewriteClasses,
+      includeEntries: input.includeEntries,
       root: rootDirResult.value,
       ...(input.classIds === undefined
         ? {}

--- a/packages/regrade/src/downstream/__tests__/radio-fixture.test.ts
+++ b/packages/regrade/src/downstream/__tests__/radio-fixture.test.ts
@@ -93,6 +93,7 @@ describe('Radio-shaped downstream fixture (TRL-846)', () => {
     try {
       const result = runRegrade({
         classes: wardenTermRewriteClasses,
+        includeEntries: 'all',
         root,
         selection: { classIds: [crossToComposeClassId] },
       });

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -250,6 +250,7 @@ describe('wardenTermRewriteClasses', () => {
     const report = buildRegradeReport({
       classes: wardenTermRewriteClasses,
       files: [{ path: 'src/a.ts', source: 'export const ok = true;' }],
+      includeEntries: 'all',
       root: '/repo',
       skipped: [],
     });
@@ -396,6 +397,7 @@ describe('buildRegradeReport', () => {
         { path: 'src/b.ts', source: 'const signalHandler = 1;' },
         { path: 'src/c.ts', source: 'const x = 1;' },
       ],
+      includeEntries: 'all',
       root: '/repo',
       skipped: [{ path: 'dist', reason: 'ignored-directory' }],
     });
@@ -417,6 +419,32 @@ describe('buildRegradeReport', () => {
     expect(byPath.get('src/b.ts')?.outcome).toBe('needs-review');
     expect(byPath.get('src/c.ts')?.outcome).toBe('no-op');
     expect(byPath.get('dist')?.outcome).toBe('skip');
+    expect(report.skipsByReason).toEqual({ 'ignored-directory': 1 });
+  });
+
+  test('defaults report entries to actionable outcomes', () => {
+    const report = buildRegradeReport({
+      classes: [signalToPing],
+      files: [
+        { path: 'src/a.ts', source: 'const signal = 1;' },
+        { path: 'src/b.ts', source: 'const signalHandler = 1;' },
+        { path: 'src/c.ts', source: 'const x = 1;' },
+      ],
+      root: '/repo',
+      skipped: [{ path: 'dist', reason: 'ignored-directory' }],
+    });
+
+    expect(report.scanned).toBe(3);
+    expect(report.skipped).toBe(1);
+    expect(report.skipsByReason).toEqual({ 'ignored-directory': 1 });
+    expect(report.entries.map((entry) => entry.path)).toEqual([
+      'src/a.ts',
+      'src/b.ts',
+    ]);
+    expect(report.entries.map((entry) => entry.outcome)).toEqual([
+      'rewrite',
+      'needs-review',
+    ]);
   });
 
   test('selection runs one class without executing the others', () => {
@@ -455,6 +483,7 @@ describe('buildRegradeReport', () => {
         // Real source file with no diagnostics — a genuine no-op scan.
         { path: 'src/auth.ts', source: 'export const x = 1;\n' },
       ],
+      includeEntries: 'all',
       root: '/repo',
       skipped: [],
     });
@@ -521,7 +550,11 @@ describe('runRegrade', () => {
   test('runRegrade reports coverage over a real root', () => {
     const root = writeReportFixture();
     try {
-      const report = expectRunRegradeOk({ classes: [signalToPing], root });
+      const report = expectRunRegradeOk({
+        classes: [signalToPing],
+        includeEntries: 'all',
+        root,
+      });
       expect(report).not.toBeNull();
       const r = report as NonNullable<typeof report>;
       // dist/out.ts is skipped at the directory level, so only 2 files scanned.
@@ -562,6 +595,7 @@ describe('runRegrade', () => {
             scanTargets: { extensions: ['.md'] },
           },
         ],
+        includeEntries: 'all',
         root,
         selection: { classIds: ['docs-term'] },
       });

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -95,6 +95,9 @@ export interface RegradeSelection {
   readonly classIds?: readonly string[];
 }
 
+/** Which report entries should be returned. Counts always cover the full run. */
+export type RegradeReportEntrySelection = 'actionable' | 'all';
+
 /** Optional write summary for an apply-mode regrade run. */
 export interface RegradeApplySummary {
   /** Safe rewrite outcomes written to disk. */
@@ -539,6 +542,8 @@ export interface RegradeReport {
   readonly review: number;
   /** Entries skipped (collection skips plus any run-level skips). */
   readonly skipped: number;
+  /** Skipped entries grouped by reason. */
+  readonly skipsByReason: Readonly<Record<string, number>>;
   /** Per-entry detail, sorted by path. */
   readonly entries: readonly RegradeReportEntry[];
   /** Apply-mode summary; absent for dry-run report-only calls. */
@@ -642,6 +647,32 @@ interface RegradeEvaluation {
   readonly rewrites: readonly RegradeRewriteCandidate[];
 }
 
+const includeEntryInReport = (
+  entry: RegradeReportEntry,
+  selection: RegradeReportEntrySelection
+): boolean =>
+  selection === 'all' ||
+  entry.outcome === 'rewrite' ||
+  entry.outcome === 'needs-review';
+
+const skipsByReason = (
+  entries: readonly RegradeReportEntry[]
+): Readonly<Record<string, number>> => {
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    if (entry.outcome !== 'skip') {
+      continue;
+    }
+    const reason = entry.reason ?? 'skipped';
+    counts.set(reason, (counts.get(reason) ?? 0) + 1);
+  }
+  return Object.fromEntries(
+    [...counts.entries()].toSorted(([left], [right]) =>
+      left.localeCompare(right)
+    )
+  );
+};
+
 /**
  * Build a coverage report from already-read source files. Pure: no filesystem
  * access, so coverage semantics are testable directly.
@@ -656,7 +687,9 @@ const buildRegradeEvaluation = (params: {
   readonly skipped: readonly SkippedSource[];
   readonly classes: readonly RegradeClass[];
   readonly selection?: RegradeSelection;
+  readonly includeEntries?: RegradeReportEntrySelection;
 }): RegradeEvaluation => {
+  const entrySelection = params.includeEntries ?? 'actionable';
   const { selected, unknownClassIds } = selectRegradeClasses(
     params.classes,
     params.selection
@@ -685,8 +718,11 @@ const buildRegradeEvaluation = (params: {
     reason: entry.reason,
   }));
 
-  const entries = [...fileEntries, ...skipEntries].toSorted((a, b) =>
+  const allEntries = [...fileEntries, ...skipEntries].toSorted((a, b) =>
     a.path.localeCompare(b.path)
+  );
+  const entries = allEntries.filter((entry) =>
+    includeEntryInReport(entry, entrySelection)
   );
 
   // Class-level skips (e.g. scan-target filtering) are accounted as skipped, not
@@ -710,6 +746,7 @@ const buildRegradeEvaluation = (params: {
       scanned: scannedEntries.length,
       selectedClassIds: selected.map((cls) => cls.id),
       skipped: skipEntries.length + fileSkipCount,
+      skipsByReason: skipsByReason(allEntries),
       unknownClassIds,
     },
     rewrites,
@@ -726,6 +763,7 @@ export const buildRegradeReport = (params: {
   readonly skipped: readonly SkippedSource[];
   readonly classes: readonly RegradeClass[];
   readonly selection?: RegradeSelection;
+  readonly includeEntries?: RegradeReportEntrySelection;
 }): RegradeReport => buildRegradeEvaluation(params).report;
 
 const applyRegradeEvaluation = (
@@ -797,6 +835,7 @@ const runRegradeEvaluation = (params: {
   readonly classes: readonly RegradeClass[];
   readonly selection?: RegradeSelection;
   readonly collection?: DownstreamCollectionOptions;
+  readonly includeEntries?: RegradeReportEntrySelection;
 }): RegradeEvaluation | null => {
   const { selected, unknownClassIds } = selectRegradeClasses(
     params.classes,
@@ -811,6 +850,9 @@ const runRegradeEvaluation = (params: {
       files: [],
       root: params.root,
       skipped: [],
+      ...(params.includeEntries === undefined
+        ? {}
+        : { includeEntries: params.includeEntries }),
       ...(params.selection === undefined
         ? {}
         : { selection: params.selection }),
@@ -844,6 +886,9 @@ const runRegradeEvaluation = (params: {
     files,
     root: params.root,
     skipped,
+    ...(params.includeEntries === undefined
+      ? {}
+      : { includeEntries: params.includeEntries }),
     ...(params.selection === undefined ? {} : { selection: params.selection }),
   });
 };
@@ -861,6 +906,7 @@ export const runRegrade = (params: {
   readonly selection?: RegradeSelection;
   readonly collection?: DownstreamCollectionOptions;
   readonly apply?: boolean;
+  readonly includeEntries?: RegradeReportEntrySelection;
 }): Result<RegradeReport | null, InternalError> => {
   const evaluation = runRegradeEvaluation(params);
   if (evaluation === null) {
@@ -941,7 +987,9 @@ export const regradeReportOutput = z.object({
     .describe('Apply-mode summary; absent for dry-run report-only calls'),
   entries: z
     .array(regradeReportEntrySchema)
-    .describe('Per-entry detail, sorted by path'),
+    .describe(
+      'Per-entry detail, sorted by path. Defaults to actionable rewrite/review entries.'
+    ),
   matched: z.number().describe('Files with a rewrite or review outcome'),
   review: z.number().describe('Files routed to review'),
   rewritten: z.number().describe('Files with a rewrite outcome'),
@@ -949,6 +997,9 @@ export const regradeReportOutput = z.object({
   scanned: z.number().describe('Source files inspected'),
   selectedClassIds: z.array(z.string()).describe('Class ids executed'),
   skipped: z.number().describe('Entries skipped'),
+  skipsByReason: z
+    .record(z.string(), z.number())
+    .describe('Skipped entries grouped by reason'),
   unknownClassIds: z
     .array(z.string())
     .describe('Selected ids that did not resolve to a class'),

--- a/packages/regrade/src/index.ts
+++ b/packages/regrade/src/index.ts
@@ -19,6 +19,7 @@ export type {
   RegradeClassResult,
   RegradeReport,
   RegradeReportEntry,
+  RegradeReportEntrySelection,
   RegradeReviewDetail,
   RegradeReviewSpan,
   RegradeScanTargets,


### PR DESCRIPTION
## Context

TRL-1015 shapes Regrade reports around operator-actionable outcomes before the project-local Warden rule dogfood work lands upstack.

## What Changed

- Added `includeEntries: "actionable" | "all"` to Regrade report/run APIs.
- Default report entries now include rewrite and review outcomes while counts stay full-run.
- Added `skipsByReason` to Regrade reports and the Trails operator output schema.
- Exposed `includeEntries` through the operator `regrade` trail.

## Verification

- `bun test packages/regrade/src/downstream/__tests__/report.test.ts apps/trails/src/__tests__/regrade.test.ts`
- `bun test packages/regrade/src/downstream/__tests__/report.test.ts packages/regrade/src/downstream/__tests__/radio-fixture.test.ts packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts packages/regrade/src/downstream/__tests__/collect.test.ts apps/trails/src/__tests__/regrade.test.ts`
- `bun run --cwd packages/regrade typecheck`
- `bun run --cwd apps/trails typecheck`
- Full stack verification on the top branch: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`

## Review

Local review found no implementation P0/P1/P2 for this branch. One stack-level Graphite topology P2 was fixed before submit; the stack dry-run passed for exactly #827 -> #828 -> #829.