### PR TITLE
feat(warden): add jurisdiction path scope

### DIFF
--- a/.changeset/trl-1073-warden-jurisdiction.md
+++ b/.changeset/trl-1073-warden-jurisdiction.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/trails": patch
+"@ontrails/warden": patch
+---
+
+Add Warden jurisdiction ignore globs through project config and the Trails CLI wrapper so governance runs can exclude local notes, scratch space, and generated state without dropping durable skills or plugin assets from scope.

--- a/apps/trails/README.md
+++ b/apps/trails/README.md
@@ -17,7 +17,7 @@ Common workflows:
 - `trails validate` checks root `trails.lock` for drift.
 - `trails wayfind`, `trails wayfind --trails --intent read`, `trails wayfind <id> --contract`, `trails wayfind <id> --deps`, `trails wayfind <id> --impact`, `trails wayfind pattern "wayfind.*"`, `trails wayfind query "release drift"`, `trails wayfind file <file> --outline`, and `trails wayfind diff ...` read graph artifacts and source outlines through Wayfinder for local navigation.
 - `trails schema <command...>` shows accepted CLI routes, aliases, flags, and schemas for an operator command.
-- `trails warden` runs Trails governance checks for contract and architecture drift.
+- `trails warden` runs Trails governance checks for contract and architecture drift. Use `--jurisdiction-ignore <glob>` or project `warden.jurisdiction.ignore` config when local notes, scratch space, or generated state should not be governed by Warden.
 - `trails regrade --root-dir <path> --json` dry-runs downstream migration checks; add `--apply` only to write safe rewrites. Use `trails regrade <from> <to> --root-dir <path> --json` for occurrence-level vocabulary regrade reports that include the authored plan, observed ledger, completion gate, and scan inventory by file type and top-level path. Add `--ignore <glob>` to keep migration scope away from local notes, scratch space, generated state, or other paths that should not be scanned for that transition; project config can provide `regrade.scope` defaults and explicit plan inputs override them. The same `regrade` trail is exposed through MCP for agent-driven migration checks.
 - `trails guide` remains available for compatibility; prefer `trails wayfind --source live --module <app-module>` or saved-artifact Wayfinder reads for agent navigation.
 

