### PR TITLE
docs: document shared glob path scope contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,8 @@ For Trails graph-navigation questions, use Wayfinder before reconstructing topo 
 
 `trails wayfind file <file> --outline` is the source-navigation exception inside Wayfinder: it parses the explicit source file live, then cross-references saved graph artifacts when they are available.
 
+Use the shared glob vocabulary precisely. Trail-id selectors use dotted globs (`entity.*`, `entity.**`, `entity.????`). Warden and Regrade scope controls use root-relative path globs through the stable `PathScope` shape: `include`, `exclude`, and `extensions`. Do not reintroduce Regrade `ignore` or Warden `jurisdiction` naming.
+
 Fall back to `rg`, qmd, source reads, or a fresh compile when Wayfinder reports missing or stale artifacts, when the task needs source text that Topographer does not project, or when writing new artifacts would violate the current work authority. When you fall back, say why so the next agent does not silently repeat the same graph reconstruction.
 
 ## Lexicon

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -95,6 +95,14 @@ deriveFields(schema, overrides?)   // → Field[] (faithfully representable fiel
 deriveCliPath(trailId)             // trail ID → hierarchical CLI command path
 Field, FieldOverride
 
+// Shared glob and scope contracts
+globToRegExp(pattern, config), matchesGlob(value, pattern, config), matchesAnyGlob(value, patterns, config)
+matchesTrailIdGlob(id, pattern), matchesAnyTrailIdGlob(id, patterns)
+pathScopeSchema, includedByPathScope(path, scope)
+matchesPathGlob(path, pattern), matchesAnyPathGlob(path, patterns)
+normalizePathScopePath(path)
+GlobConfig, TrailIdGlob, PathGlob, PathScope
+
 // Surface derivation
 validateSurfaceTopo(topo, options?) // shared established-topo guard for surface projections
 withSurfaceMarker(surface, ctx?)    // merge a surface marker into execution context extensions
@@ -133,6 +141,8 @@ SerializedError, zodToJsonSchema(schema)
 securePath, isPathSafe, deriveSafePath
 findWorkspaceRoot, isInsideWorkspace, deriveRelativePath
 ```
+
+Core owns the shared glob machinery used by surface selectors, Wayfinder ID filters, Warden scope, and Regrade scan scope. Trail-id globs use dotted separators (`entity.*`, `entity.**`, `entity.????`); path-scope globs use path separators (`.agents/notes/**`, `src/**/*.ts`). `PathScope` is the stable scan/governance shape: `{ include?: string[], exclude?: string[], extensions?: string[] }`.
 
 ## `@ontrails/core/trails`
 

--- a/docs/contributing/codebase-navigation.md
+++ b/docs/contributing/codebase-navigation.md
@@ -21,6 +21,7 @@ bun apps/trails/bin/trails.ts wayfind --overview --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind --trails --intent read --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind wayfind.search --contract --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind pattern "wayfind.*" --root-dir . --json
+bun apps/trails/bin/trails.ts wayfind pattern "wayfind.**" --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind query "release drift" --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind --errors --root-dir . --json
 bun apps/trails/bin/trails.ts wayfind --resources --root-dir . --json
@@ -32,6 +33,8 @@ bun apps/trails/bin/trails.ts wayfind --source live --module apps/trails/src/app
 ```
 
 Use `trails schema <command...>` when you need the accepted CLI routes, aliases, flags, and schemas for an operator command before invoking it from a shell.
+
+Wayfinder pattern queries and `idGlob` filters use trail-id globs: `*` matches one dotted segment, `**` matches any remaining dotted depth, and `?` matches one character inside a segment. Path scope controls use the same wildcard family with path separators instead: Warden `scope.exclude` and Regrade `scope.exclude` should receive root-relative path globs such as `.agents/notes/**`, `.scratch/**`, or `src/**/*.ts`.
 
 Use `trails wayfind file <file> --outline` before reading a large source file when you need a compact source map. It parses the explicit file path, reports imports, exports, declarations, app declarations, and authored trail IDs, and links those trail IDs to saved graph facts when artifacts exist. The underlying outline trail still supports feature-specific views; the operator CLI exposes the file resolver first so file navigation does not get mixed with graph ID lookup.
 


### PR DESCRIPTION
## Context

TRL-1079 documents the shared glob/path-scope contract and the hard-cut naming so future agents do not rebuild the old duplicate matchers.

## Changes

- Documents `PathScope` and trail-id glob APIs in the API reference.
- Updates codebase navigation with path-glob vs trail-id-glob examples.
- Updates `AGENTS.md` to route future work through the core helpers and avoid resurrecting Regrade `ignore` or Warden `jurisdiction`.

## Verification

- `bun run docs:wrap-check`
- `bun run format:check`
- `bun run changeset:check -- --changed-files /tmp/trl-1079-files.txt`
- `git diff --check`
- Full stack later passed: `bun run check`, `bun run test`, `bun run build`, `bun run changeset:check`, `bun run publish:check`, `bun run wayfinder:dogfood`

## Risks

Docs are intentionally current-term only. They do not preserve compatibility guidance for the short-lived retired names.