### PR TITLE
test(regrade): dogfood trailhead vocabulary rules

### DIFF
--- a/.agents/skills/clark/references/warden-guide.md
+++ b/.agents/skills/clark/references/warden-guide.md
@@ -71,7 +71,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `cli-command-route-coherence` (error, topo/topo-aware, external): CLI command routes and aliases resolve to one coherent trail contract. Guidance: Keep every CLI command route and alias normalized into one trail contract.
 - `duplicate-public-contract` (warn, topo/topo-aware, external): Public surface trails should not expose duplicate normalized contract facts. Guidance: Keep duplicate public contract facts from drifting into separate capabilities.
 - `library-projection-coherence` (error, topo/topo-aware, external): Resolved library projection exports are collision-free and target existing trails. Guidance: Keep resolved library projection exports collision-free and attached to one trail contract.
-- `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep surface facet maps reviewable before they reach MCP projection.
+- `surface-facet-coherence` (warn, source/source-static, external): Trailhead maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep trailhead maps reviewable before they reach MCP projection.
 - `trail-fork-coaching` (warn, all/source-static, advisory): Trails avoid hiding distinct capabilities behind branching action or operation inputs. Guidance: Keep surface accommodations from hiding several capabilities behind one branching trail input.
 
 ### Permits

--- a/.changeset/regrade-warden-fix-scan-targets.md
+++ b/.changeset/regrade-warden-fix-scan-targets.md
@@ -1,0 +1,13 @@
+---
+"@ontrails/warden": patch
+"@ontrails/regrade": patch
+"@ontrails/trails": patch
+"@ontrails/mcp": patch
+"@ontrails/wayfinder": patch
+---
+
+Let Warden fix capabilities declare downstream scan targets and have Regrade
+honor those targets for Warden-backed term-rewrite classes.
+
+Dogfood the first safe facet-to-trailhead prose rewrite through project-local
+Warden rules and Regrade.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -71,7 +71,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `cli-command-route-coherence` (error, topo/topo-aware, external): CLI command routes and aliases resolve to one coherent trail contract. Guidance: Keep every CLI command route and alias normalized into one trail contract.
 - `duplicate-public-contract` (warn, topo/topo-aware, external): Public surface trails should not expose duplicate normalized contract facts. Guidance: Keep duplicate public contract facts from drifting into separate capabilities.
 - `library-projection-coherence` (error, topo/topo-aware, external): Resolved library projection exports are collision-free and target existing trails. Guidance: Keep resolved library projection exports collision-free and attached to one trail contract.
-- `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep surface facet maps reviewable before they reach MCP projection.
+- `surface-facet-coherence` (warn, source/source-static, external): Trailhead maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep trailhead maps reviewable before they reach MCP projection.
 - `trail-fork-coaching` (warn, all/source-static, advisory): Trails avoid hiding distinct capabilities behind branching action or operation inputs. Guidance: Keep surface accommodations from hiding several capabilities behind one branching trail input.
 
 ### Permits