--- a/apps/trails/src/__tests__/warden.test.ts
+++ b/apps/trails/src/__tests__/warden.test.ts
@@ -200,6 +200,7 @@ describe('trails warden', () => {
       github: true,
       includeDrafts: false,
       json: false,
+      jurisdictionIgnore: ['.agents/notes/**', '.scratch/**'],
       lock: 'auto',
       noLockMutation: true,
       onlyDrafts: false,
@@ -221,6 +222,10 @@ describe('trails warden', () => {
       '--no-lock-mutation',
       '--fix',
       '--adapter-check',
+      '--jurisdiction-ignore',
+      '.agents/notes/**',
+      '--jurisdiction-ignore',
+      '.scratch/**',
       '--apps',
       'trails,demo',
     ]);
@@ -353,6 +358,42 @@ describe('trails warden', () => {
     );
   });
 
+  test('trails warden forwards jurisdiction ignore value flags', () => {
+    const dir = makeTempDir();
+    try {
+      mkdirSync(join(dir, '.agents', 'notes'), { recursive: true });
+      writeFileSync(
+        join(dir, '.agents', 'notes', 'ignored.ts'),
+        `export const flag = '--dev${'-permit'}';\n`
+      );
+
+      const raw = runCli(
+        trailsBinPath,
+        [
+          'warden',
+          '--depth',
+          'source',
+          '--lock',
+          'skip',
+          '--json',
+          '--root-dir',
+          dir,
+          '--jurisdiction-ignore',
+          '.agents/notes/**',
+        ],
+        repoRoot
+      );
+
+      expect(raw.exitCode).toBe(0);
+      expect(raw.json).toMatchObject({
+        passed: true,
+        summary: { errors: 0 },
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('standalone Warden bin shows help without running checks', () => {
     const raw = runRawCli(wardenBinPath, ['--help'], repoRoot);
 
@@ -362,6 +403,7 @@ describe('trails warden', () => {
     expect(raw.stdout).toContain('--depth <value>');
     expect(raw.stdout).toContain('--fix');
     expect(raw.stdout).toContain('--adapter-check');
+    expect(raw.stdout).toContain('--jurisdiction-ignore <glob>');
     expect(raw.stdout).not.toContain('Warden Report');
   });
 

--- a/apps/trails/src/cli.ts
+++ b/apps/trails/src/cli.ts
@@ -247,6 +247,7 @@ const wardenValueFlags = new Set([
   '--drafts',
   '--fail-on',
   '--format',
+  '--jurisdiction-ignore',
   '--lock',
   '--root-dir',
 ]);

--- a/apps/trails/src/trails/warden.ts
+++ b/apps/trails/src/trails/warden.ts
@@ -57,6 +57,10 @@ const wardenInputSchema = z.object({
     .default(false)
     .describe('Alias for --drafts include'),
   json: z.boolean().default(false).describe('Alias for --format json'),
+  jurisdictionIgnore: z
+    .array(z.string())
+    .optional()
+    .describe('Root-relative path globs that Warden should not govern'),
   lock: z.enum(wardenLockValues).optional().describe('Lockfile mode'),
   noLockMutation: z
     .boolean()
@@ -106,6 +110,16 @@ const pushApps = (
   }
 };
 
+const pushRepeatedValues = (
+  args: string[],
+  flag: string,
+  values: readonly string[] | undefined
+): void => {
+  for (const value of values ?? []) {
+    args.push(flag, value);
+  }
+};
+
 export const buildWardenCommandArgs = (
   input: WardenTrailInput
 ): readonly string[] => {
@@ -150,6 +164,7 @@ export const buildWardenCommandArgs = (
   pushFlag(args, input.fix, '--fix');
   pushFlag(args, input.adapterCheck, '--adapter-check');
   pushValue(args, '--config-path', input.configPath);
+  pushRepeatedValues(args, '--jurisdiction-ignore', input.jurisdictionIgnore);
   pushApps(args, input.apps);
 
   return args;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -425,6 +425,7 @@ SurfaceParityOptions, SurfaceParityComparison
 runWarden(options?), formatWardenReport(report), checkDrift(rootDir, topo?)
 // WardenOptions includes optional tier: source-static | project-static | topo-aware | drift | advisory
 // WardenOptions includes projectRules: false for embedders that opt out of project-local rules
+// WardenOptions includes jurisdiction.ignore root-relative globs for paths Warden should not govern
 loadProjectWardenRules(rootDir)    // load .trails/rules.ts or direct .trails/rules/*.ts modules
 
 // Built-in registries and wrapped topo
@@ -462,7 +463,12 @@ WardenOptions, WardenReport, WardenDiagnostic, WardenSeverity, DriftResult
 ProjectAwareWardenRule, ProjectContext, TopoAwareWardenRule, WardenRule
 WardenRuleMetadata, WardenRuleTier, WardenRuleScope, WardenRuleLifecycle
 RuleInput, ProjectAwareRuleInput, RuleOutput, TopoAwareRuleInput
+WardenJurisdiction
+matchesPathPattern(path, pattern), matchesAnyPathPattern(path, patterns)
+pathPatternToRegExp(pattern)
 ```
+
+Project `trails.config.*` files may provide `warden.jurisdiction.ignore` defaults, and `trails warden --jurisdiction-ignore <glob>` can override them for a single run. Jurisdiction globs are root-relative path-scope controls for governance; use Regrade `scope.ignore` for migration scan scope.
 
 ## `@ontrails/warden/ast`
 

--- a/docs/contributing/warden-rules.md
+++ b/docs/contributing/warden-rules.md
@@ -49,6 +49,8 @@ Warden does not recursively discover nested rule files. Keep the public project-
 
 Project-root discovery uses committed project markers such as `trails.config.*` or `trails.lock`, with source-shaped projects as fallback when no committed marker exists above them. A bare `.trails/` directory is not a root marker by itself. This lets Warden find root-local rules from nested cwd invocations without making every incidental `.trails/` folder look like a project boundary.
 
+Use `warden.jurisdiction.ignore` in project config, or `trails warden --jurisdiction-ignore <glob>` for a single run, when Warden should not govern local notes, scratch space, generated state, or other root-relative paths. Jurisdiction is a path-scope boundary for governance, not a rule skip-list: ignored files do not feed source diagnostics or project-derived facts. Keep durable skills, plugin assets, and source-owned agent guidance in scope unless the project has a concrete reason to exclude them.
+
 Use `.trails/rules.ts` or direct `.trails/rules/*.ts` children when the invariant is real for this project but not yet a framework promise. Promote the rule into `@ontrails/warden` only after the survival tests show it belongs to Trails users broadly. Delete it when the migration or temporary hardening window closes.
 
 ## Core Principle

--- a/packages/warden/README.md
+++ b/packages/warden/README.md
@@ -47,6 +47,28 @@ Warden uses the shared Trails project-root resolver when a caller does not pass 
 
 This is the right home for repo-specific migration checks or governance that has not earned a place in `@ontrails/warden` itself.
 
+## Jurisdiction
+
+Use `warden.jurisdiction.ignore` in `trails.config.*` to keep generated, scratch, or local planning paths outside Warden governance while leaving durable project paths in scope.
+
+```json
+{
+  "warden": {
+    "jurisdiction": {
+      "ignore": [".scratch/**", ".agents/notes/**"]
+    }
+  }
+}
+```
+
+For a single run, pass one or more root-relative globs:
+
+```bash
+warden --jurisdiction-ignore '.scratch/**' --jurisdiction-ignore '.agents/notes/**'
+```
+
+Jurisdiction is a governance boundary, not a migration scan boundary. Regrade uses its own `scope.ignore` / `--ignore` controls for migration plans.
+
 A rule module may export `rule`, `rules`, `sourceRule`, `sourceRules`, `topoRule`, or `topoRules`. Rules without explicit metadata receive default repo-local source-static or topo-aware metadata so short migration rules can run without extra ceremony. Project-aware source rules that provide `checkWithContext()` default to repo-local project-static metadata.
 
 ```typescript
@@ -161,6 +183,9 @@ This is the same factory used internally to build all built-in rule trails.
 | `formatGitHubAnnotations(report)` | GitHub Actions annotation format |
 | `formatJson(report)` | Machine-readable JSON |
 | `formatSummary(report)` | Compact summary line |
+| `matchesPathPattern(path, pattern)` | Test a root-relative path against a Warden jurisdiction glob |
+| `matchesAnyPathPattern(path, patterns)` | Test a root-relative path against any Warden jurisdiction glob |
+| `pathPatternToRegExp(pattern)` | Compile a Warden jurisdiction glob into a regular expression |
 | `wrapRule(rule)` | Wrap a custom rule as a trail (same factory used for all built-in rule trails) |
 
 AST parser helpers are exported from `@ontrails/warden/ast`, not the root runtime barrel. The stable authoring surface includes `parse`, `walk`, `walkScope`, `walkWithParents`, `walkWithScopeContext`, `offsetToLine`, `offsetToLineColumn`, source-edit helpers, `findTrailDefinitions`, `findBlazeBodies`, `findContourDefinitions`, `isBlazeCall`, and string-literal helpers.

--- a/packages/warden/bin/warden.ts
+++ b/packages/warden/bin/warden.ts
@@ -19,6 +19,7 @@ Options:
   --fail-on <value>            error or warning
   --format <value>             summary, github, or json
   --drafts <value>             include, exclude, or only
+  --jurisdiction-ignore <glob> Root-relative path glob Warden should not govern
   --lock <value>               auto, cached, refresh, or skip
   --no-lock-mutation           Do not write lock artifacts
   --strict                     Fail on warnings

--- a/packages/warden/src/__tests__/command.test.ts
+++ b/packages/warden/src/__tests__/command.test.ts
@@ -15,6 +15,9 @@ import { parseWardenCommandArgs, runWardenCommand } from '../command.js';
 const makeTempDir = (): string =>
   mkdtempSync(join(tmpdir(), 'warden-command-'));
 
+const unsafeDevPermitScript = (): string =>
+  `trails run dangerous --dev${'-permit'}\n`;
+
 describe('parseWardenCommandArgs', () => {
   test('expands presets and generic CLI value aliases', () => {
     const parsed = parseWardenCommandArgs([
@@ -23,6 +26,10 @@ describe('parseWardenCommandArgs', () => {
       '--strict',
       '--cached',
       '--exclude-drafts',
+      '--jurisdiction-ignore',
+      '.agents/notes/**,.scratch/**',
+      '--jurisdiction-ignore',
+      'tmp/**',
       '-a',
       'trails,admin',
       '--no-lock-mutation',
@@ -35,6 +42,9 @@ describe('parseWardenCommandArgs', () => {
       drafts: 'exclude',
       failOn: 'warning',
       format: 'json',
+      jurisdiction: {
+        ignore: ['.agents/notes/**', '.scratch/**', 'tmp/**'],
+      },
       lock: 'cached',
       noLockMutation: true,
     });
@@ -273,6 +283,94 @@ describe('runWardenCommand', () => {
         depth: 'source',
         lock: 'skip',
       });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('applies Warden jurisdiction ignores from project config', async () => {
+    const dir = makeTempDir();
+    try {
+      mkdirSync(join(dir, '.agents', 'notes'), { recursive: true });
+      mkdirSync(join(dir, '.agents', 'skills', 'demo'), { recursive: true });
+      writeFileSync(
+        join(dir, 'trails.config.json'),
+        `${JSON.stringify({
+          warden: {
+            depth: 'source',
+            jurisdiction: { ignore: ['.agents/notes/**'] },
+            lock: 'skip',
+          },
+        })}\n`
+      );
+      writeFileSync(
+        join(dir, '.agents', 'notes', 'scratch.sh'),
+        unsafeDevPermitScript()
+      );
+      writeFileSync(
+        join(dir, '.agents', 'skills', 'demo', 'SKILL.sh'),
+        unsafeDevPermitScript()
+      );
+
+      const result = await runWardenCommand({
+        args: ['--format', 'json'],
+        cwd: dir,
+        env: {},
+      });
+
+      const diagnosticPaths = result.report.diagnostics.map(
+        (diagnostic) => diagnostic.filePath
+      );
+      expect(diagnosticPaths).not.toContain(
+        join(dir, '.agents', 'notes', 'scratch.sh')
+      );
+      expect(diagnosticPaths).toContain(
+        join(dir, '.agents', 'skills', 'demo', 'SKILL.sh')
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('lets CLI jurisdiction ignores override project config', async () => {
+    const dir = makeTempDir();
+    try {
+      mkdirSync(join(dir, '.agents', 'notes'), { recursive: true });
+      mkdirSync(join(dir, '.agents', 'skills', 'demo'), { recursive: true });
+      writeFileSync(
+        join(dir, 'trails.config.json'),
+        `${JSON.stringify({
+          warden: {
+            depth: 'source',
+            jurisdiction: { ignore: ['.agents/skills/**'] },
+            lock: 'skip',
+          },
+        })}\n`
+      );
+      writeFileSync(
+        join(dir, '.agents', 'notes', 'scratch.sh'),
+        unsafeDevPermitScript()
+      );
+      writeFileSync(
+        join(dir, '.agents', 'skills', 'demo', 'SKILL.sh'),
+        unsafeDevPermitScript()
+      );
+
+      const result = await runWardenCommand({
+        args: ['--format', 'json', '--jurisdiction-ignore', '.agents/notes/**'],
+        cwd: dir,
+        env: {},
+      });
+
+      const diagnosticPaths = result.report.diagnostics.map(
+        (diagnostic) => diagnostic.filePath
+      );
+      expect(diagnosticPaths).not.toContain(
+        join(dir, '.agents', 'notes', 'scratch.sh')
+      );
+      expect(diagnosticPaths).toContain(
+        join(dir, '.agents', 'skills', 'demo', 'SKILL.sh')
+      );
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/warden/src/__tests__/config.test.ts
+++ b/packages/warden/src/__tests__/config.test.ts
@@ -15,6 +15,9 @@ describe('wardenConfigSchema', () => {
       drafts: 'include',
       failOn: 'error',
       format: 'summary',
+      jurisdiction: {
+        ignore: [],
+      },
       lock: 'auto',
     });
   });
@@ -26,6 +29,9 @@ describe('wardenConfigSchema', () => {
       drafts: 'exclude',
       failOn: 'warning',
       format: 'github',
+      jurisdiction: {
+        ignore: ['.agents/notes/**', '.scratch/**'],
+      },
       lock: 'cached',
     });
 
@@ -36,6 +42,9 @@ describe('wardenConfigSchema', () => {
       drafts: 'exclude',
       failOn: 'warning',
       format: 'github',
+      jurisdiction: {
+        ignore: ['.agents/notes/**', '.scratch/**'],
+      },
       lock: 'cached',
     });
   });
@@ -75,6 +84,9 @@ describe('wardenConfigSchema', () => {
         drafts: 'include',
         failOn: 'error',
         format: 'summary',
+        jurisdiction: {
+          ignore: [],
+        },
         lock: 'auto',
       },
     });
@@ -98,6 +110,9 @@ describe('wardenConfigSchema', () => {
       drafts: 'include',
       failOn: 'error',
       format: 'json',
+      jurisdiction: {
+        ignore: [],
+      },
       lock: 'cached',
       noLockMutation: false,
     });

--- a/packages/warden/src/__tests__/path-scope.test.ts
+++ b/packages/warden/src/__tests__/path-scope.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+
+import { matchesPathPattern } from '../path-scope.js';
+
+describe('path-scope', () => {
+  test('matches recursive globs at the root and in nested directories', () => {
+    expect(matchesPathPattern('root.ts', '**/*.ts')).toBe(true);
+    expect(matchesPathPattern('src/root.ts', '**/*.ts')).toBe(true);
+    expect(matchesPathPattern('src/nested/root.ts', '**/*.ts')).toBe(true);
+    expect(matchesPathPattern('src/root.md', '**/*.ts')).toBe(false);
+  });
+
+  test('matches directory globs without swallowing sibling paths', () => {
+    expect(matchesPathPattern('.agents/notes', '.agents/notes/**')).toBe(true);
+    expect(
+      matchesPathPattern('.agents/notes/plan.md', '.agents/notes/**')
+    ).toBe(true);
+    expect(
+      matchesPathPattern('.agents/skills/demo/SKILL.md', '.agents/notes/**')
+    ).toBe(false);
+  });
+});

--- a/packages/warden/src/__tests__/public-internal-deep-imports.test.ts
+++ b/packages/warden/src/__tests__/public-internal-deep-imports.test.ts
@@ -16,7 +16,10 @@ import {
 } from '../project-context.js';
 import { publicInternalDeepImports } from '../rules/public-internal-deep-imports.js';
 import type { ProjectContext } from '../rules/types.js';
-import type { WardenProjectContextSourceFile } from '../project-context.js';
+import type {
+  WardenProjectContextSourceFile,
+  WardenPublicWorkspace,
+} from '../project-context.js';
 
 const makeTempDir = (prefix: string): string => {
   const dir = join(
@@ -142,19 +145,29 @@ const createFixture = (): PublicSurfaceFixture => {
 
 const collectContext = (
   fixture: PublicSurfaceFixture,
-  sourceFiles: readonly WardenProjectContextSourceFile[]
+  sourceFiles: readonly WardenProjectContextSourceFile[],
+  options: {
+    readonly publicWorkspaces?: ReadonlyMap<string, WardenPublicWorkspace>;
+  } = {}
 ): ProjectContext => ({
   documentedImportResolutionsByFile:
     collectProjectDocumentationImportResolutions({
+      ...(options.publicWorkspaces
+        ? { publicWorkspaces: options.publicWorkspaces }
+        : {}),
       rootDir: fixture.rootDir,
       sourceFiles,
     }),
   importResolutionsByFile: collectProjectImportResolutions({
+    ...(options.publicWorkspaces
+      ? { publicWorkspaces: options.publicWorkspaces }
+      : {}),
     rootDir: fixture.rootDir,
     sourceFiles,
   }),
   knownTrailIds: new Set<string>(),
-  publicWorkspaces: collectPublicWorkspaces(fixture.rootDir),
+  publicWorkspaces:
+    options.publicWorkspaces ?? collectPublicWorkspaces(fixture.rootDir),
 });
 
 const checkFixture = (
@@ -211,6 +224,36 @@ describe('public-internal-deep-imports', () => {
         ];
 
       expect(target?.endsWith('/src/conditional.ts')).toBe(true);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('honors jurisdiction ignores for project-derived workspace facts', () => {
+    const fixture = createFixture();
+    try {
+      const workspaces = collectPublicWorkspaces(fixture.rootDir, {
+        ignore: ['packages/core/**'],
+      });
+      const sourceCode =
+        'Use `@ontrails/core/internal/secret` only if it is public.\\n';
+      writeSource(fixture.readmePath, sourceCode);
+      const sourceFile = {
+        filePath: fixture.readmePath,
+        kind: 'documentation' as const,
+        sourceCode,
+      };
+
+      expect([...workspaces.keys()]).not.toContain('@ontrails/core');
+      expect(
+        publicInternalDeepImports.checkWithContext(
+          sourceCode,
+          fixture.readmePath,
+          collectContext(fixture, [sourceFile], {
+            publicWorkspaces: workspaces,
+          })
+        )
+      ).toEqual([]);
     } finally {
       rmSync(fixture.rootDir, { force: true, recursive: true });
     }

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -20,6 +20,7 @@ import type {
   WardenDepth,
   WardenFailOn,
   WardenFormat,
+  WardenJurisdiction,
   WardenLockMode,
 } from './config.js';
 import { runWardenAdapterChecks } from './adapter-check.js';
@@ -28,6 +29,7 @@ import { isDraftMarkedFile } from './draft.js';
 import { applySafeFixesToSource, hasSafeFixEdits } from './fix.js';
 import type { DriftResult } from './drift.js';
 import { checkDrift } from './drift.js';
+import { matchesAnyPathPattern } from './path-scope.js';
 import { loadProjectWardenRules } from './project-rules.js';
 import type { ProjectWardenRules } from './project-rules.js';
 import {
@@ -105,6 +107,8 @@ export interface WardenRunOptions {
   readonly fix?: boolean | undefined;
   /** Output format requested by the caller. */
   readonly format?: WardenFormat | undefined;
+  /** Root-relative source paths that Warden should not govern. */
+  readonly jurisdiction?: WardenJurisdiction | undefined;
   /** Lockfile mode requested by the caller. */
   readonly lock?: WardenLockMode | undefined;
   /** Suppress lockfile mutation for CI/pre-push callers. */
@@ -259,6 +263,31 @@ const filterSourceFilesByDraftMode = (
     : sourceFiles.filter((sourceFile) =>
         draftModeIncludesFile(sourceFile.filePath, drafts)
       );
+
+const rootRelativeJurisdictionPath = (
+  rootDir: string,
+  filePath: string
+): string => relative(rootDir, filePath).replaceAll('\\', '/');
+
+const filterSourceFilesByJurisdiction = (
+  sourceFiles: readonly SourceFile[],
+  rootDir: string,
+  jurisdiction: WardenJurisdiction
+): readonly SourceFile[] => {
+  if (jurisdiction.ignore.length === 0) {
+    return sourceFiles;
+  }
+
+  return sourceFiles.filter(
+    (sourceFile) =>
+      !matchesAnyPathPattern(
+        rootRelativeJurisdictionPath(rootDir, sourceFile.filePath),
+        jurisdiction.ignore
+      )
+  );
+};
+
+const EMPTY_WARDEN_JURISDICTION: WardenJurisdiction = { ignore: [] };
 
 const collectDevPermitTestFiles = (dir: string): readonly string[] => {
   const glob = new Bun.Glob('**/*.ts');
@@ -799,6 +828,7 @@ const collectFileImportResolutions = (
   context: MutableProjectContext
 ): void => {
   const resolutionsByFile = collectProjectImportResolutions({
+    publicWorkspaces: context.publicWorkspaces,
     rootDir,
     sourceFiles,
   });
@@ -813,6 +843,7 @@ const collectFileDocumentedImportResolutions = (
   context: MutableProjectContext
 ): void => {
   const resolutionsByFile = collectProjectDocumentationImportResolutions({
+    publicWorkspaces: context.publicWorkspaces,
     rootDir,
     sourceFiles,
   });
@@ -824,7 +855,8 @@ const collectFileDocumentedImportResolutions = (
 const buildProjectContext = (
   sourceFiles: readonly SourceFile[],
   rootDir: string,
-  appTopos: readonly Topo[] = []
+  appTopos: readonly Topo[] = [],
+  jurisdiction: WardenJurisdiction = EMPTY_WARDEN_JURISDICTION
 ): ProjectContext => {
   const context = createMutableProjectContext();
   const typeScriptSourceFiles = sourceFiles.filter(
@@ -833,7 +865,9 @@ const buildProjectContext = (
   const documentationSourceFiles = sourceFiles.filter(
     (sourceFile) => sourceFile.kind === 'documentation'
   );
-  context.publicWorkspaces = collectPublicWorkspaces(rootDir);
+  context.publicWorkspaces = collectPublicWorkspaces(rootDir, {
+    ignore: jurisdiction.ignore,
+  });
 
   if (appTopos.length > 0) {
     for (const appTopo of appTopos) {
@@ -1145,6 +1179,7 @@ interface WardenLintResult {
 const lintFiles = async (
   rootDir: string,
   drafts: EffectiveWardenConfig['drafts'],
+  jurisdiction: EffectiveWardenConfig['jurisdiction'],
   topoTargets: readonly WardenTopoTarget[],
   extraTopoRules: readonly TopoAwareWardenRule[],
   extraSourceRules: readonly WardenRule[],
@@ -1159,14 +1194,16 @@ const lintFiles = async (
     };
   }
 
-  const sourceFiles = filterSourceFilesByDraftMode(
-    await loadSourceFiles(rootDir),
-    drafts
+  const sourceFiles = filterSourceFilesByJurisdiction(
+    filterSourceFilesByDraftMode(await loadSourceFiles(rootDir), drafts),
+    rootDir,
+    jurisdiction
   );
   const context = buildProjectContext(
     sourceFiles,
     rootDir,
-    topoTargets.map((target) => target.topo)
+    topoTargets.map((target) => target.topo),
+    jurisdiction
   );
   const allDiagnostics: WardenDiagnostic[] = [
     ...lintSourceFiles(sourceFiles, context, extraSourceRules, selector),
@@ -1339,6 +1376,7 @@ const buildCliConfigLayer = (options: WardenRunOptions): WardenConfigLayer => ({
   ...(options.drafts ? { drafts: options.drafts } : {}),
   ...(options.failOn ? { failOn: options.failOn } : {}),
   ...(options.format ? { format: options.format } : {}),
+  ...(options.jurisdiction ? { jurisdiction: options.jurisdiction } : {}),
   ...(options.lock ? { lock: options.lock } : {}),
   ...(options.noLockMutation === undefined
     ? {}
@@ -1476,6 +1514,7 @@ export const runWarden = async (
     ? await lintFiles(
         rootDir,
         effectiveConfig.drafts,
+        effectiveConfig.jurisdiction,
         topoTargets,
         [...projectRules.topoRules, ...(options.extraTopoRules ?? [])],
         [...projectRules.sourceRules, ...(options.extraSourceRules ?? [])],

--- a/packages/warden/src/command.ts
+++ b/packages/warden/src/command.ts
@@ -26,6 +26,7 @@ import type {
   WardenDraftsMode,
   WardenFailOn,
   WardenFormat,
+  WardenJurisdiction,
   WardenLockMode,
 } from './config.js';
 import {
@@ -57,6 +58,7 @@ interface MutableWardenConfigLayer {
   drafts?: WardenDraftsMode | undefined;
   failOn?: WardenFailOn | undefined;
   format?: WardenFormat | undefined;
+  jurisdiction?: WardenJurisdiction | undefined;
   lock?: WardenLockMode | undefined;
   noLockMutation?: boolean | undefined;
 }
@@ -90,6 +92,12 @@ const cleanUndefined = <T extends Record<string, unknown>>(
   ) as Partial<T>;
 
 const splitApps = (value: string): readonly string[] =>
+  value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+const splitCommaDelimitedValues = (value: string): readonly string[] =>
   value
     .split(',')
     .map((entry) => entry.trim())
@@ -244,6 +252,7 @@ const parseTokens = (
         'fail-on': { type: 'string' },
         fix: { type: 'boolean' },
         format: { type: 'string' },
+        'jurisdiction-ignore': { multiple: true, type: 'string' },
         lock: { type: 'string' },
         'no-lock-mutation': { type: 'boolean' },
         'pre-push': { type: 'boolean' },
@@ -395,6 +404,19 @@ const applyCommandOption = (
   }
   if (token.name === 'config-path') {
     state.configPath = value;
+    return;
+  }
+  if (token.name === 'jurisdiction-ignore') {
+    if (value === undefined) {
+      state.diagnostics.push(
+        diagnostic({ message: '--jurisdiction-ignore requires a path glob.' })
+      );
+      return;
+    }
+    const existing = state.cli.jurisdiction?.ignore ?? [];
+    state.cli.jurisdiction = {
+      ignore: [...existing, ...splitCommaDelimitedValues(value)],
+    };
     return;
   }
   if (token.name === 'fix') {
@@ -818,6 +840,7 @@ const buildRunOptions = ({
     failOn: cli.failOn,
     fix,
     format: cli.format,
+    jurisdiction: cli.jurisdiction,
     lock: cli.lock,
     noLockMutation: cli.noLockMutation,
     rootDir,

--- a/packages/warden/src/config.ts
+++ b/packages/warden/src/config.ts
@@ -10,6 +10,13 @@ export const wardenDraftsValues = ['include', 'exclude', 'only'] as const;
 
 const appNameSchema = z.string().min(1);
 
+const wardenJurisdictionSchema = z
+  .object({
+    ignore: z.array(z.string().min(1)).default([]),
+  })
+  .strict()
+  .default({ ignore: [] });
+
 const wardenConfigObjectSchema = z
   .object({
     apps: z.array(appNameSchema).min(1).optional(),
@@ -17,6 +24,7 @@ const wardenConfigObjectSchema = z
     drafts: z.enum(wardenDraftsValues).default('include'),
     failOn: z.enum(wardenFailOnValues).default('error'),
     format: z.enum(wardenFormatValues).default('summary'),
+    jurisdiction: wardenJurisdictionSchema,
     lock: z.enum(wardenLockValues).default('auto'),
   })
   .strict();
@@ -31,6 +39,7 @@ export type WardenDepth = (typeof wardenDepthValues)[number];
 export type WardenDraftsMode = (typeof wardenDraftsValues)[number];
 export type WardenFailOn = (typeof wardenFailOnValues)[number];
 export type WardenFormat = (typeof wardenFormatValues)[number];
+export type WardenJurisdiction = z.output<typeof wardenJurisdictionSchema>;
 export type WardenLockMode = (typeof wardenLockValues)[number];
 
 export interface WardenConfigLayer extends Partial<WardenConfig> {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -101,6 +101,7 @@ export type {
   WardenDraftsMode,
   WardenFailOn,
   WardenFormat,
+  WardenJurisdiction,
   WardenLockMode,
   EffectiveWardenConfig,
   ResolveWardenConfigOptions,
@@ -108,6 +109,11 @@ export type {
   WardenConfigResolution,
 } from './config.js';
 export { resolveWardenConfig } from './config.js';
+export {
+  matchesAnyPathPattern,
+  matchesPathPattern,
+  pathPatternToRegExp,
+} from './path-scope.js';
 
 // CI formatters
 export {

--- a/packages/warden/src/path-scope.ts
+++ b/packages/warden/src/path-scope.ts
@@ -1,0 +1,51 @@
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const normalizePath = (value: string): string =>
+  value.replaceAll('\\', '/').replace(/^\.\//, '');
+
+export const pathPatternToRegExp = (pattern: string): RegExp => {
+  const normalized = normalizePath(pattern);
+  const parts: string[] = ['^'];
+
+  for (let index = 0; index < normalized.length; index += 1) {
+    const char = normalized[index];
+    const next = normalized[index + 1];
+
+    if (char === '*' && next === '*') {
+      if (normalized[index + 2] === '/') {
+        parts.push('(?:.*/)?');
+        index += 2;
+      } else {
+        parts.push('.*');
+        index += 1;
+      }
+      continue;
+    }
+    if (char === '*') {
+      parts.push('[^/]*');
+      continue;
+    }
+    parts.push(escapeRegExp(char ?? ''));
+  }
+
+  parts.push('$');
+  return new RegExp(parts.join(''));
+};
+
+export const matchesPathPattern = (path: string, pattern: string): boolean => {
+  const normalizedPath = normalizePath(path);
+  const normalizedPattern = normalizePath(pattern);
+  if (
+    normalizedPattern.endsWith('/**') &&
+    normalizedPath === normalizedPattern.slice(0, -3)
+  ) {
+    return true;
+  }
+  return pathPatternToRegExp(normalizedPattern).test(normalizedPath);
+};
+
+export const matchesAnyPathPattern = (
+  path: string,
+  patterns: readonly string[]
+): boolean => patterns.some((pattern) => matchesPathPattern(path, pattern));

--- a/packages/warden/src/project-context.ts
+++ b/packages/warden/src/project-context.ts
@@ -81,16 +81,42 @@ const exportAliasesForWorkspaces = (
   return aliases;
 };
 
+const resolveOptionsWithWorkspaceAliases = (
+  publicWorkspaces: ReadonlyMap<string, WardenPublicWorkspace> | undefined,
+  resolveOptions: WardenResolverOptions['resolveOptions'] | undefined
+): WardenResolverOptions['resolveOptions'] => {
+  if (!publicWorkspaces) {
+    return resolveOptions;
+  }
+
+  const workspaceAliases = exportAliasesForWorkspaces(publicWorkspaces);
+  return {
+    ...resolveOptions,
+    alias: {
+      ...workspaceAliases,
+      ...resolveOptions?.alias,
+    },
+  };
+};
+
 export const collectProjectImportResolutions = ({
+  publicWorkspaces,
   resolveOptions,
   rootDir,
   sourceFiles,
 }: {
+  readonly publicWorkspaces?: ReadonlyMap<string, WardenPublicWorkspace>;
   readonly resolveOptions?: WardenResolverOptions['resolveOptions'];
   readonly rootDir: string;
   readonly sourceFiles: readonly WardenProjectContextSourceFile[];
 }): ReadonlyMap<string, readonly WardenImportResolution[]> => {
-  const resolver = createWardenResolver({ resolveOptions, rootDir });
+  const resolver = createWardenResolver({
+    resolveOptions: resolveOptionsWithWorkspaceAliases(
+      publicWorkspaces,
+      resolveOptions
+    ),
+    rootDir,
+  });
   const resolutionsByFile = new Map<
     string,
     readonly WardenImportResolution[]
@@ -118,13 +144,16 @@ export const collectProjectImportResolutions = ({
 };
 
 export const collectProjectDocumentationImportResolutions = ({
+  publicWorkspaces: providedPublicWorkspaces,
   rootDir,
   sourceFiles,
 }: {
+  readonly publicWorkspaces?: ReadonlyMap<string, WardenPublicWorkspace>;
   readonly rootDir: string;
   readonly sourceFiles: readonly WardenProjectContextSourceFile[];
 }): ReadonlyMap<string, readonly WardenImportResolution[]> => {
-  const publicWorkspaces = collectPublicWorkspaces(rootDir);
+  const publicWorkspaces =
+    providedPublicWorkspaces ?? collectPublicWorkspaces(rootDir);
   const resolver = createWardenResolver({
     resolveOptions: { alias: exportAliasesForWorkspaces(publicWorkspaces) },
     rootDir,

--- a/packages/warden/src/workspaces.ts
+++ b/packages/warden/src/workspaces.ts
@@ -3,7 +3,9 @@
  */
 
 import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
+
+import { matchesAnyPathPattern } from './path-scope.js';
 
 export interface WardenPublicWorkspace {
   readonly name: string;
@@ -13,6 +15,10 @@ export interface WardenPublicWorkspace {
   readonly bin?: Readonly<Record<string, string>> | undefined;
   readonly exportTargets?: Readonly<Record<string, string>> | undefined;
   readonly files?: readonly string[] | undefined;
+}
+
+export interface WardenWorkspaceCollectionOptions {
+  readonly ignore?: readonly string[];
 }
 
 interface RootManifest {
@@ -36,6 +42,9 @@ const normalizeRealPath = (path: string): string => {
     return normalizePath(resolve(path));
   }
 };
+
+const rootRelativePath = (rootDir: string, path: string): string =>
+  normalizePath(relative(rootDir, path));
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === 'object' && !Array.isArray(value));
@@ -208,7 +217,8 @@ const publicWorkspaceFromManifest = (
 };
 
 export const collectPublicWorkspaces = (
-  rootDir: string
+  rootDir: string,
+  options: WardenWorkspaceCollectionOptions = {}
 ): ReadonlyMap<string, WardenPublicWorkspace> => {
   const normalizedRoot = normalizeRealPath(rootDir);
   const rootManifest = readJson<RootManifest>(
@@ -228,7 +238,17 @@ export const collectPublicWorkspaces = (
       }
 
       const workspace = publicWorkspaceFromManifest(packageJsonPath, manifest);
-      if (workspace) {
+      if (
+        workspace &&
+        !matchesAnyPathPattern(
+          rootRelativePath(normalizedRoot, workspace.rootDir),
+          options.ignore ?? []
+        ) &&
+        !matchesAnyPathPattern(
+          rootRelativePath(normalizedRoot, workspace.packageJsonPath),
+          options.ignore ?? []
+        )
+      ) {
         workspaces.set(workspace.name, workspace);
       }
     }


### PR DESCRIPTION
## Summary
- Add Warden jurisdiction ignore config and CLI/MCP projection.
- Filter ignored source/text paths and project-derived public workspace facts before Warden diagnostics.
- Export path-scope helpers and document jurisdiction usage in the Warden package.

## Verification
- `bun test packages/warden/src/__tests__/path-scope.test.ts packages/warden/src/__tests__/command.test.ts packages/warden/src/__tests__/public-internal-deep-imports.test.ts apps/trails/src/__tests__/warden.test.ts`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run changeset:check`
- `bun run publish:check`
- `bun apps/trails/bin/trails.ts warden --depth source --lock skip --json --jurisdiction-ignore '.scratch/**' --jurisdiction-ignore '.agents/notes/**' --jurisdiction-ignore '.agents/plans/**' --jurisdiction-ignore '.agents/goals/**'`

## Notes
- This is Warden governance jurisdiction, not Regrade migration scan scope. It intentionally lets `.agents/skills/**` remain governed while notes/plans/goals can be excluded.
