### PR TITLE
fix(core): introduce shared diagnostic base

### DIFF
--- a/.changeset/core-diagnostic-base.md
+++ b/.changeset/core-diagnostic-base.md
@@ -1,0 +1,9 @@
+---
+"@ontrails/adapter-kit": patch
+"@ontrails/core": patch
+"@ontrails/permits": patch
+"@ontrails/warden": patch
+---
+
+Export shared diagnostic base types from core and align governance diagnostic
+severity vocabulary across adapter checks, permits, and Warden.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -63,6 +63,7 @@ RetryExhaustedError
 ErrorCategory, isTrailsError(value?), isRetryable(error)
 mapSurfaceError(surface, error), projectSurfaceError(surface, error)
 projectErrorClassSurface(surface, errorName)
+DiagnosticBase, DiagnosticSeverity, RuleDiagnosticBase
 
 // Implementation & context
 Implementation<I, O>              // (input, ctx) => Result | Promise<Result>
@@ -597,7 +598,7 @@ authVerify                           // verify a bearer token and return a permi
 
 // Governance
 validatePermits(trails)              // check trails against permit governance rules
-PermitDiagnostic
+PermitDiagnostic, PermitDiagnosticSeverity
 ```
 
 ### `@ontrails/permits/jwt`

--- a/packages/adapter-kit/src/check.ts
+++ b/packages/adapter-kit/src/check.ts
@@ -15,7 +15,10 @@ import {
 import { dirname, join, relative, resolve } from 'node:path';
 
 import { escapeRegExp, listWorkspacePackages } from '@ontrails/core';
-import type { WorkspacePackage as CoreWorkspacePackage } from '@ontrails/core';
+import type {
+  DiagnosticBase,
+  WorkspacePackage as CoreWorkspacePackage,
+} from '@ontrails/core';
 
 import { deriveAdapterTargetCatalog } from './catalog.js';
 import type {
@@ -36,15 +39,14 @@ export type AdapterCheckDiagnosticCode =
   | 'unknown-adapter-target'
   | 'unsupported-placement';
 
-export type AdapterCheckDiagnosticSeverity = 'error' | 'warn';
+export type AdapterCheckDiagnosticSeverity = DiagnosticBase['severity'];
 
-export interface AdapterCheckDiagnostic {
+export interface AdapterCheckDiagnostic extends DiagnosticBase<AdapterCheckDiagnosticCode> {
   readonly code: AdapterCheckDiagnosticCode;
   readonly message: string;
   readonly packageJsonPath: string;
   readonly packageName?: string | undefined;
   readonly placement?: AdapterTargetPlacement | undefined;
-  readonly severity: AdapterCheckDiagnosticSeverity;
   readonly target?: string | undefined;
 }
 

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared diagnostic vocabulary for governance-style findings.
+ *
+ * Runtime side-channel records and field-state reports can still define their
+ * own shapes. This base exists for tools that report rule or check failures.
+ */
+
+export type DiagnosticSeverity = 'error' | 'warn';
+
+export interface DiagnosticBase<TCode extends string = string> {
+  readonly code?: TCode | undefined;
+  readonly message: string;
+  readonly severity: DiagnosticSeverity;
+}
+
+export interface RuleDiagnosticBase<
+  TCode extends string = string,
+  TRule extends string = string,
+> extends DiagnosticBase<TCode> {
+  readonly rule: TRule;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,11 @@ export {
   redactErrorString,
 } from './error-projection.js';
 export type { ErrorDiagnosticsProjection } from './error-projection.js';
+export type {
+  DiagnosticBase,
+  DiagnosticSeverity,
+  RuleDiagnosticBase,
+} from './diagnostics.js';
 
 // Types
 export type {

--- a/packages/permits/src/__tests__/rules.test.ts
+++ b/packages/permits/src/__tests__/rules.test.ts
@@ -80,7 +80,7 @@ describe('writeWithoutPermit', () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]).toMatchObject({
       rule: 'writeWithoutPermit',
-      severity: 'warning',
+      severity: 'warn',
       trailId: 'user.create',
     });
   });
@@ -108,7 +108,7 @@ describe('writeWithoutPermit', () => {
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]).toMatchObject({
       rule: 'writeWithoutPermit',
-      severity: 'warning',
+      severity: 'warn',
       trailId: 'user.update',
     });
   });
@@ -150,7 +150,7 @@ describe('scopeNamingConsistency', () => {
     expect(diagnostics[0]).toMatchObject({
       message: expect.stringContaining('admin'),
       rule: 'scopeNamingConsistency',
-      severity: 'warning',
+      severity: 'warn',
       trailId: 'admin.panel',
     });
   });

--- a/packages/permits/src/index.ts
+++ b/packages/permits/src/index.ts
@@ -26,4 +26,8 @@ export {
   type PermitExtractionInput,
 } from './extraction.js';
 export { type Permit, getPermit } from './permit.js';
-export { validatePermits, type PermitDiagnostic } from './rules.js';
+export {
+  validatePermits,
+  type PermitDiagnostic,
+  type PermitDiagnosticSeverity,
+} from './rules.js';

--- a/packages/permits/src/rules.ts
+++ b/packages/permits/src/rules.ts
@@ -1,14 +1,20 @@
-import type { Trail } from '@ontrails/core';
+import type {
+  DiagnosticSeverity,
+  RuleDiagnosticBase,
+  Trail,
+} from '@ontrails/core';
 
 // ---------------------------------------------------------------------------
 // Diagnostic type
 // ---------------------------------------------------------------------------
 
+export type PermitDiagnosticSeverity = DiagnosticSeverity;
+
 /** A single governance finding from a permit rule. */
-export interface PermitDiagnostic {
+export interface PermitDiagnostic extends RuleDiagnosticBase {
   readonly trailId: string;
   readonly rule: string;
-  readonly severity: 'error' | 'warning';
+  readonly severity: PermitDiagnosticSeverity;
   readonly message: string;
 }
 
@@ -70,7 +76,7 @@ export const writeWithoutPermit: Rule = (trails) =>
     .map((t) => ({
       message: `Trail "${t.id}" has write intent but no permit declaration`,
       rule: 'writeWithoutPermit',
-      severity: 'warning' as const,
+      severity: 'warn' as const,
       trailId: t.id,
     }));
 
@@ -101,7 +107,7 @@ export const scopeNamingConsistency: Rule = (trails) =>
       .map((scope) => ({
         message: `Scope "${scope}" on trail "${t.id}" does not follow entity:action convention`,
         rule: 'scopeNamingConsistency',
-        severity: 'warning' as const,
+        severity: 'warn' as const,
         trailId: t.id,
       }))
   );
@@ -143,7 +149,7 @@ const orphanDiagnostics = (
     .map(([scope, ids]) => ({
       message: `Scope "${scope}" appears only on trail "${[...ids][0]}" — possible typo`,
       rule: 'orphanScopeDetection',
-      severity: 'warning' as const,
+      severity: 'warn' as const,
       trailId: [...ids][0] ?? '',
     }));
 

--- a/packages/warden/src/rules/permit-governance.ts
+++ b/packages/warden/src/rules/permit-governance.ts
@@ -10,7 +10,7 @@ const toWardenDiagnostic = (
   line: 1,
   message: diagnostic.message,
   rule: `permit.${diagnostic.rule}`,
-  severity: diagnostic.severity === 'error' ? 'error' : 'warn',
+  severity: diagnostic.severity,
 });
 
 export const permitGovernance: TopoAwareWardenRule = {

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -1,4 +1,9 @@
-import type { Intent, Topo } from '@ontrails/core';
+import type {
+  DiagnosticSeverity,
+  Intent,
+  RuleDiagnosticBase,
+  Topo,
+} from '@ontrails/core';
 import type { TopoGraph } from '@ontrails/topographer';
 
 import type { WardenDepth } from '../config.js';
@@ -8,7 +13,7 @@ import type { WardenPublicWorkspace } from '../workspaces.js';
 /**
  * Severity level for warden diagnostics.
  */
-export type WardenSeverity = 'error' | 'warn';
+export type WardenSeverity = DiagnosticSeverity;
 
 /**
  * Execution tier for a Warden rule.
@@ -207,7 +212,7 @@ export interface WardenRuleMetadata {
 /**
  * A single diagnostic reported by a warden rule.
  */
-export interface WardenDiagnostic {
+export interface WardenDiagnostic extends RuleDiagnosticBase {
   /** Rule identifier, e.g. "no-throw-in-implementation" */
   readonly rule: string;
   /** Optional rule-local diagnostic code for checks with multiple stable findings. */


### PR DESCRIPTION
## Context

Part of the Coherence Cleanup stack. This branch introduces a shared governance diagnostic base in @ontrails/core while keeping non-governance diagnostics independent.

## What Changed

- Added DiagnosticSeverity, DiagnosticBase, and RuleDiagnosticBase to @ontrails/core.
- Migrated adapter-kit, permits, and Warden rule diagnostics onto the shared base.
- Normalized permit diagnostic severity from warning to warn.
- Documented the new public core API and added changesets.

## Verification

- bun test packages/permits/src/__tests__/rules.test.ts && bun run --cwd packages/permits typecheck
- bun run --cwd packages/core typecheck
- bun run --cwd packages/adapter-kit typecheck
- bun run --cwd packages/warden typecheck && bun test packages/warden/src/__tests__/permit-governance.test.ts
- bun run docs:wrap-check && bun run docs:links && git diff --check
- bun run changeset:check
- bun run typecheck
- bun run lint

## Review

- In-thread local review was clean with no P0/P1/P2 findings.
- Reviewer explicitly accepted optional code on RuleDiagnosticBase as compatible with Warden and non-forcing for permits.