### PR TITLE
fix(trails): rename topo read helpers to derive

### DIFF
--- a/.changeset/trl-1101-topo-read-derive.md
+++ b/.changeset/trl-1101-topo-read-derive.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Rename read-only topo helper exports from `build*` to `derive*`.

--- a/apps/trails/src/__tests__/guide.test.ts
+++ b/apps/trails/src/__tests__/guide.test.ts
@@ -5,7 +5,7 @@ import { ConflictError, trail, topo, Result } from '@ontrails/core';
 import { z } from 'zod';
 
 import { guideTrail } from '../trails/guide.js';
-import { buildCurrentGuideEntries } from '../trails/topo-read-support.js';
+import { deriveCurrentGuideEntries } from '../trails/topo-read-support.js';
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -120,7 +120,7 @@ describe('trails guide', () => {
     });
     const versionedApp = topo('guide-versioned-app', { versioned });
 
-    expect(buildCurrentGuideEntries(versionedApp)).toEqual([
+    expect(deriveCurrentGuideEntries(versionedApp)).toEqual([
       expect.objectContaining({
         exampleCount: 1,
         id: 'guide.versioned',

--- a/apps/trails/src/__tests__/survey.test.ts
+++ b/apps/trails/src/__tests__/survey.test.ts
@@ -55,8 +55,8 @@ import {
 } from '../trails/survey.js';
 import { loadApp } from '../trails/load-app.js';
 import {
-  buildCurrentTopoMatches,
-  buildCurrentTrailDetail,
+  deriveCurrentTopoMatches,
+  deriveCurrentTrailDetail,
   readSurfaceLayerNamesFromContext,
 } from '../trails/topo-read-support.js';
 import {
@@ -657,10 +657,10 @@ describe('trails survey detail', () => {
     });
     const layeredApp = topo('layered-app', { layered });
 
-    const detail = buildCurrentTrailDetail(layeredApp, layered.id, {
+    const detail = deriveCurrentTrailDetail(layeredApp, layered.id, {
       surfaceLayerNames: { cli: ['cli-B'], http: ['http-C'] },
     });
-    const matches = buildCurrentTopoMatches(layeredApp, layered.id, {
+    const matches = deriveCurrentTopoMatches(layeredApp, layered.id, {
       surfaceLayerNames: { mcp: ['mcp-D'] },
     });
 

--- a/apps/trails/src/trails/guide.ts
+++ b/apps/trails/src/trails/guide.ts
@@ -10,8 +10,8 @@ import { z } from 'zod';
 import { withFreshOperatorApp } from './operator-context.js';
 import { trailDetailOutput } from './topo-output-schemas.js';
 import {
-  buildCurrentGuideEntries,
-  buildCurrentTopoDetail,
+  deriveCurrentGuideEntries,
+  deriveCurrentTopoDetail,
   readSurfaceLayerNamesFromContext,
 } from './topo-read-support.js';
 import { createIsolatedExampleInput } from './topo-support.js';
@@ -53,7 +53,7 @@ export const guideTrail = trail('guide', {
   blaze: async (input: GuideTrailInput, ctx) =>
     withFreshOperatorApp<GuideTrailOutput>(input, ctx, ({ lease, rootDir }) => {
       if (input.trailId) {
-        const detail = buildCurrentTopoDetail(lease.app, input.trailId, {
+        const detail = deriveCurrentTopoDetail(lease.app, input.trailId, {
           cliAliases: lease.cliAliases,
           rootDir,
           surfaceLayerNames: readSurfaceLayerNamesFromContext(ctx),
@@ -70,7 +70,7 @@ export const guideTrail = trail('guide', {
       }
 
       return Result.ok({
-        entries: buildCurrentGuideEntries(lease.app, {
+        entries: deriveCurrentGuideEntries(lease.app, {
           rootDir,
         }) as GuideEntry[],
         mode: 'list' as const,

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -30,12 +30,12 @@ import { writeIsolatedExampleJsonFile } from '../local-state-io.js';
 
 import { withFreshAppLease, withOperatorRootDir } from './operator-context.js';
 import {
-  buildCurrentTopoBrief,
-  buildCurrentTopoList,
-  buildCurrentTopoMatches,
-  buildCurrentTrailDetail,
-  buildCurrentResourceDetail,
-  buildCurrentSignalDetail,
+  deriveCurrentTopoBrief,
+  deriveCurrentTopoList,
+  deriveCurrentTopoMatches,
+  deriveCurrentTrailDetail,
+  deriveCurrentResourceDetail,
+  deriveCurrentSignalDetail,
   readSurfaceLayerNamesFromContext,
 } from './topo-read-support.js';
 import {
@@ -511,7 +511,7 @@ const buildSurveyLookup = (
     | undefined,
   surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ): Result<object, Error> => {
-  const matches = buildCurrentTopoMatches(app, entityId, {
+  const matches = deriveCurrentTopoMatches(app, entityId, {
     cliAliases,
     rootDir,
     surfaceLayerNames,
@@ -528,7 +528,7 @@ const buildSurveyTrailDetail = (
     | undefined,
   surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ): Result<object, Error> => {
-  const detail = buildCurrentTrailDetail(app, id, {
+  const detail = deriveCurrentTrailDetail(app, id, {
     cliAliases,
     rootDir,
     surfaceLayerNames,
@@ -543,7 +543,7 @@ const buildSurveyResourceDetail = (
   id: string,
   rootDir: string
 ): Result<object, Error> => {
-  const detail = buildCurrentResourceDetail(app, id, { rootDir });
+  const detail = deriveCurrentResourceDetail(app, id, { rootDir });
   return detail === undefined
     ? Result.err(new NotFoundError(`Resource not found: ${id}`))
     : Result.ok(detail);
@@ -554,7 +554,7 @@ const buildSurveySignalDetail = (
   id: string,
   rootDir: string
 ): Result<object, Error> => {
-  const detail = buildCurrentSignalDetail(app, id, { rootDir });
+  const detail = deriveCurrentSignalDetail(app, id, { rootDir });
   return detail === undefined
     ? Result.err(new NotFoundError(`Signal not found: ${id}`))
     : Result.ok(detail);
@@ -600,7 +600,7 @@ const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
           surfaceLayerNames
         ),
   overview: (app, _input, rootDir) =>
-    Result.ok(buildCurrentTopoList(app, { rootDir })),
+    Result.ok(deriveCurrentTopoList(app, { rootDir })),
 };
 
 const envelopeSurveyValue = (
@@ -824,7 +824,7 @@ export const surveyTrail = trail('survey', {
 export const surveyBriefTrail = trail('survey.brief', {
   blaze: async (input, ctx) =>
     withResolvedSurveyApp(input, ctx.cwd, (app, rootDir) =>
-      Result.ok(buildCurrentTopoBrief(app, { rootDir }))
+      Result.ok(deriveCurrentTopoBrief(app, { rootDir }))
     ),
   description: 'Summarize topo capabilities',
   examples: [

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -144,7 +144,7 @@ const readCommittedLock = async (
 // Public read-only consumers
 // ---------------------------------------------------------------------------
 
-export const buildTopoSummary = (
+export const deriveTopoSummary = (
   app: Topo,
   options?: { readonly rootDir?: string }
 ): TopoSummaryReport => {
@@ -160,17 +160,17 @@ export const buildTopoSummary = (
   };
 };
 
-export const buildCurrentTopoBrief = (
+export const deriveCurrentTopoBrief = (
   app: Topo,
   _options?: { readonly rootDir?: string }
 ): BriefReport => deriveBriefReport(app);
 
-export const buildCurrentTopoList = (
+export const deriveCurrentTopoList = (
   app: Topo,
   _options?: { readonly rootDir?: string }
 ): SurveyListReport => deriveSurveyList(app);
 
-export const buildCurrentGuideEntries = (
+export const deriveCurrentGuideEntries = (
   app: Topo,
   _options?: { readonly rootDir?: string }
 ): readonly {
@@ -189,7 +189,7 @@ export const buildCurrentGuideEntries = (
     }))
     .toSorted((a, b) => a.id.localeCompare(b.id));
 
-export const buildCurrentTrailDetail = (
+export const deriveCurrentTrailDetail = (
   app: Topo,
   id: string,
   options?: CurrentTopoReadOptions
@@ -203,7 +203,7 @@ export const buildCurrentTrailDetail = (
       });
 };
 
-export const buildCurrentResourceDetail = (
+export const deriveCurrentResourceDetail = (
   app: Topo,
   id: string,
   _options?: { readonly rootDir?: string }
@@ -212,22 +212,22 @@ export const buildCurrentResourceDetail = (
     ? undefined
     : (deriveResourceDetail(app, id) as CurrentResourceDetail);
 
-export const buildCurrentSignalDetail = (
+export const deriveCurrentSignalDetail = (
   app: Topo,
   id: string,
   _options?: { readonly rootDir?: string }
 ): SignalDetailReport | undefined => deriveSignalDetail(app, id);
 
-export const buildCurrentTopoDetail = (
+export const deriveCurrentTopoDetail = (
   app: Topo,
   id: string,
   options?: CurrentTopoReadOptions
 ): CurrentTopoDetail | undefined =>
-  buildCurrentTrailDetail(app, id, options) ??
-  buildCurrentResourceDetail(app, id) ??
-  buildCurrentSignalDetail(app, id);
+  deriveCurrentTrailDetail(app, id, options) ??
+  deriveCurrentResourceDetail(app, id) ??
+  deriveCurrentSignalDetail(app, id);
 
-export const buildCurrentTopoMatches = (
+export const deriveCurrentTopoMatches = (
   app: Topo,
   id: string,
   options?: CurrentTopoReadOptions
@@ -251,7 +251,7 @@ export const buildCurrentTopoMatches = (
     });
   }
 
-  const resource = buildCurrentResourceDetail(app, id);
+  const resource = deriveCurrentResourceDetail(app, id);
   if (resource !== undefined) {
     matches.push({ detail: resource, kind: 'resource' });
   }

--- a/apps/trails/src/trails/topo.ts
+++ b/apps/trails/src/trails/topo.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 
 import { withFreshOperatorApp } from './operator-context.js';
 import { activationOverviewOutput } from './topo-output-schemas.js';
-import { buildTopoSummary } from './topo-read-support.js';
+import { deriveTopoSummary } from './topo-read-support.js';
 import { createIsolatedExampleInput } from './topo-support.js';
 
 const summaryOutput = z.object({
@@ -74,7 +74,7 @@ const summaryOutput = z.object({
 export const topoTrail = trail('topo', {
   blaze: async (input, ctx) =>
     withFreshOperatorApp(input, ctx, ({ lease, rootDir }) =>
-      Result.ok(buildTopoSummary(lease.app, { rootDir }))
+      Result.ok(deriveTopoSummary(lease.app, { rootDir }))
     ),
   description: 'Show the current topo summary and entry list',
   examples: [


### PR DESCRIPTION
## Summary
- rename current topo read helpers from `build*` to `derive*`
- update guide, survey, topo callers, and focused tests
- keep the rename scoped to read-only helper vocabulary

## Verification
- `bun test apps/trails/src/__tests__/guide.test.ts apps/trails/src/__tests__/survey.test.ts`
- final stack: `bun run check`, `bun run test`, `bun run build`, `bun run changeset:check`, `bun run publish:check`, `bun run wayfinder:dogfood`