--- a/.trails/rules/v1-vocab-facet.ts
+++ b/.trails/rules/v1-vocab-facet.ts
@@ -1,0 +1,248 @@
+import type { WardenDiagnostic, WardenFix, WardenRule } from '@ontrails/warden';
+
+const SAFE_RULE_NAME = 'v1-vocab-facet-safe-prose';
+const REVIEW_RULE_NAME = 'v1-vocab-facet-review-inventory';
+
+const SAFE_REWRITES = [
+  { from: 'Surface Facets', to: 'Trailheads' },
+  { from: 'Surface Facet', to: 'Trailhead' },
+  { from: 'surface facets', to: 'trailheads' },
+  { from: 'surface facet', to: 'trailhead' },
+] as const;
+
+const FACET_TERM = /\b[Ff]acets?\b/g;
+
+const CURRENT_DOC_PREFIXES = [
+  '/.agents/skills/',
+  '/.claude/skills/',
+  '/AGENTS.md',
+  '/docs/',
+  '/plugin/',
+  '/packages/',
+  '/apps/',
+] as const;
+
+const HISTORICAL_DOC_PREFIXES = [
+  '/docs/adr/',
+  '/docs/migration/',
+  '/docs/releases/',
+] as const;
+
+interface RewriteMatch {
+  readonly from: string;
+  readonly index: number;
+  readonly to: string;
+}
+
+interface ReviewMatch {
+  readonly index: number;
+  readonly term: string;
+}
+
+interface TextSpan {
+  readonly end: number;
+  readonly start: number;
+}
+
+const normalizePath = (filePath: string): string =>
+  filePath.replaceAll('\\', '/');
+
+const isMarkdown = (filePath: string): boolean =>
+  normalizePath(filePath).endsWith('.md');
+
+const isCurrentFacingDoc = (filePath: string): boolean => {
+  const normalized = normalizePath(filePath);
+  if (!isMarkdown(normalized) || normalized.includes('/CHANGELOG.md')) {
+    return false;
+  }
+  if (HISTORICAL_DOC_PREFIXES.some((prefix) => normalized.includes(prefix))) {
+    return false;
+  }
+  return CURRENT_DOC_PREFIXES.some(
+    (prefix) => normalized.endsWith(prefix) || normalized.includes(prefix)
+  );
+};
+
+const lineForOffset = (sourceCode: string, offset: number): number => {
+  let line = 1;
+  for (let index = 0; index < offset; index += 1) {
+    if (sourceCode.codePointAt(index) === 10) {
+      line += 1;
+    }
+  }
+  return line;
+};
+
+const findSafeMatches = (sourceCode: string): readonly RewriteMatch[] => {
+  const candidates: RewriteMatch[] = [];
+  for (const rewrite of SAFE_REWRITES) {
+    let fromIndex = 0;
+    while (fromIndex < sourceCode.length) {
+      const index = sourceCode.indexOf(rewrite.from, fromIndex);
+      if (index === -1) {
+        break;
+      }
+      candidates.push({ ...rewrite, index });
+      fromIndex = index + rewrite.from.length;
+    }
+  }
+  const matches: RewriteMatch[] = [];
+  for (const candidate of candidates.toSorted((left, right) => {
+    if (left.index !== right.index) {
+      return left.index - right.index;
+    }
+    return right.from.length - left.from.length;
+  })) {
+    const end = candidate.index + candidate.from.length;
+    if (
+      matches.some((match) => {
+        const matchEnd = match.index + match.from.length;
+        return candidate.index < matchEnd && end > match.index;
+      })
+    ) {
+      continue;
+    }
+    matches.push(candidate);
+  }
+  return matches.toSorted((left, right) => left.index - right.index);
+};
+
+const safeSpans = (sourceCode: string): readonly TextSpan[] =>
+  findSafeMatches(sourceCode).map((match) => ({
+    end: match.index + match.from.length,
+    start: match.index,
+  }));
+
+const inlineCodeSpans = (sourceCode: string): readonly TextSpan[] =>
+  [...sourceCode.matchAll(/`[^`\n]*`/g)].map((match) => ({
+    end: (match.index ?? 0) + match[0].length,
+    start: match.index ?? 0,
+  }));
+
+const fencedCodeSpans = (sourceCode: string): readonly TextSpan[] =>
+  [...sourceCode.matchAll(/```[\s\S]*?```/g)].map((match) => ({
+    end: (match.index ?? 0) + match[0].length,
+    start: match.index ?? 0,
+  }));
+
+const markdownLinkTargetSpans = (sourceCode: string): readonly TextSpan[] =>
+  [...sourceCode.matchAll(/\]\([^)]+\)/g)].map((match) => ({
+    end: (match.index ?? 0) + match[0].length - 1,
+    start: (match.index ?? 0) + 2,
+  }));
+
+const isInsideSpan = (index: number, spans: readonly TextSpan[]): boolean =>
+  spans.some((span) => index >= span.start && index < span.end);
+
+const isSchemaFacetPhrase = (sourceCode: string, index: number): boolean =>
+  sourceCode
+    .slice(Math.max(0, index - 'schema '.length), index)
+    .toLowerCase()
+    .endsWith('schema ');
+
+const findReviewMatches = (sourceCode: string): readonly ReviewMatch[] => {
+  const spans = [
+    ...safeSpans(sourceCode),
+    ...fencedCodeSpans(sourceCode),
+    ...inlineCodeSpans(sourceCode),
+    ...markdownLinkTargetSpans(sourceCode),
+  ];
+  const matches: ReviewMatch[] = [];
+  for (const match of sourceCode.matchAll(FACET_TERM)) {
+    const index = match.index ?? 0;
+    if (isInsideSpan(index, spans) || isSchemaFacetPhrase(sourceCode, index)) {
+      continue;
+    }
+    matches.push({ index, term: match[0] ?? 'facet' });
+  }
+  return matches;
+};
+
+const safeFix = (match: RewriteMatch): WardenFix => ({
+  class: 'term-rewrite',
+  edits: [
+    {
+      end: match.index + match.from.length,
+      replacement: match.to,
+      start: match.index,
+    },
+  ],
+  reason: `Retired surface accommodation vocabulary '${match.from}' has a mechanical v1 replacement '${match.to}'.`,
+  safety: 'safe',
+});
+
+const reviewFix = (term: string): WardenFix => ({
+  class: 'term-rewrite',
+  reason: `Retired surface accommodation vocabulary '${term}' remains in an ambiguous or API-shaped context. Review before migrating to trailhead vocabulary.`,
+  safety: 'review',
+});
+
+const baseMetadata = {
+  concern: 'meta',
+  depth: 'source',
+  invariant: 'Facet vocabulary migrates through the v1 trailhead family proof.',
+  lifecycle: {
+    retireWhen: 'facet to trailhead cutover completes',
+    state: 'temporary',
+  },
+  scope: 'repo-local',
+  tier: 'source-static',
+} as const;
+
+export const v1VocabFacetSafeProse: WardenRule = {
+  check(sourceCode, filePath): readonly WardenDiagnostic[] {
+    if (!isCurrentFacingDoc(filePath)) {
+      return [];
+    }
+    return findSafeMatches(sourceCode).map((match) => ({
+      filePath,
+      fix: safeFix(match),
+      line: lineForOffset(sourceCode, match.index),
+      message: `Retired surface accommodation vocabulary '${match.from}' should be '${match.to}'.`,
+      rule: SAFE_RULE_NAME,
+      severity: 'warn',
+    }));
+  },
+  description:
+    'Rewrite safe current-facing surface facet prose to trailhead vocabulary.',
+  metadata: {
+    ...baseMetadata,
+    fix: {
+      class: 'term-rewrite',
+      safety: 'safe',
+      scanTargets: { extensions: ['.md'] },
+    },
+  },
+  name: SAFE_RULE_NAME,
+  severity: 'warn',
+};
+
+export const v1VocabFacetReviewInventory: WardenRule = {
+  check(sourceCode, filePath): readonly WardenDiagnostic[] {
+    if (!isCurrentFacingDoc(filePath)) {
+      return [];
+    }
+    return findReviewMatches(sourceCode).map((match) => ({
+      filePath,
+      fix: reviewFix(match.term),
+      line: lineForOffset(sourceCode, match.index),
+      message: `Retired surface accommodation vocabulary '${match.term}' needs review before migrating to trailhead vocabulary.`,
+      rule: REVIEW_RULE_NAME,
+      severity: 'warn',
+    }));
+  },
+  description:
+    'Inventory remaining ambiguous surface facet vocabulary for review.',
+  metadata: {
+    ...baseMetadata,
+    fix: {
+      class: 'term-rewrite',
+      safety: 'review',
+      scanTargets: { extensions: ['.md'] },
+    },
+  },
+  name: REVIEW_RULE_NAME,
+  severity: 'warn',
+};
+
+export const sourceRules = [v1VocabFacetSafeProse, v1VocabFacetReviewInventory];

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,11 +90,11 @@ Use the project language consistently:
 
 ## Surface Accommodations
 
-Land the capability in the trail and accommodate the surface in projection. Surface accommodations include aliases, future input mappings, and surface facets. They are valid only while the same authored trail contract remains true.
+Land the capability in the trail and accommodate the surface in projection. Surface accommodations include aliases, future input mappings, and trailheads. They are valid only while the same authored trail contract remains true.
 
 - Aliases and input mappings live on the approach axis: many approaches may converge on one trail, but they must normalize without lying.
-- Surface facets live on the entry axis: one grouped entry may gather several trails, but it must preserve selected member trail identity at invocation and response time.
-- Treat a shape as a trail fork when it changes intent, permits, errors, outputs, lifecycle, side effects, or hides which trail is running. Use a distinct trail, a composing trail, or a surface facet that preserves member identity instead.
+- Trailheads live on the entry axis: one grouped entry may gather several trails, but it must preserve selected member trail identity at invocation and response time.
+- Treat a shape as a trail fork when it changes intent, permits, errors, outputs, lifecycle, side effects, or hides which trail is running. Use a distinct trail, a composing trail, or a trailhead that preserves member identity instead.
 
 See [ADR-0050](docs/adr/0050-surface-accommodations-preserve-trail-identity.md) and [Surface Accommodations](docs/surfaces/surface-accommodations.md).
 
@@ -164,7 +164,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `cli-command-route-coherence` (error, topo/topo-aware, external): CLI command routes and aliases resolve to one coherent trail contract.
 - `duplicate-public-contract` (warn, topo/topo-aware, external): Public surface trails should not expose duplicate normalized contract facts.
 - `library-projection-coherence` (error, topo/topo-aware, external): Resolved library projection exports are collision-free and target existing trails.
-- `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors.
+- `surface-facet-coherence` (warn, source/source-static, external): Trailhead maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors.
 - `trail-fork-coaching` (warn, all/source-static, advisory): Trails avoid hiding distinct capabilities behind branching action or operation inputs.
 
 #### Permits
@@ -218,7 +218,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `resource-exists`: Make declared resources resolve to authored resource definitions.
 - `resource-mock-coverage`: Make each resource declare a test mock or an explicit unmockable reason.
 - `static-resource-accessor-preference`: Use statically scoped resource helpers when the resource definition is already available.
-- `surface-facet-coherence`: Keep surface facet maps reviewable before they reach MCP projection.
+- `surface-facet-coherence`: Keep trailhead maps reviewable before they reach MCP projection.
 - `trail-fork-coaching`: Keep surface accommodations from hiding several capabilities behind one branching trail input.
 
 <!-- warden-guide:end -->

--- a/apps/trails/src/trails/warden-guide.ts
+++ b/apps/trails/src/trails/warden-guide.ts
@@ -37,6 +37,12 @@ const wardenRuleGuideEntrySchema = z.object({
     .object({
       class: z.enum(wardenFixClasses),
       safety: z.enum(wardenFixSafeties),
+      scanTargets: z
+        .object({
+          extensions: z.array(z.string()).readonly().optional(),
+          ignoredDirectories: z.array(z.string()).readonly().optional(),
+        })
+        .optional(),
     })
     .optional(),
   guidance: wardenGuidanceSchema.optional(),
@@ -54,10 +60,9 @@ const wardenRuleGuideEntrySchema = z.object({
 const wardenGuideManifestSchema = z.object({
   generatedFrom: z.object({
     package: z.literal('@ontrails/warden'),
-    registries: z.tuple([
-      z.literal('wardenRules'),
-      z.literal('wardenTopoRules'),
-    ]),
+    registries: z
+      .tuple([z.literal('wardenRules'), z.literal('wardenTopoRules')])
+      .readonly(),
     source: z.literal('builtin-rule-metadata'),
   }),
   kind: z.literal('trails-warden-guide-manifest'),

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -2861,7 +2861,7 @@
           "fromPath": "docs/surfaces/cli.md"
         },
         {
-          "context": "Dense MCP surfaces can use surface facets to group related trails into fewer agent-facing tools while preserving the underlying trail contracts. Facets are surface accommodations on the entry axis: th",
+          "context": "Dense MCP surfaces can use trailheads to group related trails into fewer agent-facing tools while preserving the underlying trail contracts. Trailheads are surface accommodations on the entry axis: th",
           "from": "mcp",
           "fromPath": "docs/surfaces/mcp.md"
         },
@@ -2871,12 +2871,12 @@
           "fromPath": "docs/surfaces/surface-accommodations.md"
         },
         {
-          "context": "Use the surface-accommodation vocabulary from [ADR-0050](../adr/0050-surface-accommodations-preserve-trail-identity.md) when evaluating parity. Facets live on the entry axis: one grouped surface entry",
+          "context": "Use the surface-accommodation vocabulary from [ADR-0050](../adr/0050-surface-accommodations-preserve-trail-identity.md) when evaluating parity. Trailheads live on the entry axis: one grouped surface e",
           "from": "surface-facet-parity",
           "fromPath": "docs/surfaces/surface-facet-parity.md"
         },
         {
-          "context": "A facet is a surface accommodation on the entry axis: one grouped surface entry over several trails. It is not an alternate approach to one trail. Aliases and input mappings are N-to-1 accommodations ",
+          "context": "A trailhead is a surface accommodation on the entry axis: one grouped surface entry over several trails. It is not an alternate approach to one trail. Aliases and input mappings are N-to-1 accommodati",
           "from": "surface-facets",
           "fromPath": "docs/surfaces/surface-facets.md"
         }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -487,11 +487,12 @@ AstParseResult, AstParseDiagnostic, SourceEdit, SourceLocation
 
 ```typescript
 // Downstream migration reporting and safe rewrites
-runRegrade({ root, classes, selection?, collection?, apply? }) // Result<RegradeReport | null, InternalError>
-buildRegradeReport({ root, files, skipped, classes, selection? })
+runRegrade({ root, classes, selection?, collection?, apply?, includeEntries? }) // Result<RegradeReport | null, InternalError>
+buildRegradeReport({ root, files, skipped, classes, selection?, includeEntries? })
 selectRegradeClasses(classes, selection?)
 
 // Built-in Warden-backed migration classes
+loadWardenTermRewriteClasses(root?)
 wardenTermRewriteClasses
 createWardenTermRewriteClass(rule)
 createTermRewriteClass({ from, to, id?, describe? })
@@ -508,6 +509,8 @@ literalRegradeTopo, literalRegradeTrail
 RegradeClass, RegradeClassResult, RegradeReport, RegradeReportEntry
 RegradeReviewDetail, RegradeReviewSpan, RegradeScanTargets, RegradeSelection
 ```
+
+Regrade reports always include full aggregate counts, unknown class IDs, scan statistics, and skip reasons. Report `entries` default to actionable rewrite and review outcomes; pass `includeEntries: 'all'` to include no-op and skip entries.
 
 ## `@ontrails/config`
 
@@ -702,7 +705,7 @@ The adapter emits stable `trails.*` attributes for trace identity, lineage, trai
 | Name | Intent |
 | --- | --- |
 | `trailblaze(topo, options?)` | Future hosted runtime; not shipped |
-| `trailhead` | Historical boundary term retired from active user-facing vocabulary |
+| `trailhead()` | Historical boundary API retired in favor of `surface()` |
 | `scout` | Agent-side runtime discovery |
 | `validateExample`, `validateCompose` | Contract verification family |
 | `generateDocs`, `generateOpenApi`, `generateLlmsTxt` | Build-time doc generation |

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@
 - **[Stable Cutover Runbook](./releases/stable-cutover.md)** — Beta-to-1.0 cutover sequence, publish boundaries, and recovery checks
 - **[Beta Channel Policy](./releases/beta-channel-policy.md)** — Beta install tags, `latest` posture, version cadence, and read-only registry checks
 - **[Plugin Release Runbook](./releases/plugin-release.md)** — Claude plugin/skills refresh, dogfood, and manual publication checks
-- **[Surface Facets Release Notes](./releases/surface-facets.md)** — Release prep, migration posture, and publish path for MCP surface facets
+- **[Trailheads Release Notes](./releases/surface-facets.md)** — Release prep, migration posture, and publish path for MCP trailheads
 - **[Wayfinder V0 Release Notes](./releases/wayfinder-v0.md)** — Release prep, MCP exposure posture, and non-goals for the first real Wayfinder catalog
 - **[Beta 15](./releases/beta15.md)** — Beta 15 release-prep notes and known CLI follow-up work
 - **[Beta 15 to Beta 19](./releases/beta15-to-beta19.md)** — Downstream operator guide: package install, surface decisions, `cross`→`compose` rename, trail versioning, adapter authoring, Topographer adoption, validation checklist
@@ -33,10 +33,10 @@
 
 - **[CLI Surface](./surfaces/cli.md)** — Shipped today. Flag derivation, output modes, exit codes, `--dry-run`
 - **[MCP Surface](./surfaces/mcp.md)** — Shipped today. Tool naming, annotations, progress bridge
-- **[Surface Accommodations](./surfaces/surface-accommodations.md)** — How aliases, input mappings, facets, and trail forks keep surfaces honest
-- **[Surface Facets](./surfaces/surface-facets.md)** — MCP shaping for dense topos without adding a core facet primitive
+- **[Surface Accommodations](./surfaces/surface-accommodations.md)** — How aliases, input mappings, trailheads, and trail forks keep surfaces honest
+- **[Trailheads](./surfaces/surface-facets.md)** — MCP shaping for dense topos without adding a new core primitive
 - **[HTTP Surface](./surfaces/http.md)** — Shipped today. Route derivation, Web Fetch kernel, Hono adapter, Bun-native serving, webhook activation
-- **[Surface Facet Parity](./surfaces/surface-facet-parity.md)** — Deferred CLI/HTTP parity decision after MCP proves grouped projection
+- **[Trailhead Parity](./surfaces/surface-facet-parity.md)** — Deferred CLI/HTTP parity decision after MCP proves grouped projection
 - **WebSocket Surface** — Planned, not yet implemented. See [Horizons](./horizons.md) for the current direction.
 
 ## Governing your codebase?

--- a/docs/lexicon-pending.md
+++ b/docs/lexicon-pending.md
@@ -2,9 +2,9 @@
 
 `docs/lexicon.md` is the source of truth for current vocabulary. The terms below are ratified to change in the v1 ADR Canon Reset (TRL). This file is a heads-up, not a second lexicon — until the reset lands:
 
-- current code, docs, examples, and lexicon entries use the **Current** column — keep using it when describing live reality;
+- current code, API identifiers, examples, and lexicon entries use the **Current** column — keep using it when describing live API reality;
 - the **Target** column is the agreed direction — do not treat the current term as permanent;
-- do not adopt a target term in code, docs, or examples yet. Doing so before the cutover creates exactly the drift this file exists to prevent.
+- do not adopt a target term in code or examples yet. Prose documentation may move only when a cutover branch also updates this file and leaves live API identifiers explicit.
 
 | Current (live) | Target (v1 reset) | Scope |
 | --- | --- | --- |
@@ -19,3 +19,5 @@ Also in flight, tracked for the reset:
 - The docs information architecture (the draft documentation-structure ADR) and the location of release notes are unsettled. Do not build on a specific docs taxonomy yet.
 
 This file is temporary. When the v1 reset lands, these changes fold into `docs/lexicon.md` and this file is deleted.
+
+The `facet` to `trailhead` prose cutover has started. Current API identifiers such as `facets`, `facetId`, `McpSurfaceFacetMap`, `wayfind.facets`, and `surface-facet-coherence` remain live until their code/API migration lands.

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -487,10 +487,10 @@ A mechanically derived output from authored information. The topo store is a rel
 | `path` | Surface-local realization of an approach: command path, tool name, HTTP path, or export name |
 | `alias` | Alternate approach to the same surface entry and same trail contract |
 | `input mapping` | Surface-shaped input normalization into the same authored trail input contract |
-| `facet` | Qualified projection-slice vocabulary; use `surface facet` or `schema facet`, not bare `facet` as a primitive |
-| `surface facet` | Surface-side grouped entry over existing trails; not a graph node, package category, or core `Facet` primitive |
+| `facet` | Qualified projection-slice vocabulary; use `trailhead` or `schema facet`, not bare `facet` as a primitive |
+| `trailhead` | Surface-side grouped entry over existing trails; not a graph node, package category, or core `Facet` primitive |
 | `schema facet` | Descriptive phrase for a schema-owned slice or view when docs need it; not a decided public API |
-| `trail fork` | Doctrine phrase for the point where a surface accommodation would change semantics or merge or hide member identity; author a distinct trail, composing trail, or surface facet that preserves identity instead |
+| `trail fork` | Doctrine phrase for the point where a surface accommodation would change semantics or merge or hide member identity; author a distinct trail, composing trail, or trailhead that preserves identity instead |
 | `MCP resources` | MCP protocol resources used for cold context; not Trails `resource()` infrastructure declarations |
 | `integration (colloquial)` | Ordinary English for places Trails integrates with an external system; not a public taxonomy category |
 | `logger` / `logging` | Structured logging — framework provides the interface; developers bring their own |
@@ -520,7 +520,7 @@ These are directional. They should not be reused for unrelated concepts.
 | `pack` | Distributable capability bundle |
 | `depot` | Registry or distribution point for packs and shared assets |
 | `dispatch` | Activation/source fan-out from a source to consuming trails; not the direct execution helper |
-| `trailhead` | Historical boundary term retired from active user-facing vocabulary. Use `surface` in docs, examples, and public APIs. |
+| `trailhead()` | Historical boundary API retired in favor of `surface()`. Use `trailhead` only for a grouped surface entry over existing trails. |
 | `connector` | Historical package-boundary term retired from active user-facing taxonomy. Use `adapter` in docs, examples, and public APIs. |
 | `_draft.` | Reserved ID prefix for draft state. Trails, signals, and other primitives with `_draft.` IDs are visible in source but excluded from the resolved graph, established surfaces, and graph exports. Draft state is visible debt — it must never leak into established outputs. See ADR-0021. |
 

--- a/docs/surfaces/mcp.md
+++ b/docs/surfaces/mcp.md
@@ -68,15 +68,15 @@ When a trail declares `output`, the MCP tool definition includes an `outputSchem
 
 Trail examples are exposed as structured tool metadata under `_meta["ontrails/examples"]`. Each example keeps the authored input, expected output or error, a success/error kind, and provenance pointing back to `trail.examples`; clients do not need to scrape example JSON from prose descriptions.
 
-## Surface Facets
+## Trailheads
 
-Dense MCP surfaces can use surface facets to group related trails into fewer agent-facing tools while preserving the underlying trail contracts. Facets are surface accommodations on the entry axis: they group and select without merging. The full guide is [Surface Facets](surface-facets.md), and the accepted cross-surface doctrine is [ADR-0050](../adr/0050-surface-accommodations-preserve-trail-identity.md). The short version:
+Dense MCP surfaces can use trailheads to group related trails into fewer agent-facing tools while preserving the underlying trail contracts. Trailheads are surface accommodations on the entry axis: they group and select without merging. The full guide is [Trailheads](surface-facets.md), and the accepted cross-surface doctrine is [ADR-0050](../adr/0050-surface-accommodations-preserve-trail-identity.md). The short version:
 
-- author a facet map in MCP surface options;
-- each facet becomes one MCP tool;
-- call the facet with `{ trail, input }`;
+- author a trailhead map in MCP surface options;
+- each trailhead becomes one MCP tool;
+- call the trailhead with `{ trail, input }`;
 - successful responses return `{ trail, output }`;
-- inspect `trails://surface-map` for facet IDs, member trail IDs, schemas, and deferred-loading hints, and use `trails://examples/<trailId>` for member examples.
+- inspect `trails://surface-map` for trailhead IDs, member trail IDs, schemas, and deferred-loading hints, and use `trails://examples/<trailId>` for member examples.
 
 ## MCP Resources For Cold Context
 
@@ -84,7 +84,7 @@ Cold context belongs in **MCP resources**, not in extra tools and not in Trails 
 
 | Resource URI | Contents |
 | --- | --- |
-| `trails://surface-map` | Resolved MCP surface projection: tool names, trail IDs, facet IDs, member trail IDs, input/output schemas, versions, annotations, and deferred hints |
+| `trails://surface-map` | Resolved MCP surface projection: tool names, trail IDs, `facetId` values, member trail IDs, input/output schemas, versions, annotations, and deferred hints |
 | `trails://examples/<trailId>` | Structured examples for an exposed trail, when the trail defines examples |
 | `trails://trail/<trailId>` | MCP-visible graph facts for an exposed trail: identity, intent, visibility, composition, resource and signal references, and projected MCP tool metadata |
 
@@ -108,7 +108,7 @@ The resource naming is intentionally qualified: `McpResource`, `McpResources`, a
 
 ## Deferred Loading Hint
 
-Facet tools may opt into deferred loading:
+Trailhead tools may opt into deferred loading:
 
 ```typescript
 await surface(graph, {
@@ -122,7 +122,7 @@ await surface(graph, {
 });
 ```
 
-Deferred loading is a compatibility hint under `_meta["ontrails/deferred"]`. It does not omit required tool schemas from `tools/list` in this release, so older MCP clients still receive a complete tool definition. Clients that understand the hint can prefer the surface-map resource and defer expensive schema inspection until they need the facet.
+Deferred loading is a compatibility hint under `_meta["ontrails/deferred"]`. It does not omit required tool schemas from `tools/list` in this release, so older MCP clients still receive a complete tool definition. Clients that understand the hint can prefer the surface-map resource and defer expensive schema inspection until they need the trailhead.
 
 ## Annotations
 
@@ -230,13 +230,13 @@ await surface(graph, {
 
 Wayfinder trails are internal read tools over saved graph artifacts and package evidence. Expose them on MCP only when the host operator wants agents to inspect facts directly, and include explicit trail IDs instead of widening the whole `wayfind.*` namespace.
 
-The Trails operator MCP surface starts with selected first-class Wayfinder tools: `wayfind.overview`, `wayfind.search`, `wayfind.trails`, `wayfind.contract`, `wayfind.examples`, `wayfind.errors`, `wayfind.nearby`, `wayfind.impact`, `wayfind.adapters`, and `wayfind.diff`. It also enables `trails://trail/<trailId>` graph resources for exposed trails. The tools remain direct rather than one broad Wayfinder facet so agents can see read-only annotations, descriptions, output schemas, and permission boundaries at the tool boundary. The cohesive `trails wayfind` navigation grammar is a CLI accommodation over these graph-read trails; MCP keeps explicit tools until a server-owned workspace-root binding can safely expose file outline and combined selector behavior. Live-source outline stays on the local CLI until that binding exists. Adjacent saved-topo inspection stays grouped in the operator's existing `inspect` facet; unselected Wayfinder queries are not exposed by default.
+The Trails operator MCP surface starts with selected first-class Wayfinder tools: `wayfind.overview`, `wayfind.search`, `wayfind.trails`, `wayfind.contract`, `wayfind.examples`, `wayfind.errors`, `wayfind.nearby`, `wayfind.impact`, `wayfind.adapters`, and `wayfind.diff`. It also enables `trails://trail/<trailId>` graph resources for exposed trails. The tools remain direct rather than one broad Wayfinder trailhead so agents can see read-only annotations, descriptions, output schemas, and permission boundaries at the tool boundary. The cohesive `trails wayfind` navigation grammar is a CLI accommodation over these graph-read trails; MCP keeps explicit tools until a server-owned workspace-root binding can safely expose file outline and combined selector behavior. Live-source outline stays on the local CLI until that binding exists. Adjacent saved-topo inspection stays grouped in the operator's existing `inspect` trailhead; unselected Wayfinder queries are not exposed by default.
 
 Do not document or expose deferred Wayfinder ideas as if they exist. V0 has no semantic search, signposts, or `wayfind.implications`; the CLI text-query selector is deterministic indexed graph filtering, not semantic search.
 
-## Surface Facet Field Notes
+## Trailhead Field Notes
 
-Dense MCP surfaces can use surface facets to group related trails into fewer agent-facing tools. The current evidence ledger lives in [Surface Facet Field Notes](surface-facet-field-notes.md). Read it before generalizing facet behavior to another app or surface. It records the first Trails operator MCP shaping pass, the shortened evidence window, what survived contact, and what remains deferred.
+Dense MCP surfaces can use trailheads to group related trails into fewer agent-facing tools. The current evidence ledger lives in [Trailhead Field Notes](surface-facet-field-notes.md). Read it before generalizing trailhead behavior to another app or surface. It records the first Trails operator MCP shaping pass, the shortened evidence window, what survived contact, and what remains deferred.
 
 ## Server Configuration
 

--- a/docs/surfaces/surface-accommodations.md
+++ b/docs/surfaces/surface-accommodations.md
@@ -21,8 +21,8 @@ Use these terms when deciding whether a surface concern belongs on a trail, in a
 | `path` | The surface-local realization of an approach: a CLI command path, MCP tool name, HTTP path, or library export name. |
 | `alias` | An alternate approach to the same surface entry and the same trail contract. |
 | `input mapping` | Surface-shaped input that normalizes into the same authored trail input contract. |
-| `surface facet` | One grouped surface entry over multiple trails, with member trail identity preserved at invocation and response time. |
-| `trail fork` | The point where a proposed accommodation is no longer honest. Author a distinct trail, a composing trail, or a facet that preserves member identity. |
+| `trailhead` | One grouped surface entry over multiple trails, with member trail identity preserved at invocation and response time. |
+| `trail fork` | The point where a proposed accommodation is no longer honest. Author a distinct trail, a composing trail, or a trailhead that preserves member identity. |
 
 `trail fork` is doctrine language, not a new API primitive. Do not confuse it with lifecycle/version forks in trail versioning.
 
@@ -39,11 +39,11 @@ The **approach axis** is N-to-1. Several approaches can reach the same trail:
 
 The invariant is: converge without lying.
 
-The **entry axis** is 1-to-N when a surface facet is involved. One grouped surface entry can expose several trails, but it must keep the selected member trail visible.
+The **entry axis** is 1-to-N when a trailhead is involved. One grouped surface entry can expose several trails, but it must keep the selected member trail visible.
 
 The invariant is: gather without merging.
 
-Those axes are related, but not interchangeable. An alias is not a facet. A facet is not a generic action bag. An input mapping is not alternate behavior.
+Those axes are related, but not interchangeable. An alias is not a trailhead. A trailhead is not a generic action bag. An input mapping is not alternate behavior.
 
 ## Fork Test
 
@@ -62,7 +62,7 @@ When the test fails, use one of these shapes instead:
 
 - a distinct trail for a distinct capability;
 - a composing trail when the capability truly coordinates existing trails;
-- a surface facet when the surface needs one grouped entry over existing trails and can preserve member identity.
+- a trailhead when the surface needs one grouped entry over existing trails and can preserve member identity.
 
 ## Examples
 
@@ -70,9 +70,9 @@ A CLI compatibility command such as `wayfind find` for `wayfind.search` is an al
 
 A CLI spelling that accepts a different ergonomic shape but normalizes into the same authored input is an input mapping. It must remain inspectable and cannot invent hidden behavior.
 
-An MCP `inspect` tool over several read-only topo inspection trails is a surface facet when the call includes the selected `trail` and the result returns the same selected `trail` with its output.
+An MCP `inspect` tool over several read-only topo inspection trails is a trailhead when the call includes the selected `trail` and the result returns the same selected `trail` with its output.
 
-A command like `manage users --action delete` that hides create, update, and delete behind one action field is usually a trail fork. Prefer separate trails and, if the surface needs grouping, a facet that still exposes the selected member trail.
+A command like `manage users --action delete` that hides create, update, and delete behind one action field is usually a trail fork. Prefer separate trails and, if the surface needs grouping, a trailhead that still exposes the selected member trail.
 
 ## Classification
 
@@ -80,7 +80,7 @@ A command like `manage users --action delete` that hides create, update, and del
 | --- | --- |
 | One trail, another path, no input reshape | Alias |
 | One trail, surface-shaped input that normalizes honestly | Input mapping |
-| Many trails, one grouped entry, member trail identity preserved | Surface facet |
+| Many trails, one grouped entry, member trail identity preserved | Trailhead |
 | Different intent, permits, errors, outputs, lifecycle, side effects, or hidden member identity | Distinct trail or composing trail |
 
 ## Surface-Local Words

--- a/docs/surfaces/surface-facet-field-notes.md
+++ b/docs/surfaces/surface-facet-field-notes.md
@@ -1,14 +1,14 @@
-# Surface Facet Field Notes
+# Trailhead Field Notes
 
-Surface facets should stay evidence-led. Use this file for lightweight notes from real MCP surface use before widening facet behavior to more surfaces or adding stronger governance.
+Trailheads should stay evidence-led. Use this file for lightweight notes from real MCP surface use before widening trailhead behavior to more surfaces or adding stronger governance.
 
 ## Evidence Window
 
-TRL-890 originally called for two sprints between the ad-hoc Trails operator MCP surface and the reusable facet engine. Matt shortened that window during the Surface Facets & MCP Shaping sprint so the full stack could land together. Treat these notes as first-contact evidence plus a standing place for the next two sprints of follow-up, not as proof that every cross-surface question is settled.
+TRL-890 originally called for two sprints between the ad-hoc Trails operator MCP surface and the reusable trailhead engine. Matt shortened that window during the Trailheads & MCP Shaping sprint so the full stack could land together. Treat these notes as first-contact evidence plus a standing place for the next two sprints of follow-up, not as proof that every cross-surface question is settled.
 
 ## Trails Operator Surface
 
-The first shaped surface was `apps/trails/src/mcp-options.ts`. It projected the Trails operator app into seven deferred MCP facet tools:
+The first shaped surface was `apps/trails/src/mcp-options.ts`. It projected the Trails operator app into seven deferred MCP trailhead tools:
 
 - `artifacts`
 - `authoring`
@@ -18,24 +18,24 @@ The first shaped surface was `apps/trails/src/mcp-options.ts`. It projected the 
 - `shell`
 - `workspace`
 
-Each facet uses an explicit trail list instead of a broad namespace glob. That made review easier: agent reviewers could verify coverage of public trails, confirm that internal trails stayed hidden, and reason about the grouping without expanding a hidden selector mentally.
+Each trailhead uses an explicit trail list instead of a broad namespace glob. That made review easier: agent reviewers could verify coverage of public trails, confirm that internal trails stayed hidden, and reason about the grouping without expanding a hidden selector mentally.
 
-TRL-908 revised the dogfood surface around permission boundaries. The Trails operator MCP server now keeps high-signal and permission-sensitive affordances as direct tools, removes shell completion trails from MCP, and uses one deferred `inspect` facet for saved read-only topo inspection. Selected Wayfinder graph-read trails are explicitly included as direct tools on the operator MCP topo, rather than hidden behind a generic Wayfinder bucket.
+TRL-908 revised the dogfood surface around permission boundaries. The Trails operator MCP server now keeps high-signal and permission-sensitive affordances as direct tools, removes shell completion trails from MCP, and uses one deferred `inspect` trailhead for saved read-only topo inspection. Selected Wayfinder graph-read trails are explicitly included as direct tools on the operator MCP topo, rather than hidden behind a generic Wayfinder bucket.
 
 ## What Survived Contact
 
 - **Tool count:** a smaller tool surface still matters, but permission boundaries matter more than minimizing count.
-- **Invocation shape:** `{ trail, input }` keeps the underlying trail visible and avoids a new action vocabulary inside the facet.
-- **Output correlation:** `{ trail, output }` is necessary. Heterogeneous facet tools need the returned trail ID so an agent can connect a response to the selected contract without guessing from output fields.
+- **Invocation shape:** `{ trail, input }` keeps the underlying trail visible and avoids a new action vocabulary inside the trailhead.
+- **Output correlation:** `{ trail, output }` is necessary. Heterogeneous trailhead tools need the returned trail ID so an agent can connect a response to the selected contract without guessing from output fields.
 - **Cold context:** the resolved MCP surface map belongs in MCP resources. Agents can inspect grouped tools, member trail IDs, examples, and deferred hints without paying that context cost in every tool schema.
-- **Explicit selectors:** authored facet lists are boring, but boring helped. They made visibility and overlap review much more mechanical.
-- **Direct sensitive tools:** Warden, run, compile, authoring, topo pinning, and developer-state mutation are clearer as direct MCP tools than as members of broad facets.
+- **Explicit selectors:** authored trailhead lists are boring, but boring helped. They made visibility and overlap review much more mechanical.
+- **Direct sensitive tools:** Warden, run, compile, authoring, topo pinning, and developer-state mutation are clearer as direct MCP tools than as members of broad trailheads.
 
 ## What To Keep Watching
 
 - **Schema size:** deferred loading is only a compatibility hint today. Clients that still load all schemas need to keep working, and large member schemas may still be expensive until richer MCP client support exists.
 - **Description drift:** descriptions can become false as member lists evolve. `descriptionStableThrough` should be reserved for intentional stability, not used as a routine silencer.
-- **Missing metadata:** the surface map should remain the place to look for member trail IDs, facet IDs, output schemas, examples, versions, and deferred hints. If agents still need to inspect source after reading it, the resource shape needs more work.
+- **Missing metadata:** the surface map should remain the place to look for member trail IDs, `facetId` values, output schemas, examples, versions, and deferred hints. If agents still need to inspect source after reading it, the resource shape needs more work.
 - **Selector overlap:** overlap should stay visible as a Warden finding unless future evidence shows a precise, governed exception is needed.
 
 ## Dropped Or Deferred
@@ -50,7 +50,7 @@ TRL-908 revised the dogfood surface around permission boundaries. The Trails ope
 When adding future notes, include:
 
 - app or topo under test;
-- number of raw trails and projected facet tools;
+- number of raw trails and projected trailhead tools;
 - client used;
 - whether agents found the right tool without source inspection;
 - confusing invocation or output cases;

--- a/docs/surfaces/surface-facet-parity.md
+++ b/docs/surfaces/surface-facet-parity.md
@@ -1,28 +1,28 @@
-# Surface Facet Parity
+# Trailhead Parity
 
-Surface facets start with MCP because MCP pays the tool-count and schema-context cost first. CLI and HTTP remain peer surfaces, but peer-ness does not mean every surface gets the same projection at the same time.
+Trailheads start with MCP because MCP pays the tool-count and schema-context cost first. CLI and HTTP remain peer surfaces, but peer-ness does not mean every surface gets the same projection at the same time.
 
 ## Current Verdict
 
-CLI and HTTP facet parity are deferred. The MCP implementation should not be weakened to make other surfaces easier, and no CLI or HTTP facet behavior ships with this decision.
+CLI and HTTP trailhead parity are deferred. The MCP implementation should not be weakened to make other surfaces easier, and no CLI or HTTP trailhead behavior ships with this decision.
 
-The same facet declaration may remain the conceptual source for future parity, but each surface must earn its own materialization:
+The same trailhead declaration may remain the conceptual source for future parity, but each surface must earn its own materialization:
 
 - CLI parity should be evaluated as command-group consolidation.
 - HTTP parity should be evaluated as route-group projection or explicitly rejected as a non-fit.
 - Per-surface overrides are allowed only when the surface economics differ in a way the shared declaration cannot express honestly.
 
-Use the surface-accommodation vocabulary from [ADR-0050](../adr/0050-surface-accommodations-preserve-trail-identity.md) when evaluating parity. Facets live on the entry axis: one grouped surface entry over multiple trails. CLI aliases and future input mappings live on the approach axis: multiple ways to reach one trail. Do not use facets to solve a problem that is really an alternate approach to one trail, and do not use aliases to hide a grouped affordance.
+Use the surface-accommodation vocabulary from [ADR-0050](../adr/0050-surface-accommodations-preserve-trail-identity.md) when evaluating parity. Trailheads live on the entry axis: one grouped surface entry over multiple trails. CLI aliases and future input mappings live on the approach axis: multiple ways to reach one trail. Do not use trailheads to solve a problem that is really an alternate approach to one trail, and do not use aliases to hide a grouped affordance.
 
 ## CLI Evaluation
 
-MCP facets group many trails into one tool because agent clients pay for every tool schema they inspect. CLI already has a hierarchical command tree from dotted trail IDs, so a raw copy of MCP grouping would be awkward:
+MCP trailheads group many trails into one tool because agent clients pay for every tool schema they inspect. CLI already has a hierarchical command tree from dotted trail IDs, so a raw copy of MCP grouping would be awkward:
 
 ```text
 trails governance --trail warden --input-json '{}'
 ```
 
-That shape hides the command affordance a CLI user expects. A credible CLI facet would instead consolidate command groups while preserving normal command help and shell completion:
+That shape hides the command affordance a CLI user expects. A credible CLI trailhead would instead consolidate command groups while preserving normal command help and shell completion:
 
 ```text
 trails governance warden --apps apps/trails/src/app.ts
@@ -32,7 +32,7 @@ trails governance guide
 Open questions before CLI parity:
 
 - Does the grouped command path reduce discoverability cost beyond the existing dotted ID command tree?
-- Can command aliases or help grouping solve the problem without a facet materialization?
+- Can command aliases or help grouping solve the problem without a trailhead materialization?
 - How do positional args, structured input, and completions project when a group is editorial rather than ID-derived?
 
 ## HTTP Evaluation
@@ -44,7 +44,7 @@ POST /facets/governance
 { "trail": "warden", "input": {} }
 ```
 
-That shape turns ordinary HTTP routes into a generic RPC envelope. A credible HTTP facet would need to be route-group projection, documentation grouping, or OpenAPI organization rather than a replacement for direct trail routes:
+That shape turns ordinary HTTP routes into a generic RPC envelope. A credible HTTP trailhead would need to be route-group projection, documentation grouping, or OpenAPI organization rather than a replacement for direct trail routes:
 
 ```text
 /governance/warden
@@ -59,9 +59,9 @@ Open questions before HTTP parity:
 
 ## Shared Declaration And Overrides
 
-The preferred future path is one surface facet declaration interpreted by each surface that chooses to support it. Surface-specific hints may be added under surface-qualified keys such as `mcp`, `cli`, or `http` only when real evidence shows the shared declaration is insufficient.
+The preferred future path is one trailhead declaration interpreted by each surface that chooses to support it. Surface-specific hints may be added under surface-qualified keys such as `mcp`, `cli`, or `http` only when real evidence shows the shared declaration is insufficient.
 
-Do not add generic `overlapsWith`, `facet()`, or adapter-kit-owned facet configuration to make parity easier.
+Do not add generic `overlapsWith`, `facet()`, or adapter-kit-owned trailhead configuration to make parity easier.
 
 ## Follow-Up Trigger
 

--- a/docs/surfaces/surface-facets.md
+++ b/docs/surfaces/surface-facets.md
@@ -1,39 +1,39 @@
-# Surface Facets
+# Trailheads
 
-Surface facets group and select without merging. They expose related trails through one surface affordance while preserving the trails themselves. They are useful when a dense topo is still semantically clear but a surface becomes hard to scan.
+Trailheads group and select without merging. They expose related trails through one surface affordance while preserving the trails themselves. They are useful when a dense topo is still semantically clear but a surface becomes hard to scan.
 
-MCP hits this pressure first. MCP clients often load tool names, descriptions, input schemas, output schemas, and examples into agent context. A flat one-trail-one-tool projection stays faithful, but it can make a dense operator surface expensive to inspect. A surface facet lets the surface say "these trails belong together here" while the trail contracts remain the source of truth.
+MCP hits this pressure first. MCP clients often load tool names, descriptions, input schemas, output schemas, and examples into agent context. A flat one-trail-one-tool projection stays faithful, but it can make a dense operator surface expensive to inspect. A trailhead lets the surface say "these trails belong together here" while the trail contracts remain the source of truth.
 
-Surface facets are not a core `Facet` primitive. Do not look for `facet()`, do not create a shared `Facet` type, and do not add facet authoring configuration to adapter-kit.
+Trailheads are not a core `Facet` primitive. Do not look for `facet()`, do not create a shared `Facet` type, and do not add trailhead authoring configuration to adapter-kit.
 
-A facet is a surface accommodation on the entry axis: one grouped surface entry over several trails. It is not an alternate approach to one trail. Aliases and input mappings are N-to-1 accommodations that converge on one trail contract; facets are 1-to-N accommodations that gather several trails while preserving member identity. See [ADR-0050](../adr/0050-surface-accommodations-preserve-trail-identity.md) and [Surface Accommodations](surface-accommodations.md) for the full vocabulary.
+A trailhead is a surface accommodation on the entry axis: one grouped surface entry over several trails. It is not an alternate approach to one trail. Aliases and input mappings are N-to-1 accommodations that converge on one trail contract; trailheads are 1-to-N accommodations that gather several trails while preserving member identity. See [ADR-0050](../adr/0050-surface-accommodations-preserve-trail-identity.md) and [Surface Accommodations](surface-accommodations.md) for the full vocabulary.
 
 ## When To Use One
 
-Use a surface facet when:
+Use a trailhead when:
 
 - the underlying trails are still the right product boundary;
 - a surface has too many adjacent affordances for agents or users to scan cheaply;
 - the grouped affordance can keep the original trail ID visible at invocation and response time;
 - the surface can expose resolved metadata so agents can inspect membership without reading source.
 
-Do not use a surface facet when:
+Do not use a trailhead when:
 
 - you are really trying to create a new domain operation;
 - grouping would hide important trail identity or output shape;
 - direct trail projection is already clear enough;
 - you need CLI or HTTP parity before MCP has proved the pattern for your app.
 
-The fork test still applies. If a grouped affordance would merge contracts, hide which trail is selected, or introduce an action vocabulary such as `{ action: "create" | "delete" }`, split the capability into distinct trails or a composing trail first. A facet may group and select; it must not merge and obscure.
+The fork test still applies. If a grouped affordance would merge contracts, hide which trail is selected, or introduce an action vocabulary such as `{ action: "create" | "delete" }`, split the capability into distinct trails or a composing trail first. A trailhead may group and select; it must not merge and obscure.
 
 That boundary has two parts:
 
-- **Semantic:** the facet does not change member intent, permits, errors, outputs, lifecycle, or side effects.
-- **Structural:** the facet keeps member trail identity visible at invocation and response time.
+- **Semantic:** the trailhead does not change member intent, permits, errors, outputs, lifecycle, or side effects.
+- **Structural:** the trailhead keeps member trail identity visible at invocation and response time.
 
 ## MCP Authoring Shape
 
-`@ontrails/mcp` accepts `facets` in the surface options:
+`@ontrails/mcp` accepts the `facets` option in surface options:
 
 ```typescript
 import type { McpSurfaceFacetMap } from '@ontrails/mcp';
@@ -61,11 +61,11 @@ await surface(graph, {
 });
 ```
 
-Prefer explicit lists for editorial groups. Glob selectors such as `topo.*` reuse the normal surface filtering grammar, but broad selectors need more care: membership drift can make descriptions stale and can create facet overlap.
+Prefer explicit lists for editorial groups. Glob selectors such as `topo.*` reuse the normal surface filtering grammar, but broad selectors need more care: membership drift can make descriptions stale and can create trailhead overlap.
 
 ## MCP Projection Shape
 
-Each MCP surface facet projects as one MCP tool named from the topo name and facet ID. A `governance` facet in topo `trails` derives `trails_governance`.
+Each MCP trailhead projects as one MCP tool named from the topo name and trailhead ID. A `governance` trailhead in topo `trails` derives `trails_governance`.
 
 The input schema requires a trail discriminator plus the selected trail input:
 
@@ -92,15 +92,15 @@ Successful outputs are correlated with the selected trail:
 }
 ```
 
-That envelope is intentional. A facet can contain trails with different output schemas, so the returned trail ID must stay visible for agents and downstream readers. If a proposed grouped tool would remove that correlation, it has become a trail fork rather than a facet.
+That envelope is intentional. A trailhead can contain trails with different output schemas, so the returned trail ID must stay visible for agents and downstream readers. If a proposed grouped tool would remove that correlation, it has become a trail fork rather than a trailhead.
 
 ## Visibility And Overlap
 
-Trail visibility remains authoritative. A facet may narrow the projection, but it cannot make an internal trail public. If a public facet selector matches an internal trail, runtime projection omits that internal member.
+Trail visibility remains authoritative. A trailhead may narrow the projection, but it cannot make an internal trail public. If a public trailhead selector matches an internal trail, runtime projection omits that internal member.
 
-Facet selector overlap is treated as drift. Narrow the selectors instead of adding an escape hatch. The rejected shape is `overlapsWith`; it would let a facet map silence ambiguity without clarifying ownership.
+Trailhead selector overlap is treated as drift. Narrow the selectors instead of adding an escape hatch. The rejected shape is `overlapsWith`; it would let a map silence ambiguity without clarifying ownership.
 
-When a facet intentionally spans visibility tiers, record the acknowledgement:
+When a trailhead intentionally spans visibility tiers, record the acknowledgement:
 
 ```typescript
 const facets = {
@@ -116,7 +116,7 @@ The acknowledgement does not widen runtime behavior. It only tells governance th
 
 ## Description Drift
 
-Facet descriptions are authored prose over resolved membership. If the member set changes, the description may become false even when every individual trail is valid.
+Trailhead descriptions are authored prose over resolved membership. If the member set changes, the description may become false even when every individual trail is valid.
 
 Use `descriptionStableThrough` only when the description is intentionally stable through a known member-set hash. Do not use it as routine noise suppression.
 
@@ -137,16 +137,16 @@ Use MCP resources for cold context. The default MCP surface exposes:
 - `trails://surface-map` for the resolved MCP surface projection;
 - `trails://examples/<trailId>` for structured examples on exposed trails.
 
-The surface map includes ordinary tools and facet tools. Facet entries expose `facetId`, `memberTrailIds`, input/output schemas, annotations, and deferred-loading hints.
+The surface map includes ordinary tools and trailhead tools. Trailhead entries expose `facetId`, `memberTrailIds`, input/output schemas, annotations, and deferred-loading hints.
 
 The phrase is **MCP resources**. Trails `resource()` still means an infrastructure dependency declared on a trail contract.
 
 ## Adapter-Kit Boundary
 
-Adapter-kit does not author surface facets. It may expose raw adapter evidence, such as `adapterType` and target conformance paths, that future surface or governance checks can interpret against resolved projection metadata.
+Adapter-kit does not author trailheads. It may expose raw adapter evidence, such as `adapterType` and target conformance paths, that future surface or governance checks can interpret against resolved projection metadata.
 
-If an adapter claims grouped affordances later, the validator should consume resolved surface data: facet ID, member trail IDs, effective visibility, description, member-set hash, and `{ trail, output }` correlation shape. No adapter target is required to support grouping unless it explicitly claims that capability.
+If an adapter claims grouped affordances later, the validator should consume resolved surface data: trailhead ID, member trail IDs, effective visibility, description, member-set hash, and `{ trail, output }` correlation shape. No adapter target is required to support grouping unless it explicitly claims that capability.
 
 ## CLI And HTTP
 
-CLI and HTTP parity are deferred. CLI should be evaluated as command-group consolidation, not as an MCP-style generic action tool. HTTP should be evaluated as route-group projection, OpenAPI organization, or a rejected non-fit. See [Surface Facet Parity](surface-facet-parity.md) for the current decision.
+CLI and HTTP parity are deferred. CLI should be evaluated as command-group consolidation, not as an MCP-style generic action tool. HTTP should be evaluated as route-group projection, OpenAPI organization, or a rejected non-fit. See [Trailhead Parity](surface-facet-parity.md) for the current decision.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -84,7 +84,7 @@ Trail examples are projected as structured metadata under `_meta["ontrails/examp
 
 Cold context is projected through MCP resources, not extra Trails resources. `surface(graph)` and `createServer(graph)` expose MCP resources by default:
 
-- `trails://surface-map` lists the resolved MCP tool projection, including ordinary tools, facet tools, schemas, versions, deferred hints, and member trail IDs.
+- `trails://surface-map` lists the resolved MCP tool projection, including ordinary tools, trailhead tools, schemas, versions, deferred hints, and member trail IDs.
 - `trails://examples/<trailId>` exposes structured examples for exposed trails that define examples.
 - `trails://trail/<trailId>` exposes MCP-visible graph facts for an exposed trail when graph resources are enabled.
 
@@ -104,7 +104,7 @@ await surface(graph, {
 
 Graph resources are opt-in for general MCP hosts because they widen cold context for every exposed trail. The Trails operator enables them so agents can inspect high-signal graph facts without invoking another tool.
 
-Facet definitions may set `mcp: { loading: 'deferred' }`. In this release, deferred loading is a compatibility hint under `_meta["ontrails/deferred"]`; the MCP tool schema remains present so clients that do not understand deferred loading continue to work.
+Trailhead definitions may set `mcp: { loading: 'deferred' }`. In this release, deferred loading is a compatibility hint under `_meta["ontrails/deferred"]`; the MCP tool schema remains present so clients that do not understand deferred loading continue to work.
 
 ## Tool naming
 

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -319,7 +319,11 @@ describe('wardenTermRewriteClasses', () => {
       metadata: {
         concern: 'meta',
         depth: 'source',
-        fix: { class: 'term-rewrite', safety: 'safe' },
+        fix: {
+          class: 'term-rewrite',
+          safety: 'safe',
+          scanTargets: { extensions: ['.md'] },
+        },
         invariant: 'Project-local Warden term rewrites can feed Regrade.',
         lifecycle: { retireWhen: 'migration completes', state: 'temporary' },
         scope: 'repo-local',
@@ -332,6 +336,7 @@ describe('wardenTermRewriteClasses', () => {
     const cls = createWardenTermRewriteClass(rule);
 
     expect(cls?.id).toBe('term-rewrite:project-local-term-rewrite');
+    expect(cls?.scanTargets).toEqual({ extensions: ['.md'] });
   });
 
   test('preserves Warden scan-target filtering for Warden-backed classes', () => {

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -209,6 +209,24 @@ type WardenEditApplication =
   | { readonly ok: true; readonly nextSource: string }
   | { readonly ok: false; readonly reason: string };
 
+const regradeScanTargetsFromWardenFix = (
+  scanTargets: NonNullable<
+    NonNullable<ReturnType<typeof getWardenRuleMetadata>>['fix']
+  >['scanTargets']
+): RegradeScanTargets | undefined => {
+  if (scanTargets === undefined) {
+    return undefined;
+  }
+  return {
+    ...(scanTargets.extensions === undefined
+      ? {}
+      : { extensions: scanTargets.extensions }),
+    ...(scanTargets.ignoredDirectories === undefined
+      ? {}
+      : { ignoredDirectories: scanTargets.ignoredDirectories }),
+  };
+};
+
 const diagnosticNote = (diagnostic: WardenDiagnostic): string => {
   const reason = diagnostic.fix?.reason ?? diagnostic.message;
   return `${diagnostic.rule}:${diagnostic.line}: ${reason}`;
@@ -366,6 +384,7 @@ export const createWardenTermRewriteClass = (
   if (metadata?.fix?.class !== TERM_REWRITE_FIX_CLASS) {
     return null;
   }
+  const scanTargets = regradeScanTargetsFromWardenFix(metadata.fix.scanTargets);
 
   return {
     apply: (
@@ -456,6 +475,7 @@ export const createWardenTermRewriteClass = (
     },
     describe: `${rule.description} (${metadata.fix.safety} ${metadata.fix.class})`,
     id: `${metadata.fix.class}:${rule.name}`,
+    ...(scanTargets === undefined ? {} : { scanTargets }),
   };
 };
 

--- a/packages/warden/src/__tests__/trail-fork-coaching.test.ts
+++ b/packages/warden/src/__tests__/trail-fork-coaching.test.ts
@@ -40,7 +40,7 @@ export const usersManage = trail('users.manage', {
     expect(diagnostics[0]?.message).toContain('input.action');
     expect(diagnostics[0]?.message).toContain('trail fork');
     expect(diagnostics[0]?.message).toContain('change semantics');
-    expect(diagnostics[0]?.message).toContain('surface facet');
+    expect(diagnostics[0]?.message).toContain('trailhead');
   });
 
   test('warns when a trail branches on an extracted input schema', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -18,6 +18,7 @@ export type {
   WardenFixCapability,
   WardenFixClass,
   WardenFixEdit,
+  WardenFixScanTargets,
   WardenFixSafety,
   WardenGuidance,
   WardenGuidanceLink,

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -77,6 +77,7 @@ export type {
   WardenFixCapability,
   WardenFixClass,
   WardenFixEdit,
+  WardenFixScanTargets,
   WardenFixSafety,
   WardenGuidance,
   WardenGuidanceLink,

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -610,7 +610,7 @@ const builtinWardenRuleMetadataInput = {
     guidance: {
       docs: [
         {
-          label: 'Surface Facets ADR',
+          label: 'Trailheads ADR',
           path: 'docs/adr/drafts/20260603-surface-facets-shape-dense-topos.md',
         },
       ],
@@ -620,10 +620,10 @@ const builtinWardenRuleMetadataInput = {
         'Record explicit visibility-widening acceptance and stable-description metadata when a facet intentionally widens visibility.',
       ],
       summary:
-        'Keep surface facet maps reviewable before they reach MCP projection.',
+        'Keep trailhead maps reviewable before they reach MCP projection.',
     },
     invariant:
-      'Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors.',
+      'Trailhead maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors.',
     tier: 'source-static',
   },
   'trail-fork-coaching': {

--- a/packages/warden/src/rules/surface-facet-coherence.ts
+++ b/packages/warden/src/rules/surface-facet-coherence.ts
@@ -356,7 +356,7 @@ export const surfaceFacetCoherence: WardenRule = {
     return diagnostics;
   },
   description:
-    'Coach surface facet maps away from selector overlap, hidden visibility widening, and drift-prone dynamic selectors.',
+    'Coach trailhead maps away from selector overlap, hidden visibility widening, and drift-prone dynamic selectors.',
   name: RULE_NAME,
   severity: 'warn',
 };

--- a/packages/warden/src/rules/trail-fork-coaching.ts
+++ b/packages/warden/src/rules/trail-fork-coaching.ts
@@ -554,7 +554,7 @@ const diagnosticForField = (
     .map((option) => `"${option}"`)
     .join(
       ', '
-    )}). This may be a trail fork hidden as a surface accommodation. If branches change semantics (intent, permits, errors, outputs, lifecycle, or side effects) or structure (selected trail identity), split them into distinct trails, a composing trail, or a surface facet that preserves member identity.`,
+    )}). This may be a trail fork hidden as a surface accommodation. If branches change semantics (intent, permits, errors, outputs, lifecycle, or side effects) or structure (selected trail identity), split them into distinct trails, a composing trail, or a trailhead that preserves member identity.`,
   rule: RULE_NAME,
   severity: 'warn',
 });

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -131,6 +131,20 @@ export interface WardenFixEdit {
 }
 
 /**
+ * Source targets a fix class can inspect when projected into downstream tools.
+ *
+ * Warden itself decides which committed files it scans. This metadata is for
+ * consumers such as Regrade that need to derive a narrower collection before
+ * invoking the rule against an explicit downstream root.
+ */
+export interface WardenFixScanTargets {
+  /** Source extensions the fix class can inspect. */
+  readonly extensions?: readonly string[] | undefined;
+  /** Directory names to skip during downstream collection. */
+  readonly ignoredDirectories?: readonly string[] | undefined;
+}
+
+/**
  * Per-finding fix metadata attached to a diagnostic.
  *
  * Authored on the diagnostic at construction because only the rule that matched
@@ -164,6 +178,8 @@ export interface WardenFixCapability {
   readonly class: WardenFixClass;
   /** Default safety for fixes this rule emits. */
   readonly safety: WardenFixSafety;
+  /** Downstream scan targets for tools that project this fix capability. */
+  readonly scanTargets?: WardenFixScanTargets | undefined;
 }
 
 /**

--- a/packages/warden/src/trails/surface-facet-coherence.trail.ts
+++ b/packages/warden/src/trails/surface-facet-coherence.trail.ts
@@ -18,7 +18,7 @@ export const surfaceFacetCoherenceTrail = wrapRule({
   },
 };`,
       },
-      name: 'Reviewable surface facet map',
+      name: 'Reviewable trailhead map',
     },
   ],
   rule: surfaceFacetCoherence,

--- a/packages/warden/src/trails/trail-fork-coaching.trail.ts
+++ b/packages/warden/src/trails/trail-fork-coaching.trail.ts
@@ -10,7 +10,7 @@ export const trailForkCoachingTrail = wrapRule({
             filePath: 'users.ts',
             line: 9,
             message:
-              'Trail "users.manage" branches on input.action ("create", "delete"). This may be a trail fork hidden as a surface accommodation. If branches change semantics (intent, permits, errors, outputs, lifecycle, or side effects) or structure (selected trail identity), split them into distinct trails, a composing trail, or a surface facet that preserves member identity.',
+              'Trail "users.manage" branches on input.action ("create", "delete"). This may be a trail fork hidden as a surface accommodation. If branches change semantics (intent, permits, errors, outputs, lifecycle, or side effects) or structure (selected trail identity), split them into distinct trails, a composing trail, or a trailhead that preserves member identity.',
             rule: 'trail-fork-coaching',
             severity: 'warn',
           },

--- a/packages/wayfinder/README.md
+++ b/packages/wayfinder/README.md
@@ -17,7 +17,7 @@ The package exports `wayfinderTopo` plus individual graph-read trails.
 | `wayfind.resources` | List resource summaries and declaring trails. |
 | `wayfind.signals` | List signal summaries, producers, and consumers. |
 | `wayfind.surfaces` | List saved surface membership facts. |
-| `wayfind.facets` | List resolved surface facet metadata and members. |
+| `wayfind.facets` | List resolved trailhead metadata and members. |
 | `wayfind.versions` | List current and historical trail version records. |
 | `wayfind.examples` | List saved examples without executing trails. |
 | `wayfind.errors` | List saved trail error facts with provenance and completeness. |
@@ -58,7 +58,7 @@ const result = await wayfindOverviewTrail.blaze(
 );
 ```
 
-The output includes counts for trails, contours, resources, signals, surfaces, facets, versions, and examples, along with the TopoGraph artifact source.
+The output includes counts for trails, contours, resources, signals, surfaces, trailheads, versions, and examples, along with the TopoGraph artifact source.
 
 ## Typed Filtering
 
@@ -83,7 +83,7 @@ const result = await wayfindSearchTrail.blaze(
 );
 ```
 
-Supported filters include entity kind, exact ID, ID glob, text query, ID prefix, namespace, intent, surface, facet, versioning, example coverage, resource usage, and signal usage. Use `createWayfinderGraphEntityPredicate` or `filterWayfinderEntityRefs` when matching relationship filters directly in code so facet membership and derived surfaces are evaluated with graph-derived context.
+Supported filters include entity kind, exact ID, ID glob, text query, ID prefix, namespace, intent, surface, trailhead, versioning, example coverage, resource usage, and signal usage. Use `createWayfinderGraphEntityPredicate` or `filterWayfinderEntityRefs` when matching relationship filters directly in code so trailhead membership and derived surfaces are evaluated with graph-derived context.
 
 Example coverage filters are evaluated against the entity being returned. `wayfind.examples` widens parent trail matches to include current examples plus historical version examples, exact historical-version matches return only that version's examples, and exact current-version matches return the current entry examples. `exampleCoverage: false` is intentionally not widened into covered historical version examples.
 
@@ -163,13 +163,13 @@ apps/trails/src/trails/compile.ts
 
 When saved graph artifacts are missing, `outline` still renders source facts and emits an actionable diagnostic with the compile command shape, including the app module, root directory, and required `topo:write` permit scope. That diagnostic is a prompt to refresh graph evidence; it is not required for source-only navigation.
 
-## Surfaces, Facets, Versions, And Examples
+## Surfaces, Trailheads, Versions, And Examples
 
-`wayfind.surfaces` includes both directly rendered trail surfaces and facet-rendered surfaces. `wayfind.facets` returns facet membership, visibility, and descriptions. `wayfind.versions` returns current and historical trail versions sorted by trail ID and numeric version. `wayfind.examples` lists saved examples without executing any trail.
+`wayfind.surfaces` includes both directly rendered trail surfaces and trailhead-rendered surfaces. `wayfind.facets` returns trailhead membership, visibility, and descriptions. `wayfind.versions` returns current and historical trail versions sorted by trail ID and numeric version. `wayfind.examples` lists saved examples without executing any trail.
 
 ## Nearby, Impact, And Diff
 
-`wayfind.nearby` returns the direct saved graph relationships around one entity. The relation graph is typed and deterministic: resources point to trails that use them, signals point to producing or consuming trails, surfaces and facets point to rendered member trails, composed trails point to their composers, and trails point to saved version records.
+`wayfind.nearby` returns the direct saved graph relationships around one entity. The relation graph is typed and deterministic: resources point to trails that use them, signals point to producing or consuming trails, surfaces and trailheads point to rendered member trails, composed trails point to their composers, and trails point to saved version records.
 
 ```ts
 import {
@@ -203,6 +203,6 @@ await wayfindDiffTrail.blaze(
 );
 ```
 
-`wayfind.impact` walks those typed relation edges with `downstream`, `upstream`, or `both` direction. `downstream` follows the stored edge direction, which is oriented from contract substrate to affected graph members: resource-to-trail, signal-to-trail, surface-to-trail, facet-to-trail, composed-trail-to-composer, and trail-to-version. `wayfind.diff` compares two saved TopoGraph artifacts with `deriveTopoGraphDiff`; it requires an explicit `againstDir` or `againstRootDir` baseline instead of deriving either graph from live source.
+`wayfind.impact` walks those typed relation edges with `downstream`, `upstream`, or `both` direction. `downstream` follows the stored edge direction, which is oriented from contract substrate to affected graph members: resource-to-trail, signal-to-trail, surface-to-trail, trailhead-to-trail, composed-trail-to-composer, and trail-to-version. `wayfind.diff` compares two saved TopoGraph artifacts with `deriveTopoGraphDiff`; it requires an explicit `againstDir` or `againstRootDir` baseline instead of deriving either graph from live source.
 
 These queries are intentionally graph-read only. They do not provide semantic search, signposts, or implications yet.

--- a/plugin/rules/lexicon.md
+++ b/plugin/rules/lexicon.md
@@ -13,7 +13,7 @@ Use Trails-branded terms consistently. These are non-negotiable in code, docs, a
 | `surface` | serve, mount, start, wire up |
 | `surface accommodation` | surface workaround, alternate behavior, generic route vocabulary |
 | `surface entry` | endpoint, route, action (when cross-surface) |
-| `approach` | route, path, facet (when cross-surface) |
+| `approach` | route, path, trailhead (when cross-surface) |
 | `resource` | provider, dependency, service |
 | `signal` | event, notification, message |
 | `layer` | gate, middleware |
@@ -24,7 +24,7 @@ Use Trails-branded terms consistently. These are non-negotiable in code, docs, a
 | `survey` | introspect, inspect, describe |
 | `guide` | docs, help, manual |
 | `adapter` | connector, bridge, transport shim |
-| `surface facet` | facet primitive, facet API, facet package |
+| `trailhead` | `facet` primitive, `facet` API, `facet` package |
 | `MCP resources` | Trails resources, dependencies, services (when referring to MCP protocol resources) |
 
 ## When Writing
@@ -36,7 +36,7 @@ Use Trails-branded terms consistently. These are non-negotiable in code, docs, a
 - Standard terms stay standard: `config`, `Result`, and `Error`.
 - `connector` is retired public taxonomy. Use `adapter` for a thin runtime-specific layer.
 - `resource` is a branded term: `resource()` defines a typed infrastructure dependency. Use `resources: [...]` on trail specs to declare dependencies. Do not use "resource" for generic helpers or utility classes.
-- `facet` is qualified projection vocabulary. Use `surface facet` for surface-side grouped projection and `schema facet` only as descriptive schema-slice prose. Do not invent a core `Facet` primitive, `facet()`, or adapter-kit facet config.
-- `surface accommodation` is the cross-surface family for aliases, input mappings, and surface facets. Use the ADR-0050 fork test before suggesting one.
+- `facet` is qualified projection vocabulary. Use `trailhead` for surface-side grouped projection and `schema facet` only as descriptive schema-slice prose. Do not invent a core `Facet` primitive, `facet()`, or adapter-kit `facet` config.
+- `surface accommodation` is the cross-surface family for aliases, input mappings, and trailheads. Use the ADR-0050 fork test before suggesting one.
 - `surface entry` and `approach` are named concepts, not necessarily authored primitives. Do not turn them into APIs unless the repo has already done so.
 - `MCP resources` are MCP protocol resources for cold context. Keep the qualifier when writing about `trails://surface-map` or example resources so they do not collide with Trails `resource()` declarations.

--- a/plugin/skills/trails/SKILL.md
+++ b/plugin/skills/trails/SKILL.md
@@ -3,7 +3,7 @@ name: trails
 description: Build with the Trails framework — define trail contracts, open CLI/MCP surfaces, test with examples, debug errors, migrate codebases, run governance. Use when creating trails, adding surfaces, testing, debugging Trails errors, migrating to Trails, running warden, or any work involving @ontrails/* packages.
 metadata:
   trails:
-    version: 1.0.0-beta.25
+    version: 1.0.0-beta.30
 ---
 
 # Trails
@@ -172,7 +172,7 @@ await surface(graph);
 
 Use `cli` on a trail only for canonical command overrides or trail-owned aliases that still normalize into the same trail contract. String aliases are sibling leaf aliases (`find` beside `search`); string-array aliases are absolute command paths (`['wf', 'search']`). App-owned compatibility aliases belong in CLI surface options and should also be exported from the app module as `cliAliases` or `trailsCliAliases` so compile, validate, Wayfinder, and `trails schema` inspect the same routes the runtime CLI accepts.
 
-Treat aliases, future input mappings, and surface facets as **surface accommodations**: projection-level fit adjustments, not alternate behavior. The trail stays the capability. A surface entry is the invocable affordance on a surface; an approach is the way a caller reaches it. Aliases add alternate approaches to the same trail, input mappings normalize surface-shaped input into the same trail input, and surface facets group several trails into one entry while preserving the selected trail ID. Use the ADR-0050 test: if the fit would change intent, permits, errors, outputs, lifecycle, side effects, or hide which trail is running, call it a trail fork and author a distinct or composing trail instead.
+Treat aliases, future input mappings, and trailheads as **surface accommodations**: projection-level fit adjustments, not alternate behavior. The trail stays the capability. A surface entry is the invocable affordance on a surface; an approach is the way a caller reaches it. Aliases add alternate approaches to the same trail, input mappings normalize surface-shaped input into the same trail input, and trailheads group several trails into one entry while preserving the selected trail ID. Use the ADR-0050 test: if the fit would change intent, permits, errors, outputs, lifecycle, side effects, or hide which trail is running, call it a trail fork and author a distinct or composing trail instead.
 
 Classify surface-fit work before editing:
 
@@ -180,7 +180,7 @@ Classify surface-fit work before editing:
 | --- | --- |
 | One trail, another path, no input reshape | Alias |
 | One trail, surface-shaped input that normalizes honestly | Input mapping |
-| Many trails, one grouped entry, member trail identity preserved | Surface facet |
+| Many trails, one grouped entry, member trail identity preserved | Trailhead |
 | Different intent, permits, errors, outputs, lifecycle, side effects, or hidden member identity | Distinct trail or composing trail |
 
 **MCP**: Tool names from trail IDs, JSON Schema from Zod, annotations from intent, idempotency, and description.
@@ -190,7 +190,7 @@ import { surface } from '@ontrails/mcp';
 await surface(graph);
 ```
 
-Dense MCP surfaces may use **surface facets** to group related trails into fewer agent-facing tools. A surface facet is surface-side projection configuration, not a core `Facet` primitive and not a new domain operation. It groups and selects without merging. Author it in MCP surface options, call it with `{ trail, input }`, and expect successful results as `{ trail, output }` so the underlying trail stays visible.
+Dense MCP surfaces may use **trailheads** to group related trails into fewer agent-facing tools. A trailhead is surface-side projection configuration, not a core `Facet` primitive and not a new domain operation. It groups and selects without merging. Author it in MCP surface options, call it with `{ trail, input }`, and expect successful results as `{ trail, output }` so the underlying trail stays visible.
 
 ```typescript
 await surface(graph, {
@@ -205,7 +205,7 @@ await surface(graph, {
 });
 ```
 
-Use `trails://surface-map` and per-trail MCP resources for cold context before guessing at grouped affordances. Adapter-kit may validate resolved projection evidence for future surface adapters, but it does not define or author facets. Do not invent `facet()`, `overlapsWith`, or adapter-kit facet config.
+Use `trails://surface-map` and per-trail MCP resources for cold context before guessing at grouped affordances. Adapter-kit may validate resolved projection evidence for future surface adapters, but it does not define or author trailheads. Do not invent `facet()`, `overlapsWith`, or adapter-kit `facet` config.
 
 **HTTP**: Routes from trail IDs (dots become path segments), verbs from intent, error responses from taxonomy. Use Hono for framework portability or Bun-native HTTP when you want Bun serving without a third-party runtime; both share the `@ontrails/http` route/fetch kernel.
 

--- a/plugin/skills/trails/references/mcp-surface.md
+++ b/plugin/skills/trails/references/mcp-surface.md
@@ -65,9 +65,9 @@ blaze: async (input, ctx) => {
 
 Trail `examples` are included in MCP tool metadata. Agents use these to understand expected input/output shapes and plan tool usage without trial and error.
 
-## Surface Facets
+## Trailheads
 
-Use surface facets only when a dense MCP surface needs grouped affordances. A surface facet is an MCP projection over existing trails, not a new trail, graph node, package category, or core `Facet` primitive. It groups and selects without merging.
+Use trailheads only when a dense MCP surface needs grouped affordances. A trailhead is an MCP projection over existing trails, not a new trail, graph node, package category, or core `Facet` primitive. It groups and selects without merging.
 
 ```typescript
 import type { McpSurfaceFacetMap } from '@ontrails/mcp';
@@ -86,7 +86,7 @@ await surface(graph, {
 });
 ```
 
-Facet tools are called with a trail discriminator and nested input:
+Trailhead tools are called with a trail discriminator and nested input:
 
 ```json
 {
@@ -115,7 +115,7 @@ Rules for agents:
 - Check both trail fork boundaries: no changed intent, permits, errors, outputs, lifecycle, or side effects, and no hidden member trail identity.
 - Prefer explicit selector lists for editorial groups.
 - Treat selector overlap and description drift as governance findings, not routine silencing candidates.
-- Do not invent `facet()`, `overlapsWith`, or adapter-kit facet config.
+- Do not invent `facet()`, `overlapsWith`, or adapter-kit `facet` config.
 - Do not assume CLI or HTTP parity; those surfaces have separate economics.
 
 ## MCP Resources
@@ -124,7 +124,7 @@ MCP resources are protocol resources for cold context. They are not Trails `reso
 
 By default, `surface(graph)` and `createServer(graph)` expose:
 
-- `trails://surface-map` for the resolved MCP projection, including facet IDs, member trail IDs, schemas, examples metadata, versions, and deferred hints.
+- `trails://surface-map` for the resolved MCP projection, including `facetId` values, member trail IDs, schemas, examples metadata, versions, and deferred hints.
 - `trails://examples/<trailId>` for structured examples on exposed trails.
 
 Use `mcpResources: false` only when the host intentionally wants no MCP resource capability. Use `mcpResources: { examples: false, surfaceMap: true }` to keep a narrower resource set.
@@ -169,6 +169,6 @@ Each `McpToolDefinition` includes:
 - `description` — trail description with first example appended
 - `handler` — async function that runs the full `executeTrail` pipeline
 - `trailId` — the original trail ID this tool was derived from (useful for filtering and introspection)
-- `facetId` / `memberTrailIds` — present when the tool was derived from a surface facet
+- `facetId` / `memberTrailIds` — present when the tool was derived from a trailhead
 
 This gives you the raw tool definitions to register manually while still benefiting from automatic schema derivation and annotation mapping.

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -71,7 +71,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `cli-command-route-coherence` (error, topo/topo-aware, external): CLI command routes and aliases resolve to one coherent trail contract. Guidance: Keep every CLI command route and alias normalized into one trail contract.
 - `duplicate-public-contract` (warn, topo/topo-aware, external): Public surface trails should not expose duplicate normalized contract facts. Guidance: Keep duplicate public contract facts from drifting into separate capabilities.
 - `library-projection-coherence` (error, topo/topo-aware, external): Resolved library projection exports are collision-free and target existing trails. Guidance: Keep resolved library projection exports collision-free and attached to one trail contract.
-- `surface-facet-coherence` (warn, source/source-static, external): Surface facet maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep surface facet maps reviewable before they reach MCP projection.
+- `surface-facet-coherence` (warn, source/source-static, external): Trailhead maps avoid selector overlap, hidden visibility widening, and drift-prone dynamic selectors. Guidance: Keep trailhead maps reviewable before they reach MCP projection.
 - `trail-fork-coaching` (warn, all/source-static, advisory): Trails avoid hiding distinct capabilities behind branching action or operation inputs. Guidance: Keep surface accommodations from hiding several capabilities behind one branching trail input.
 
 ### Permits

--- a/scripts/vocab-cutover-map.ts
+++ b/scripts/vocab-cutover-map.ts
@@ -359,10 +359,10 @@ export const auditRules: readonly VocabAuditRule[] = [
   {
     allowMatches: surfaceTermAllowedMatches,
     description:
-      'Old boundary terminology still uses trailhead instead of surface',
+      'Old surface API terminology still uses trailhead entrypoints or keys instead of surface',
     excludePaths: reviewedSurfaceMentionPaths,
     id: 'surface-term',
-    pattern: String.raw`\b[Tt]railhead(s)?\b|TRAILHEAD_KEY|__trails_trailhead`,
+    pattern: String.raw`\btrailhead\(|\bTRAILHEAD_KEY\b|__trails_trailhead|\btrailhead\.lock\b|_trailhead\.json`,
   },
   {
     description:


### PR DESCRIPTION
## Context

TRL-1017 dogfoods the first v1 vocabulary family through Regrade using project-local Warden rules: facet prose moves to trailhead while live API identifiers remain unchanged.

## What Changed

- Added Warden fix `scanTargets` metadata and projected it into Regrade class scan targets.
- Added `.trails/rules/v1-vocab-facet.ts` with a safe prose rewrite class and a review-inventory class.
- Dogfooded the safe class across current-facing docs, repo skills, plugin skills, and Warden guidance.
- Preserved live API identifiers such as `facets`, `facetId`, `McpSurfaceFacetMap`, `wayfind.facets`, and `surface-facet-coherence`.
- Updated generated Warden guidance, ADR decision map context, and plugin Trails skill metadata.

## Verification

- `bun scripts/vocab-cutover-audit.ts --rule surface-term`
- `bun scripts/vocab-cutover-audit.ts`
- `bun apps/trails/bin/trails.ts regrade --root-dir . --class-ids term-rewrite:v1-vocab-facet-safe-prose --include-entries all --json` returned 0 matched, 0 rewritten, 0 review after apply.
- `bun apps/trails/bin/trails.ts regrade --root-dir . --class-ids term-rewrite:v1-vocab-facet-review-inventory --include-entries all --json` returned 0 matched, 0 rewritten, 0 review.
- `bun run check`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run changeset:check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun run plugin:metadata:check`
- `bun scripts/adr.ts check`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`

## Review

Local review loop found one P2 topology issue and one relevant P3 mirror-coverage issue. Both were fixed before submit. No remaining local P0/P1/P2 findings are known.