### PR TITLE
fix(core): share escape regexp helper

### DIFF
--- a/.changeset/core-escape-regexp-helper.md
+++ b/.changeset/core-escape-regexp-helper.md
@@ -1,0 +1,9 @@
+---
+'@ontrails/adapter-kit': patch
+'@ontrails/core': patch
+'@ontrails/regrade': patch
+'@ontrails/trails': patch
+'@ontrails/warden': patch
+---
+
+Export a shared `escapeRegExp` helper from core and migrate first-party callers off local copies.

--- a/apps/trails/src/release/pack-coherence.ts
+++ b/apps/trails/src/release/pack-coherence.ts
@@ -1,5 +1,6 @@
 import { readFile, readdir, writeFile } from 'node:fs/promises';
 import { join, relative } from 'node:path';
+import { escapeRegExp } from '@ontrails/core';
 
 export interface ReleasePackCoherenceInput {
   readonly branchName?: string | undefined;
@@ -233,9 +234,6 @@ export const findLockfileWorkspaceMetadataMismatches = ({
   }
   return mismatches;
 };
-
-const escapeRegExp = (text: string): string =>
-  text.replaceAll(/[.*+?^${}()|[\]\\]/gu, '\\$&');
 
 const findWorkspaceBlockRange = (
   text: string,

--- a/bun.lock
+++ b/bun.lock
@@ -126,6 +126,9 @@
     "packages/adapter-kit": {
       "name": "@ontrails/adapter-kit",
       "version": "1.0.0-beta.31",
+      "dependencies": {
+        "@ontrails/core": "workspace:^",
+      },
     },
     "packages/cli": {
       "name": "@ontrails/cli",

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -96,7 +96,7 @@ deriveCliPath(trailId)             // trail ID → hierarchical CLI command path
 Field, FieldOverride
 
 // Shared glob and scope contracts
-globToRegExp(pattern, config), matchesGlob(value, pattern, config), matchesAnyGlob(value, patterns, config)
+escapeRegExp(value), globToRegExp(pattern, config), matchesGlob(value, pattern, config), matchesAnyGlob(value, patterns, config)
 matchesTrailIdGlob(id, pattern), matchesAnyTrailIdGlob(id, patterns)
 pathScopeSchema, includedByPathScope(path, scope)
 matchesPathGlob(path, pattern), matchesAnyPathGlob(path, patterns)

--- a/packages/adapter-kit/package.json
+++ b/packages/adapter-kit/package.json
@@ -19,5 +19,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "oxlint ./src",
     "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "dependencies": {
+    "@ontrails/core": "workspace:^"
   }
 }

--- a/packages/adapter-kit/src/check.ts
+++ b/packages/adapter-kit/src/check.ts
@@ -14,6 +14,8 @@ import {
 } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 
+import { escapeRegExp } from '@ontrails/core';
+
 import { deriveAdapterTargetCatalog } from './catalog.js';
 import type {
   AdapterTargetCatalog,
@@ -432,9 +434,6 @@ const collectSourceFiles = (dir: string): readonly string[] => {
   visit(dir);
   return files.toSorted();
 };
-
-const escapeRegExp = (value: string): string =>
-  value.replaceAll(/[.*+?^${}()|[\]\\]/gu, '\\$&');
 
 const isIdentifierChar = (char: string | undefined): boolean =>
   char !== undefined && /[$\w]/u.test(char);

--- a/packages/core/src/__tests__/glob.test.ts
+++ b/packages/core/src/__tests__/glob.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, test } from 'bun:test';
 
-import { matchesGlob } from '../glob.js';
+import { escapeRegExp, matchesGlob } from '../glob.js';
 import { includedByPathScope, matchesPathGlob } from '../path-scope.js';
 import { matchesTrailIdGlob } from '../trail-id-glob.js';
 
 describe('glob engine', () => {
+  test('escapes strings for literal regexp embedding', () => {
+    const pattern = new RegExp(`^${escapeRegExp('@ontrails/core?')}$`);
+
+    expect(pattern.test('@ontrails/core?')).toBe(true);
+    expect(pattern.test('@ontrails/corex')).toBe(false);
+  });
+
   test('matches segment wildcards without crossing the separator', () => {
     expect(matchesGlob('entity.show', 'entity.*', { separator: '.' })).toBe(
       true

--- a/packages/core/src/glob.ts
+++ b/packages/core/src/glob.ts
@@ -2,7 +2,15 @@ export interface GlobConfig {
   readonly separator: '/' | '.';
 }
 
-const escapeRegExp = (value: string): string =>
+/**
+ * Escape a literal string so it can be embedded safely in a RegExp source.
+ *
+ * @example
+ * ```ts
+ * const pattern = new RegExp(`^${escapeRegExp('@ontrails/core')}$`);
+ * ```
+ */
+export const escapeRegExp = (value: string): string =>
   value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const separatorRegExp = (separator: GlobConfig['separator']): string =>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,7 +113,12 @@ export type {
 export { createTrailContext, passthroughTrace } from './context.js';
 
 // Glob and path scope
-export { globToRegExp, matchesAnyGlob, matchesGlob } from './glob.js';
+export {
+  escapeRegExp,
+  globToRegExp,
+  matchesAnyGlob,
+  matchesGlob,
+} from './glob.js';
 export type { GlobConfig } from './glob.js';
 export {
   includedByPathScope,

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -1,4 +1,4 @@
-import { InternalError, Result } from '@ontrails/core';
+import { InternalError, Result, escapeRegExp } from '@ontrails/core';
 import type {
   WardenDiagnostic,
   WardenFixEdit,
@@ -154,9 +154,6 @@ export interface RegradeReviewDetail {
   /** Symbol or term that triggered review. */
   readonly symbol?: string;
 }
-
-const escapeRegExp = (value: string): string =>
-  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /**
  * Build a whole-word term-rewrite class.

--- a/packages/regrade/src/downstream/vocabulary.ts
+++ b/packages/regrade/src/downstream/vocabulary.ts
@@ -2,6 +2,7 @@ import {
   InternalError,
   Result,
   ValidationError,
+  escapeRegExp,
   matchesAnyPathGlob,
 } from '@ontrails/core';
 import { readFileSync, writeFileSync } from 'node:fs';
@@ -118,9 +119,6 @@ const VOCABULARY_SOURCE_EXTENSIONS = Object.freeze([
   '.yaml',
   '.yml',
 ]);
-
-const escapeRegExp = (value: string): string =>
-  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const uniqueSorted = (values: readonly string[]): readonly string[] =>
   [...new Set(values)].toSorted((a, b) => a.localeCompare(b));

--- a/packages/warden/src/rules/implementation-returns-result.ts
+++ b/packages/warden/src/rules/implementation-returns-result.ts
@@ -8,6 +8,7 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, isAbsolute, resolve } from 'node:path';
+import { escapeRegExp } from '@ontrails/core';
 import type { AstNode } from './ast.js';
 import {
   collectScopeFrameBindings,
@@ -287,9 +288,6 @@ const extractIdentifierName = (node: AstNode | undefined): string | null =>
   node?.type === 'Identifier' ? (getNodeName(node) ?? null) : null;
 
 const DEFAULT_RESULT_TYPE_NAMES = new Set(['Result']);
-
-const escapeRegExp = (value: string): string =>
-  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const hasGenericTypeReference = (
   annotationText: string,

--- a/packages/warden/src/rules/public-internal-deep-imports.ts
+++ b/packages/warden/src/rules/public-internal-deep-imports.ts
@@ -1,5 +1,6 @@
 import { existsSync, realpathSync } from 'node:fs';
 import { resolve, sep } from 'node:path';
+import { escapeRegExp } from '@ontrails/core';
 
 import {
   extractStringLiteral,
@@ -302,9 +303,6 @@ const rootBarrelDiagnostics = (
 
 const stripLeadingDotSlash = (path: string): string =>
   path.startsWith('./') ? path.slice(2) : path;
-
-const escapeRegExp = (value: string): string =>
-  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const wildcardPatternSource = (pattern: string): string => {
   let regexSource = '';

--- a/scripts/import-scratch-to-notion.ts
+++ b/scripts/import-scratch-to-notion.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 
+import { escapeRegExp } from '@ontrails/core';
 import { spawnSync } from 'node:child_process';
 import { basename, dirname, extname } from 'node:path';
 
@@ -105,9 +106,6 @@ const titleFromMarkdown = (file: string, markdown: string) => {
 };
 
 const stripFirstH1 = (markdown: string) => markdown.replace(/^#\s+.+\n+/, '');
-
-const escapeRegExp = (value: string) =>
-  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const readFrontmatterValue = (frontmatter: string | undefined, key: string) => {
   if (!frontmatter) {


### PR DESCRIPTION
## Context

Part of the Coherence Cleanup stack. This branch makes literal regex escaping a single core-owned helper instead of repeated local implementations.

## What Changed

- Exported and tested escapeRegExp from @ontrails/core.
- Replaced local duplicate helpers in adapter-kit, regrade, warden, Trails release code, and a repo script.
- Added API docs and branch-local changesets for affected packages.

## Verification

- bun test packages/core/src/__tests__/glob.test.ts
- bun run --cwd packages/core typecheck
- bun run --cwd packages/adapter-kit typecheck && bun run --cwd packages/adapter-kit test
- bun run --cwd packages/regrade typecheck && bun run --cwd packages/regrade test
- bun run --cwd packages/warden typecheck && bun run --cwd packages/warden test
- bun run --cwd apps/trails typecheck
- bun run changeset:check
- bun run lint
- bun run docs:wrap-check
- bun run docs:links
- bun run publish:check
- git diff --check

## Review

- In-thread local review round 1 found one P2 docs gap for the new public helper; fixed in docs/api-reference.md.
- In-thread local review round 2 was clean.