### PR TITLE
feat(regrade): add transition reports to cli and mcp

### DIFF
--- a/.agents/memory/decisions.md
+++ b/.agents/memory/decisions.md
@@ -198,3 +198,13 @@ Merit aside: a *gate* is a point (binary allow/deny on a path); the job is a *br
 **Basis:** Gate-on-demonstrated-need applied to vocabulary; tenets "add with intent" + the evaluation hierarchy (codify after the pattern recurs in shipped code). Lewis's discipline.
 
 **Confidence:** High. Low cost to defer; reversible.
+
+### 2026-06-27 Regrade verdict vocabulary: `modified` / `skipped` / `deferred`
+
+**Question:** What are the regrade verdict words, and do the form (triage) and occurrence (resolution) levels share them?
+
+**Decision:** One verdict triple at **both** levels — verbs `modify` / `skip` / `defer`, stored states **`modified` / `skipped` / `deferred`**. The rollup over everything still `deferred` is **`open`** (retires the generic `review`). `preserve` survives only as an authored plan rule (a `preserve` match makes a use come out `skipped`); `capture` / `ignore` / `uncertain` / `review` retired as verdict words.
+
+**Basis (principles):** (1) name the level by the *record* (form vs occurrence), not the word, so the triple can be shared; (2) full-symmetric or full-distinct, never messy-partial (the old `preserve`-at-both-but-not-the-rest was the bug); (3) verdicts name the thing's resolved *state* (participles), which makes the set uniform and dissolves `pending`'s odd-one-out problem; (4) agent-native — the defer goes to a *judge* (agent first), so "needs judgment," not "needs human"; (5) a defer is an active decision (route to the judge), so `deferred`, not `pending`. Word calls: `modify` over `rename` (too narrow) and `update` (CRUD collision); `skip` over `keep` (fate-framing); `open` over `review` (agent-neutral, parallels the gate).
+
+**Confidence:** High. Full rationale: `.agents/notes/2026-06-27-regrade-verdict-vocabulary.md`; reflected in `.agents/notes/2026-06-26-regrade.md`. PR #831 was amended before merge so the new vocabulary regrade `run` contract uses this verdict set and a per-form triage map; the generic class-mode report keeps its existing `rewrite` / `needs-review` outcomes for compatibility.

--- a/.changeset/regrade-vocabulary-cli-mcp.md
+++ b/.changeset/regrade-vocabulary-cli-mcp.md
@@ -1,0 +1,9 @@
+---
+"@ontrails/regrade": patch
+"@ontrails/trails": patch
+---
+
+Add occurrence-level vocabulary regrade reports with plan, ledger,
+and completion-gate facts. The Trails `regrade` operator command now supports
+positional `<from> <to>` regrade runs and exposes the same capability through
+the curated MCP surface.

--- a/apps/trails/README.md
+++ b/apps/trails/README.md
@@ -18,7 +18,7 @@ Common workflows:
 - `trails wayfind`, `trails wayfind --trails --intent read`, `trails wayfind <id> --contract`, `trails wayfind <id> --deps`, `trails wayfind <id> --impact`, `trails wayfind pattern "wayfind.*"`, `trails wayfind query "release drift"`, `trails wayfind file <file> --outline`, and `trails wayfind diff ...` read graph artifacts and source outlines through Wayfinder for local navigation.
 - `trails schema <command...>` shows accepted CLI routes, aliases, flags, and schemas for an operator command.
 - `trails warden` runs Trails governance checks for contract and architecture drift.
