### PR TITLE
fix(wayfinder): adopt shared trail id globs

### DIFF
--- a/.changeset/trl-1078-wayfinder-trail-id-globs.md
+++ b/.changeset/trl-1078-wayfinder-trail-id-globs.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/core": patch
+"@ontrails/wayfinder": patch
+---
+
+Adopt the shared trail-id glob engine for surface filtering and Wayfinder entity filters so dotted `*`, `**`, and `?` patterns behave consistently across graph inspection and surface selection.

--- a/packages/core/src/__tests__/surface-filter.test.ts
+++ b/packages/core/src/__tests__/surface-filter.test.ts
@@ -73,6 +73,12 @@ describe('matchesTrailPattern', () => {
     expect(matchesTrailPattern('entity.admin.show', 'entity.*')).toBe(false);
   });
 
+  test('? matches one character inside a dotted segment', () => {
+    expect(matchesTrailPattern('entity.show', 'entity.????')).toBe(true);
+    expect(matchesTrailPattern('entity.admin', 'entity.????')).toBe(false);
+    expect(matchesTrailPattern('entity.admin.show', 'entity.????')).toBe(false);
+  });
+
   test('** matches any remaining dotted depth', () => {
     expect(matchesTrailPattern('entity.admin.show', 'entity.**')).toBe(true);
     expect(matchesTrailPattern('entity.show', 'entity.**')).toBe(true);

--- a/packages/core/src/surface-filter.ts
+++ b/packages/core/src/surface-filter.ts
@@ -1,4 +1,5 @@
 import type { Intent, Trail } from './trail.js';
+import { matchesAnyTrailIdGlob, matchesTrailIdGlob } from './trail-id-glob.js';
 import type { SurfaceSelectionOptions } from './surface-derivation.js';
 
 // ---------------------------------------------------------------------------
@@ -7,84 +8,10 @@ import type { SurfaceSelectionOptions } from './surface-derivation.js';
 
 export type SurfaceFilterOptions = SurfaceSelectionOptions;
 
-// ---------------------------------------------------------------------------
-// Glob matching
-// ---------------------------------------------------------------------------
-
-const trailIdSegments = (trailId: string): readonly string[] =>
-  trailId.split('.');
-
-const patternSegments = (pattern: string): readonly string[] =>
-  pattern.split('.');
-
-type SegmentMatcher = (
-  trail: readonly string[],
-  pattern: readonly string[],
-  trailIndex: number,
-  patternIndex: number
-) => boolean;
-
-const matchesDoubleStar = (
-  trail: readonly string[],
-  pattern: readonly string[],
-  trailIndex: number,
-  patternIndex: number,
-  matchSegments: SegmentMatcher
-): boolean =>
-  patternIndex === pattern.length - 1 ||
-  Array.from(
-    { length: trail.length - trailIndex + 1 },
-    (_, offset) => trailIndex + offset
-  ).some((index) => matchSegments(trail, pattern, index, patternIndex + 1));
-
-const matchesSingleSegment = (
-  trail: readonly string[],
-  pattern: readonly string[],
-  trailIndex: number,
-  patternIndex: number,
-  current: string,
-  matchSegments: SegmentMatcher
-): boolean =>
-  trailIndex < trail.length &&
-  (current === '*' || current === trail[trailIndex]) &&
-  matchSegments(trail, pattern, trailIndex + 1, patternIndex + 1);
-
-const matchesFrom = function matchesFrom(
-  trail: readonly string[],
-  pattern: readonly string[],
-  trailIndex: number,
-  patternIndex: number
-): boolean {
-  if (patternIndex >= pattern.length) {
-    return trailIndex >= trail.length;
-  }
-
-  const current = pattern[patternIndex];
-  if (current === undefined) {
-    return false;
-  }
-
-  return current === '**'
-    ? matchesDoubleStar(trail, pattern, trailIndex, patternIndex, matchesFrom)
-    : matchesSingleSegment(
-        trail,
-        pattern,
-        trailIndex,
-        patternIndex,
-        current,
-        matchesFrom
-      );
-};
-
 export const matchesTrailPattern = (
   trailId: string,
   pattern: string
-): boolean => {
-  if (pattern === trailId) {
-    return true;
-  }
-  return matchesFrom(trailIdSegments(trailId), patternSegments(pattern), 0, 0);
-};
+): boolean => matchesTrailIdGlob(trailId, pattern);
 
 // ---------------------------------------------------------------------------
 // Surface filtering
@@ -93,9 +20,7 @@ export const matchesTrailPattern = (
 const matchesAnyPattern = (
   trailId: string,
   patterns: readonly string[] | undefined
-): boolean =>
-  patterns !== undefined &&
-  patterns.some((pattern) => matchesTrailPattern(trailId, pattern));
+): boolean => matchesAnyTrailIdGlob(trailId, patterns);
 
 const isExplicitInternalInclude = (
   trailId: string,

--- a/packages/wayfinder/src/__tests__/filters.test.ts
+++ b/packages/wayfinder/src/__tests__/filters.test.ts
@@ -42,6 +42,13 @@ const userCreate = trail('user.create', {
   resources: [db],
 });
 
+const userAdminAudit = trail('user.admin.audit', {
+  blaze: () => Result.ok({ ok: true }),
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({ ok: z.boolean() }),
+});
+
 const auditRebuild = trail('audit.rebuild', {
   blaze: () => Result.ok({ ok: true }),
   input: z.object({}),
@@ -93,6 +100,7 @@ const makeGraph = (): TopoGraph =>
         auditRebuild,
         db,
         inviteCreate,
+        userAdminAudit,
         userCreate,
         userCreated,
         userShow,
@@ -160,12 +168,18 @@ describe('wayfinder typed filters', () => {
     const graph = makeGraph();
 
     expect(ids(graph, { kind: 'trail', namespace: 'user' })).toEqual([
+      'user.admin.audit',
       'user.create',
       'user.show',
     ]);
     expect(ids(graph, { id: 'user.show' })).toEqual(['user.show']);
     expect(ids(graph, { idPrefix: 'audit.' })).toEqual(['audit.rebuild']);
     expect(ids(graph, { idGlob: 'user.*', kind: 'trail' })).toEqual([
+      'user.create',
+      'user.show',
+    ]);
+    expect(ids(graph, { idGlob: 'user.**', kind: 'trail' })).toEqual([
+      'user.admin.audit',
       'user.create',
       'user.show',
     ]);
@@ -244,6 +258,6 @@ describe('wayfinder typed filters', () => {
       listWayfinderEntityRefs(graph)
         .filter(graphPredicate)
         .map((ref) => ref.id)
-    ).toEqual(['user.create', 'user.show']);
+    ).toEqual(['user.admin.audit', 'user.create', 'user.show']);
   });
 });

--- a/packages/wayfinder/src/filters.ts
+++ b/packages/wayfinder/src/filters.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { matchesAnyTrailIdGlob } from '@ontrails/core';
 import type {
   TopoGraph,
   TopoGraphEntry,
@@ -98,12 +99,6 @@ const includesAny = (
 
 const namespaceMatches = (id: string, namespace: string): boolean =>
   id === namespace || id.startsWith(`${namespace}.`);
-
-const globToRegExp = (glob: string): RegExp => {
-  const escaped = glob.replaceAll(/[.+^${}()|[\]\\]/g, '\\$&');
-  const pattern = `^${escaped.replaceAll('*', '.*').replaceAll('?', '.')}$`;
-  return new RegExp(pattern);
-};
 
 const entryHasVersioning = (entry: TopoGraphEntry): boolean =>
   entry.version !== undefined ||
@@ -288,7 +283,7 @@ const matchesIdentityFilters = (
   }
   if (
     filters.idGlobs.length > 0 &&
-    !filters.idGlobs.some((glob) => globToRegExp(glob).test(ref.id))
+    !matchesAnyTrailIdGlob(ref.id, filters.idGlobs)
   ) {
     return false;
   }


### PR DESCRIPTION
## Context

TRL-1078 makes Wayfinder and surface filtering consume the shared trail-id glob helper instead of maintaining duplicate dot-glob semantics.

## Changes

- Updates core `matchesTrailPattern` to delegate to `matchesTrailIdGlob`.
- Updates Wayfinder filters to use `matchesAnyTrailIdGlob`.
- Adds nested trail-id fixtures proving `entity.*` stays segment-local and `entity.**` crosses dot-separated descendants.

## Verification

- `bun test packages/core/src/__tests__/surface-filter.test.ts packages/core/src/__tests__/glob.test.ts packages/wayfinder/src/__tests__/filters.test.ts`
- `bun run --cwd packages/core typecheck`
- `bun run --cwd packages/wayfinder typecheck`
- `bun run changeset:check -- --changed-files /tmp/trl-1078-files.txt`
- Full stack later passed: `bun run check`, `bun run test`, `bun run build`, `bun run changeset:check`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`

## Risks

The main risk is semantic drift between surface filters and Wayfinder. Both now share one implementation and test the same grammar.