### PR TITLE
fix(core): centralize workspace package discovery

### DIFF
--- a/.changeset/core-workspace-package-discovery.md
+++ b/.changeset/core-workspace-package-discovery.md
@@ -1,0 +1,8 @@
+---
+'@ontrails/adapter-kit': patch
+'@ontrails/core': patch
+'@ontrails/trails': patch
+'@ontrails/warden': patch
+---
+
+Export shared workspace package discovery helpers from core and migrate first-party discovery callers.

--- a/apps/trails/src/trails/create-adapter.ts
+++ b/apps/trails/src/trails/create-adapter.ts
@@ -13,9 +13,16 @@ import type {
   AdapterTargetConformanceManifest,
   AdapterTargetPlacement,
 } from '@ontrails/adapter-kit';
-import { Result, trail, ValidationError } from '@ontrails/core';
-import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import {
+  findWorkspacePackage,
+  listWorkspacePatterns,
+  Result,
+  trail,
+  ValidationError,
+} from '@ontrails/core';
+import type { WorkspaceRootManifest } from '@ontrails/core';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { z } from 'zod';
 
 import {
@@ -69,18 +76,9 @@ interface AdapterOperationPlan {
   readonly targetKey: string;
 }
 
-interface RootManifest {
-  readonly workspaces?: unknown;
-}
-
 interface WorkspacePackageManifest {
   readonly exports?: unknown;
   readonly name?: unknown;
-}
-
-interface WorkspacePackageName {
-  readonly name: string;
-  readonly workspacePath: string;
 }
 
 interface LocalNamedReexport {
@@ -123,27 +121,6 @@ const readJson = <T>(path: string): T | undefined => {
   }
 };
 
-const workspacePatternsFromManifest = (
-  manifest: RootManifest | undefined
-): readonly string[] => {
-  const { workspaces } = manifest ?? {};
-  if (Array.isArray(workspaces)) {
-    return workspaces.filter(
-      (pattern): pattern is string => typeof pattern === 'string'
-    );
-  }
-
-  const packages =
-    workspaces && typeof workspaces === 'object' && !Array.isArray(workspaces)
-      ? (workspaces as Record<string, unknown>)['packages']
-      : undefined;
-  return Array.isArray(packages)
-    ? packages.filter(
-        (pattern): pattern is string => typeof pattern === 'string'
-      )
-    : [];
-};
-
 const normalizeWorkspacePattern = (pattern: string): string =>
   pattern.replace(/^\.\//u, '').replace(/\/+$/u, '');
 
@@ -169,52 +146,12 @@ const rootWorkspaceIncludesPath = (
   rootDir: string,
   workspacePath: string
 ): boolean => {
-  const rootManifest = readJson<RootManifest>(join(rootDir, 'package.json'));
-  return workspacePatternsFromManifest(rootManifest).some((pattern) =>
+  const rootManifest = readJson<WorkspaceRootManifest>(
+    join(rootDir, 'package.json')
+  );
+  return listWorkspacePatterns(rootManifest).some((pattern) =>
     workspacePatternCoversPath(pattern, workspacePath)
   );
-};
-
-const workspaceDirsForPattern = (
-  rootDir: string,
-  pattern: string
-): readonly string[] => {
-  if (!pattern.endsWith('/*')) {
-    const workspaceDir = join(rootDir, pattern);
-    return existsSync(workspaceDir) ? [workspaceDir] : [];
-  }
-
-  const groupDir = join(rootDir, pattern.slice(0, -2));
-  if (!existsSync(groupDir)) {
-    return [];
-  }
-
-  return readdirSync(groupDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => join(groupDir, entry.name))
-    .toSorted();
-};
-
-const findWorkspacePackageName = (
-  rootDir: string,
-  packageName: string
-): WorkspacePackageName | undefined => {
-  const rootManifest = readJson<RootManifest>(join(rootDir, 'package.json'));
-  for (const pattern of workspacePatternsFromManifest(rootManifest)) {
-    for (const workspaceDir of workspaceDirsForPattern(rootDir, pattern)) {
-      const manifest = readJson<WorkspacePackageManifest>(
-        join(workspaceDir, 'package.json')
-      );
-      if (manifest?.name === packageName) {
-        return {
-          name: packageName,
-          workspacePath: relative(rootDir, workspaceDir),
-        };
-      }
-    }
-  }
-
-  return undefined;
 };
 
 const resolvePhysicalRootDir = (
@@ -882,10 +819,13 @@ const buildExtractedPlan = (
   if (!packageNamePattern.test(packageName)) {
     return fail(packageNameMessage);
   }
-  const existingPackage = findWorkspacePackageName(rootDir, packageName);
+  const existingPackage = findWorkspacePackage<WorkspacePackageManifest>(
+    rootDir,
+    packageName
+  );
   if (existingPackage) {
     return fail(
-      `Workspace package name "${existingPackage.name}" already exists at ${existingPackage.workspacePath}.`
+      `Workspace package name "${packageName}" already exists at ${existingPackage.workspacePath}.`
     );
   }
 

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -19,6 +19,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import {
   deriveSafePath,
   isTrailsError,
+  listWorkspacePackages,
   PermissionError,
   Result,
   ValidationError,
@@ -278,6 +279,8 @@ interface PackageJson {
   readonly workspaces?: unknown;
 }
 
+type NamedPackageJson = PackageJson & { readonly name: string };
+
 const readPackageJson = (packagePath: string): PackageJson | undefined => {
   try {
     return JSON.parse(readFileSync(packagePath, 'utf8')) as PackageJson;
@@ -327,20 +330,6 @@ const isPackageLocalImport = (
 const isScannableModule = (modulePath: string): boolean =>
   SCANNABLE_EXTENSIONS.has(extname(modulePath));
 
-const resolveImportedModulePath = (
-  importerPath: string,
-  importPath: string
-): string => {
-  const resolved = import.meta.resolve(
-    importPath,
-    pathToFileURL(importerPath).href
-  );
-  return resolveFilesystemModulePath(
-    fileURLToPath(resolved),
-    dirname(importerPath)
-  );
-};
-
 const readDirectoryEntries = (directoryPath: string): readonly string[] => {
   try {
     return readdirSync(directoryPath);
@@ -359,25 +348,18 @@ const safeStat = (
   }
 };
 
-const readWorkspacePatterns = (cwd: string): readonly string[] => {
-  const rootPackage = readPackageJson(join(cwd, 'package.json'));
-  const workspaces = rootPackage?.workspaces;
-  if (Array.isArray(workspaces)) {
-    return workspaces.filter(
-      (pattern): pattern is string => typeof pattern === 'string'
-    );
-  }
-  if (
-    typeof workspaces === 'object' &&
-    workspaces !== null &&
-    'packages' in workspaces &&
-    Array.isArray(workspaces.packages)
-  ) {
-    return workspaces.packages.filter(
-      (pattern): pattern is string => typeof pattern === 'string'
-    );
-  }
-  return [];
+const resolveImportedModulePath = (
+  importerPath: string,
+  importPath: string
+): string => {
+  const resolved = import.meta.resolve(
+    importPath,
+    pathToFileURL(importerPath).href
+  );
+  return resolveFilesystemModulePath(
+    fileURLToPath(resolved),
+    dirname(importerPath)
+  );
 };
 
 interface WorkspacePackage {
@@ -386,45 +368,12 @@ interface WorkspacePackage {
   readonly packageRoot: string;
 }
 
-const listWorkspacePackageRoots = (cwd: string): readonly string[] => {
-  const roots: string[] = [];
-  for (const pattern of readWorkspacePatterns(cwd)) {
-    if (pattern.endsWith('/*')) {
-      const baseDir = resolve(cwd, pattern.slice(0, -2));
-      for (const entry of readDirectoryEntries(baseDir)) {
-        const entryPath = join(baseDir, entry);
-        if (safeStat(entryPath)?.isDirectory()) {
-          roots.push(entryPath);
-        }
-      }
-      continue;
-    }
-
-    if (!pattern.includes('*')) {
-      roots.push(resolve(cwd, pattern));
-    }
-  }
-  return roots;
-};
-
-const readWorkspacePackages = (cwd: string): readonly WorkspacePackage[] => {
-  const packages: WorkspacePackage[] = [];
-  for (const packageRoot of listWorkspacePackageRoots(cwd)) {
-    const packageJson = readPackageJson(join(packageRoot, 'package.json'));
-    if (
-      packageJson !== undefined &&
-      typeof packageJson.name === 'string' &&
-      packageJson.name.length > 0
-    ) {
-      packages.push({
-        name: packageJson.name,
-        packageJson,
-        packageRoot,
-      });
-    }
-  }
-  return packages;
-};
+const readWorkspacePackages = (cwd: string): readonly WorkspacePackage[] =>
+  listWorkspacePackages<NamedPackageJson>(cwd).map((workspacePackage) => ({
+    name: workspacePackage.manifest.name,
+    packageJson: workspacePackage.manifest,
+    packageRoot: workspacePackage.packageRoot,
+  }));
 
 const parsePackageSpecifier = (
   importPath: string

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -139,7 +139,9 @@ SerializedError, zodToJsonSchema(schema)
 
 // Path security & workspace
 securePath, isPathSafe, deriveSafePath
-findWorkspaceRoot, isInsideWorkspace, deriveRelativePath
+findWorkspaceRoot, isInsideWorkspace, deriveRelativePath, listWorkspacePatterns
+listWorkspacePackageDirs, listWorkspacePackages, findWorkspacePackage
+WorkspaceRootManifest, WorkspacePackage
 ```
 
 Core owns the shared glob machinery used by surface selectors, Wayfinder ID filters, Warden scope, and Regrade scan scope. Trail-id globs use dotted separators (`entity.*`, `entity.**`, `entity.????`); path-scope globs use path separators (`.agents/notes/**`, `src/**/*.ts`). `PathScope` is the stable scan/governance shape: `{ include?: string[], exclude?: string[], extensions?: string[] }`.

--- a/packages/adapter-kit/src/catalog.ts
+++ b/packages/adapter-kit/src/catalog.ts
@@ -6,14 +6,10 @@
  * internal tooling package.
  */
 
-import {
-  existsSync,
-  readdirSync,
-  readFileSync,
-  realpathSync,
-  statSync,
-} from 'node:fs';
+import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+
+import { listWorkspacePackages } from '@ontrails/core';
 
 export const adapterTargetPlacements = ['extracted', 'subpath'] as const;
 
@@ -66,15 +62,15 @@ export interface AdapterTargetCatalog {
   readonly targets: readonly AdapterTargetCatalogEntry[];
 }
 
-interface RootManifest {
-  readonly workspaces?: unknown;
-}
-
 export interface AdapterTargetPackageManifest {
   readonly exports?: unknown;
   readonly name?: unknown;
   readonly trails?: unknown;
 }
+
+type NamedAdapterTargetPackageManifest = AdapterTargetPackageManifest & {
+  readonly name: string;
+};
 
 export interface AdapterTargetParseContext {
   readonly blockedExportSpecifiers: readonly string[];
@@ -179,14 +175,6 @@ const localDeclarationKind = (
     'u'
   );
   return typeDeclarationPattern.test(code) ? 'type' : undefined;
-};
-
-const readJson = <T>(path: string): T | undefined => {
-  try {
-    return JSON.parse(readFileSync(path, 'utf8')) as T;
-  } catch {
-    return undefined;
-  }
 };
 
 const maskDeadSourceText = (
@@ -412,44 +400,6 @@ const exportedLocalBindingKind = (
     return 'type';
   }
   return importSpecifier ? resolveImportKind(importSpecifier) : undefined;
-};
-
-const workspacePatternsFromManifest = (
-  manifest: RootManifest | undefined
-): readonly string[] => {
-  const { workspaces } = manifest ?? {};
-  if (Array.isArray(workspaces)) {
-    return workspaces.filter(
-      (pattern): pattern is string => typeof pattern === 'string'
-    );
-  }
-
-  const packages = isRecord(workspaces) ? workspaces['packages'] : undefined;
-  return Array.isArray(packages)
-    ? packages.filter(
-        (pattern): pattern is string => typeof pattern === 'string'
-      )
-    : [];
-};
-
-const workspaceDirsForPattern = (
-  rootDir: string,
-  pattern: string
-): readonly string[] => {
-  if (!pattern.endsWith('/*')) {
-    const workspaceDir = join(rootDir, pattern);
-    return existsSync(workspaceDir) ? [workspaceDir] : [];
-  }
-
-  const groupDir = join(rootDir, pattern.slice(0, -2));
-  if (!existsSync(groupDir)) {
-    return [];
-  }
-
-  return readdirSync(groupDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => join(groupDir, entry.name))
-    .toSorted();
 };
 
 const exportConditions = new Set([
@@ -1401,40 +1351,27 @@ export const parseAdapterTargetsFromManifest = (
 export const deriveAdapterTargetCatalog = (
   rootDir: string
 ): AdapterTargetCatalog => {
-  const normalizedRoot = normalizeRealPath(rootDir);
-  const rootManifest = readJson<RootManifest>(
-    join(normalizedRoot, 'package.json')
-  );
   const diagnostics: AdapterTargetCatalogDiagnostic[] = [];
   const targets: AdapterTargetCatalogEntry[] = [];
 
-  for (const pattern of workspacePatternsFromManifest(rootManifest)) {
-    for (const workspaceDir of workspaceDirsForPattern(
-      normalizedRoot,
-      pattern
-    )) {
-      const packageJsonPath = join(workspaceDir, 'package.json');
-      const manifest = readJson<AdapterTargetPackageManifest>(packageJsonPath);
-      if (!manifest || typeof manifest.name !== 'string') {
-        continue;
-      }
-
-      const packageRoot = normalizeRealPath(dirname(packageJsonPath));
-      const normalizedExports = normalizeExportTargets(
-        packageRoot,
-        manifest.name,
-        manifest.exports
-      );
-      const parsed = parseAdapterTargetsFromManifest(manifest, {
-        blockedExportSpecifiers: normalizedExports.blocked,
-        exportTargets: normalizedExports.targets,
-        packageJsonPath: normalizeRealPath(packageJsonPath),
-        packageName: manifest.name,
-        packageRoot,
-      });
-      diagnostics.push(...parsed.diagnostics);
-      targets.push(...parsed.targets);
-    }
+  for (const workspacePackage of listWorkspacePackages<NamedAdapterTargetPackageManifest>(
+    rootDir
+  )) {
+    const { manifest, packageJsonPath, packageRoot } = workspacePackage;
+    const normalizedExports = normalizeExportTargets(
+      packageRoot,
+      manifest.name,
+      manifest.exports
+    );
+    const parsed = parseAdapterTargetsFromManifest(manifest, {
+      blockedExportSpecifiers: normalizedExports.blocked,
+      exportTargets: normalizedExports.targets,
+      packageJsonPath,
+      packageName: manifest.name,
+      packageRoot,
+    });
+    diagnostics.push(...parsed.diagnostics);
+    targets.push(...parsed.targets);
   }
 
   const sortedTargets = targets.toSorted((left, right) =>

--- a/packages/adapter-kit/src/check.ts
+++ b/packages/adapter-kit/src/check.ts
@@ -14,7 +14,8 @@ import {
 } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 
-import { escapeRegExp } from '@ontrails/core';
+import { escapeRegExp, listWorkspacePackages } from '@ontrails/core';
+import type { WorkspacePackage as CoreWorkspacePackage } from '@ontrails/core';
 
 import { deriveAdapterTargetCatalog } from './catalog.js';
 import type {
@@ -95,10 +96,6 @@ export interface AdapterCheckReport {
   readonly targets: readonly AdapterTargetCatalogEntry[];
 }
 
-interface RootManifest {
-  readonly workspaces?: unknown;
-}
-
 interface AdapterCheckPackageManifest {
   readonly dependencies?: unknown;
   readonly devDependencies?: unknown;
@@ -109,12 +106,7 @@ interface AdapterCheckPackageManifest {
   readonly trails?: unknown;
 }
 
-interface WorkspacePackage {
-  readonly manifest: AdapterCheckPackageManifest;
-  readonly packageJsonPath: string;
-  readonly packageRoot: string;
-  readonly workspacePath: string;
-}
+type WorkspacePackage = CoreWorkspacePackage<AdapterCheckPackageManifest>;
 
 interface AdapterMetadata {
   readonly target: string;
@@ -137,84 +129,8 @@ const normalizeRealPath = (path: string): string => {
   }
 };
 
-const readJson = <T>(path: string): T | undefined => {
-  try {
-    return JSON.parse(readFileSync(path, 'utf8')) as T;
-  } catch {
-    return undefined;
-  }
-};
-
-const workspacePatternsFromManifest = (
-  manifest: RootManifest | undefined
-): readonly string[] => {
-  const { workspaces } = manifest ?? {};
-  if (Array.isArray(workspaces)) {
-    return workspaces.filter(
-      (pattern): pattern is string => typeof pattern === 'string'
-    );
-  }
-
-  const packages = isRecord(workspaces) ? workspaces['packages'] : undefined;
-  return Array.isArray(packages)
-    ? packages.filter(
-        (pattern): pattern is string => typeof pattern === 'string'
-      )
-    : [];
-};
-
-const workspaceDirsForPattern = (
-  rootDir: string,
-  pattern: string
-): readonly string[] => {
-  if (!pattern.endsWith('/*')) {
-    const workspaceDir = join(rootDir, pattern);
-    return existsSync(workspaceDir) ? [workspaceDir] : [];
-  }
-
-  const groupDir = join(rootDir, pattern.slice(0, -2));
-  if (!existsSync(groupDir)) {
-    return [];
-  }
-
-  return readdirSync(groupDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => join(groupDir, entry.name))
-    .toSorted();
-};
-
-const workspacePackages = (rootDir: string): readonly WorkspacePackage[] => {
-  const normalizedRoot = normalizeRealPath(rootDir);
-  const rootManifest = readJson<RootManifest>(
-    join(normalizedRoot, 'package.json')
-  );
-  const packages: WorkspacePackage[] = [];
-
-  for (const pattern of workspacePatternsFromManifest(rootManifest)) {
-    for (const workspaceDir of workspaceDirsForPattern(
-      normalizedRoot,
-      pattern
-    )) {
-      const packageJsonPath = join(workspaceDir, 'package.json');
-      const manifest = readJson<AdapterCheckPackageManifest>(packageJsonPath);
-      if (!manifest || typeof manifest.name !== 'string') {
-        continue;
-      }
-
-      const packageRoot = normalizeRealPath(dirname(packageJsonPath));
-      packages.push({
-        manifest,
-        packageJsonPath: normalizeRealPath(packageJsonPath),
-        packageRoot,
-        workspacePath: normalizePath(relative(normalizedRoot, packageRoot)),
-      });
-    }
-  }
-
-  return packages.toSorted((left, right) =>
-    left.workspacePath.localeCompare(right.workspacePath)
-  );
-};
+const workspacePackages = (rootDir: string): readonly WorkspacePackage[] =>
+  listWorkspacePackages<AdapterCheckPackageManifest>(rootDir);
 
 const resolveExportTarget = (
   target: unknown,

--- a/packages/core/src/__tests__/workspace.test.ts
+++ b/packages/core/src/__tests__/workspace.test.ts
@@ -5,9 +5,13 @@ import { resolve, join } from 'node:path';
 
 import { NotFoundError } from '../errors.js';
 import {
+  findWorkspacePackage,
   findWorkspaceRoot,
   isInsideWorkspace,
   deriveRelativePath,
+  listWorkspacePackageDirs,
+  listWorkspacePackages,
+  listWorkspacePatterns,
 } from '../workspace.js';
 
 // ---------------------------------------------------------------------------
@@ -128,6 +132,108 @@ describe('findWorkspaceRoot', () => {
         result.isOk() ||
         (result as unknown as { error: Error }).error instanceof NotFoundError;
       expect(isAcceptable).toBe(true);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// workspace package discovery
+// ---------------------------------------------------------------------------
+
+describe('workspace package discovery', () => {
+  test('lists patterns from array and packages-object manifest forms', () => {
+    expect(
+      listWorkspacePatterns({ workspaces: ['packages/*', 123, 'apps/demo'] })
+    ).toEqual(['packages/*', 'apps/demo']);
+    expect(
+      listWorkspacePatterns({
+        workspaces: { packages: ['adapters/*', false, 'apps/*'] },
+      })
+    ).toEqual(['adapters/*', 'apps/*']);
+    expect(
+      listWorkspacePatterns({ workspaces: { nope: ['packages/*'] } })
+    ).toEqual([]);
+  });
+
+  test('lists exact and one-level workspace package directories only', () => {
+    const root = createTempDir();
+    try {
+      const packagesDir = join(root, 'packages');
+      const core = join(packagesDir, 'core');
+      const docs = join(packagesDir, 'docs');
+      const nested = join(packagesDir, 'nested', 'child');
+      const app = join(root, 'apps', 'demo');
+      mkdirSync(core, { recursive: true });
+      mkdirSync(docs, { recursive: true });
+      mkdirSync(nested, { recursive: true });
+      mkdirSync(app, { recursive: true });
+      writeJson(core, 'package.json', { name: '@scope/core' });
+      writeJson(nested, 'package.json', { name: '@scope/nested-child' });
+      writeJson(app, 'package.json', { name: '@scope/app' });
+
+      expect(
+        listWorkspacePackageDirs(root, ['packages/*', 'apps/demo']).map((dir) =>
+          dir.replace(root, '<root>')
+        )
+      ).toEqual(['<root>/packages/core', '<root>/apps/demo']);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('lists workspace packages with normalized metadata and stable ordering', () => {
+    const root = createTempDir();
+    try {
+      writeJson(root, 'package.json', {
+        name: 'root',
+        workspaces: ['packages/*', 'apps/demo'],
+      });
+      mkdirSync(join(root, 'packages', 'b'), { recursive: true });
+      mkdirSync(join(root, 'packages', 'a'), { recursive: true });
+      mkdirSync(join(root, 'apps', 'demo'), { recursive: true });
+      writeJson(join(root, 'packages', 'b'), 'package.json', {
+        name: '@scope/b',
+      });
+      writeJson(join(root, 'packages', 'a'), 'package.json', {
+        name: '@scope/a',
+      });
+      writeJson(join(root, 'apps', 'demo'), 'package.json', {
+        name: '@scope/demo',
+      });
+
+      expect(
+        listWorkspacePackages(root).map((workspacePackage) => ({
+          name: workspacePackage.manifest.name,
+          workspacePath: workspacePackage.workspacePath,
+        }))
+      ).toEqual([
+        { name: '@scope/demo', workspacePath: 'apps/demo' },
+        { name: '@scope/a', workspacePath: 'packages/a' },
+        { name: '@scope/b', workspacePath: 'packages/b' },
+      ]);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('finds a workspace package by package name', () => {
+    const root = createTempDir();
+    try {
+      writeJson(root, 'package.json', {
+        name: 'root',
+        workspaces: ['packages/*'],
+      });
+      mkdirSync(join(root, 'packages', 'core'), { recursive: true });
+      writeJson(join(root, 'packages', 'core'), 'package.json', {
+        name: '@scope/core',
+      });
+
+      expect(findWorkspacePackage(root, '@scope/core')?.workspacePath).toBe(
+        'packages/core'
+      );
+      expect(findWorkspacePackage(root, '@scope/missing')).toBeUndefined();
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -600,10 +600,15 @@ export { securePath, isPathSafe, deriveSafePath } from './path-security.js';
 
 // Workspace
 export {
+  deriveRelativePath,
+  findWorkspacePackage,
   findWorkspaceRoot,
   isInsideWorkspace,
-  deriveRelativePath,
+  listWorkspacePackageDirs,
+  listWorkspacePackages,
+  listWorkspacePatterns,
 } from './workspace.js';
+export type { WorkspacePackage, WorkspaceRootManifest } from './workspace.js';
 
 // Blob
 export {

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -5,10 +5,45 @@
  * helpers for working with paths relative to a workspace.
  */
 
+import { existsSync, readFileSync, readdirSync, realpathSync } from 'node:fs';
 import { resolve, relative, dirname, join, isAbsolute } from 'node:path';
 
 import { NotFoundError } from './errors.js';
 import { Result } from './result.js';
+
+export interface WorkspaceRootManifest {
+  readonly workspaces?: unknown;
+}
+
+export interface WorkspacePackage<
+  Manifest extends object = Record<string, unknown>,
+> {
+  readonly manifest: Manifest;
+  readonly packageJsonPath: string;
+  readonly packageRoot: string;
+  readonly workspacePath: string;
+}
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const normalizePath = (path: string): string => path.replaceAll('\\', '/');
+
+const normalizeRealPath = (path: string): string => {
+  try {
+    return normalizePath(realpathSync(path));
+  } catch {
+    return normalizePath(resolve(path));
+  }
+};
+
+const readJsonSync = <T>(path: string): T | undefined => {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as T;
+  } catch {
+    return undefined;
+  }
+};
 
 /** Check if a directory has a package.json with a `workspaces` field. */
 const hasWorkspacesField = async (dir: string): Promise<boolean> => {
@@ -24,6 +59,132 @@ const hasWorkspacesField = async (dir: string): Promise<boolean> => {
     return false;
   }
 };
+
+/**
+ * List workspace patterns from a root package manifest.
+ *
+ * Supports npm/Bun's array form and Yarn-style `{ packages: [] }` form.
+ *
+ * @example
+ * ```ts
+ * listWorkspacePatterns({ workspaces: ['packages/*'] });
+ * ```
+ */
+export const listWorkspacePatterns = (
+  manifest: WorkspaceRootManifest | undefined
+): readonly string[] => {
+  const { workspaces } = manifest ?? {};
+  if (Array.isArray(workspaces)) {
+    return workspaces.filter(
+      (pattern): pattern is string => typeof pattern === 'string'
+    );
+  }
+
+  const packages = isRecord(workspaces) ? workspaces['packages'] : undefined;
+  return Array.isArray(packages)
+    ? packages.filter(
+        (pattern): pattern is string => typeof pattern === 'string'
+      )
+    : [];
+};
+
+const workspaceDirsForPattern = (
+  rootDir: string,
+  pattern: string
+): readonly string[] => {
+  if (!pattern.endsWith('/*')) {
+    const workspaceDir = join(rootDir, pattern);
+    return existsSync(join(workspaceDir, 'package.json')) ? [workspaceDir] : [];
+  }
+
+  const groupDir = join(rootDir, pattern.slice(0, -2));
+  if (!existsSync(groupDir)) {
+    return [];
+  }
+
+  return readdirSync(groupDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(groupDir, entry.name))
+    .filter((workspaceDir) => existsSync(join(workspaceDir, 'package.json')))
+    .toSorted();
+};
+
+/**
+ * List package directories matched by workspace patterns.
+ *
+ * Only directories containing `package.json` are returned.
+ *
+ * @example
+ * ```ts
+ * listWorkspacePackageDirs('/repo', ['packages/*']);
+ * ```
+ */
+export const listWorkspacePackageDirs = (
+  rootDir: string,
+  patterns: readonly string[]
+): readonly string[] =>
+  patterns.flatMap((pattern) => workspaceDirsForPattern(rootDir, pattern));
+
+/**
+ * List workspace package manifests from a workspace root.
+ *
+ * @example
+ * ```ts
+ * const packages = listWorkspacePackages('/repo');
+ * ```
+ */
+export const listWorkspacePackages = <
+  Manifest extends { readonly name?: unknown } = { readonly name?: unknown },
+>(
+  rootDir: string
+): readonly WorkspacePackage<Manifest>[] => {
+  const normalizedRoot = normalizeRealPath(rootDir);
+  const rootManifest = readJsonSync<WorkspaceRootManifest>(
+    join(normalizedRoot, 'package.json')
+  );
+  const packages: WorkspacePackage<Manifest>[] = [];
+
+  for (const workspaceDir of listWorkspacePackageDirs(
+    normalizedRoot,
+    listWorkspacePatterns(rootManifest)
+  )) {
+    const packageJsonPath = join(workspaceDir, 'package.json');
+    const manifest = readJsonSync<Manifest>(packageJsonPath);
+    if (!manifest || typeof manifest.name !== 'string') {
+      continue;
+    }
+
+    const packageRoot = normalizeRealPath(dirname(packageJsonPath));
+    packages.push({
+      manifest,
+      packageJsonPath: normalizeRealPath(packageJsonPath),
+      packageRoot,
+      workspacePath: normalizePath(relative(normalizedRoot, packageRoot)),
+    });
+  }
+
+  return packages.toSorted((left, right) =>
+    left.workspacePath.localeCompare(right.workspacePath)
+  );
+};
+
+/**
+ * Find a workspace package by its package name.
+ *
+ * @example
+ * ```ts
+ * const workspace = findWorkspacePackage('/repo', '@ontrails/core');
+ * ```
+ */
+export const findWorkspacePackage = <
+  Manifest extends { readonly name?: unknown } = { readonly name?: unknown },
+>(
+  rootDir: string,
+  packageName: string
+): WorkspacePackage<Manifest> | undefined =>
+  listWorkspacePackages<Manifest>(rootDir).find(
+    (workspacePackage) => workspacePackage.manifest.name === packageName
+  );
 
 /**
  * Walks up from `startDir` (defaults to `process.cwd()`) looking for a

--- a/packages/warden/src/workspaces.ts
+++ b/packages/warden/src/workspaces.ts
@@ -2,10 +2,10 @@
  * Workspace-manifest discovery for Warden project-aware rules.
  */
 
-import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
+import { realpathSync } from 'node:fs';
 import { dirname, join, relative, resolve } from 'node:path';
 
-import { matchesAnyPathGlob } from '@ontrails/core';
+import { listWorkspacePackages, matchesAnyPathGlob } from '@ontrails/core';
 
 export interface WardenPublicWorkspace {
   readonly name: string;
@@ -19,10 +19,6 @@ export interface WardenPublicWorkspace {
 
 export interface WardenWorkspaceCollectionOptions {
   readonly exclude?: readonly string[];
-}
-
-interface RootManifest {
-  readonly workspaces?: unknown;
 }
 
 interface PackageManifest {
@@ -48,52 +44,6 @@ const rootRelativePath = (rootDir: string, path: string): string =>
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === 'object' && !Array.isArray(value));
-
-const readJson = <T>(path: string): T | undefined => {
-  try {
-    return JSON.parse(readFileSync(path, 'utf8')) as T;
-  } catch {
-    return undefined;
-  }
-};
-
-const workspacePatternsFromManifest = (
-  manifest: RootManifest | undefined
-): readonly string[] => {
-  const { workspaces } = manifest ?? {};
-  if (Array.isArray(workspaces)) {
-    return workspaces.filter(
-      (pattern): pattern is string => typeof pattern === 'string'
-    );
-  }
-
-  const packages = isRecord(workspaces) ? workspaces['packages'] : undefined;
-  return Array.isArray(packages)
-    ? packages.filter(
-        (pattern): pattern is string => typeof pattern === 'string'
-      )
-    : [];
-};
-
-const workspaceDirsForPattern = (
-  rootDir: string,
-  pattern: string
-): readonly string[] => {
-  if (!pattern.endsWith('/*')) {
-    const workspaceDir = join(rootDir, pattern);
-    return existsSync(workspaceDir) ? [workspaceDir] : [];
-  }
-
-  const groupDir = join(rootDir, pattern.slice(0, -2));
-  if (!existsSync(groupDir)) {
-    return [];
-  }
-
-  return readdirSync(groupDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => join(groupDir, entry.name))
-    .toSorted();
-};
 
 const packageLocalName = (name: string): string =>
   name.split('/').at(-1) ?? name;
@@ -221,36 +171,27 @@ export const collectPublicWorkspaces = (
   options: WardenWorkspaceCollectionOptions = {}
 ): ReadonlyMap<string, WardenPublicWorkspace> => {
   const normalizedRoot = normalizeRealPath(rootDir);
-  const rootManifest = readJson<RootManifest>(
-    join(normalizedRoot, 'package.json')
-  );
   const workspaces = new Map<string, WardenPublicWorkspace>();
 
-  for (const pattern of workspacePatternsFromManifest(rootManifest)) {
-    for (const workspaceDir of workspaceDirsForPattern(
-      normalizedRoot,
-      pattern
-    )) {
-      const packageJsonPath = join(workspaceDir, 'package.json');
-      const manifest = readJson<PackageManifest>(packageJsonPath);
-      if (!manifest) {
-        continue;
-      }
-
-      const workspace = publicWorkspaceFromManifest(packageJsonPath, manifest);
-      if (
-        workspace &&
-        !matchesAnyPathGlob(
-          rootRelativePath(normalizedRoot, workspace.rootDir),
-          options.exclude ?? []
-        ) &&
-        !matchesAnyPathGlob(
-          rootRelativePath(normalizedRoot, workspace.packageJsonPath),
-          options.exclude ?? []
-        )
-      ) {
-        workspaces.set(workspace.name, workspace);
-      }
+  for (const workspacePackage of listWorkspacePackages<PackageManifest>(
+    normalizedRoot
+  )) {
+    const workspace = publicWorkspaceFromManifest(
+      workspacePackage.packageJsonPath,
+      workspacePackage.manifest
+    );
+    if (
+      workspace &&
+      !matchesAnyPathGlob(
+        rootRelativePath(normalizedRoot, workspace.rootDir),
+        options.exclude ?? []
+      ) &&
+      !matchesAnyPathGlob(
+        rootRelativePath(normalizedRoot, workspace.packageJsonPath),
+        options.exclude ?? []
+      )
+    ) {
+      workspaces.set(workspace.name, workspace);
     }
   }
 


### PR DESCRIPTION
## Context

Part of the Coherence Cleanup stack. This branch centralizes synchronous workspace package discovery in @ontrails/core.

## What Changed

- Added listWorkspacePatterns, listWorkspacePackageDirs, listWorkspacePackages, and findWorkspacePackage to @ontrails/core.
- Migrated adapter-kit catalog/check, Warden workspace collection, and Trails create/load app call sites.
- Left stricter release-policy discovery and adapter-check root validators local where they have different semantics.
- Added tests, API docs, and changesets.

## Verification

- bun test packages/core/src/__tests__/workspace.test.ts && bun run --cwd packages/core typecheck
- bun run --cwd apps/trails typecheck && bun test apps/trails/src/__tests__/create-adapter.test.ts apps/trails/src/__tests__/load-app.test.ts
- bun run --cwd packages/adapter-kit typecheck && bun run --cwd packages/adapter-kit test
- bun run --cwd packages/warden typecheck && bun test packages/warden/src/__tests__/public-internal-deep-imports.test.ts packages/warden/src/__tests__/resolve.test.ts
- bun run docs:wrap-check && bun run docs:links
- bun run lint
- git diff --check

## Review

- In-thread local review was clean with no P0/P1/P2 findings.