### PR TITLE
feat(core): add shared glob path scope contracts

### DIFF
--- a/.changeset/trl-1075-core-glob-path-scope.md
+++ b/.changeset/trl-1075-core-glob-path-scope.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/core": patch
+---
+
+Add shared glob, path-scope, and trail-id glob contracts for downstream Trails tooling.

--- a/packages/core/src/__tests__/glob.test.ts
+++ b/packages/core/src/__tests__/glob.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+
+import { matchesGlob } from '../glob.js';
+import { includedByPathScope, matchesPathGlob } from '../path-scope.js';
+import { matchesTrailIdGlob } from '../trail-id-glob.js';
+
+describe('glob engine', () => {
+  test('matches segment wildcards without crossing the separator', () => {
+    expect(matchesGlob('entity.show', 'entity.*', { separator: '.' })).toBe(
+      true
+    );
+    expect(
+      matchesGlob('entity.admin.show', 'entity.*', { separator: '.' })
+    ).toBe(false);
+  });
+
+  test('matches recursive wildcards across separator depth', () => {
+    expect(matchesGlob('src/app.ts', 'src/**/*.ts', { separator: '/' })).toBe(
+      true
+    );
+    expect(
+      matchesGlob('src/nested/app.ts', 'src/**/*.ts', { separator: '/' })
+    ).toBe(true);
+  });
+
+  test('matches terminal recursive patterns at zero depth', () => {
+    expect(matchesGlob('entity', 'entity.**', { separator: '.' })).toBe(true);
+    expect(matchesGlob('entity.show', 'entity.**', { separator: '.' })).toBe(
+      true
+    );
+    expect(
+      matchesGlob('.agents/notes', '.agents/notes/**', {
+        separator: '/',
+      })
+    ).toBe(true);
+  });
+
+  test('matches question marks within a segment', () => {
+    expect(matchesGlob('user.read', 'user.????', { separator: '.' })).toBe(
+      true
+    );
+    expect(matchesGlob('user.read.many', 'user.????', { separator: '.' })).toBe(
+      false
+    );
+  });
+});
+
+describe('path scope', () => {
+  test('normalizes leading dot-slash and backslash paths', () => {
+    expect(matchesPathGlob('./src/app.ts', 'src/**/*.ts')).toBe(true);
+    expect(matchesPathGlob('src\\nested\\app.ts', 'src/**/*.ts')).toBe(true);
+    expect(
+      includedByPathScope('src/app.ts', {
+        include: ['src\\**'],
+      })
+    ).toBe(true);
+  });
+
+  test('applies include, exclude, and extension filters together', () => {
+    const scope = {
+      exclude: ['src/generated/**'],
+      extensions: ['ts'],
+      include: ['src/**'],
+    };
+
+    expect(includedByPathScope('src/app.ts', scope)).toBe(true);
+    expect(includedByPathScope('src/generated/app.ts', scope)).toBe(false);
+    expect(includedByPathScope('docs/app.md', scope)).toBe(false);
+    expect(includedByPathScope('src/readme.md', scope)).toBe(false);
+  });
+});
+
+describe('trail-id glob', () => {
+  test('matches dotted trail IDs without treating path globs as interchangeable', () => {
+    expect(matchesTrailIdGlob('wayfind.search', 'wayfind.*')).toBe(true);
+    expect(matchesTrailIdGlob('wayfind.search.deep', 'wayfind.*')).toBe(false);
+    expect(matchesTrailIdGlob('wayfind.search.deep', 'wayfind.**')).toBe(true);
+  });
+});

