### PR TITLE
fix(core): rename topo and draft diagnostics

### DIFF
--- a/.changeset/trl-1100-topo-draft-diagnostics.md
+++ b/.changeset/trl-1100-topo-draft-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/core": patch
+---
+
+Rename topo and draft report types to `TopoDiagnostic` and `DraftDiagnostic`, with deprecated `TopoIssue` and `DraftFinding` aliases preserved for source compatibility.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -89,7 +89,7 @@ validateOutput(schema, data)       // → Result<T, ValidationError>
 stripDefaultWrappers(schema), stripDefaultsFromShape(schema)
 validateTopo(topo)                 // → Result<void, ValidationError>; called by testAll()
 validateEstablishedTopo(topo)      // → Result<void, ValidationError>; rejects draft-contaminated outputs
-TopoIssue
+TopoDiagnostic
 
 // Schema derivation
 deriveFields(schema, overrides?)   // → Field[] (faithfully representable fields only)

--- a/packages/core/src/__tests__/validate-topo.test.ts
+++ b/packages/core/src/__tests__/validate-topo.test.ts
@@ -9,7 +9,7 @@ import { resource } from '../resource.js';
 import { Result } from '../result.js';
 import { trail } from '../trail.js';
 import { topo } from '../topo.js';
-import type { TopoIssue } from '../validate-topo.js';
+import type { TopoDiagnostic } from '../validate-topo.js';
 import { validateTopo } from '../validate-topo.js';
 import { webhook } from '../webhook.js';
 
@@ -62,12 +62,13 @@ const mockSignal = (id: string, from?: readonly string[]) => ({
 });
 
 /** Extract issues from a failed validateTopo result. */