-- `trails regrade --root-dir <path> --json` dry-runs downstream migration checks; add `--apply` only to write safe rewrites.
+- `trails regrade --root-dir <path> --json` dry-runs downstream migration checks; add `--apply` only to write safe rewrites. Use `trails regrade <from> <to> --root-dir <path> --json` for occurrence-level vocabulary regrade reports that include the authored plan, observed ledger, and completion gate. The same `regrade` trail is exposed through MCP for agent-driven migration checks.
 - `trails guide` remains available for compatibility; prefer `trails wayfind --source live --module <app-module>` or saved-artifact Wayfinder reads for agent navigation.
 
 Trails is contract-first: define trails once with typed input, Result output, examples, and meta; the framework derives CLI, MCP, HTTP, and future surfaces from the same contracts.

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -1,4 +1,13 @@
 import { describe, expect, test } from 'bun:test';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 import {
   MCP_EXAMPLES_RESOURCE_PREFIX,
@@ -29,6 +38,15 @@ const parseJson = (text: string | undefined): unknown => {
   return JSON.parse(text ?? 'null');
 };
 
+const makeTempDir = (): string =>
+  mkdtempSync(join(tmpdir(), `trails-mcp-regrade-test-${Date.now()}-`));
+
+const writeFile = (root: string, path: string, value: string): void => {
+  const filePath = join(root, path);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value);
+};
+
 const requireTool = (
   tools: ReturnType<typeof unwrapTools>,
   name: string
@@ -56,6 +74,7 @@ describe('Trails MCP surface shaping', () => {
       'trails_doctor',
       'trails_draft_promote',
       'trails_inspect',
+      'trails_regrade',
       'trails_release_check',
       'trails_release_smoke',
       'trails_revise',
@@ -113,6 +132,7 @@ describe('Trails MCP surface shaping', () => {
     const wayfindAdapters = requireTool(tools, 'trails_wayfind_adapters');
     const wayfindErrors = requireTool(tools, 'trails_wayfind_errors');
     const wayfindSearch = requireTool(tools, 'trails_wayfind_search');
+    const regrade = requireTool(tools, 'trails_regrade');
     const warden = requireTool(tools, 'trails_warden');
     const devClean = requireTool(tools, 'trails_dev_clean');
     const topoUnpin = requireTool(tools, 'trails_topo_unpin');
@@ -140,6 +160,20 @@ describe('Trails MCP surface shaping', () => {
     expect(wayfindSearch.annotations).toMatchObject({
       readOnlyHint: true,
       title: 'Find topo graph entities with typed filters',
+    });
+
+    expect(regrade.description).toBe(
+      'Run downstream migration checks and safe rewrites'
+    );
+    expect(regrade.annotations).toMatchObject({
+      title: 'Run downstream migration checks and safe rewrites',
+    });
+    expect(regrade.inputSchema).toMatchObject({
+      properties: {
+        from: expect.objectContaining({ type: 'string' }),
+        to: expect.objectContaining({ type: 'string' }),
+      },
+      type: 'object',
     });
 
     expect(warden.description).toBe('Run governance checks (lint + drift)');
@@ -179,9 +213,40 @@ describe('Trails MCP surface shaping', () => {
     expect(shapedTrailIds).not.toContain('completions');
     expect(shapedTrailIds).not.toContain('completions.__complete');
     expect(shapedTrailIds).toContain('wayfind.adapters');
+    expect(shapedTrailIds).toContain('regrade');
     expect(shapedTrailIds).toContain('wayfind.errors');
     expect(shapedTrailIds).not.toContain('wayfind.outline');
     expect(shapedTrailIds).not.toContain('wayfind.query');
+  });
+
+  test('executes regrade through the MCP tool handler', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'export const facet = "facet";\n');
+      const tools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
+      const regrade = requireTool(tools, 'trails_regrade');
+
+      const result = await regrade.handler(
+        { from: 'facet', rootDir: dir, to: 'trailhead' },
+        {}
+      );
+
+      expect(result.isError).toBeUndefined();
+      expect(result.structuredContent).toMatchObject({
+        run: {
+          plan: { from: 'facet', to: 'trailhead' },
+          report: {
+            modified: 2,
+            open: 2,
+          },
+        },
+      });
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
+        'facet'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
   });
 
   test('keeps app-authored facet selectors explicit enough for review', () => {
@@ -190,6 +255,7 @@ describe('Trails MCP surface shaping', () => {
     expect(Object.keys(trailsMcpFacets)).toEqual(['inspect']);
     expect(trailsMcpIncludedTrails).toContain('release.check');
     expect(trailsMcpIncludedTrails).toContain('release.smoke');
+    expect(trailsMcpIncludedTrails).toContain('regrade');
     expect(trailsMcpIncludedTrails).toContain('warden');
     expect(trailsMcpIncludedTrails).toContain('wayfind.adapters');
     expect(trailsMcpIncludedTrails).toContain('wayfind.diff');
@@ -208,6 +274,7 @@ describe('Trails MCP surface shaping', () => {
     const surfaceMap = resources.read(MCP_SURFACE_MAP_RESOURCE_URI);
     const runExampleUri = `${MCP_EXAMPLES_RESOURCE_PREFIX}${encodeURIComponent('run.example')}`;
     const wayfindSearchGraphUri = `${MCP_TRAIL_RESOURCE_PREFIX}${encodeURIComponent('wayfind.search')}`;
+    const regradeGraphUri = `${MCP_TRAIL_RESOURCE_PREFIX}${encodeURIComponent('regrade')}`;
 
     expect(resources.list.map((resource) => resource.uri)).toContain(
       MCP_SURFACE_MAP_RESOURCE_URI
@@ -220,6 +287,9 @@ describe('Trails MCP surface shaping', () => {
     );
     expect(resources.list.map((resource) => resource.uri)).toContain(
       wayfindSearchGraphUri
+    );
+    expect(resources.list.map((resource) => resource.uri)).toContain(
+      regradeGraphUri
     );
     const wayfindSearchGraph = parseJson(
       resources.read(wayfindSearchGraphUri)?.text
@@ -243,6 +313,24 @@ describe('Trails MCP surface shaping', () => {
       expect.objectContaining({
         name: 'trails_wayfind_search',
         trailId: 'wayfind.search',
+      }),
+    ]);
+    const regradeGraph = parseJson(resources.read(regradeGraphUri)?.text) as {
+      readonly intent?: string | undefined;
+      readonly tools?: readonly {
+        readonly name?: string | undefined;
+        readonly trailId?: string | undefined;
+      }[];
+      readonly trailId?: string | undefined;
+    };
+    expect(regradeGraph).toMatchObject({
+      intent: 'write',
+      trailId: 'regrade',
+    });
+    expect(regradeGraph.tools).toEqual([
+      expect.objectContaining({
+        name: 'trails_regrade',
+        trailId: 'regrade',
       }),
     ]);
     const projectedMap = parseJson(surfaceMap?.text) as {

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -9,13 +9,70 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { operatorApp } from '../app.js';
 import { regradeTrail } from '../trails/regrade.js';
 
 const makeTempDir = (): string =>
   mkdtempSync(join(tmpdir(), `trails-regrade-test-${Date.now()}-`));
+
+const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url));
+const trailsBinPath = fileURLToPath(
+  new URL('../../bin/trails.ts', import.meta.url)
+);
+const cliTimeoutMs = 30_000;
+
+interface RawCliRun {
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stdout: string;
+}
+
+const runRawCli = (
+  args: readonly string[],
+  cwd: string = repoRoot
+): RawCliRun => {
+  const command = [process.execPath, trailsBinPath, ...args];
+  const proc = Bun.spawnSync({
+    cmd: command,
+    cwd,
+    env: { ...process.env, NO_COLOR: '1' } as Record<string, string>,
+    stderr: 'pipe',
+    stdout: 'pipe',
+    timeout: cliTimeoutMs,
+  });
+  const stdout = proc.stdout.toString();
+  const stderr = proc.stderr.toString();
+  const signalCode = proc.signalCode ?? undefined;
+  if (proc.exitedDueToTimeout || signalCode !== undefined) {
+    throw new Error(
+      [
+        `Regrade CLI subprocess ${proc.exitedDueToTimeout ? 'timed out' : 'terminated'} before producing output.`,
+        `command: ${command.join(' ')}`,
+        `cwd: ${cwd}`,
+        ...(proc.exitedDueToTimeout ? [`timeoutMs: ${cliTimeoutMs}`] : []),
+        `exitCode: ${proc.exitCode ?? 'null'}`,
+        `signal: ${signalCode ?? 'null'}`,
+        `stdout: ${stdout}`,
+        `stderr: ${stderr}`,
+      ].join('\n')
+    );
+  }
+
+  return {
+    exitCode: proc.exitCode ?? -1,
+    stderr,
+    stdout,
+  };
+};
+
+const writeFile = (root: string, path: string, value: string): void => {
+  const filePath = join(root, path);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value);
+};
 
 const unwrapCommands = () => {
   const result = deriveCliCommands(operatorApp);
@@ -34,7 +91,229 @@ describe('trails regrade', () => {
 
     expect(command).toBeDefined();
     expect(command?.path).toEqual(['regrade']);
+    expect(command?.args.map((arg) => arg.name).slice(0, 2)).toEqual([
+      'from',
+      'to',
+    ]);
     expect(command?.trail.intent).toBe('write');
+  });
+
+  test('dry-runs vocabulary regrades with an occurrence-level ledger', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/surface.ts',
+        [
+          'export const facet = "facet";',
+          'export const facetId = facet;',
+          'export const facets = ["inspect"];',
+          '',
+        ].join('\n')
+      );
+
+      const result = await regradeTrail.blaze(
+        {
+          from: 'facet',
+          include: ['src/**/*.ts'],
+          rootDir: dir,
+          to: 'trailhead',
+        },
+        { cwd: dir, env: {} } as never
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.run?.plan).toMatchObject({
+        from: 'facet',
+        kind: 'vocabulary',
+        to: 'trailhead',
+      });
+      expect(result.value.run?.ledger.forms).toEqual({
+        facet: 'modified',
+        facetId: 'deferred',
+        facets: 'modified',
+      });
+      expect(
+        result.value.run?.ledger.occurrences.map((occurrence) => ({
+          form: occurrence.form,
+          replacement: occurrence.replacement,
+          verdict: occurrence.verdict,
+        }))
+      ).toEqual([
+        { form: 'facet', replacement: 'trailhead', verdict: 'modified' },
+        { form: 'facet', replacement: 'trailhead', verdict: 'modified' },
+        { form: 'facet', replacement: 'trailhead', verdict: 'modified' },
+        { form: 'facets', replacement: 'trailheads', verdict: 'modified' },
+        { form: 'facetId', replacement: undefined, verdict: 'deferred' },
+      ]);
+      expect(result.value.run?.report).toMatchObject({
+        applied: 0,
+        deferred: 1,
+        gate: {
+          reasons: [
+            'safe-modifications-not-yet-applied',
+            'deferred-forms-or-occurrences',
+          ],
+          remaining: 5,
+          status: 'open',
+        },
+        modified: 4,
+        open: 5,
+        skipped: 0,
+      });
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
+        'facet'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('apply mode writes safe vocabulary regrades but keeps review inventory open', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'docs/surface.md',
+        'Facet docs mention facet and facets.\n'
+      );
+      writeFile(
+        dir,
+        'src/surface.ts',
+        'export const facetId = "manual";\nexport const facet = "facet";\n'
+      );
+
+      const result = await regradeTrail.blaze(
+        {
+          apply: true,
+          extensions: ['.md', '.ts'],
+          from: 'facet',
+          rootDir: dir,
+          to: 'trailhead',
+        },
+        { cwd: dir, env: {} } as never
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.apply).toMatchObject({
+        applied: 5,
+        filesChanged: 2,
+        review: 1,
+      });
+      expect(result.value.run?.report).toMatchObject({
+        applied: 5,
+        deferred: 1,
+        gate: {
+          reasons: ['deferred-forms-or-occurrences'],
+          remaining: 1,
+          status: 'open',
+        },
+        modified: 0,
+        open: 1,
+      });
+      expect(readFileSync(join(dir, 'docs', 'surface.md'), 'utf8')).toBe(
+        'Trailhead docs mention trailhead and trailheads.\n'
+      );
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
+        'facetId'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI accepts regrade source and target as positional arguments', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'export const facet = "facet";\n');
+
+      const result = runRawCli([
+        'regrade',
+        'facet',
+        'trailhead',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        readonly run?: {
+          readonly plan?: { readonly from?: string; readonly to?: string };
+          readonly report?: {
+            readonly modified?: number;
+            readonly open?: number;
+          };
+        };
+      };
+      expect(parsed.run?.plan).toMatchObject({
+        from: 'facet',
+        to: 'trailhead',
+      });
+      expect(parsed.run?.report?.modified).toBe(2);
+      expect(parsed.run?.report?.open).toBe(2);
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
+        'facet'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects vocabulary-only inputs without a source and target', async () => {
+    const dir = makeTempDir();
+    try {
+      const result = await regradeTrail.blaze(
+        { include: ['src/**/*.ts'], rootDir: dir },
+        { cwd: dir, env: {} } as never
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.constructor.name).toBe('ValidationError');
+        expect(result.error.message).toContain('requires both `from` and `to`');
+      }
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI rejects vocabulary-only inputs without a source and target', () => {
+    const dir = makeTempDir();
+    try {
+      const result = runRawCli([
+        'regrade',
+        '--include',
+        'src/**/*.ts',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stderr) as {
+        readonly error?: {
+          readonly category?: string;
+          readonly message?: string;
+          readonly name?: string;
+        };
+        readonly ok?: boolean;
+      };
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toMatchObject({
+        category: 'validation',
+        name: 'ValidationError',
+      });
+      expect(parsed.error?.message).toContain('requires both `from` and `to`');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
   });
 
   test('dry-runs safe downstream rewrites by default', async () => {

--- a/apps/trails/src/mcp-options.ts
+++ b/apps/trails/src/mcp-options.ts
@@ -14,6 +14,7 @@ export const trailsMcpIncludedTrails = [
   'doctor',
   'draft.promote',
   'guide',
+  'regrade',
   'release.check',
   'release.smoke',
   'revise',

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -6,16 +6,18 @@ import {
   InternalError,
   NotFoundError,
   Result,
+  ValidationError,
   trail,
   validateOutput,
 } from '@ontrails/core';
 import type { Result as TrailsResult } from '@ontrails/core';
 import {
+  loadWardenTermRewriteClasses,
   regradeReportOutput,
   runRegrade,
-  loadWardenTermRewriteClasses,
+  runVocabularyRegrade,
 } from '@ontrails/regrade';
-import type { RegradeReport } from '@ontrails/regrade';
+import type { RegradeReport, VocabularyRegradePlan } from '@ontrails/regrade';
 import { z } from 'zod';
 
 import { resolveTrailRootDir } from './root-dir.js';
@@ -29,20 +31,145 @@ const regradeInputSchema = z.object({
     .array(z.string())
     .optional()
     .describe('Regrade class ids to run (defaults to all built-in classes)'),
+  exclude: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Root-relative path patterns to exclude in vocabulary regrade mode'
+    ),
+  extensions: z
+    .array(z.string())
+    .optional()
+    .describe('Source file extensions to scan in vocabulary regrade mode'),
+  from: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Source vocabulary term for a vocabulary regrade'),
+  include: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Root-relative path patterns to include in vocabulary regrade mode'
+    ),
   includeEntries: z
     .enum(['actionable', 'all'])
     .default('actionable')
     .describe(
       'Report entry detail to include; counts always cover the full run'
     ),
+  intent: z
+    .string()
+    .optional()
+    .describe('Human-authored migration intent for a vocabulary regrade'),
+  overrides: z
+    .record(z.string().min(1), z.string().min(1))
+    .optional()
+    .describe('Explicit source-form to target-form mappings'),
+  preserve: z
+    .array(z.string().min(1))
+    .optional()
+    .describe(
+      'Regex or literal contexts to preserve during a vocabulary regrade'
+    ),
   rootDir: z.string().optional().describe('Workspace root directory'),
+  to: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Target vocabulary term for a vocabulary regrade'),
 });
 
+const hasVocabularyInput = (input: z.output<typeof regradeInputSchema>) =>
+  input.exclude !== undefined ||
+  input.extensions !== undefined ||
+  input.from !== undefined ||
+  input.include !== undefined ||
+  input.intent !== undefined ||
+  input.overrides !== undefined ||
+  input.preserve !== undefined ||
+  input.to !== undefined;
+
+const buildVocabularyPlan = (
+  input: z.output<typeof regradeInputSchema>
+): TrailsResult<VocabularyRegradePlan, ValidationError> => {
+  if (input.from === undefined || input.to === undefined) {
+    return Result.err(
+      new ValidationError('A vocabulary regrade requires both `from` and `to`.')
+    );
+  }
+  if (input.classIds !== undefined) {
+    return Result.err(
+      new ValidationError(
+        '`classIds` selects class-mode Regrade and cannot be combined with vocabulary-regrade `from`/`to`.'
+      )
+    );
+  }
+
+  return Result.ok({
+    from: input.from,
+    id: `vocabulary:${input.from}->${input.to}`,
+    kind: 'vocabulary',
+    ...(input.intent === undefined ? {} : { intent: input.intent }),
+    ...(input.overrides === undefined ? {} : { overrides: input.overrides }),
+    ...(input.preserve === undefined
+      ? {}
+      : {
+          preserve: input.preserve.map((pattern) => ({
+            pattern,
+            reason: 'preserved-by-operator-input',
+          })),
+        }),
+    scope: {
+      ...(input.exclude === undefined ? {} : { exclude: input.exclude }),
+      ...(input.extensions === undefined
+        ? {}
+        : { extensions: input.extensions }),
+      ...(input.include === undefined ? {} : { include: input.include }),
+    },
+    to: input.to,
+  });
+};
+
 export const regradeTrail = trail('regrade', {
+  args: ['from', 'to'],
   blaze: async (input, ctx) => {
     const rootDirResult = resolveTrailRootDir(input.rootDir, ctx.cwd);
     if (rootDirResult.isErr()) {
       return rootDirResult;
+    }
+
+    if (hasVocabularyInput(input)) {
+      const planResult = buildVocabularyPlan(input);
+      if (planResult.isErr()) {
+        return planResult;
+      }
+      const reportResult: TrailsResult<RegradeReport | null, Error> =
+        runVocabularyRegrade({
+          apply: input.apply,
+          includeEntries: input.includeEntries,
+          plan: planResult.value,
+          root: rootDirResult.value,
+        });
+      if (reportResult.isErr()) {
+        return reportResult;
+      }
+      const report = reportResult.value;
+      if (report === null) {
+        return Result.err(
+          new NotFoundError(
+            `Regrade root "${rootDirResult.value}" could not be read as a directory.`
+          )
+        );
+      }
+      const validated: TrailsResult<
+        z.output<typeof regradeReportOutput>,
+        Error
+      > = validateOutput(regradeReportOutput, report);
+      if (validated.isErr()) {
+        return validated;
+      }
+      return Result.ok(validated.value);
     }
 
     const classSet = await loadWardenTermRewriteClasses(rootDirResult.value);

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -488,6 +488,7 @@ AstParseResult, AstParseDiagnostic, SourceEdit, SourceLocation
 ```typescript
 // Downstream migration reporting and safe rewrites
 runRegrade({ root, classes, selection?, collection?, apply?, includeEntries? }) // Result<RegradeReport | null, InternalError>
+runVocabularyRegrade({ root, plan, apply?, includeEntries? }) // Result<RegradeReport | null, Error>
 buildRegradeReport({ root, files, skipped, classes, selection?, includeEntries? })
 selectRegradeClasses(classes, selection?)
 
@@ -503,14 +504,16 @@ createAstIdentifierRenameClass({ from, to, id?, describe?, reviewDeclarationType
 
 // Schemas
 regradeReportOutput
+vocabularyRegradePlanSchema, vocabularyRegradeRunOutput
 literalRegradeTopo, literalRegradeTrail
 
 // Types
 RegradeClass, RegradeClassResult, RegradeReport, RegradeReportEntry
 RegradeReviewDetail, RegradeReviewSpan, RegradeScanTargets, RegradeSelection
+VocabularyRegradePlan, VocabularyRunLedger, VocabularyRunReport
 ```
 
-Regrade reports always include full aggregate counts, unknown class IDs, scan statistics, and skip reasons. Report `entries` default to actionable rewrite and review outcomes; pass `includeEntries: 'all'` to include no-op and skip entries.
+Regrade reports always include full aggregate counts, unknown class IDs, scan statistics, and skip reasons. Report `entries` default to actionable rewrite and review outcomes; pass `includeEntries: 'all'` to include no-op and skip entries. Vocabulary regrade runs add a `run` block with the authored plan, observed form and occurrence ledger, and projected completion gate so CLI and MCP callers can see what was modified, skipped, or deferred with an `open` count.
 
 ## `@ontrails/config`
 

--- a/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
+++ b/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
@@ -1,0 +1,535 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { runVocabularyRegrade } from '../vocabulary.js';
+
+const makeTempDir = (): string =>
+  mkdtempSync(join(tmpdir(), `trails-vocabulary-regrade-${Date.now()}-`));
+
+const writeFile = (root: string, path: string, value: string): void => {
+  const filePath = join(root, path);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value);
+};
+
+describe('runVocabularyRegrade', () => {
+  test('dry-runs authored vocabulary plans into plan ledger report shape', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/surface.ts',
+        'export const facets = ["facet"];\nexport const facetId = "manual";\n'
+      );
+
+      const result = runVocabularyRegrade({
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          scope: { include: ['src/**/*.ts'] },
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value?.run?.plan).toMatchObject({
+        from: 'facet',
+        kind: 'vocabulary',
+        to: 'trailhead',
+      });
+      expect(result.value?.run?.ledger.forms).toEqual({
+        facet: 'modified',
+        facetId: 'deferred',
+        facets: 'modified',
+      });
+      expect(result.value?.run?.report).toMatchObject({
+        applied: 0,
+        deferred: 1,
+        gate: {
+          reasons: [
+            'safe-modifications-not-yet-applied',
+            'deferred-forms-or-occurrences',
+          ],
+          remaining: 3,
+          status: 'open',
+        },
+        modified: 2,
+        open: 3,
+        skipped: 0,
+      });
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
+        'facet'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('applies safe captures and preserves authored contexts', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'docs/surface.md',
+        'facet belongs here\nlegacy facet stays here\n'
+      );
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          preserve: [
+            { pattern: 'legacy facet', reason: 'documented old example' },
+          ],
+          scope: { extensions: ['.md'] },
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value?.apply).toMatchObject({
+        applied: 1,
+        filesChanged: 1,
+        review: 0,
+        skipped: 1,
+      });
+      expect(result.value?.run?.report).toMatchObject({
+        applied: 1,
+        gate: { status: 'green' },
+        modified: 0,
+        open: 0,
+        skipped: 1,
+      });
+      expect(
+        result.value?.run?.ledger.occurrences.find(
+          (occurrence) => occurrence.verdict === 'skipped'
+        )
+      ).not.toHaveProperty('replacement');
+      expect(readFileSync(join(dir, 'docs', 'surface.md'), 'utf8')).toBe(
+        'trailhead belongs here\nlegacy facet stays here\n'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('scopes path discovery before judging occurrences', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/keep.ts', 'export const facet = "facet";\n');
+      writeFile(dir, 'test/skip.ts', 'export const facet = "facet";\n');
+
+      const result = runVocabularyRegrade({
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          scope: { exclude: ['test/**'] },
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value?.scanned).toBe(1);
+      expect(result.value?.skipsByReason).toMatchObject({
+        'excluded-by-regrade-scope': 1,
+      });
+      expect(result.value?.run?.ledger.occurrences.map((o) => o.path)).toEqual([
+        'src/keep.ts',
+        'src/keep.ts',
+      ]);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('prefers longer override captures over overlapping defaults', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'facet-like\n');
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          overrides: { 'facet-like': 'trailhead-like' },
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toBe(
+        'trailhead-like\n'
+      );
+      expect(result.value?.run?.report).toMatchObject({
+        applied: 1,
+        gate: { status: 'green' },
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('defers hyphenated neighbor forms unless explicitly overridden', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'facet-like\n');
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: { from: 'facet', kind: 'vocabulary', to: 'trailhead' },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toBe(
+        'facet-like\n'
+      );
+      expect(result.value?.run?.ledger.forms).toMatchObject({
+        'facet-like': 'deferred',
+      });
+      expect(result.value?.run?.report).toMatchObject({
+        deferred: 1,
+        gate: { status: 'open' },
+        modified: 0,
+        open: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('defers dollar identifier neighbors instead of partial rewrites', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/surface.ts',
+        'const facet$Id = $facet;\nconst _facet = 1;\n'
+      );
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: { from: 'facet', kind: 'vocabulary', to: 'trailhead' },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toBe(
+        'const facet$Id = $facet;\nconst _facet = 1;\n'
+      );
+      expect(result.value?.run?.ledger.forms).toEqual({
+        $facet: 'deferred',
+        _facet: 'deferred',
+        facet$Id: 'deferred',
+      });
+      expect(result.value?.run?.report).toMatchObject({
+        deferred: 3,
+        gate: { status: 'open' },
+        modified: 0,
+        open: 3,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('defers phrase neighbors instead of reporting green', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'export const label = "old termsId";\n');
+
+      const result = runVocabularyRegrade({
+        plan: { from: 'old term', kind: 'vocabulary', to: 'new term' },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toBe(
+        'export const label = "old termsId";\n'
+      );
+      expect(result.value?.run?.ledger.forms).toEqual({
+        'old termsId': 'deferred',
+      });
+      expect(result.value?.run?.ledger.occurrences).toHaveLength(1);
+      expect(result.value?.run?.report).toMatchObject({
+        deferred: 1,
+        gate: {
+          reasons: ['deferred-forms-or-occurrences'],
+          remaining: 1,
+          status: 'open',
+        },
+        modified: 0,
+        open: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('lets preserve rules skip unclassified neighbor forms', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'facetId\n');
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          preserve: [{ pattern: 'facetId', reason: 'intentional API name' }],
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toBe(
+        'facetId\n'
+      );
+      expect(result.value?.run?.ledger.forms).toMatchObject({
+        facetId: 'skipped',
+      });
+      expect(result.value?.run?.report).toMatchObject({
+        deferred: 0,
+        gate: { status: 'green' },
+        modified: 0,
+        open: 0,
+        skipped: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('reports form verdicts from observed occurrences only', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'legacy facet\n');
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          preserve: [{ pattern: 'legacy facet', reason: 'documented name' }],
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value?.run?.ledger.forms).toEqual({
+        facet: 'skipped',
+      });
+      expect(result.value?.run?.report).toMatchObject({
+        modified: 0,
+        open: 0,
+        skipped: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('keeps repeated neighbor occurrences reviewable after contextual preserve', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'legacy facetId\nactive facetId\n');
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          preserve: [
+            { pattern: '^legacy facetId$', reason: 'legacy API name' },
+          ],
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toBe(
+        'legacy facetId\nactive facetId\n'
+      );
+      expect(result.value?.run?.ledger.occurrences).toMatchObject([
+        { form: 'facetId', reason: 'legacy API name', verdict: 'skipped' },
+        {
+          form: 'facetId',
+          reason: 'unclassified-neighbor',
+          verdict: 'deferred',
+        },
+      ]);
+      expect(result.value?.run?.report).toMatchObject({
+        deferred: 1,
+        gate: { reasons: ['deferred-forms-or-occurrences'], status: 'open' },
+        open: 1,
+        skipped: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('keeps post-apply source forms open when the target contains the source', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'const label = "API";\n');
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: { from: 'API', kind: 'vocabulary', to: 'REST API' },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toBe(
+        'const label = "REST API";\n'
+      );
+      expect(result.value?.run?.report).toMatchObject({
+        applied: 1,
+        gate: {
+          reasons: ['source-forms-remain-after-apply'],
+          status: 'open',
+        },
+        modified: 1,
+        open: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('keeps the compatibility apply summary file-oriented', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'facetId facetName facetOther facet\n');
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          preserve: [{ pattern: '^facetName$', reason: 'public symbol' }],
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value?.apply).toMatchObject({
+        applied: 1,
+        filesChanged: 1,
+        review: 1,
+        skipped: 1,
+      });
+      expect(result.value?.run?.report).toMatchObject({
+        applied: 1,
+        deferred: 2,
+        filesChanged: 1,
+        modified: 0,
+        open: 2,
+        skipped: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects empty source, override, or preserve forms before scanning', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'facet\n');
+
+      const emptySource = runVocabularyRegrade({
+        plan: { from: '', kind: 'vocabulary', to: 'trailhead' },
+        root: dir,
+      });
+      expect(emptySource.isErr()).toBe(true);
+      if (emptySource.isErr()) {
+        expect(emptySource.error.constructor.name).toBe('ValidationError');
+      }
+
+      const emptyOverride = runVocabularyRegrade({
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          overrides: { '': 'trailhead' },
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+      expect(emptyOverride.isErr()).toBe(true);
+      if (emptyOverride.isErr()) {
+        expect(emptyOverride.error.constructor.name).toBe('ValidationError');
+      }
+
+      const emptyPreserve = runVocabularyRegrade({
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          preserve: [{ pattern: '' }],
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+      expect(emptyPreserve.isErr()).toBe(true);
+      if (emptyPreserve.isErr()) {
+        expect(emptyPreserve.error.constructor.name).toBe('ValidationError');
+      }
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -19,6 +19,8 @@ import {
   collectDownstreamSources,
 } from './collect.js';
 import type { DownstreamCollectionOptions, SkippedSource } from './collect.js';
+import type { VocabularyRegradeRun } from './vocabulary.js';
+import { vocabularyRegradeRunOutput } from './vocabulary.js';
 
 /**
  * Regrade-class selection and coverage reporting (TRL-845).
@@ -576,6 +578,8 @@ export interface RegradeReport {
   readonly entries: readonly RegradeReportEntry[];
   /** Apply-mode summary; absent for dry-run report-only calls. */
   readonly apply?: RegradeApplySummary;
+  /** Vocabulary regrade run: plan, ledger, and completion report. */
+  readonly run?: VocabularyRegradeRun;
 }
 
 interface RegradeRewriteCandidate {
@@ -1022,6 +1026,9 @@ export const regradeReportOutput = z.object({
   review: z.number().describe('Files routed to review'),
   rewritten: z.number().describe('Files with a rewrite outcome'),
   root: z.string().describe('Root the run scanned'),
+  run: vocabularyRegradeRunOutput
+    .optional()
+    .describe('Vocabulary regrade run: plan, ledger, and completion report'),
   scanned: z.number().describe('Source files inspected'),
   selectedClassIds: z.array(z.string()).describe('Class ids executed'),
   skipped: z.number().describe('Entries skipped'),

--- a/packages/regrade/src/downstream/vocabulary.ts
+++ b/packages/regrade/src/downstream/vocabulary.ts
@@ -1,0 +1,978 @@
+import { InternalError, Result, ValidationError } from '@ontrails/core';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { z } from 'zod';
+
+import {
+  DEFAULT_IGNORED_DIRECTORIES,
+  collectDownstreamSources,
+} from './collect.js';
+import type { DownstreamCollectionOptions, SkippedSource } from './collect.js';
+import type {
+  RegradeApplySummary,
+  RegradeReport,
+  RegradeReportEntry,
+} from './report.js';
+
+export type VocabularyVerdict = 'deferred' | 'modified' | 'skipped';
+
+export interface VocabularyPreserveRule {
+  readonly pattern: string;
+  readonly reason?: string;
+  readonly paths?: readonly string[];
+}
+
+export interface VocabularyRegradeScope {
+  readonly exclude?: readonly string[];
+  readonly extensions?: readonly string[];
+  readonly ignoredDirectories?: readonly string[];
+  readonly include?: readonly string[];
+}
+
+export interface VocabularyRegradePlan {
+  readonly from: string;
+  readonly id?: string;
+  readonly intent?: string;
+  readonly kind: 'vocabulary';
+  readonly overrides?: Readonly<Record<string, string>>;
+  readonly preserve?: readonly VocabularyPreserveRule[];
+  readonly scope?: VocabularyRegradeScope;
+  readonly to: string;
+}
+
+export interface VocabularyOccurrence {
+  readonly column: number;
+  readonly context: string;
+  readonly end: number;
+  readonly form: string;
+  readonly line: number;
+  readonly path: string;
+  readonly reason: string;
+  readonly replacement?: string;
+  readonly start: number;
+  readonly verdict: VocabularyVerdict;
+}
+
+export interface VocabularyRunLedger {
+  readonly cycle: number;
+  readonly forms: Readonly<Record<string, VocabularyVerdict>>;
+  readonly occurrences: readonly VocabularyOccurrence[];
+}
+
+export interface VocabularyRunGate {
+  readonly remaining: number;
+  readonly reasons: readonly string[];
+  readonly status: 'green' | 'open';
+}
+
+export interface VocabularyRunReport {
+  readonly applied: number;
+  readonly deferred: number;
+  readonly filesChanged: number;
+  readonly gate: VocabularyRunGate;
+  readonly modified: number;
+  readonly open: number;
+  readonly skipped: number;
+}
+
+export interface VocabularyRegradeRun {
+  readonly ledger: VocabularyRunLedger;
+  readonly plan: VocabularyRegradePlan;
+  readonly report: VocabularyRunReport;
+}
+
+interface SourceFile {
+  readonly absolutePath: string;
+  readonly path: string;
+  readonly source: string;
+}
+
+interface SourceOccurrence extends VocabularyOccurrence {
+  readonly absolutePath: string;
+}
+
+interface VocabularyEvaluation {
+  readonly entries: readonly RegradeReportEntry[];
+  readonly occurrences: readonly SourceOccurrence[];
+  readonly scanned: number;
+  readonly skipped: readonly SkippedSource[];
+  readonly run: VocabularyRegradeRun;
+}
+
+const VOCABULARY_SOURCE_EXTENSIONS = Object.freeze([
+  '.js',
+  '.jsx',
+  '.json',
+  '.jsonc',
+  '.md',
+  '.mdx',
+  '.mjs',
+  '.ts',
+  '.tsx',
+  '.txt',
+  '.yaml',
+  '.yml',
+]);
+
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const uniqueSorted = (values: readonly string[]): readonly string[] =>
+  [...new Set(values)].toSorted((a, b) => a.localeCompare(b));
+
+const isVocabularyTokenCharacter = (value: string): boolean =>
+  /[A-Za-z0-9_$-]/.test(value);
+
+const hasWordBoundary = (
+  source: string,
+  start: number,
+  end: number
+): boolean => {
+  const before = start === 0 ? '' : (source.at(start - 1) ?? '');
+  const after = end >= source.length ? '' : (source.at(end) ?? '');
+  return (
+    !isVocabularyTokenCharacter(before) && !isVocabularyTokenCharacter(after)
+  );
+};
+
+const expandVocabularyNeighborSpan = (
+  source: string,
+  start: number,
+  end: number
+): { readonly end: number; readonly start: number } => {
+  let expandedStart = start;
+  while (
+    expandedStart > 0 &&
+    isVocabularyTokenCharacter(source.at(expandedStart - 1) ?? '')
+  ) {
+    expandedStart -= 1;
+  }
+
+  let expandedEnd = end;
+  while (
+    expandedEnd < source.length &&
+    isVocabularyTokenCharacter(source.at(expandedEnd) ?? '')
+  ) {
+    expandedEnd += 1;
+  }
+
+  return { end: expandedEnd, start: expandedStart };
+};
+
+const lineColumnForOffset = (
+  source: string,
+  offset: number
+): { readonly column: number; readonly line: number } => {
+  let line = 1;
+  let column = 1;
+  for (let index = 0; index < offset; index += 1) {
+    if (source.codePointAt(index) === 10) {
+      line += 1;
+      column = 1;
+    } else {
+      column += 1;
+    }
+  }
+  return { column, line };
+};
+
+const contextForOffset = (
+  source: string,
+  start: number,
+  end: number
+): string => {
+  const lineStart = source.lastIndexOf('\n', start - 1) + 1;
+  const nextLine = source.indexOf('\n', end);
+  const lineEnd = nextLine === -1 ? source.length : nextLine;
+  return source.slice(lineStart, lineEnd).trim();
+};
+
+const preserveCase = (sourceForm: string, replacement: string): string => {
+  if (sourceForm.toUpperCase() === sourceForm) {
+    return replacement.toUpperCase();
+  }
+  const first = sourceForm.at(0);
+  if (first !== undefined && first.toUpperCase() === first) {
+    return replacement.at(0)?.toUpperCase() + replacement.slice(1);
+  }
+  return replacement;
+};
+
+const pluralize = (value: string): string =>
+  value.endsWith('s') || value.endsWith('x') || value.endsWith('ch')
+    ? `${value}es`
+    : `${value}s`;
+
+const defaultVocabularyForms = (from: string, to: string) =>
+  new Map<string, string>([
+    [from, to],
+    [pluralize(from), pluralize(to)],
+  ]);
+
+const normalizedOverrideEntries = (
+  overrides: Readonly<Record<string, string>> | undefined
+): readonly [string, string][] =>
+  Object.entries(overrides ?? {}).toSorted(([left], [right]) =>
+    left.localeCompare(right)
+  );
+
+const targetFormsForPlan = (
+  plan: VocabularyRegradePlan
+): Map<string, string> => {
+  const forms = defaultVocabularyForms(plan.from, plan.to);
+  for (const [form, replacement] of normalizedOverrideEntries(plan.overrides)) {
+    forms.set(form, replacement);
+  }
+  return forms;
+};
+
+const validateVocabularyPlan = (
+  plan: VocabularyRegradePlan
+): Result<void, ValidationError> => {
+  if (plan.from.trim().length === 0) {
+    return Result.err(
+      new ValidationError('Vocabulary Regrade plan `from` cannot be empty.')
+    );
+  }
+  if (plan.to.trim().length === 0) {
+    return Result.err(
+      new ValidationError('Vocabulary Regrade plan `to` cannot be empty.')
+    );
+  }
+  for (const [form, replacement] of normalizedOverrideEntries(plan.overrides)) {
+    if (form.trim().length === 0) {
+      return Result.err(
+        new ValidationError(
+          'Vocabulary Regrade plan override keys cannot be empty.'
+        )
+      );
+    }
+    if (replacement.trim().length === 0) {
+      return Result.err(
+        new ValidationError(
+          `Vocabulary Regrade plan override "${form}" cannot map to an empty replacement.`
+        )
+      );
+    }
+  }
+  for (const rule of plan.preserve ?? []) {
+    if (rule.pattern.trim().length === 0) {
+      return Result.err(
+        new ValidationError(
+          'Vocabulary Regrade plan preserve patterns cannot be empty.'
+        )
+      );
+    }
+  }
+  return Result.ok();
+};
+
+const pathPatternToRegExp = (pattern: string): RegExp => {
+  let expression = '';
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern.at(index);
+    if (char === '*' && pattern.at(index + 1) === '*') {
+      if (pattern.at(index + 2) === '/') {
+        expression += '(?:.*/)?';
+        index += 2;
+      } else {
+        expression += '.*';
+        index += 1;
+      }
+      continue;
+    }
+    expression += char === '*' ? '[^/]*' : escapeRegExp(char ?? '');
+  }
+  return new RegExp(`^${expression}$`);
+};
+
+const matchesAnyPathPattern = (
+  path: string,
+  patterns: readonly string[] | undefined
+): boolean => {
+  if (patterns === undefined || patterns.length === 0) {
+    return false;
+  }
+  return patterns.some((pattern) => pathPatternToRegExp(pattern).test(path));
+};
+
+const includedByScope = (
+  path: string,
+  scope: VocabularyRegradeScope | undefined
+): boolean =>
+  (scope?.include === undefined ||
+    scope.include.length === 0 ||
+    matchesAnyPathPattern(path, scope.include)) &&
+  !matchesAnyPathPattern(path, scope?.exclude);
+
+const compilePreservePattern = (pattern: string): RegExp => {
+  try {
+    return new RegExp(pattern);
+  } catch {
+    return new RegExp(escapeRegExp(pattern));
+  }
+};
+
+const preserveRuleForOccurrence = (
+  occurrence: Omit<SourceOccurrence, 'reason' | 'verdict'>,
+  plan: VocabularyRegradePlan
+): VocabularyPreserveRule | undefined =>
+  plan.preserve?.find((rule) => {
+    if (
+      rule.paths !== undefined &&
+      !matchesAnyPathPattern(occurrence.path, rule.paths)
+    ) {
+      return false;
+    }
+    return (
+      compilePreservePattern(rule.pattern).test(occurrence.context) ||
+      compilePreservePattern(rule.pattern).test(occurrence.form)
+    );
+  });
+
+const occurrencesForFile = (
+  file: SourceFile,
+  plan: VocabularyRegradePlan,
+  targetForms: Map<string, string>
+): readonly SourceOccurrence[] => {
+  const occurrences: SourceOccurrence[] = [];
+  const candidates: SourceOccurrence[] = [];
+  const forms = [...targetForms.entries()].toSorted(
+    ([left], [right]) => right.length - left.length || left.localeCompare(right)
+  );
+
+  for (const [form, replacement] of forms) {
+    const pattern = new RegExp(escapeRegExp(form), 'gi');
+    for (const match of file.source.matchAll(pattern)) {
+      const start = match.index ?? 0;
+      const end = start + match[0].length;
+      if (!hasWordBoundary(file.source, start, end)) {
+        continue;
+      }
+      const { column, line } = lineColumnForOffset(file.source, start);
+      const baseOccurrence = {
+        absolutePath: file.absolutePath,
+        column,
+        context: contextForOffset(file.source, start, end),
+        end,
+        form: match[0],
+        line,
+        path: file.path,
+        start,
+      };
+      const preserveRule = preserveRuleForOccurrence(baseOccurrence, plan);
+      candidates.push({
+        ...baseOccurrence,
+        reason:
+          preserveRule?.reason ??
+          (preserveRule === undefined ? 'captured-form' : 'preserved-by-plan'),
+        ...(preserveRule === undefined
+          ? { replacement: preserveCase(match[0], replacement) }
+          : {}),
+        verdict: preserveRule === undefined ? 'modified' : 'skipped',
+      });
+    }
+  }
+
+  for (const candidate of candidates.toSorted(
+    (left, right) =>
+      right.end - right.start - (left.end - left.start) ||
+      left.start - right.start
+  )) {
+    const overlaps = occurrences.some(
+      (occurrence) =>
+        candidate.start < occurrence.end && occurrence.start < candidate.end
+    );
+    if (!overlaps) {
+      occurrences.push(candidate);
+    }
+  }
+
+  return occurrences.toSorted((left, right) =>
+    left.path === right.path
+      ? left.start - right.start
+      : left.path.localeCompare(right.path)
+  );
+};
+
+const deferredOccurrencesForFile = (
+  file: SourceFile,
+  plan: VocabularyRegradePlan,
+  targetForms: Map<string, string>
+): readonly SourceOccurrence[] => {
+  const knownForms = new Set(
+    [...targetForms.keys()].flatMap((form) => [form, form.toLowerCase()])
+  );
+  const lowerFrom = plan.from.toLowerCase();
+  const tokenPattern = /[A-Za-z_$][A-Za-z0-9_$-]*/g;
+  const occurrences: SourceOccurrence[] = [];
+  const pushOccurrence = (
+    baseOccurrence: Omit<SourceOccurrence, 'reason' | 'verdict'>
+  ): void => {
+    const preserveRule = preserveRuleForOccurrence(baseOccurrence, plan);
+    occurrences.push({
+      ...baseOccurrence,
+      reason:
+        preserveRule?.reason ??
+        (preserveRule === undefined
+          ? 'unclassified-neighbor'
+          : 'preserved-by-plan'),
+      verdict: preserveRule === undefined ? 'deferred' : 'skipped',
+    });
+  };
+
+  for (const form of targetForms.keys()) {
+    const pattern = new RegExp(escapeRegExp(form), 'gi');
+    for (const match of file.source.matchAll(pattern)) {
+      const matchStart = match.index ?? 0;
+      const matchEnd = matchStart + match[0].length;
+      if (hasWordBoundary(file.source, matchStart, matchEnd)) {
+        continue;
+      }
+      const { end, start } = expandVocabularyNeighborSpan(
+        file.source,
+        matchStart,
+        matchEnd
+      );
+      const matchedForm = file.source.slice(start, end);
+      const lowerMatchedForm = matchedForm.toLowerCase();
+      const overlaps = occurrences.some(
+        (occurrence) => start < occurrence.end && occurrence.start < end
+      );
+      if (
+        overlaps ||
+        knownForms.has(matchedForm) ||
+        knownForms.has(lowerMatchedForm) ||
+        !lowerMatchedForm.includes(lowerFrom)
+      ) {
+        continue;
+      }
+      const { column, line } = lineColumnForOffset(file.source, start);
+      pushOccurrence({
+        absolutePath: file.absolutePath,
+        column,
+        context: contextForOffset(file.source, start, end),
+        end,
+        form: matchedForm,
+        line,
+        path: file.path,
+        start,
+      });
+    }
+  }
+
+  for (const match of file.source.matchAll(tokenPattern)) {
+    const [form] = match;
+    const lower = form.toLowerCase();
+    if (knownForms.has(form) || knownForms.has(lower)) {
+      continue;
+    }
+    if (!lower.includes(lowerFrom)) {
+      continue;
+    }
+    const start = match.index ?? 0;
+    const end = start + form.length;
+    const overlaps = occurrences.some(
+      (occurrence) => start < occurrence.end && occurrence.start < end
+    );
+    if (overlaps) {
+      continue;
+    }
+    const { column, line } = lineColumnForOffset(file.source, start);
+    pushOccurrence({
+      absolutePath: file.absolutePath,
+      column,
+      context: contextForOffset(file.source, start, end),
+      end,
+      form,
+      line,
+      path: file.path,
+      start,
+    });
+  }
+  return occurrences.toSorted((left, right) =>
+    left.path === right.path
+      ? left.start - right.start
+      : left.path.localeCompare(right.path)
+  );
+};
+
+const entryForOccurrences = (
+  path: string,
+  occurrences: readonly SourceOccurrence[]
+): RegradeReportEntry | null => {
+  if (occurrences.length === 0) {
+    return null;
+  }
+  const hasDeferred = occurrences.some(
+    (occurrence) => occurrence.verdict === 'deferred'
+  );
+  const hasModified = occurrences.some(
+    (occurrence) => occurrence.verdict === 'modified'
+  );
+  if (hasDeferred) {
+    return {
+      notes: [
+        `Found ${occurrences.length} vocabulary occurrence(s); judgment deferred.`,
+      ],
+      outcome: 'needs-review',
+      path,
+      reason: 'vocabulary-judgment-deferred',
+      reviewDetails: occurrences
+        .filter((occurrence) => occurrence.verdict === 'deferred')
+        .map((occurrence) => ({
+          expectedTarget:
+            'Add an override or preserve rule to the regrade plan.',
+          reason: occurrence.reason,
+          span: {
+            column: occurrence.column,
+            end: occurrence.end,
+            line: occurrence.line,
+            start: occurrence.start,
+          },
+          symbol: occurrence.form,
+        })),
+    };
+  }
+  if (hasModified) {
+    return {
+      notes: [
+        `Found ${occurrences.length} vocabulary occurrence(s); safe modifications available.`,
+      ],
+      outcome: 'rewrite',
+      path,
+    };
+  }
+  return {
+    notes: [`Skipped ${occurrences.length} vocabulary occurrence(s).`],
+    outcome: 'no-op',
+    path,
+  };
+};
+
+const applyOccurrenceRewrites = (
+  file: SourceFile,
+  occurrences: readonly SourceOccurrence[]
+): string => {
+  let nextSource = file.source;
+  for (const occurrence of occurrences.toReversed()) {
+    if (
+      occurrence.verdict !== 'modified' ||
+      occurrence.replacement === undefined
+    ) {
+      continue;
+    }
+    nextSource =
+      nextSource.slice(0, occurrence.start) +
+      occurrence.replacement +
+      nextSource.slice(occurrence.end);
+  }
+  return nextSource;
+};
+
+const buildVocabularyEvaluation = (params: {
+  readonly apply?: boolean;
+  readonly files: readonly SourceFile[];
+  readonly plan: VocabularyRegradePlan;
+  readonly root: string;
+  readonly skipped: readonly SkippedSource[];
+}): VocabularyEvaluation => {
+  const targetForms = targetFormsForPlan(params.plan);
+  const scopedFiles = params.files.filter((file) =>
+    includedByScope(file.path, params.plan.scope)
+  );
+  const scopeSkipped: SkippedSource[] = params.files
+    .filter((file) => !includedByScope(file.path, params.plan.scope))
+    .map((file) => ({ path: file.path, reason: 'excluded-by-regrade-scope' }));
+  const occurrences = scopedFiles.flatMap((file) => [
+    ...occurrencesForFile(file, params.plan, targetForms),
+    ...deferredOccurrencesForFile(file, params.plan, targetForms),
+  ]);
+  const occurrencesByPath = new Map<string, SourceOccurrence[]>();
+  for (const occurrence of occurrences) {
+    const existing = occurrencesByPath.get(occurrence.path) ?? [];
+    occurrencesByPath.set(occurrence.path, [...existing, occurrence]);
+  }
+  const entries = [...occurrencesByPath.entries()]
+    .flatMap(([path, pathOccurrences]) => {
+      const entry = entryForOccurrences(path, pathOccurrences);
+      return entry === null ? [] : [entry];
+    })
+    .toSorted((left, right) => left.path.localeCompare(right.path));
+  const rewrittenPaths = new Set(
+    occurrences
+      .filter((occurrence) => occurrence.verdict === 'modified')
+      .map((occurrence) => occurrence.path)
+  );
+  const deferredForms = uniqueSorted(
+    occurrences
+      .filter((occurrence) => occurrence.verdict === 'deferred')
+      .map((occurrence) => occurrence.form)
+  );
+  const modifiedOccurrences = occurrences.filter(
+    (occurrence) => occurrence.verdict === 'modified'
+  );
+  const skippedOccurrences = occurrences.filter(
+    (occurrence) => occurrence.verdict === 'skipped'
+  );
+  const deferredOccurrences = occurrences.filter(
+    (occurrence) => occurrence.verdict === 'deferred'
+  );
+  const forms: Record<string, VocabularyVerdict> = {};
+  for (const occurrence of occurrences) {
+    const current = forms[occurrence.form];
+    if (occurrence.verdict === 'deferred') {
+      forms[occurrence.form] = 'deferred';
+      continue;
+    }
+    if (occurrence.verdict === 'modified' && current !== 'deferred') {
+      forms[occurrence.form] = 'modified';
+      continue;
+    }
+    if (current === undefined) {
+      forms[occurrence.form] = 'skipped';
+    }
+  }
+  const gateReasons: string[] = [];
+  if (modifiedOccurrences.length > 0) {
+    gateReasons.push(
+      params.apply === true
+        ? 'source-forms-remain-after-apply'
+        : 'safe-modifications-not-yet-applied'
+    );
+  }
+  if (deferredForms.length > 0) {
+    gateReasons.push('deferred-forms-or-occurrences');
+  }
+  const open = modifiedOccurrences.length + deferredOccurrences.length;
+
+  return {
+    entries: [
+      ...entries,
+      ...params.skipped.map((entry) => ({
+        outcome: 'skip' as const,
+        path: entry.path,
+        reason: entry.reason,
+      })),
+      ...scopeSkipped.map((entry) => ({
+        outcome: 'skip' as const,
+        path: entry.path,
+        reason: entry.reason,
+      })),
+    ].toSorted((left, right) => left.path.localeCompare(right.path)),
+    occurrences,
+    run: {
+      ledger: {
+        cycle: 1,
+        forms,
+        occurrences: occurrences.map(
+          ({ absolutePath: _absolutePath, ...occurrence }) => occurrence
+        ),
+      },
+      plan: params.plan,
+      report: {
+        applied: params.apply === true ? modifiedOccurrences.length : 0,
+        deferred: deferredOccurrences.length,
+        filesChanged: params.apply === true ? rewrittenPaths.size : 0,
+        gate: {
+          reasons: gateReasons,
+          remaining: open,
+          status: gateReasons.length === 0 ? 'green' : 'open',
+        },
+        modified: modifiedOccurrences.length,
+        open,
+        skipped: skippedOccurrences.length,
+      },
+    },
+    scanned: scopedFiles.length,
+    skipped: [...params.skipped, ...scopeSkipped],
+  };
+};
+
+const skippedByReason = (
+  skipped: readonly SkippedSource[]
+): Readonly<Record<string, number>> => {
+  const counts = new Map<string, number>();
+  for (const entry of skipped) {
+    counts.set(entry.reason, (counts.get(entry.reason) ?? 0) + 1);
+  }
+  return Object.fromEntries(
+    [...counts.entries()].toSorted(([left], [right]) =>
+      left.localeCompare(right)
+    )
+  );
+};
+
+const withApplySummary = (
+  report: RegradeReport,
+  apply: RegradeApplySummary
+): RegradeReport => ({
+  ...report,
+  apply,
+});
+
+const applyVocabularyEvaluation = (
+  files: readonly SourceFile[],
+  evaluation: VocabularyEvaluation
+): Result<RegradeApplySummary, InternalError> => {
+  const changedFiles = new Set<string>();
+  let applied = 0;
+  for (const file of files) {
+    const fileOccurrences = evaluation.occurrences.filter(
+      (occurrence) =>
+        occurrence.path === file.path && occurrence.verdict === 'modified'
+    );
+    if (fileOccurrences.length === 0) {
+      continue;
+    }
+    const nextSource = applyOccurrenceRewrites(file, fileOccurrences);
+    if (nextSource === file.source) {
+      continue;
+    }
+    try {
+      writeFileSync(file.absolutePath, nextSource, 'utf8');
+    } catch (error: unknown) {
+      return Result.err(
+        new InternalError(
+          `Failed to apply vocabulary regrade rewrite for "${file.path}".`,
+          {
+            cause: error instanceof Error ? error : new Error(String(error)),
+            context: {
+              applied,
+              filesChanged: changedFiles.size,
+              path: file.path,
+            },
+          }
+        )
+      );
+    }
+    applied += fileOccurrences.length;
+    changedFiles.add(file.path);
+  }
+
+  const reviewFiles = new Set(
+    evaluation.occurrences
+      .filter((occurrence) => occurrence.verdict === 'deferred')
+      .map((occurrence) => occurrence.path)
+  );
+  const skippedOccurrences = evaluation.occurrences.filter(
+    (occurrence) => occurrence.verdict === 'skipped'
+  );
+
+  return Result.ok({
+    applied,
+    filesChanged: changedFiles.size,
+    review: reviewFiles.size,
+    skipped: skippedOccurrences.length + evaluation.skipped.length,
+    unknown: 0,
+  });
+};
+
+export const runVocabularyRegrade = (params: {
+  readonly apply?: boolean;
+  readonly includeEntries?: 'actionable' | 'all';
+  readonly plan: VocabularyRegradePlan;
+  readonly root: string;
+}): Result<RegradeReport | null, InternalError | ValidationError> => {
+  const planValidation = validateVocabularyPlan(params.plan);
+  if (planValidation.isErr()) {
+    return planValidation;
+  }
+
+  const collected = collectDownstreamSources(params.root, {
+    extensions: params.plan.scope?.extensions ?? VOCABULARY_SOURCE_EXTENSIONS,
+    ignoredDirectories:
+      params.plan.scope?.ignoredDirectories ?? DEFAULT_IGNORED_DIRECTORIES,
+  } satisfies DownstreamCollectionOptions);
+  if (collected === null) {
+    return Result.ok(null);
+  }
+
+  const files: SourceFile[] = [];
+  const skipped: SkippedSource[] = [...collected.skipped];
+  for (const file of collected.files) {
+    try {
+      files.push({
+        absolutePath: file.absolutePath,
+        path: file.path,
+        source: readFileSync(file.absolutePath, 'utf8'),
+      });
+    } catch {
+      skipped.push({ path: file.path, reason: 'unreadable-file' });
+    }
+  }
+
+  const dryRunEvaluation = buildVocabularyEvaluation({
+    apply: false,
+    files,
+    plan: params.plan,
+    root: params.root,
+    skipped,
+  });
+  let reportEvaluation = dryRunEvaluation;
+  let applySummary: RegradeApplySummary | undefined;
+
+  if (params.apply === true) {
+    const applyResult = applyVocabularyEvaluation(files, dryRunEvaluation);
+    if (applyResult.isErr()) {
+      return applyResult;
+    }
+    applySummary = applyResult.value;
+    const appliedFiles = files.map((file) => ({
+      ...file,
+      source: readFileSync(file.absolutePath, 'utf8'),
+    }));
+    reportEvaluation = buildVocabularyEvaluation({
+      apply: true,
+      files: appliedFiles,
+      plan: params.plan,
+      root: params.root,
+      skipped,
+    });
+  }
+
+  const entrySelection = params.includeEntries ?? 'actionable';
+  const report: RegradeReport = {
+    entries:
+      entrySelection === 'all'
+        ? reportEvaluation.entries
+        : reportEvaluation.entries.filter(
+            (entry) =>
+              entry.outcome === 'rewrite' || entry.outcome === 'needs-review'
+          ),
+    matched: reportEvaluation.entries.filter(
+      (entry) => entry.outcome === 'rewrite' || entry.outcome === 'needs-review'
+    ).length,
+    review: reportEvaluation.entries.filter(
+      (entry) => entry.outcome === 'needs-review'
+    ).length,
+    rewritten: reportEvaluation.entries.filter(
+      (entry) => entry.outcome === 'rewrite'
+    ).length,
+    root: collected.root,
+    run:
+      applySummary === undefined
+        ? reportEvaluation.run
+        : {
+            ...reportEvaluation.run,
+            report: {
+              ...reportEvaluation.run.report,
+              applied: applySummary.applied,
+              filesChanged: applySummary.filesChanged,
+            },
+          },
+    scanned: reportEvaluation.scanned,
+    selectedClassIds: [
+      params.plan.id ?? `vocabulary:${params.plan.from}->${params.plan.to}`,
+    ],
+    skipped: reportEvaluation.skipped.length,
+    skipsByReason: skippedByReason(reportEvaluation.skipped),
+    unknownClassIds: [],
+  };
+
+  return Result.ok(
+    applySummary === undefined ? report : withApplySummary(report, applySummary)
+  );
+};
+
+const vocabularyPreserveRuleSchema = z.object({
+  paths: z
+    .array(z.string())
+    .optional()
+    .describe('Root-relative path patterns where the preserve rule applies'),
+  pattern: z.string().describe('Regex or literal pattern to preserve'),
+  reason: z.string().optional().describe('Why this form is preserved'),
+});
+
+const vocabularyRegradeScopeSchema = z.object({
+  exclude: z
+    .array(z.string())
+    .optional()
+    .describe('Root-relative path patterns to exclude from this regrade'),
+  extensions: z
+    .array(z.string())
+    .optional()
+    .describe('Source file extensions to scan for this regrade'),
+  ignoredDirectories: z
+    .array(z.string())
+    .optional()
+    .describe('Directory names to skip during collection'),
+  include: z
+    .array(z.string())
+    .optional()
+    .describe('Root-relative path patterns to include in this regrade'),
+});
+
+export const vocabularyRegradePlanSchema = z.object({
+  from: z.string().min(1).describe('Source vocabulary term or phrase'),
+  id: z.string().optional().describe('Stable authored regrade plan id'),
+  intent: z.string().optional().describe('Human-authored migration intent'),
+  kind: z.literal('vocabulary').describe('Regrade plan kind'),
+  overrides: z
+    .record(z.string().min(1), z.string().min(1))
+    .optional()
+    .describe('Explicit source-form to target-form mappings'),
+  preserve: z
+    .array(vocabularyPreserveRuleSchema)
+    .optional()
+    .describe('Forms or contexts that are intentionally preserved'),
+  scope: vocabularyRegradeScopeSchema
+    .optional()
+    .describe('Source scope for this regrade plan'),
+  to: z.string().min(1).describe('Target vocabulary term or phrase'),
+});
+
+export const vocabularyRegradeRunOutput = z.object({
+  ledger: z
+    .object({
+      cycle: z.number().describe('Observed regrade run cycle'),
+      forms: z
+        .record(z.string(), z.enum(['deferred', 'modified', 'skipped']))
+        .describe('Observed per-form triage verdicts for this run'),
+      occurrences: z
+        .array(
+          z.object({
+            column: z.number().describe('One-based source column'),
+            context: z.string().describe('Source-line context'),
+            end: z.number().describe('Source end offset'),
+            form: z.string().describe('Matched vocabulary form'),
+            line: z.number().describe('One-based source line'),
+            path: z.string().describe('Root-relative POSIX path'),
+            reason: z.string().describe('Why the occurrence got this verdict'),
+            replacement: z
+              .string()
+              .optional()
+              .describe('Replacement text for modified verdicts'),
+            start: z.number().describe('Source start offset'),
+            verdict: z
+              .enum(['deferred', 'modified', 'skipped'])
+              .describe('Occurrence-level verdict'),
+          })
+        )
+        .describe('Observed occurrence-level ledger for this run'),
+    })
+    .describe('Observed run ledger'),
+  plan: vocabularyRegradePlanSchema.describe('Authored regrade plan'),
+  report: z
+    .object({
+      applied: z.number().describe('Modified occurrences applied to disk'),
+      deferred: z.number().describe('Deferred occurrence count'),
+      filesChanged: z.number().describe('Distinct files changed on disk'),
+      gate: z
+        .object({
+          reasons: z.array(z.string()).describe('Open-gate reasons'),
+          remaining: z.number().describe('Unresolved occurrence count'),
+          status: z
+            .enum(['green', 'open'])
+            .describe('Whether the run is complete'),
+        })
+        .describe('Completion gate derived from the run ledger'),
+      modified: z.number().describe('Modified occurrence count'),
+      open: z
+        .number()
+        .describe(
+          'Deferred or unapplied modified occurrences holding the gate open'
+        ),
+      skipped: z.number().describe('Skipped occurrence count'),
+    })
+    .describe('Projected run report'),
+});

--- a/packages/regrade/src/index.ts
+++ b/packages/regrade/src/index.ts
@@ -13,6 +13,11 @@ export {
   selectRegradeClasses,
   wardenTermRewriteClasses,
 } from './downstream/report.js';
+export {
+  runVocabularyRegrade,
+  vocabularyRegradePlanSchema,
+  vocabularyRegradeRunOutput,
+} from './downstream/vocabulary.js';
 export type {
   RegradeApplySummary,
   RegradeClass,
@@ -27,6 +32,17 @@ export type {
   RegradeSelection,
   RegradeWardenClassSet,
 } from './downstream/report.js';
+export type {
+  VocabularyOccurrence,
+  VocabularyPreserveRule,
+  VocabularyRegradePlan,
+  VocabularyRegradeScope,
+  VocabularyRegradeRun,
+  VocabularyRunGate,
+  VocabularyRunLedger,
+  VocabularyRunReport,
+  VocabularyVerdict,
+} from './downstream/vocabulary.js';
 export {
   createAstIdentifierRenameClass,
   createAstRewriteClass,


### PR DESCRIPTION
## Summary

- add occurrence-level vocabulary transition Regrade support with authored plan, observed ledger, projected report, and completion gate facts
- expose transition mode through `trails regrade <from> <to>` while preserving existing class-mode Regrade behavior
- include `trails_regrade` in the curated MCP operator surface and prove handler execution
- document the API and operator usage, plus branch-local patch changesets for `@ontrails/regrade` and `@ontrails/trails`

## Tests

- `bun test packages/regrade/src/downstream/__tests__/vocabulary.test.ts apps/trails/src/__tests__/regrade.test.ts apps/trails/src/__tests__/mcp.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run check`
- `bun run build`
- `bun run test`
- `bun run wayfinder:dogfood`
- `bun run publish:check`
- `bun run changeset:check`
- `git diff --check`

## Surface Proof

- CLI smoke: `trails regrade facet trailhead --root-dir <tmp> --json` returned `vocabulary:facet->trailhead`, `run.ledger.forms` entries marked `modified`, two modified occurrences, `open: 2`, and an open dry-run gate without changing the source file.
- MCP smoke: derived the curated MCP tools, invoked `trails_regrade.handler({ from: "facet", to: "trailhead", rootDir: <tmp> }, {})`, and received the same `modified`/`open` transition report while preserving the source file in dry-run mode.

## Review

- Local engine/API review found and verified fixes for overlapping captures, empty source/override validation, and skipped occurrence replacement metadata.
- Local CLI/MCP/docs review found and verified an MCP handler execution test.
- Closure reviews reported no remaining P0/P1/P2 findings.

## Risks

- Transition mode is intentionally a safe occurrence-level vocabulary pass, not the full future transition-plan lifecycle. Deferred inventory and completion gates stay explicit when not all occurrences are applied or classified.