--- a/packages/core/src/glob.ts
+++ b/packages/core/src/glob.ts
@@ -1,0 +1,73 @@
+export interface GlobConfig {
+  readonly separator: '/' | '.';
+}
+
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const separatorRegExp = (separator: GlobConfig['separator']): string =>
+  escapeRegExp(separator);
+
+export const globToRegExp = (pattern: string, config: GlobConfig): RegExp => {
+  const separator = separatorRegExp(config.separator);
+  const parts: string[] = ['^'];
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index];
+    const next = pattern[index + 1];
+
+    if (char === '*' && next === '*') {
+      if (pattern[index + 2] === config.separator) {
+        parts.push(`(?:.*${separator})?`);
+        index += 2;
+      } else {
+        parts.push('.*');
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === '*') {
+      parts.push(`[^${separator}]*`);
+      continue;
+    }
+
+    if (char === '?') {
+      parts.push(`[^${separator}]`);
+      continue;
+    }
+
+    parts.push(escapeRegExp(char ?? ''));
+  }
+
+  parts.push('$');
+  return new RegExp(parts.join(''));
+};
+
+export const matchesGlob = (
+  value: string,
+  pattern: string,
+  config: GlobConfig
+): boolean => {
+  if (value === pattern) {
+    return true;
+  }
+
+  const terminalDoubleStar = `${config.separator}**`;
+  if (pattern.endsWith(terminalDoubleStar)) {
+    const parent = pattern.slice(0, -terminalDoubleStar.length);
+    if (value === parent) {
+      return true;
+    }
+  }
+
+  return globToRegExp(pattern, config).test(value);
+};
+
+export const matchesAnyGlob = (
+  value: string,
+  patterns: readonly string[] | undefined,
+  config: GlobConfig
+): boolean =>
+  patterns !== undefined &&
+  patterns.some((pattern) => matchesGlob(value, pattern, config));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -112,6 +112,20 @@ export type {
 // Context factory
 export { createTrailContext, passthroughTrace } from './context.js';
 
+// Glob and path scope
+export { globToRegExp, matchesAnyGlob, matchesGlob } from './glob.js';
+export type { GlobConfig } from './glob.js';
+export {
+  includedByPathScope,
+  matchesAnyPathGlob,
+  matchesPathGlob,
+  normalizePathScopePath,
+  pathScopeSchema,
+} from './path-scope.js';
+export type { PathGlob, PathScope } from './path-scope.js';
+export { matchesAnyTrailIdGlob, matchesTrailIdGlob } from './trail-id-glob.js';
+export type { TrailIdGlob } from './trail-id-glob.js';
+
 // Resource
 export {
   createResourceLookup,

--- a/packages/core/src/path-scope.ts
+++ b/packages/core/src/path-scope.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+
+import { matchesAnyGlob, matchesGlob } from './glob.js';
+
+declare const pathGlobBrand: unique symbol;
+
+export type PathGlob = string & {
+  readonly [pathGlobBrand]: 'PathGlob';
+};
+
+export const normalizePathScopePath = (value: string): string =>
+  value.replaceAll('\\', '/').replace(/^\.\//, '');
+
+export const matchesPathGlob = (path: string, pattern: string): boolean =>
+  matchesGlob(normalizePathScopePath(path), normalizePathScopePath(pattern), {
+    separator: '/',
+  });
+
+export const matchesAnyPathGlob = (
+  path: string,
+  patterns: readonly string[] | undefined
+): boolean =>
+  matchesAnyGlob(
+    normalizePathScopePath(path),
+    patterns?.map(normalizePathScopePath),
+    { separator: '/' }
+  );
+
+const pathGlobArraySchema = z.array(z.string()).readonly();
+
+export const pathScopeSchema = z
+  .object({
+    exclude: pathGlobArraySchema.optional(),
+    extensions: z.array(z.string()).readonly().optional(),
+    include: pathGlobArraySchema.optional(),
+  })
+  .strict();
+
+export type PathScope = z.output<typeof pathScopeSchema>;
+
+const extensionOf = (path: string): string => {
+  const normalized = normalizePathScopePath(path);
+  const name = normalized.slice(normalized.lastIndexOf('/') + 1);
+  const dot = name.lastIndexOf('.');
+  return dot <= 0 ? '' : name.slice(dot);
+};
+
+const normalizeExtension = (extension: string): string =>
+  extension === '' || extension.startsWith('.') ? extension : `.${extension}`;
+
+const includedByExtension = (
+  path: string,
+  extensions: readonly string[] | undefined
+): boolean =>
+  extensions === undefined ||
+  extensions.length === 0 ||
+  extensions.map(normalizeExtension).includes(extensionOf(path));
+
+export const includedByPathScope = (path: string, scope?: PathScope): boolean =>
+  (scope?.include === undefined ||
+    scope.include.length === 0 ||
+    matchesAnyPathGlob(path, scope.include)) &&
+  !matchesAnyPathGlob(path, scope?.exclude) &&
+  includedByExtension(path, scope?.extensions);

--- a/packages/core/src/trail-id-glob.ts
+++ b/packages/core/src/trail-id-glob.ts
@@ -1,0 +1,15 @@
+import { matchesAnyGlob, matchesGlob } from './glob.js';
+
+declare const trailIdGlobBrand: unique symbol;
+
+export type TrailIdGlob = string & {
+  readonly [trailIdGlobBrand]: 'TrailIdGlob';
+};
+
+export const matchesTrailIdGlob = (id: string, pattern: string): boolean =>
+  matchesGlob(id, pattern, { separator: '.' });
+
+export const matchesAnyTrailIdGlob = (
+  id: string,
+  patterns: readonly string[] | undefined
+): boolean => matchesAnyGlob(id, patterns, { separator: '.' });


### PR DESCRIPTION
## Context

This is the foundation branch for TRL-1075. It creates the shared glob and path-scope contract so Regrade, Warden, Wayfinder, and surface filtering stop carrying duplicate matcher semantics.

## Changes

- Adds separator-parameterized glob helpers in `@ontrails/core` for path (`/`) and trail-id (`.`) matching.
- Adds `PathScope` helpers with `{ include, exclude, extensions }` semantics.
- Adds `TrailIdGlob` helpers for dot-separated trail IDs.
- Exports the new helpers from core.

## Verification

- `bun test packages/core/src/__tests__/glob.test.ts packages/core/src/__tests__/surface-filter.test.ts`
- `bun run --cwd packages/core typecheck`
- Full stack later passed: `bun run check`, `bun run test`, `bun run build`, `bun run changeset:check`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`

## Risks

The sensitive contract is glob grammar. Tests cover `*`, `?`, `**`, terminal parent matching, path separators, and dot-separated trail ID behavior.