### PR TITLE
fix(config): rename config check reports

### DIFF
--- a/.changeset/trl-1099-config-report.md
+++ b/.changeset/trl-1099-config-report.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/config": patch
+---
+
+Rename config check reports to `ConfigReport` and `ConfigFieldReport`, and return field reports from `config.check`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -577,7 +577,7 @@ configDescribe                       // describe all schema fields
 configExplain                        // show which source won per field
 configInit                           // generate example config files
 
-DefineConfigOptions, ConfigState, ConfigFieldMeta, ConfigDiagnostic
+DefineConfigOptions, ConfigState, ConfigFieldMeta, ConfigReport, ConfigFieldReport
 ```
 
 ## `@ontrails/permits`

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -166,7 +166,7 @@ export const myTrail = trail('my.trail', {
 
 ### `config.check`
 
-Validate config values against the schema. Returns diagnostics with field-level status (valid, missing, invalid, deprecated, default).
+Validate config values against the schema. Returns a config report with field-level status (valid, missing, invalid, deprecated, default) and the checked field values when available.
 
 ### `config.describe`
 

--- a/packages/config/src/__tests__/config-check.test.ts
+++ b/packages/config/src/__tests__/config-check.test.ts
@@ -4,6 +4,7 @@ import type { TrailContext } from '@ontrails/core';
 import { z } from 'zod';
 
 import { configCheck } from '../trails/config-check.js';
+import { env, secret } from '../extensions.js';
 import type { ConfigState } from '../registry.js';
 
 /**
@@ -49,6 +50,39 @@ describe('config.check trail', () => {
       expect(configCheck.output).toBeDefined();
     });
 
+    test('output schema accepts reported field values', () => {
+      expect(
+        configCheck.output?.safeParse({
+          fields: [
+            {
+              message: 'Config value is valid',
+              path: 'port',
+              status: 'valid',
+              value: 6543,
+            },
+          ],
+          valid: true,
+        }).success
+      ).toBe(true);
+    });
+
+    test('output schema accepts redacted field markers', () => {
+      expect(
+        configCheck.output?.safeParse({
+          fields: [
+            {
+              message: 'OK',
+              path: 'apiKey',
+              redacted: true,
+              status: 'valid',
+              value: '[REDACTED]',
+            },
+          ],
+          valid: true,
+        }).success
+      ).toBe(true);
+    });
+
     test('declares configResource dependency', () => {
       expect(configCheck.resources).toBeDefined();
       expect(configCheck.resources?.length).toBe(1);
@@ -77,7 +111,7 @@ describe('config.check trail', () => {
       expect(result.isOk()).toBe(true);
       const value = result.unwrap();
       expect(value.valid).toBe(true);
-      expect(value.diagnostics.length).toBeGreaterThan(0);
+      expect(value.fields.length).toBeGreaterThan(0);
     });
 
     test('reports missing for required fields without values', async () => {
@@ -95,7 +129,7 @@ describe('config.check trail', () => {
       expect(result.isOk()).toBe(true);
       const value = result.unwrap();
       expect(value.valid).toBe(false);
-      const missing = value.diagnostics.filter((d) => d.status === 'missing');
+      const missing = value.fields.filter((d) => d.status === 'missing');
       expect(missing.length).toBe(2);
     });
 
@@ -113,8 +147,182 @@ describe('config.check trail', () => {
       expect(result.isOk()).toBe(true);
       const value = result.unwrap();
       expect(value.valid).toBe(true);
-      expect(value.diagnostics.length).toBe(1);
-      expect(value.diagnostics[0]?.status).toBe('valid');
+      expect(value.fields.length).toBe(1);
+      expect(value.fields[0]?.status).toBe('valid');
+    });
+
+    test('redacts secret values before returning surface output', async () => {
+      const schema = z.object({
+        apiKey: secret(z.string()),
+        port: z.number(),
+      });
+      const state: ConfigState = {
+        resolved: { apiKey: 'sk-test-secret', port: 3000 },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configCheck.blaze({ values: {} }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const apiKey = result.unwrap().fields.find((f) => f.path === 'apiKey');
+      const port = result.unwrap().fields.find((f) => f.path === 'port');
+      expect(apiKey).toEqual(
+        expect.objectContaining({
+          redacted: true,
+          status: 'valid',
+          value: '[REDACTED]',
+        })
+      );
+      expect(port).toEqual(
+        expect.objectContaining({
+          value: 3000,
+        })
+      );
+      expect(port?.redacted).toBeUndefined();
+    });
+
+    test('does not redact missing optional secret values', async () => {
+      const schema = z.object({
+        apiKey: secret(z.string().optional()),
+        port: z.number(),
+      });
+      const state: ConfigState = {
+        resolved: { port: 3000 },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configCheck.blaze({ values: {} }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const apiKey = result.unwrap().fields.find((f) => f.path === 'apiKey');
+      expect(apiKey).toEqual(
+        expect.objectContaining({
+          status: 'valid',
+          value: undefined,
+        })
+      );
+      expect(apiKey?.redacted).toBeUndefined();
+    });
+
+    test('redacts likely-secret env-backed values', async () => {
+      const schema = z.object({
+        apiKey: env(z.string(), 'API_KEY'),
+        host: env(z.string(), 'APP_HOST'),
+      });
+      const state: ConfigState = {
+        resolved: { apiKey: 'sk-test-secret', host: 'localhost' },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configCheck.blaze({ values: {} }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const { fields } = result.unwrap();
+      expect(fields.find((f) => f.path === 'apiKey')).toEqual(
+        expect.objectContaining({
+          redacted: true,
+          status: 'valid',
+          value: '[REDACTED]',
+        })
+      );
+      expect(fields.find((f) => f.path === 'host')).toEqual(
+        expect.objectContaining({
+          status: 'valid',
+          value: 'localhost',
+        })
+      );
+      expect(fields.find((f) => f.path === 'host')?.redacted).toBeUndefined();
+    });
+
+    test('redacts descendants of likely-secret env parent objects', async () => {
+      const schema = z.object({
+        credentials: env(
+          z.object({
+            password: z.string(),
+            username: z.string(),
+          }),
+          'DB_CREDENTIALS'
+        ),
+        host: z.string(),
+      });
+      const state: ConfigState = {
+        resolved: {
+          credentials: { password: 'secret-password', username: 'admin' },
+          host: 'db.internal',
+        },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configCheck.blaze({ values: {} }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const { fields } = result.unwrap();
+      expect(fields.find((f) => f.path === 'credentials.password')).toEqual(
+        expect.objectContaining({
+          redacted: true,
+          status: 'valid',
+          value: '[REDACTED]',
+        })
+      );
+      expect(fields.find((f) => f.path === 'credentials.username')).toEqual(
+        expect.objectContaining({
+          redacted: true,
+          status: 'valid',
+          value: '[REDACTED]',
+        })
+      );
+      expect(fields.find((f) => f.path === 'host')).toEqual(
+        expect.objectContaining({
+          status: 'valid',
+          value: 'db.internal',
+        })
+      );
+      expect(fields.find((f) => f.path === 'host')?.redacted).toBeUndefined();
+    });
+
+    test('redacts descendants of secret parent objects', async () => {
+      const schema = z.object({
+        db: secret(
+          z.object({
+            host: z.string(),
+            password: z.string(),
+          })
+        ),
+        region: z.string(),
+      });
+      const state: ConfigState = {
+        resolved: {
+          db: { host: 'db.internal', password: 'secret-password' },
+          region: 'us-east-1',
+        },
+        schema,
+      };
+      const ctx = buildCtx(state);
+      const result = await configCheck.blaze({ values: {} }, ctx);
+
+      expect(result.isOk()).toBe(true);
+      const { fields } = result.unwrap();
+      expect(fields.find((f) => f.path === 'db.host')).toEqual(
+        expect.objectContaining({
+          redacted: true,
+          status: 'valid',
+          value: '[REDACTED]',
+        })
+      );
+      expect(fields.find((f) => f.path === 'db.password')).toEqual(
+        expect.objectContaining({
+          redacted: true,
+          status: 'valid',
+          value: '[REDACTED]',
+        })
+      );
+      expect(fields.find((f) => f.path === 'region')).toEqual(
+        expect.objectContaining({
+          status: 'valid',
+          value: 'us-east-1',
+        })
+      );
+      expect(fields.find((f) => f.path === 'region')?.redacted).toBeUndefined();
     });
 
     test('deep merges nested input overrides with resolved values', async () => {
@@ -136,7 +344,7 @@ describe('config.check trail', () => {
 
       expect(result.isOk()).toBe(true);
       expect(result.unwrap().valid).toBe(true);
-      expect(result.unwrap().diagnostics).toEqual([
+      expect(result.unwrap().fields).toEqual([
         expect.objectContaining({
           path: 'db.host',
           status: 'valid',
@@ -164,7 +372,7 @@ describe('config.check trail', () => {
       expect(result.isOk()).toBe(true);
       const defaults = result
         .unwrap()
-        .diagnostics.filter((d) => d.status === 'default');
+        .fields.filter((d) => d.status === 'default');
       expect(defaults.length).toBe(1);
     });
   });

--- a/packages/config/src/__tests__/derive-provenance.test.ts
+++ b/packages/config/src/__tests__/derive-provenance.test.ts
@@ -106,6 +106,30 @@ describe('deriveConfigProvenance', () => {
       expect(host?.source).toBe('env');
       expect(host?.value).toBe('env.example.com');
     });
+
+    test('does not report env as source for skipped container bindings', () => {
+      const envSchema = z.object({
+        db: env(
+          z
+            .object({
+              host: z.string(),
+            })
+            .catch({ host: 'fallback' }),
+          'DB_CONFIG'
+        ),
+      });
+
+      const entries = deriveConfigProvenance({
+        base: { db: { host: 'base.example.com' } },
+        env: { DB_CONFIG: '{"host":"env.example.com"}' },
+        resolved: { db: { host: 'base.example.com' } },
+        schema: envSchema,
+      });
+
+      const db = entries.find((entry) => entry.path === 'db');
+      expect(db?.source).toBe('base');
+      expect(db?.value).toEqual({ host: 'base.example.com' });
+    });
   });
 
   describe('secret redaction', () => {

--- a/packages/config/src/__tests__/derive.test.ts
+++ b/packages/config/src/__tests__/derive.test.ts
@@ -256,6 +256,23 @@ describe('deriveConfigEnvExample()', () => {
     expect(result).toContain('default: 3000');
   });
 
+  test('does not advertise ignored object env bindings', () => {
+    const objectEnvSchema = z.object({
+      db: env(
+        z.object({
+          host: env(z.string(), 'DB_HOST'),
+          port: z.number().default(5432),
+        }),
+        'DB_CONFIG'
+      ),
+    });
+
+    const result = deriveConfigEnvExample(objectEnvSchema);
+
+    expect(result).not.toContain('DB_CONFIG=');
+    expect(result).toContain('DB_HOST=');
+  });
+
   test('returns empty string when no env vars are present', () => {
     const noEnvSchema = z.object({
       name: z.string(),

--- a/packages/config/src/__tests__/doctor.test.ts
+++ b/packages/config/src/__tests__/doctor.test.ts
@@ -15,7 +15,7 @@ describe('checkConfig', () => {
     test('reports status "valid" for present and valid fields', () => {
       const result = checkConfig(schema, { host: 'localhost', port: 8080 });
 
-      const hostDiag = result.diagnostics.find((d) => d.path === 'host');
+      const hostDiag = result.fields.find((d) => d.path === 'host');
       expect(hostDiag?.status).toBe('valid');
       expect(hostDiag?.value).toBe('localhost');
     });
@@ -25,7 +25,7 @@ describe('checkConfig', () => {
     test('reports status "missing" for absent required fields', () => {
       const result = checkConfig(schema, { port: 8080 });
 
-      const hostDiag = result.diagnostics.find((d) => d.path === 'host');
+      const hostDiag = result.fields.find((d) => d.path === 'host');
       expect(hostDiag?.status).toBe('missing');
       expect(hostDiag?.message).toContain('host');
     });
@@ -35,11 +35,11 @@ describe('checkConfig', () => {
     test('reports status "default" when field uses schema default', () => {
       const result = checkConfig(schema, { host: 'localhost' });
 
-      const portDiag = result.diagnostics.find((d) => d.path === 'port');
+      const portDiag = result.fields.find((d) => d.path === 'port');
       expect(portDiag?.status).toBe('default');
       expect(portDiag?.value).toBe(3000);
 
-      const debugDiag = result.diagnostics.find((d) => d.path === 'debug');
+      const debugDiag = result.fields.find((d) => d.path === 'debug');
       expect(debugDiag?.status).toBe('default');
       expect(debugDiag?.value).toBe(false);
     });
@@ -52,9 +52,30 @@ describe('checkConfig', () => {
         port: 'not-a-number',
       });
 
-      const portDiag = result.diagnostics.find((d) => d.path === 'port');
+      const portDiag = result.fields.find((d) => d.path === 'port');
       expect(portDiag?.status).toBe('invalid');
       expect(portDiag?.message).toBeDefined();
+    });
+
+    test('preserves catch semantics for object fields', () => {
+      const catchSchema = z.object({
+        db: z
+          .object({
+            host: z.string(),
+          })
+          .catch({ host: 'fallback' }),
+      });
+
+      const result = checkConfig(catchSchema, { db: 'bad' });
+
+      expect(result.valid).toBe(true);
+      expect(result.fields).toEqual([
+        expect.objectContaining({
+          path: 'db',
+          status: 'valid',
+          value: 'bad',
+        }),
+      ]);
     });
   });
 
@@ -72,9 +93,7 @@ describe('checkConfig', () => {
         legacyMode: true,
       });
 
-      const legacyDiag = result.diagnostics.find(
-        (d) => d.path === 'legacyMode'
-      );
+      const legacyDiag = result.fields.find((d) => d.path === 'legacyMode');
       expect(legacyDiag?.status).toBe('deprecated');
       expect(legacyDiag?.message).toContain('Use "mode" instead');
     });
@@ -126,9 +145,31 @@ describe('checkConfig', () => {
         {},
         { env: { APP_HOST: 'envhost' } }
       );
-      const hostDiag = result.diagnostics.find((d) => d.path === 'host');
+      const hostDiag = result.fields.find((d) => d.path === 'host');
       expect(hostDiag?.status).toBe('valid');
       expect(hostDiag?.value).toBe('envhost');
+    });
+
+    test('coerces primitive env vars before reporting field validity', () => {
+      const envSchema = z.object({
+        debug: env(z.boolean(), 'DEBUG'),
+        port: env(z.number(), 'PORT'),
+      });
+
+      const result = checkConfig(
+        envSchema,
+        {},
+        { env: { DEBUG: 'true', PORT: '8080' } }
+      );
+
+      const debugDiag = result.fields.find((d) => d.path === 'debug');
+      const portDiag = result.fields.find((d) => d.path === 'port');
+
+      expect(result.valid).toBe(true);
+      expect(debugDiag?.status).toBe('valid');
+      expect(debugDiag?.value).toBe(true);
+      expect(portDiag?.status).toBe('valid');
+      expect(portDiag?.value).toBe(8080);
     });
 
     test('resolves env vars for nested schema fields', () => {
@@ -144,7 +185,7 @@ describe('checkConfig', () => {
         { db: {} },
         { env: { DB_HOST: 'dbhost.local' } }
       );
-      const dbHostDiag = result.diagnostics.find((d) => d.path === 'db.host');
+      const dbHostDiag = result.fields.find((d) => d.path === 'db.host');
       expect(dbHostDiag?.status).toBe('valid');
       expect(dbHostDiag?.value).toBe('dbhost.local');
     });
@@ -163,10 +204,62 @@ describe('checkConfig', () => {
         {},
         { env: { DB_HOST: 'dbhost.local' } }
       );
-      const dbHostDiag = result.diagnostics.find((d) => d.path === 'db.host');
+      const dbHostDiag = result.fields.find((d) => d.path === 'db.host');
 
       expect(dbHostDiag?.status).toBe('valid');
       expect(dbHostDiag?.value).toBe('dbhost.local');
+    });
+
+    test('skips object env bindings instead of replacing nested values with a string', () => {
+      const envSchema = z.object({
+        db: env(
+          z.object({
+            host: z.string(),
+            port: z.number(),
+          }),
+          'DB_CONFIG'
+        ),
+      });
+
+      const result = checkConfig(
+        envSchema,
+        { db: { host: 'db.local', port: 5432 } },
+        { env: { DB_CONFIG: '{"host":"env.local","port":9999}' } }
+      );
+
+      expect(result.valid).toBe(true);
+      expect(result.fields.find((d) => d.path === 'db.host')?.value).toBe(
+        'db.local'
+      );
+      expect(result.fields.find((d) => d.path === 'db.port')?.value).toBe(5432);
+    });
+
+    test('skips catch-wrapped object env bindings', () => {
+      const envSchema = z.object({
+        db: env(
+          z
+            .object({
+              host: z.string(),
+            })
+            .catch({ host: 'fallback' }),
+          'DB_CONFIG'
+        ),
+      });
+
+      const result = checkConfig(
+        envSchema,
+        { db: { host: 'db.local' } },
+        { env: { DB_CONFIG: '{"host":"env.local"}' } }
+      );
+
+      expect(result.valid).toBe(true);
+      expect(result.fields).toEqual([
+        expect.objectContaining({
+          path: 'db',
+          status: 'valid',
+          value: { host: 'db.local' },
+        }),
+      ]);
     });
   });
 });

--- a/packages/config/src/__tests__/resolve.test.ts
+++ b/packages/config/src/__tests__/resolve.test.ts
@@ -134,6 +134,62 @@ describe('deriveConfig', () => {
       expect(result.unwrap().port).toBe(8080);
     });
 
+    test('coerces env values through catch wrappers', () => {
+      const schema = z.object({
+        port: env(z.number().catch(3000), 'PORT'),
+      });
+
+      const result = deriveConfig({
+        env: { PORT: '8080' },
+        schema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().port).toBe(8080);
+    });
+
+    test('coerces env values through prefault wrappers', () => {
+      const schema = z.object({
+        port: env(z.number().prefault(3000), 'PORT'),
+      });
+
+      const result = deriveConfig({
+        env: { PORT: '8080' },
+        schema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().port).toBe(8080);
+    });
+
+    test('coerces env values through nonoptional wrappers', () => {
+      const schema = z.object({
+        port: env(z.number().optional().nonoptional(), 'PORT'),
+      });
+
+      const result = deriveConfig({
+        env: { PORT: '8080' },
+        schema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().port).toBe(8080);
+    });
+
+    test('coerces env values through readonly wrappers', () => {
+      const schema = z.object({
+        port: env(z.number().readonly(), 'PORT'),
+      });
+
+      const result = deriveConfig({
+        env: { PORT: '8080' },
+        schema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().port).toBe(8080);
+    });
+
     test('rejects non-numeric string with Zod error instead of NaN', () => {
       const schema = z.object({
         port: env(z.number(), 'PORT').default(3000),
@@ -168,6 +224,44 @@ describe('deriveConfig', () => {
       expect(falseValues.isOk()).toBe(true);
       expect(falseValues.unwrap().debug).toBe(false);
       expect(falseValues.unwrap().verbose).toBe(false);
+    });
+
+    test('preserves enum-backed env overrides', () => {
+      const schema = z.object({
+        mode: env(z.enum(['dev', 'prod']), 'APP_MODE').default('dev'),
+      });
+
+      const result = deriveConfig({
+        env: { APP_MODE: 'prod' },
+        schema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().mode).toBe('prod');
+    });
+
+    test('skips object env bindings instead of replacing nested config with a string', () => {
+      const schema = z.object({
+        db: env(
+          z.object({
+            host: z.string(),
+            port: z.number(),
+          }),
+          'DB_CONFIG'
+        ),
+      });
+
+      const result = deriveConfig({
+        base: { db: { host: 'db.example.com', port: 5432 } },
+        env: { DB_CONFIG: '{"host":"env.example.com","port":9999}' },
+        schema,
+      });
+
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap().db).toEqual({
+        host: 'db.example.com',
+        port: 5432,
+      });
     });
   });
 

--- a/packages/config/src/app-config.ts
+++ b/packages/config/src/app-config.ts
@@ -7,7 +7,7 @@ import { dirname, join } from 'node:path';
 import { NotFoundError, Result, ValidationError } from '@ontrails/core';
 import type { z } from 'zod';
 
-import type { CheckResult } from './doctor.js';
+import type { ConfigReport } from './doctor.js';
 import { checkConfig } from './doctor.js';
 import type { FieldDescription } from './derive-fields.js';
 import { deriveConfigFields } from './derive-fields.js';
@@ -58,11 +58,11 @@ export interface AppConfig<T extends z.ZodType> {
   /** Describe all fields in the schema without needing values. */
   describe(): readonly FieldDescription[];
 
-  /** Check a config object against the schema and return diagnostics. */
+  /** Check a config object against the schema and return field reports. */
   check(
     values: Record<string, unknown>,
     options?: { readonly env?: Record<string, string | undefined> }
-  ): CheckResult;
+  ): ConfigReport;
 
   /** Show which source won for each config field. */
   explain(

--- a/packages/config/src/collect.ts
+++ b/packages/config/src/collect.ts
@@ -79,6 +79,10 @@ const walkObjectShape = (
 
   for (const [key, fieldSchema] of Object.entries(shape)) {
     const path = prefix ? `${prefix}.${key}` : key;
+    const meta = extractConfigMeta(fieldSchema);
+    if (meta) {
+      result.set(path, meta);
+    }
 
     if (isZodObject(fieldSchema)) {
       queue.push({
@@ -87,11 +91,6 @@ const walkObjectShape = (
           Record<string, z.ZodType>
         >,
       });
-    } else {
-      const meta = extractConfigMeta(fieldSchema);
-      if (meta) {
-        result.set(path, meta);
-      }
     }
   }
 };

--- a/packages/config/src/derive-provenance.ts
+++ b/packages/config/src/derive-provenance.ts
@@ -8,7 +8,14 @@ import type { z } from 'zod';
 
 import { collectConfigMeta } from './collect.js';
 import { isLikelySecret } from './secret-heuristics.js';
-import { getAtPath, isZodObject, unwrapToBase, zodDef } from './zod-utils.js';
+import {
+  getAtPath,
+  getSchemaAtPath,
+  isZodContainer,
+  isZodObject,
+  unwrapToBase,
+  zodDef,
+} from './zod-utils.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -64,11 +71,62 @@ const buildSecretSet = (
   return result;
 };
 
+/** Build a set of env-backed container paths that env overlay skips. */
+const buildSkippedEnvContainerSet = (
+  schema: z.ZodObject<Record<string, z.ZodType>>,
+  envMap: Map<string, string>
+): Set<string> => {
+  const result = new Set<string>();
+  for (const path of envMap.keys()) {
+    const fieldSchema = getSchemaAtPath(schema, path);
+    if (fieldSchema && isZodContainer(fieldSchema)) {
+      result.add(path);
+    }
+  }
+  return result;
+};
+
 /** Source entries in reverse precedence order for winner detection. */
 type SourceEntry = readonly [
   name: ProvenanceEntry['source'],
   values: Record<string, unknown> | undefined,
 ];
+
+/** Compare JSON-shaped config values for provenance winner detection. */
+const areConfigValuesEqual = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!(Array.isArray(left) && Array.isArray(right))) {
+      return false;
+    }
+    return (
+      left.length === right.length &&
+      left.every((value, index) => areConfigValuesEqual(value, right[index]))
+    );
+  }
+  if (
+    typeof left !== 'object' ||
+    left === null ||
+    typeof right !== 'object' ||
+    right === null
+  ) {
+    return false;
+  }
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const leftKeys = Object.keys(leftRecord);
+  const rightKeys = Object.keys(rightRecord);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) =>
+        Object.hasOwn(rightRecord, key) &&
+        areConfigValuesEqual(leftRecord[key], rightRecord[key])
+    )
+  );
+};
 
 /** Determine which source provided the winning value for a given path. */
 const determineSource = (
@@ -76,9 +134,10 @@ const determineSource = (
   resolved: Record<string, unknown>,
   sources: readonly SourceEntry[],
   envMap: Map<string, string>,
+  skippedEnvContainers: Set<string>,
   envVars: Record<string, string | undefined> | undefined
 ): ProvenanceEntry['source'] => {
-  if (envVars && envMap.has(path)) {
+  if (envVars && envMap.has(path) && !skippedEnvContainers.has(path)) {
     const envVar = envMap.get(path);
     if (envVar && envVars[envVar] !== undefined) {
       return 'env';
@@ -87,7 +146,10 @@ const determineSource = (
 
   const resolvedValue = getAtPath(resolved, path);
   for (const [name, values] of sources) {
-    if (values && getAtPath(values, path) === resolvedValue) {
+    if (
+      values &&
+      areConfigValuesEqual(getAtPath(values, path), resolvedValue)
+    ) {
       return name;
     }
   }
@@ -143,6 +205,7 @@ export const deriveConfigProvenance = <T extends z.ZodType>(
   >;
   const envMap = buildEnvMap(objSchema);
   const secretSet = buildSecretSet(objSchema);
+  const skippedEnvContainers = buildSkippedEnvContainerSet(objSchema, envMap);
 
   const sources: readonly SourceEntry[] = [
     ['local', options.local],
@@ -158,6 +221,7 @@ export const deriveConfigProvenance = <T extends z.ZodType>(
       options.resolved,
       sources,
       envMap,
+      skippedEnvContainers,
       options.env
     );
     const envVarName = envMap.get(path);

--- a/packages/config/src/derive/env.ts
+++ b/packages/config/src/derive/env.ts
@@ -10,6 +10,7 @@ import { collectConfigMeta } from '../collect.js';
 import type { ConfigFieldMeta } from '../extensions.js';
 
 import { isLikelySecret } from '../secret-heuristics.js';
+import { isZodContainer } from '../zod-utils.js';
 
 import {
   formatValue,
@@ -78,6 +79,9 @@ const collectEnvEntries = (
     }
     const fieldSchema = deriveFieldByPath(schema, path);
     if (!fieldSchema) {
+      continue;
+    }
+    if (isZodContainer(fieldSchema)) {
       continue;
     }
     entries.push(...envEntry(fieldMeta.env, fieldSchema, fieldMeta));

--- a/packages/config/src/doctor.ts
+++ b/packages/config/src/doctor.ts
@@ -1,5 +1,5 @@
 /**
- * Config doctor — structured diagnostics for a config object against a schema.
+ * Config doctor — structured field reports for a config object against a schema.
  *
  * Reports which fields are valid, missing, using defaults, deprecated, or invalid.
  */
@@ -7,14 +7,22 @@
 import type { z } from 'zod';
 
 import { collectConfigMeta } from './collect.js';
-import { getAtPath, isZodObject, unwrapToBase, zodDef } from './zod-utils.js';
+import {
+  coerceEnvValue,
+  getAtPath,
+  getSchemaAtPath,
+  isZodContainer,
+  isZodObject,
+  unwrapToBase,
+  zodDef,
+} from './zod-utils.js';
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-/** Diagnostic status for a single config field. */
-export interface ConfigDiagnostic {
+/** Validation status for a single config field. */
+export interface ConfigFieldReport {
   readonly path: string;
   readonly status: 'valid' | 'missing' | 'invalid' | 'deprecated' | 'default';
   readonly message: string;
@@ -22,8 +30,8 @@ export interface ConfigDiagnostic {
 }
 
 /** Aggregated result from checking config against a schema. */
-export interface CheckResult {
-  readonly diagnostics: readonly ConfigDiagnostic[];
+export interface ConfigReport {
+  readonly fields: readonly ConfigFieldReport[];
   readonly valid: boolean;
 }
 
@@ -74,9 +82,20 @@ const applyEnvToValues = (
   const meta = collectConfigMeta(schema);
   const result = structuredClone(values) as Record<string, unknown>;
   for (const [path, fieldMeta] of meta) {
-    if (fieldMeta.env && envVars[fieldMeta.env] !== undefined) {
-      setAtPath(result, path, envVars[fieldMeta.env]);
+    const fieldSchema = getSchemaAtPath(schema, path);
+    const envName = fieldMeta.env;
+    const envValue = envName ? envVars[envName] : undefined;
+    if (!envName || envValue === undefined) {
+      continue;
     }
+    if (fieldSchema && isZodContainer(fieldSchema)) {
+      continue;
+    }
+    setAtPath(
+      result,
+      path,
+      fieldSchema ? coerceEnvValue(envValue, fieldSchema) : envValue
+    );
   }
   return result;
 };
@@ -96,7 +115,7 @@ const validateFieldValue = (
   path: string,
   fieldSchema: z.ZodType,
   value: unknown
-): ConfigDiagnostic => {
+): ConfigFieldReport => {
   const result = fieldSchema.safeParse(value);
   if (result.success) {
     return { message: 'OK', path, status: 'valid', value };
@@ -112,7 +131,7 @@ const classifyField = (
   fieldSchema: z.ZodType,
   values: Record<string, unknown>,
   deprecatedMeta: Map<string, string>
-): ConfigDiagnostic => {
+): ConfigFieldReport => {
   const value = getAtPath(values, path);
   const deprecationMsg = deprecatedMeta.get(path);
 
@@ -190,7 +209,7 @@ const collectLeaves = (schema: z.ZodType): WalkEntry[] => {
 // ---------------------------------------------------------------------------
 
 /**
- * Check a config object against a schema and return structured diagnostics.
+ * Check a config object against a schema and return structured field reports.
  *
  * Reports which fields are valid, missing, using defaults, deprecated, or invalid.
  */
@@ -198,7 +217,7 @@ export const checkConfig = <T extends z.ZodType>(
   schema: T,
   values: Record<string, unknown>,
   options?: { readonly env?: Record<string, string | undefined> }
-): CheckResult => {
+): ConfigReport => {
   const objSchema = schema as unknown as z.ZodObject<Record<string, z.ZodType>>;
   const effectiveValues = options?.env
     ? applyEnvToValues(values, objSchema, options.env)
@@ -207,13 +226,13 @@ export const checkConfig = <T extends z.ZodType>(
   const deprecatedMeta = collectDeprecatedPaths(objSchema);
   const leaves = collectLeaves(objSchema);
 
-  const diagnostics = leaves.map((leaf) =>
+  const fields = leaves.map((leaf) =>
     classifyField(leaf.path, leaf.schema, effectiveValues, deprecatedMeta)
   );
 
-  const valid = diagnostics.every(
+  const valid = fields.every(
     (d) => d.status !== 'missing' && d.status !== 'invalid'
   );
 
-  return { diagnostics, valid };
+  return { fields, valid };
 };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -36,8 +36,8 @@ export {
 export { deriveConfigFields, type FieldDescription } from './derive-fields.js';
 export {
   checkConfig,
-  type CheckResult,
-  type ConfigDiagnostic,
+  type ConfigReport,
+  type ConfigFieldReport,
 } from './doctor.js';
 export { env, secret, deprecated, type ConfigFieldMeta } from './extensions.js';
 export {

--- a/packages/config/src/resolve.ts
+++ b/packages/config/src/resolve.ts
@@ -9,7 +9,12 @@ import { Result, ValidationError } from '@ontrails/core';
 
 import { collectConfigMeta } from './collect.js';
 import { deepMerge } from './merge.js';
-import { zodDef } from './zod-utils.js';
+import {
+  coerceEnvValue,
+  getSchemaAtPath,
+  isZodContainer,
+  zodDef,
+} from './zod-utils.js';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -24,72 +29,6 @@ export interface DeriveConfigOptions<T extends z.ZodType> {
   readonly localOverrides?: Record<string, unknown> | undefined;
   readonly env?: Record<string, string | undefined> | undefined;
 }
-
-// ---------------------------------------------------------------------------
-// Env coercion helpers (defined before consumers)
-// ---------------------------------------------------------------------------
-
-/** Boolean string values we accept from environment variables. */
-const BOOL_TRUE = new Set(['true', '1']);
-const BOOL_FALSE = new Set(['false', '0']);
-
-/** Primitive type names we can coerce env strings into. */
-const PRIMITIVE_TYPES = new Set(['number', 'boolean', 'string']);
-
-/** Try to advance one level through a Zod wrapper, returning the inner type or undefined. */
-const unwrapOne = (
-  schema: z.ZodType
-): { typeName: string | undefined; inner: z.ZodType | undefined } => {
-  const def = zodDef(schema);
-  return {
-    inner: def['innerType'] as z.ZodType | undefined,
-    typeName: def['type'] as string | undefined,
-  };
-};
-
-/** Unwrap ZodDefault / ZodOptional / ZodNullable to find the base type name. */
-const resolveBaseTypeName = (schema: z.ZodType): string => {
-  let current: z.ZodType = schema;
-
-  for (let depth = 0; depth < 10; depth += 1) {
-    const { typeName, inner } = unwrapOne(current);
-    if (typeName && PRIMITIVE_TYPES.has(typeName)) {
-      return typeName;
-    }
-    if (!inner) {
-      break;
-    }
-    current = inner;
-  }
-
-  return 'string';
-};
-
-/** Coerce a boolean env string. Returns the original string if unrecognized. */
-const coerceBooleanEnv = (raw: string): unknown => {
-  if (BOOL_TRUE.has(raw)) {
-    return true;
-  }
-  if (BOOL_FALSE.has(raw)) {
-    return false;
-  }
-  return raw;
-};
-
-/** Coerce env var lookup table keyed by base type name. */
-const ENV_COERCERS: Record<string, (raw: string) => unknown> = {
-  boolean: coerceBooleanEnv,
-  number: (raw: string) => {
-    const n = Number(raw);
-    return Number.isNaN(n) ? raw : n;
-  },
-};
-
-/** Coerce a string env value to the type expected by the schema field. */
-const coerceEnvValue = (raw: string, schema: z.ZodType): unknown => {
-  const coercer = ENV_COERCERS[resolveBaseTypeName(schema)];
-  return coercer ? coercer(raw) : raw;
-};
 
 // ---------------------------------------------------------------------------
 // Path utilities
@@ -132,33 +71,6 @@ const setAtPath = (
   parent[parts.at(-1) as string] = value;
 };
 
-/** Resolve one step of a Zod shape walk: find the field schema for a key. */
-const resolveShapeStep = (
-  current: z.ZodType,
-  key: string
-): z.ZodType | undefined => {
-  const shape = zodDef(current)['shape'] as
-    | Record<string, z.ZodType>
-    | undefined;
-  return shape?.[key];
-};
-
-/** Walk a Zod schema shape to find the field at a dot-separated path. */
-const getFieldSchema = (
-  schema: z.ZodType,
-  path: string
-): z.ZodType | undefined => {
-  let current: z.ZodType = schema;
-  for (const part of path.split('.')) {
-    const next = resolveShapeStep(current, part);
-    if (!next) {
-      return undefined;
-    }
-    current = next;
-  }
-  return current;
-};
-
 // ---------------------------------------------------------------------------
 // Env overlay
 // ---------------------------------------------------------------------------
@@ -170,7 +82,10 @@ const applyOneEnvOverride = (
   path: string,
   envValue: string
 ): void => {
-  const fieldSchema = getFieldSchema(schema, path);
+  const fieldSchema = getSchemaAtPath(schema, path);
+  if (fieldSchema && isZodContainer(fieldSchema)) {
+    return;
+  }
   const coerced = fieldSchema
     ? coerceEnvValue(envValue, fieldSchema)
     : envValue;

--- a/packages/config/src/trails/config-check.ts
+++ b/packages/config/src/trails/config-check.ts
@@ -1,26 +1,35 @@
 /**
  * Infrastructure trail that validates config values against a schema.
  *
- * Returns structured diagnostics indicating which fields are valid,
+ * Returns structured field reports indicating which fields are valid,
  * missing, invalid, deprecated, or using defaults.
  */
 import { Result, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { configResource } from '../config-resource.js';
+import { collectConfigMeta } from '../collect.js';
 import { checkConfig } from '../doctor.js';
 import { deepMerge } from '../merge.js';
+import { isLikelySecret } from '../secret-heuristics.js';
 
-const diagnosticSchema = z.object({
+const fieldReportSchema = z.object({
   message: z.string(),
   path: z.string(),
+  redacted: z.boolean().optional(),
   status: z.enum(['valid', 'missing', 'invalid', 'deprecated', 'default']),
+  value: z.unknown().optional(),
 });
 
 const outputSchema = z.object({
-  diagnostics: z.array(diagnosticSchema),
+  fields: z.array(fieldReportSchema),
   valid: z.boolean(),
 });
+
+type ConfigCheckFieldReport = ReturnType<typeof checkConfig>['fields'][number] &
+  Readonly<{
+    redacted?: boolean;
+  }>;
 
 /** Merge input values on top of resolved config values. */
 const mergeValues = (
@@ -31,13 +40,39 @@ const mergeValues = (
   return hasOverrides ? deepMerge(resolved, overrides) : resolved;
 };
 
+const redactSecretFields = (
+  schema: z.ZodObject<Record<string, z.ZodType>>,
+  fields: ReturnType<typeof checkConfig>['fields']
+): ConfigCheckFieldReport[] => {
+  const meta = collectConfigMeta(schema);
+  const redactedPaths = new Set(
+    [...meta.entries()]
+      .filter(
+        ([, fieldMeta]) =>
+          fieldMeta.secret === true ||
+          (fieldMeta.env !== undefined && isLikelySecret(fieldMeta.env))
+      )
+      .map(([path]) => path)
+  );
+  return fields.map((field) => {
+    const shouldRedact = [...redactedPaths].some(
+      (path) => field.path === path || field.path.startsWith(`${path}.`)
+    );
+    if (!shouldRedact || !('value' in field) || field.value === undefined) {
+      return field;
+    }
+
+    return { ...field, redacted: true, value: '[REDACTED]' };
+  });
+};
+
 export const configCheck = trail('config.check', {
   blaze: (input, ctx) => {
     const state = configResource.from(ctx);
     const effective = mergeValues(state.resolved, input.values);
     const checked = checkConfig(state.schema, effective);
     return Result.ok({
-      diagnostics: [...checked.diagnostics],
+      fields: redactSecretFields(state.schema, checked.fields),
       valid: checked.valid,
     });
   },

--- a/packages/config/src/zod-utils.ts
+++ b/packages/config/src/zod-utils.ts
@@ -9,15 +9,27 @@ import type { z } from 'zod';
 export const zodDef = (schema: z.ZodType): Record<string, unknown> =>
   schema.def as unknown as Record<string, unknown>;
 
-/** Wrapper types that should be peeled before checking the base type. */
-const WRAPPER_TYPES = new Set(['optional', 'default', 'nullable']);
+/** Wrapper types that preserve object traversal shape. */
+const TRAVERSAL_WRAPPER_TYPES = new Set(['optional', 'default', 'nullable']);
 
-/** Unwrap through optional/default/nullable wrappers to find the base schema. */
-export const unwrapToBase = (schema: z.ZodType): z.ZodType => {
+/** Wrapper types env overlay can inspect before coercing a string value. */
+const ENV_WRAPPER_TYPES = new Set([
+  ...TRAVERSAL_WRAPPER_TYPES,
+  'catch',
+  'nonoptional',
+  'prefault',
+  'readonly',
+]);
+
+/** Unwrap through selected wrappers to find the base schema. */
+const unwrapWith = (
+  schema: z.ZodType,
+  wrapperTypes: ReadonlySet<string>
+): z.ZodType => {
   let current = schema;
   for (let depth = 0; depth < 10; depth += 1) {
     const def = zodDef(current);
-    if (!WRAPPER_TYPES.has(def['type'] as string)) {
+    if (!wrapperTypes.has(def['type'] as string)) {
       return current;
     }
     const inner = def['innerType'] as z.ZodType | undefined;
@@ -29,12 +41,99 @@ export const unwrapToBase = (schema: z.ZodType): z.ZodType => {
   return current;
 };
 
+/** Unwrap through shape-preserving wrappers to find the base schema. */
+export const unwrapToBase = (schema: z.ZodType): z.ZodType =>
+  unwrapWith(schema, TRAVERSAL_WRAPPER_TYPES);
+
+/** Unwrap through env-coercion wrappers to find the env target schema. */
+const unwrapToEnvBase = (schema: z.ZodType): z.ZodType =>
+  unwrapWith(schema, ENV_WRAPPER_TYPES);
+
 /** Check if a schema is (or wraps) a ZodObject by inspecting its def. */
 export const isZodObject = (
   schema: z.ZodType
 ): schema is z.ZodObject<Record<string, z.ZodType>> => {
   const def = zodDef(unwrapToBase(schema));
   return def['type'] === 'object' && 'shape' in def;
+};
+
+/** Container types an env string should not replace wholesale. */
+const CONTAINER_TYPES = new Set([
+  'object',
+  'array',
+  'tuple',
+  'record',
+  'map',
+  'set',
+]);
+
+/** Check whether a schema is a container shape after unwrapping defaults. */
+export const isZodContainer = (schema: z.ZodType): boolean => {
+  const def = zodDef(unwrapToEnvBase(schema));
+  return CONTAINER_TYPES.has(def['type'] as string);
+};
+
+/** Boolean string values we accept from environment variables. */
+const BOOL_TRUE = new Set(['true', '1']);
+const BOOL_FALSE = new Set(['false', '0']);
+
+/** Primitive type names we can coerce env strings into. */
+const PRIMITIVE_TYPES = new Set(['number', 'boolean', 'string']);
+
+/** Resolve the primitive base type name after unwrapping defaults. */
+const resolvePrimitiveBaseTypeName = (
+  schema: z.ZodType
+): string | undefined => {
+  const def = zodDef(unwrapToEnvBase(schema));
+  const typeName = def['type'] as string | undefined;
+  return typeName && PRIMITIVE_TYPES.has(typeName) ? typeName : undefined;
+};
+
+/** Coerce a boolean env string. Returns the original string if unrecognized. */
+const coerceBooleanEnv = (raw: string): unknown => {
+  if (BOOL_TRUE.has(raw)) {
+    return true;
+  }
+  if (BOOL_FALSE.has(raw)) {
+    return false;
+  }
+  return raw;
+};
+
+/** Coerce env var lookup table keyed by base type name. */
+const ENV_COERCERS: Record<string, (raw: string) => unknown> = {
+  boolean: coerceBooleanEnv,
+  number: (raw: string) => {
+    const n = Number(raw);
+    return Number.isNaN(n) ? raw : n;
+  },
+};
+
+/** Coerce a string env value to the type expected by the schema field. */
+export const coerceEnvValue = (raw: string, schema: z.ZodType): unknown => {
+  const typeName = resolvePrimitiveBaseTypeName(schema);
+  const coercer = typeName ? ENV_COERCERS[typeName] : undefined;
+  return coercer ? coercer(raw) : raw;
+};
+
+/** Resolve a schema at a dot-separated path through nested object shapes. */
+export const getSchemaAtPath = (
+  schema: z.ZodType,
+  path: string
+): z.ZodType | undefined => {
+  let current = schema;
+  for (const part of path.split('.')) {
+    const base = unwrapToBase(current);
+    const shape = zodDef(base)['shape'] as
+      | Record<string, z.ZodType>
+      | undefined;
+    const next = shape?.[part];
+    if (!next) {
+      return undefined;
+    }
+    current = next;
+  }
+  return current;
 };
 
 /** Read a value at a dot-separated path from a plain object. */


### PR DESCRIPTION
## Context

Finishes [TRL-1099](https://linear.app/outfitter/issue/TRL-1099) by renaming config check diagnostics to field reports without changing the trail contract shape unexpectedly.

## What changed

- Renamed `ConfigDiagnostic` / `CheckResult` style surfaces to `ConfigFieldReport` / `ConfigReport`.
- Renamed aggregate `diagnostics` output to `fields` for `config.check`.
- Updated config docs and README examples for the report vocabulary.
- Preserved lower-stack API docs ordering: this branch still documents `TopoIssue`; [PR #849](https://github.com/outfitter-dev/trails/pull/849) owns the `TopoDiagnostic` rename.
- Hardened config redaction so explicit `secret()` fields, likely-secret env-backed fields, secret parent objects, and likely-secret env parent objects redact descendants before surface output.
- Preserved missing optional secret values as absent (`undefined`) instead of implying a secret exists.
- Kept object-shaped env metadata inspectable without applying raw string env overrides to nested config objects.

## Verification

- `bun test packages/config/src/__tests__/config-check.test.ts packages/config/src/__tests__/resolve.test.ts packages/config/src/__tests__/derive-provenance.test.ts packages/config/src/__tests__/extensions.test.ts`
- `bun run --filter @ontrails/config typecheck`
- Full stack verification on the top branch: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`, Graphite dry-run, and Graphite pre-push stable checks.

## Risks

Low. This is a vocabulary/API cleanup with compatibility-oriented redaction and env-overlay hardening; public docs remain branch-ordered through the stack.