### PR TITLE
fix(cli): re-export canonical AnyTrail type

### DIFF
--- a/.changeset/trl-1103-cli-anytrail.md
+++ b/.changeset/trl-1103-cli-anytrail.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/cli": patch
+---
+
+Re-export the canonical `AnyTrail` type from `@ontrails/core`.

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -7,25 +7,15 @@
  */
 
 import type {
+  AnyTrail,
   Layer,
   Result,
   CliCommandRoute,
   SurfaceTrailVersionProjection,
-  Trail,
   TrailContext,
 } from '@ontrails/core';
 
-// ---------------------------------------------------------------------------
-// AnyTrail -- type-erased trail for the CLI boundary
-// ---------------------------------------------------------------------------
-
-/**
- * Type-erased trail reference. At the CLI adapter boundary we lose
- * generic type information since flags/args are parsed as strings.
- * Using `any` here is intentional -- the Zod schema validates at runtime.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type AnyTrail = Trail<any, any, any>;
+export type { AnyTrail } from '@ontrails/core';
 
 // ---------------------------------------------------------------------------
 // CliFlag


### PR DESCRIPTION
## Summary
- remove the CLI-local `AnyTrail` shadow type
- re-export the canonical `AnyTrail` type from `@ontrails/core`
- keep CLI command typing attached to the shared public trail type

## Verification
- `bun run typecheck`
- final stack: `bun run check`, `bun run test`, `bun run build`, `bun run changeset:check`, `bun run publish:check`, `bun run wayfinder:dogfood`
