### PR TITLE
docs: record coherence canon rulings

### DIFF
--- a/docs/adr/0001-naming-conventions.md
+++ b/docs/adr/0001-naming-conventions.md
@@ -4,7 +4,7 @@ slug: naming-conventions
 title: Naming Conventions — Guessable API Through Structural Rules
 status: accepted
 created: 2026-03-27
-updated: 2026-05-26
+updated: 2026-06-29
 owners: ['[galligan](https://github.com/galligan)']
 ---
 
@@ -183,6 +183,51 @@ deriveHttpRoutes(graph);
 ```
 
 Derivations stay pure. When a derivation can fail because the authored graph is invalid or collides with itself, it reports that failure as `Result.err(...)` rather than throwing.
+
+### Accessor verb family
+
+The `get` / `read` / `find` / `list` family is distinct-on-purpose. Do not flatten it into one generic accessor verb.
+
+| Verb | Meaning | Examples |
+| --- | --- | --- |
+| `get*` | In-memory access to a known object, field, or registry entry | `getTraceSink()`, `getWebhookHeader()` |
+| `read*` | External source IO, including files, registry state, and persisted artifacts | `readPackageJson()`, `readTrailsLock()` |
+| `find*` | May-miss discovery or search where absence is a normal result | `findWorkspaceRoot()`, `findTrailsProjectRoot()` |
+| `list*` | Enumerate a collection without implying lookup by one key | `listTopoSnapshots()`, `listWayfinderEntityRefs()` |
+
+Use this family as call-site discipline. If a helper reads the filesystem, a registry, or a persisted lock, it should not be named `get*`. If a helper searches and can miss, it should not be named `read*`. If a helper enumerates many values, `list*` is clearer than `find*`.
+
+### `build*` vs `derive*`
+
+Use `derive*` when a helper mechanically projects facts from an authored contract, resolved graph, or other framework-owned source of truth. Use `build*` when a helper assembles a report, string, fixture, or runtime shape from raw materials and formatting choices.
+
+The test is source ownership: if the result should change only because the source contract changed, it is probably a derivation. If the result carries presentation, formatting, aggregation policy, or non-contract inputs, it may be a build.
+
+### Location field names
+
+Use location fields consistently:
+
+| Name | Meaning |
+| --- | --- |
+| `path` | Root-relative POSIX path or logical path in the current project scope |
+| `absolutePath` | Absolute filesystem path |
+| `filePath` | Public file-scoped diagnostic field or function parameter naming the analyzed file |
+| `sourcePath` | Source-analysis path when it must be distinguished from another file path in the same shape |
+| `file` | Surface or schema input name when the caller literally provides a file argument |
+
+Do not mix `file` and `filePath` inside the same returned diagnostic shape unless they name different concepts.
+
+### `scope`, `selector`, and `filter`
+
+These three words are related but not interchangeable.
+
+| Term | Meaning |
+| --- | --- |
+| `scope` | Boundary of what a command, rule, or query is allowed to inspect |
+| `selector` | Expression that chooses members inside an already chosen scope |
+| `filter` | Predicate or parameter that narrows an already selected set |
+
+Warden and Regrade path boundaries use `scope`. Trailhead and Wayfinder member matching may use `selector` when the value chooses members. Query options that remove items from a result set may use `filter`.
 
 ### `validate*` for contract verification
 

--- a/docs/adr/0007-governance-as-trails.md
+++ b/docs/adr/0007-governance-as-trails.md
@@ -32,7 +32,7 @@ Each source-file rule is wrapped via `wrapRule()` into a trail with ID `warden.r
 
 **Intent** is always `'read'` — rules are pure analysis, they never modify source files.
 
-Rules have examples showing both clean code (empty diagnostics array) and violations (expected diagnostics with specific messages and line numbers). This means every rule's behavior is documented in the contract itself, not in separate test files or prose.
+Rules have examples showing both clean code (empty diagnostics array) and diagnostic cases (expected diagnostics with specific messages and line numbers). This means every rule's behavior is documented in the contract itself, not in separate test files or prose.
 
 The built-in wrappers are collected into `wardenTopo`, but dispatch now follows the runtime shape instead of pretending every rule is file-scoped. `runWardenTrails(filePath, sourceCode, options?)` iterates only the file-scoped wrappers. `runTopoAwareWardenTrails(topo)` dispatches topo-aware wrappers once per resolved graph. `runWarden()` composes both paths, running file-scoped analysis across the requested sources and then adding topo-aware diagnostics when invoked with a resolved `Topo`.
 

--- a/docs/adr/0036-warden-rules-ship-only-as-trails.md
+++ b/docs/adr/0036-warden-rules-ship-only-as-trails.md
@@ -39,7 +39,7 @@ A trail wrapper is a `trail()` instance. It carries:
 
 - `.blaze` — the authored implementation that establishes how the rule trail runs
 - `.input` / `.output` — schemas describing the contract