-const extractIssues = (result: Result<void, Error>): TopoIssue[] => {
+const extractIssues = (result: Result<void, Error>): TopoDiagnostic[] => {
   if (result.isOk()) {
     return [];
   }
-  const ctx = (result.error as { context?: { issues?: TopoIssue[] } }).context;
-  return (ctx?.issues ?? []) as TopoIssue[];
+  const ctx = (result.error as { context?: { issues?: TopoDiagnostic[] } })
+    .context;
+  return (ctx?.issues ?? []) as TopoDiagnostic[];
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/draft.ts
+++ b/packages/core/src/draft.ts
@@ -25,7 +25,7 @@ export interface DraftDependency {
   readonly toId: string;
 }
 
-export interface DraftFinding {
+export interface DraftDiagnostic {
   readonly id: string;
   readonly kind: 'contour' | 'resource' | 'signal' | 'trail' | 'unknown';
   readonly message: string;
@@ -34,11 +34,19 @@ export interface DraftFinding {
   readonly dependsOn?: string | undefined;
 }
 
+/**
+ * @deprecated Use {@link DraftDiagnostic}. Kept as a source-compatible alias
+ * during the v1 vocabulary cutover.
+ */
+export interface DraftFinding extends DraftDiagnostic {
+  readonly id: DraftDiagnostic['id'];
+}
+
 export interface DraftReport {
   readonly contaminatedIds: ReadonlySet<string>;
   readonly declaredDraftIds: ReadonlySet<string>;
   readonly dependencies: readonly DraftDependency[];
-  readonly findings: readonly DraftFinding[];
+  readonly findings: readonly DraftDiagnostic[];
 }
 
 interface DraftReason {
@@ -120,7 +128,7 @@ const nodeKind = (
   trails: ReadonlyMap<string, AnyTrail>,
   signals: ReadonlyMap<string, AnySignal>,
   resources: ReadonlyMap<string, AnyResource>
-): DraftFinding['kind'] => {
+): DraftDiagnostic['kind'] => {
   if (contours.has(id)) {
     return 'contour';
   }
@@ -136,7 +144,7 @@ const nodeKind = (
   return 'unknown';
 };
 
-const displayKind = (kind: DraftFinding['kind']): string =>
+const displayKind = (kind: DraftDiagnostic['kind']): string =>
   kind === 'unknown' ? 'Node' : kind[0]?.toUpperCase() + kind.slice(1);
 
 const draftIdsFromKeys = (keys: Iterable<string>): string[] =>
@@ -152,8 +160,8 @@ const collectDeclaredDraftIds = (topo: Topo): ReadonlySet<string> =>
 
 const findingForDraftId = (
   id: string,
-  kind: DraftFinding['kind']
-): DraftFinding => ({
+  kind: DraftDiagnostic['kind']
+): DraftDiagnostic => ({
   id,
   kind,
   message: `${displayKind(id ? kind : 'unknown')} "${id}" is draft and cannot appear in the established graph.`,
@@ -162,9 +170,9 @@ const findingForDraftId = (
 
 const findingForContamination = (
   id: string,
-  kind: DraftFinding['kind'],
+  kind: DraftDiagnostic['kind'],
   reason: DraftReason
-): DraftFinding => {
+): DraftDiagnostic => {
   const dependencyLabel = isDraftId(reason.dependsOn)
     ? `draft "${reason.dependsOn}"`
     : `draft-contaminated "${reason.dependsOn}"`;
@@ -244,7 +252,7 @@ const contaminationFindingForId = (
   trails: ReadonlyMap<string, AnyTrail>,
   signals: ReadonlyMap<string, AnySignal>,
   resources: ReadonlyMap<string, AnyResource>
-): DraftFinding | undefined => {
+): DraftDiagnostic | undefined => {
   if (declaredDraftIds.has(id)) {
     return undefined;
   }
@@ -269,7 +277,7 @@ const collectFindings = (
   trails: ReadonlyMap<string, AnyTrail>,
   signals: ReadonlyMap<string, AnySignal>,
   resources: ReadonlyMap<string, AnyResource>
-): DraftFinding[] => [
+): DraftDiagnostic[] => [
   ...[...declaredDraftIds]
     .toSorted()
     .map((id) =>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -441,13 +441,14 @@ export {
 export type {
   DraftDependency,
   DraftDependencyKind,
+  DraftDiagnostic,
   DraftFinding,
   DraftReport,
 } from './draft.js';
 
 // Topo validation
 export { validateTopo } from './validate-topo.js';
-export type { TopoIssue } from './validate-topo.js';
+export type { TopoDiagnostic, TopoIssue } from './validate-topo.js';
 export { validateEstablishedTopo } from './validate-established-topo.js';
 
 // Layer

--- a/packages/core/src/type-checks.test-d.ts
+++ b/packages/core/src/type-checks.test-d.ts
@@ -23,7 +23,27 @@ import type { BasePermit } from './permits.js';
 import { Result } from './result.js';
 import type { ComposeFn, FireFn } from './types.js';
 import type { ComposeInput, TrailInput, TrailOutput } from './type-utils.js';
+import type { DraftFinding as DirectDraftFinding } from './draft.js';
+import type { TopoIssue as DirectTopoIssue } from './validate-topo.js';
+import type {
+  DraftDiagnostic as BarrelDraftDiagnostic,
+  DraftFinding as BarrelDraftFinding,
+  TopoDiagnostic as BarrelTopoDiagnostic,
+  TopoIssue as BarrelTopoIssue,
+} from './index.js';
 import { z } from 'zod';
+
+declare module './draft.js' {
+  interface DraftFinding {
+    readonly extensionField?: string;
+  }
+}
+
+declare module './validate-topo.js' {
+  interface TopoIssue {
+    readonly extensionField?: string;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -36,8 +56,39 @@ type IsExact<A, B> =
       ? true
       : false
     : false;
+type IsAssignable<A, B> = A extends B ? true : false;
 
 declare const compose: ComposeFn;
+
+export type DraftFindingDeprecatedNameStaysCompatible = Assert<
+  IsAssignable<BarrelDraftFinding, BarrelDraftDiagnostic>
+>;
+export type DraftFindingCanonicalStaysAssignable = Assert<
+  IsAssignable<BarrelDraftDiagnostic, BarrelDraftFinding>
+>;
+export type TopoIssueDeprecatedNameStaysCompatible = Assert<
+  IsAssignable<BarrelTopoIssue, BarrelTopoDiagnostic>
+>;
+export type TopoIssueCanonicalStaysAssignable = Assert<
+  IsAssignable<BarrelTopoDiagnostic, BarrelTopoIssue>
+>;
+
+const augmentedDraftFinding: DirectDraftFinding = {
+  extensionField: 'ok',
+  id: 'draft.example',
+  kind: 'trail',
+  message: 'Draft example',
+  rule: 'draft-id',
+};
+void augmentedDraftFinding;
+
+const augmentedTopoIssue: DirectTopoIssue = {
+  extensionField: 'ok',
+  message: 'Topo example',
+  rule: 'example',
+  trailId: 'example',
+};
+void augmentedTopoIssue;
 
 const defaultedTrail = trail('typecheck.defaulted-input', {
   blaze: (input) => {

--- a/packages/core/src/validate-established-topo.ts
+++ b/packages/core/src/validate-established-topo.ts
@@ -2,7 +2,7 @@ import { ValidationError } from './errors.js';
 import { Result } from './result.js';
 import type { Topo } from './topo.js';
 import { validateDraftFreeTopo } from './draft.js';
-import type { TopoIssue } from './validate-topo.js';
+import type { TopoDiagnostic } from './validate-topo.js';
 import { validateTopo } from './validate-topo.js';
 
 const PROJECTION_BLOCKING_RULES = new Set([
@@ -27,7 +27,7 @@ const keepProjectionBlockingIssues = (
   }
 
   const issues = (
-    result.error.context as { issues?: readonly TopoIssue[] } | undefined
+    result.error.context as { issues?: readonly TopoDiagnostic[] } | undefined
   )?.issues;
   const remainingIssues = issues?.filter((issue) =>
     PROJECTION_BLOCKING_RULES.has(issue.rule)

--- a/packages/core/src/validate-topo.ts
+++ b/packages/core/src/validate-topo.ts
@@ -34,7 +34,7 @@ import { validateWebhookSource } from './webhook.js';
 // Issue shape
 // ---------------------------------------------------------------------------
 
-export interface TopoIssue {
+export interface TopoDiagnostic {
   readonly trailId: string;
   readonly rule: string;
   readonly message: string;
@@ -42,6 +42,14 @@ export interface TopoIssue {
   readonly schemaIssues?: readonly TopoSchemaIssue[];
   readonly sourceId?: string;
   readonly sourceKind?: string;
+}
+
+/**
+ * @deprecated Use {@link TopoDiagnostic}. Kept as a source-compatible alias
+ * during the v1 vocabulary cutover.
+ */
+export interface TopoIssue extends TopoDiagnostic {
+  readonly trailId: TopoDiagnostic['trailId'];
 }
 
 export type TopoSchemaIssue = ActivationSchemaIssue;
@@ -92,8 +100,8 @@ const buildComposeGraph = (
 /** Detect multi-node cycles in the trail composing graph via DFS. */
 const detectComposeCycles = (
   trails: ReadonlyMap<string, AnyTrail>
-): TopoIssue[] => {
-  const issues: TopoIssue[] = [];
+): TopoDiagnostic[] => {
+  const issues: TopoDiagnostic[] = [];
   const { color, graph } = buildComposeGraph(trails);
 
   const dfs = (node: string, path: string[]): void => {
@@ -128,8 +136,8 @@ const detectComposeCycles = (
 const checkComposes = (
   trails: ReadonlyMap<string, AnyTrail>,
   topo: Topo
-): TopoIssue[] => {
-  const issues: TopoIssue[] = [];
+): TopoDiagnostic[] => {
+  const issues: TopoDiagnostic[] = [];
   for (const [id, trail] of trails) {
     for (const composedId of trail.composes) {
       if (composedId === id) {
@@ -182,8 +190,8 @@ const checkComposes = (
 const checkResources = (
   trails: ReadonlyMap<string, AnyTrail>,
   topo: Topo
-): TopoIssue[] => {
-  const issues: TopoIssue[] = [];
+): TopoDiagnostic[] => {
+  const issues: TopoDiagnostic[] = [];
 
   for (const [id, trail] of trails) {
     for (const declaredResource of trail.resources) {
@@ -237,8 +245,8 @@ const checkOneExample = (
   inputSchema: { safeParse: (data: unknown) => { success: boolean } },
   hasOutput: boolean,
   label = `Example "${example.name}"`
-): TopoIssue[] => {
-  const issues: TopoIssue[] = [];
+): TopoDiagnostic[] => {
+  const issues: TopoDiagnostic[] = [];
   const result = validateInput(inputSchema as AnyTrail['input'], example.input);
   if (result.isErr() && example.error !== 'ValidationError') {
     issues.push({
@@ -257,7 +265,7 @@ const checkOneExample = (
   return issues;
 };
 
-const checkVersionExamples = (id: string, trail: AnyTrail): TopoIssue[] =>
+const checkVersionExamples = (id: string, trail: AnyTrail): TopoDiagnostic[] =>
   Object.entries(trail.versions ?? {}).flatMap(([version, entry]) => {
     if (isArchivedTrailVersionEntry(entry)) {
       return [];
@@ -274,8 +282,10 @@ const checkVersionExamples = (id: string, trail: AnyTrail): TopoIssue[] =>
     );
   });
 
-const checkExamples = (trails: ReadonlyMap<string, AnyTrail>): TopoIssue[] => {
-  const issues: TopoIssue[] = [];
+const checkExamples = (
+  trails: ReadonlyMap<string, AnyTrail>
+): TopoDiagnostic[] => {
+  const issues: TopoDiagnostic[] = [];
   for (const [id, trail] of trails) {
     if (trail.examples) {
       for (const example of trail.examples) {
@@ -292,8 +302,8 @@ const checkExamples = (trails: ReadonlyMap<string, AnyTrail>): TopoIssue[] => {
 const checkSignalOrigins = (
   signals: ReadonlyMap<string, AnySignal>,
   topo: Topo
-): TopoIssue[] => {
-  const issues: TopoIssue[] = [];
+): TopoDiagnostic[] => {
+  const issues: TopoDiagnostic[] = [];
   for (const [id, evt] of signals) {
     if (!evt.from) {
       continue;
@@ -314,8 +324,8 @@ const checkSignalOrigins = (
 const checkSignalReferences = (
   trails: ReadonlyMap<string, AnyTrail>,
   signals: ReadonlyMap<string, AnySignal>
-): TopoIssue[] => {
-  const issues: TopoIssue[] = [];
+): TopoDiagnostic[] => {
+  const issues: TopoDiagnostic[] = [];
 
   for (const [id, trail] of trails) {
     for (const signalId of trail.fires ?? []) {
@@ -344,8 +354,8 @@ const checkSignalReferences = (
 
 const checkActivationSources = (
   trails: ReadonlyMap<string, AnyTrail>
-): TopoIssue[] => {
-  const issues: TopoIssue[] = [];
+): TopoDiagnostic[] => {
+  const issues: TopoDiagnostic[] = [];
   const sourceDeclarations = new Map<
     string,
     {
@@ -440,7 +450,7 @@ const createSourceCompatibilityIssue = (
   trailId: string,
   activation: ActivationEntry,
   schemaIssues: readonly TopoSchemaIssue[]
-): TopoIssue => {
+): TopoDiagnostic => {
   const [firstIssue] = schemaIssues;
   const inputPath = firstIssue?.path ?? Object.freeze([]);
   return {
@@ -458,7 +468,7 @@ const checkSourcePayloadCompatibility = (
   trail: AnyTrail,
   activation: ActivationEntry,
   signals: ReadonlyMap<string, AnySignal>
-): TopoIssue | undefined => {
+): TopoDiagnostic | undefined => {
   if (
     !isKnownActivationSourceKind(activation.source.kind) ||
     isDraftId(activation.source.id)
@@ -483,8 +493,8 @@ const checkSourcePayloadCompatibility = (
 const checkActivationSourceInputCompatibility = (
   trails: ReadonlyMap<string, AnyTrail>,
   signals: ReadonlyMap<string, AnySignal>
-): TopoIssue[] => {
-  const issues: TopoIssue[] = [];
+): TopoDiagnostic[] => {
+  const issues: TopoDiagnostic[] = [];
 
   for (const trail of trails.values()) {
     for (const activation of trail.activationSources ?? []) {
@@ -501,8 +511,8 @@ const checkActivationSourceInputCompatibility = (
 const checkContourReferences = (
   contours: ReadonlyMap<string, AnyContour>,
   topo: Topo
-): TopoIssue[] => {
-  const issues: TopoIssue[] = [];
+): TopoDiagnostic[] => {
+  const issues: TopoDiagnostic[] = [];
 
   for (const [name, contourDef] of contours) {
     for (const ref of getContourReferences(contourDef)) {

--- a/packages/topographer/src/__tests__/derive.test.ts
+++ b/packages/topographer/src/__tests__/derive.test.ts
@@ -13,7 +13,7 @@ import {
   trail,
   webhook,
 } from '@ontrails/core';
-import type { Layer, Topo, TopoIssue } from '@ontrails/core';
+import type { Layer, Topo, TopoDiagnostic } from '@ontrails/core';
 import { z } from 'zod';
 
 import { deriveTopoGraph } from '../derive.js';
@@ -78,13 +78,13 @@ const expectSchemaProperties = (
   );
 };
 
-const expectTopoGraphTopoIssue = (tp: Topo, rule: string) => {
+const expectTopoGraphTopoDiagnostic = (tp: Topo, rule: string) => {
   try {
     deriveTopoGraph(tp);
   } catch (error) {
     expect(error).toBeInstanceOf(ValidationError);
     const issues = (error as ValidationError).context?.['issues'] as
-      | readonly TopoIssue[]
+      | readonly TopoDiagnostic[]
       | undefined;
     expect(issues).toContainEqual(expect.objectContaining({ rule }));
     return;
@@ -1297,7 +1297,10 @@ describe('deriveTopoGraph', () => {
         input: z.object({}),
       });
 
-      expectTopoGraphTopoIssue(topoFrom({ producer }), 'signal-fire-exists');
+      expectTopoGraphTopoDiagnostic(
+        topoFrom({ producer }),
+        'signal-fire-exists'
+      );
     });
 
     test('rejects consumer references to missing signals', () => {
@@ -1307,7 +1310,7 @@ describe('deriveTopoGraph', () => {
         on: ['entity.missing'],
       });
 
-      expectTopoGraphTopoIssue(topoFrom({ consumer }), 'signal-on-exists');
+      expectTopoGraphTopoDiagnostic(topoFrom({ consumer }), 'signal-on-exists');
     });
   });
 });


### PR DESCRIPTION
## Context

Finishes [TRL-1100](https://linear.app/outfitter/issue/TRL-1100) by aligning topo/draft validation vocabulary around diagnostics.

## What changed

- Renamed `TopoIssue` to `TopoDiagnostic` and `DraftFinding` to `DraftDiagnostic`.
- Preserved deprecated type aliases so downstream consumers do not break immediately.
- Updated exports and type assertions for the compatibility aliases.
- Updated API docs on this branch, after [PR #848](https://github.com/outfitter-dev/trails/pull/848), so the `TopoDiagnostic` docs land with the actual public type rename.

## Verification

- `bun test packages/core/src/__tests__/validate-topo.test.ts packages/core/src/type-checks.test-d.ts`
- `bun run --filter @ontrails/core typecheck`
- Full stack verification on the top branch: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`, Graphite dry-run, and Graphite pre-push stable checks.

## Risks

Low. Deprecated aliases preserve the existing published names while new vocabulary becomes canonical.