### PR TITLE
fix(regrade): load project warden rewrite rules

### DIFF
--- a/.changeset/regrade-project-warden-rules.md
+++ b/.changeset/regrade-project-warden-rules.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/regrade": patch
+"@ontrails/trails": patch
+---
+
+Load project-local Warden term-rewrite rules from the Regrade root so repo-owned
+migration classes can run through `trails regrade`.

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -94,6 +94,95 @@ describe('trails regrade', () => {
     }
   });
 
+  test('loads project-local Warden term rewrites from the regrade root', async () => {
+    const dir = makeTempDir();
+    try {
+      mkdirSync(join(dir, '.trails'), { recursive: true });
+      mkdirSync(join(dir, 'src'), { recursive: true });
+      const target = join(dir, 'src', 'surface.ts');
+      writeFileSync(target, 'export const facet = "inspect";\n');
+      writeFileSync(
+        join(dir, '.trails', 'rules.ts'),
+        `
+import type { WardenRule } from '@ontrails/warden';
+
+const lineForOffset = (source: string, offset: number): number => {
+  let line = 1;
+  for (let index = 0; index < offset; index += 1) {
+    if (source.codePointAt(index) === 10) {
+      line += 1;
+    }
+  }
+  return line;
+};
+
+const rule = {
+  check(sourceCode: string, filePath: string) {
+    const diagnostics = [];
+    const matcher = /\\bfacet\\b/g;
+    for (const match of sourceCode.matchAll(matcher)) {
+      const start = match.index ?? 0;
+      diagnostics.push({
+        filePath,
+        fix: {
+          class: 'term-rewrite',
+          edits: [{ end: start + 'facet'.length, replacement: 'trailhead', start }],
+          reason: "Rename 'facet' to 'trailhead'.",
+          safety: 'safe',
+        },
+        line: lineForOffset(sourceCode, start),
+        message: "Rename 'facet' to 'trailhead'.",
+        rule: 'repo-local-facet-vocab',
+        severity: 'error',
+      });
+    }
+    return diagnostics;
+  },
+  description: 'Rename repo-local facet vocabulary.',
+  metadata: {
+    concern: 'meta',
+    depth: 'source',
+    fix: { class: 'term-rewrite', safety: 'safe' },
+    invariant: 'Repo-local facet vocabulary migrates through Regrade.',
+    lifecycle: { state: 'temporary', retireWhen: 'facet family cutover completes' },
+    scope: 'repo-local',
+    tier: 'source-static',
+  },
+  name: 'repo-local-facet-vocab',
+  severity: 'error',
+} satisfies WardenRule;
+
+export default rule;
+`
+      );
+
+      const result = await regradeTrail.blaze(
+        {
+          apply: true,
+          classIds: ['term-rewrite:repo-local-facet-vocab'],
+          rootDir: dir,
+        },
+        { cwd: dir, env: {} } as never
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.selectedClassIds).toEqual([
+        'term-rewrite:repo-local-facet-vocab',
+      ]);
+      expect(result.value.apply).toMatchObject({
+        applied: 1,
+        filesChanged: 1,
+        review: 0,
+      });
+      expect(readFileSync(target, 'utf8')).toContain('trailhead');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('apply mode returns a Trails error when a rewrite cannot be written', async () => {
     const dir = makeTempDir();
     try {

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -2,12 +2,18 @@
  * `regrade` trail -- Run downstream migration checks and safe rewrites.
  */
 
-import { NotFoundError, Result, trail, validateOutput } from '@ontrails/core';
+import {
+  InternalError,
+  NotFoundError,
+  Result,
+  trail,
+  validateOutput,
+} from '@ontrails/core';
 import type { Result as TrailsResult } from '@ontrails/core';
 import {
   regradeReportOutput,
   runRegrade,
-  wardenTermRewriteClasses,
+  loadWardenTermRewriteClasses,
 } from '@ontrails/regrade';
 import type { RegradeReport } from '@ontrails/regrade';
 import { z } from 'zod';
@@ -33,15 +39,27 @@ const regradeInputSchema = z.object({
 });
 
 export const regradeTrail = trail('regrade', {
-  blaze: (input, ctx) => {
+  blaze: async (input, ctx) => {
     const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
     if (rootDirResult.isErr()) {
       return rootDirResult;
     }
 
+    const classSet = await loadWardenTermRewriteClasses(rootDirResult.value);
+    if (classSet.diagnostics.length > 0) {
+      return Result.err(
+        new InternalError('Failed to load Regrade project Warden rules.', {
+          context: {
+            diagnostics: classSet.diagnostics,
+            rootDir: rootDirResult.value,
+          },
+        })
+      );
+    }
+
     const reportResult: TrailsResult<RegradeReport | null, Error> = runRegrade({
       apply: input.apply,
-      classes: wardenTermRewriteClasses,
+      classes: classSet.classes,
       includeEntries: input.includeEntries,
       root: rootDirResult.value,
       ...(input.classIds === undefined

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -312,6 +312,28 @@ describe('wardenTermRewriteClasses', () => {
     );
   });
 
+  test('projects rule-local term-rewrite metadata for project rules', () => {
+    const rule = {
+      check: () => [],
+      description: 'Project-local term rewrite.',
+      metadata: {
+        concern: 'meta',
+        depth: 'source',
+        fix: { class: 'term-rewrite', safety: 'safe' },
+        invariant: 'Project-local Warden term rewrites can feed Regrade.',
+        lifecycle: { retireWhen: 'migration completes', state: 'temporary' },
+        scope: 'repo-local',
+        tier: 'source-static',
+      },
+      name: 'project-local-term-rewrite',
+      severity: 'error',
+    } satisfies WardenRule;
+
+    const cls = createWardenTermRewriteClass(rule);
+
+    expect(cls?.id).toBe('term-rewrite:project-local-term-rewrite');
+  });
+
   test('preserves Warden scan-target filtering for Warden-backed classes', () => {
     const checkedPaths: string[] = [];
     const rule = {

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -7,6 +7,7 @@ import type {
 import {
   getWardenRuleMetadata,
   isWardenSourceScanTarget,
+  loadProjectWardenRules,
   wardenRules,
 } from '@ontrails/warden';
 import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
@@ -87,6 +88,13 @@ export interface RegradeClass {
   ) => RegradeClassResult;
   /** Scan targets this class knows how to inspect. */
   readonly scanTargets?: RegradeScanTargets;
+}
+
+export interface RegradeWardenClassSet {
+  /** Built-in and project-local Warden term-rewrite classes. */
+  readonly classes: readonly RegradeClass[];
+  /** Diagnostics raised while loading project-local rules. */
+  readonly diagnostics: readonly WardenDiagnostic[];
 }
 
 /** Which regrade classes a run should execute. */
@@ -354,7 +362,7 @@ const applyWardenEdits = (
 export const createWardenTermRewriteClass = (
   rule: WardenRule
 ): RegradeClass | null => {
-  const metadata = getWardenRuleMetadata(rule.name);
+  const metadata = getWardenRuleMetadata(rule);
   if (metadata?.fix?.class !== TERM_REWRITE_FIX_CLASS) {
     return null;
   }
@@ -1018,3 +1026,55 @@ export const wardenTermRewriteClasses: readonly RegradeClass[] = Object.freeze(
     return cls === null ? [] : [cls];
   })
 );
+
+const duplicateClassDiagnostics = (
+  root: string,
+  classes: readonly RegradeClass[]
+): readonly WardenDiagnostic[] => {
+  const seen = new Set<string>();
+  const diagnostics: WardenDiagnostic[] = [];
+  for (const cls of classes) {
+    if (!seen.has(cls.id)) {
+      seen.add(cls.id);
+      continue;
+    }
+    diagnostics.push({
+      filePath: root,
+      line: 1,
+      message: `Duplicate Regrade class id "${cls.id}" from Warden term-rewrite rules.`,
+      rule: 'regrade-warden-term-rewrite-classes',
+      severity: 'error',
+    });
+  }
+  return diagnostics;
+};
+
+/**
+ * Load built-in and project-local Warden term-rewrite rules as Regrade classes.
+ *
+ * Built-ins are always available. When `root` is provided, committed
+ * project-local Warden rules under `.trails/rules.ts` or direct
+ * `.trails/rules/*.ts` modules are loaded and any term-rewrite-capable source
+ * rules join the class set.
+ */
+export const loadWardenTermRewriteClasses = async (
+  root?: string
+): Promise<RegradeWardenClassSet> => {
+  if (root === undefined) {
+    return { classes: wardenTermRewriteClasses, diagnostics: [] };
+  }
+
+  const projectRules = await loadProjectWardenRules(root);
+  const projectClasses = projectRules.sourceRules.flatMap((rule) => {
+    const cls = createWardenTermRewriteClass(rule);
+    return cls === null ? [] : [cls];
+  });
+  const classes = [...wardenTermRewriteClasses, ...projectClasses];
+  return {
+    classes,
+    diagnostics: [
+      ...projectRules.diagnostics,
+      ...duplicateClassDiagnostics(root, classes),
+    ],
+  };
+};

--- a/packages/regrade/src/index.ts
+++ b/packages/regrade/src/index.ts
@@ -7,6 +7,7 @@ export {
   buildRegradeReport,
   createTermRewriteClass,
   createWardenTermRewriteClass,
+  loadWardenTermRewriteClasses,
   regradeReportOutput,
   runRegrade,
   selectRegradeClasses,
@@ -24,6 +25,7 @@ export type {
   RegradeReviewSpan,
   RegradeScanTargets,
   RegradeSelection,
+  RegradeWardenClassSet,
 } from './downstream/report.js';
 export {
   createAstIdentifierRenameClass,


### PR DESCRIPTION
## Context

TRL-1004 lets Regrade load project-local Warden term-rewrite classes so migration contracts can live in the same Warden rule home as project governance.

## What Changed

- Added a Regrade loader for built-in plus project-local Warden term-rewrite classes.
- Loaded `.trails/rules.ts` and `.trails/rules/*.ts` from the target root for the operator `regrade` trail.
- Failed loudly on project rule load diagnostics.
- Fixed `createWardenTermRewriteClass` to honor rule-local metadata instead of only built-in metadata-by-name.
- Added a temp-root regression proving `trails regrade` applies a repo-local Warden term-rewrite class.

## Verification

- `bun test apps/trails/src/__tests__/regrade.test.ts packages/regrade/src/downstream/__tests__/report.test.ts`
- `bun run --cwd packages/regrade typecheck`
- `bun run --cwd apps/trails typecheck`
- Full stack verification on the top branch: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`

## Review

Local Regrade/Warden review found no P0/P1/P2. The relevant P3 on tracked agent skill mirrors was fixed upstack in #829.