-- `.examples` — the happy-path and violation cases that feed `testAll()`
+- `.examples` — the happy-path and diagnostic cases that feed `testAll()`
 - `.id` — the canonical `warden.rule.<name>` identifier
 - The rest of the trail contract
 

--- a/docs/adr/0037-owner-first-authority.md
+++ b/docs/adr/0037-owner-first-authority.md
@@ -4,7 +4,7 @@ slug: owner-first-authority
 title: Owner-First Authority
 status: accepted
 created: 2026-04-30
-updated: 2026-04-30
+updated: 2026-06-29
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [0, 7, 26, 35, 36]
 ---
@@ -58,6 +58,20 @@ This means:
 | Adapter descriptors | the adapter package or descriptor owner once the descriptor model lands |
 
 The export is boring on purpose. Prefer an `as const` array, a typed object, or a small mapper that directly represents the owner's knowledge. Do not introduce a generic authority system before the natural owner has been tested.
+
+### Natural altitude chooses the owner
+
+Ownership belongs at the lowest package altitude where the fact remains true without depending on a particular app, surface, command, or consumer.
+
+Use this test before extracting a helper or moving a duplicated fact:
+
+1. **Concept fact:** if the fact defines a primitive or contract category, it belongs to that concept's package.
+2. **Durable graph fact:** if the fact is derived from the resolved graph and is persisted, hashed, diffed, or compared across processes, it belongs to Topographer.
+3. **Surface fact:** if the fact only exists because a surface renders the graph in that surface's idiom, it belongs to that surface package.
+4. **App fact:** if the fact is true only for one app or operator command, it stays in the app.
+5. **Repo fact:** if the fact only helps this repository build, test, or migrate itself, it stays in repo tooling or repo-local Warden rules.
+
+Do not move a helper upward merely because two packages want convenience. Move it upward when its lower copies would otherwise re-derive the same owner-held truth.
 
 ### Consumers import owner data instead of copying it
 

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -306,7 +306,7 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Naming Conventions — Guessable API Through Structural Rules",
-      "updated": "2026-05-26"
+      "updated": "2026-06-29"
     },
     {
       "created": "2026-03-29",
@@ -2359,7 +2359,7 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Owner-First Authority",
-      "updated": "2026-04-30"
+      "updated": "2026-06-29"
     },
     {
       "created": "2026-03-31",

--- a/docs/contributing/warden-rules.md
+++ b/docs/contributing/warden-rules.md
@@ -234,4 +234,4 @@ When an audit produces a prevention candidate:
 6. Add tests that prove both accepted code and the diagnostic shape.
 7. Record any temporary rule's deletion trigger.
 
-Forward-looking skills, docs, and advisory reports can consume owner data and Warden findings. They do not become parallel authority.
+Forward-looking skills, docs, and advisory reports can consume owner data and Warden diagnostics. They do not become parallel authority.

--- a/docs/lexicon.md
+++ b/docs/lexicon.md
@@ -480,6 +480,7 @@ A mechanically derived output from authored information. The topo store is a rel
 | `meta` | Annotations for tooling and filtering |
 | `Result` | Ok/Err return type |
 | `error` | Error types |
+| `diagnostic` | Analyzer-reported problem or guidance item emitted by Warden, config checks, validation, or similar tooling. Do not use `issue`, `finding`, or `violation` as the framework noun for this shape. |
 | `adapter` | Canonical public category for a package or subpath that connects Trails to a named external library, framework, tool, platform, format, or ecosystem |
 | `surface accommodation` | Projection-level fit adjustment that lets a surface feel native without changing the trail contract |
 | `surface entry` | Invocable affordance exposed by a surface: CLI command, MCP tool, HTTP route, or library export |


### PR DESCRIPTION
## Context

Part of the Coherence Cleanup stack. This bottom branch records the canon and ownership rulings that the implementation branches build on.

## What Changed

- Updated ADR and lexicon language for owner-first authority, governance-as-trails, diagnostics, and Warden rule ownership.
- Kept current-live vocabulary distinct from pending v1 reset vocabulary.
- Tightened Warden contribution docs so accepted rule guidance aligns with the live diagnostic shape.

## Verification

- bun scripts/adr.ts check
- bun run docs:wrap-check
- bun run docs:links
- git diff --check
- Full stack gates also passed locally: bun run typecheck, lint, lint:ast-grep, test, build, check, changeset:check, publish:check, wayfinder:dogfood.

## Review

- In-thread local review round 1 found two P2 documentation coherence issues; both fixed.
- In-thread local review round 2 was clean.