### PR TITLE
fix(trails): align version lifecycle path fields

### DIFF
--- a/.changeset/trl-1102-version-lifecycle-paths.md
+++ b/.changeset/trl-1102-version-lifecycle-paths.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Rename version lifecycle result paths from `file` to `filePath`.

--- a/apps/trails/src/__tests__/version-lifecycle.test.ts
+++ b/apps/trails/src/__tests__/version-lifecycle.test.ts
@@ -287,6 +287,7 @@ describe('trails lifecycle commands', () => {
       if (revised.isErr()) {
         throw revised.error;
       }
+      expect(revised.value.filePath).toBe(join(dir, 'src', 'app.ts'));
       let source = readFileSync(join(dir, 'src', 'app.ts'), 'utf8');
       expect(source).toContain('version: 2');
       expect(source).toContain('versions: {');
@@ -306,6 +307,7 @@ describe('trails lifecycle commands', () => {
       if (deprecated.isErr()) {
         throw deprecated.error;
       }
+      expect(deprecated.value.filePath).toBe(join(dir, 'src', 'app.ts'));
       source = readFileSync(join(dir, 'src', 'app.ts'), 'utf8');
       expect(source).toContain(
         '      status: { state: \'deprecated\', successor: 2, note: "Use v2." }'

--- a/apps/trails/src/trails/deprecate.ts
+++ b/apps/trails/src/trails/deprecate.ts
@@ -51,7 +51,7 @@ export const deprecateTrail = trail('deprecate', {
   }),
   intent: 'write',
   output: z.object({
-    file: z.string(),
+    filePath: z.string(),
     trailId: z.string(),
     updated: z.boolean(),
   }),

--- a/apps/trails/src/trails/revise.ts
+++ b/apps/trails/src/trails/revise.ts
@@ -44,7 +44,7 @@ export const reviseTrail = trail('revise', {
   }),
   intent: 'write',
   output: z.object({
-    file: z.string(),
+    filePath: z.string(),
     trailId: z.string(),
     updated: z.boolean(),
     warnings: z.array(z.string()).optional(),

--- a/apps/trails/src/trails/version-lifecycle-support.ts
+++ b/apps/trails/src/trails/version-lifecycle-support.ts
@@ -23,7 +23,7 @@ export interface LifecycleCommandInput {
 }
 
 export interface LifecycleWriteResult {
-  readonly file: string;
+  readonly filePath: string;
   readonly trailId: string;
   readonly updated: boolean;
   readonly warnings?: readonly string[] | undefined;
@@ -32,8 +32,8 @@ export interface LifecycleWriteResult {
 interface TrailSourceMatch {
   readonly configEnd: number;
   readonly configStart: number;
-  readonly filePath: string;
   readonly source: string;
+  readonly sourcePath: string;
 }
 
 interface PropertyMatch {
@@ -108,8 +108,8 @@ const findTrailSource = (
       return Result.ok({
         configEnd: match.config.end,
         configStart: match.config.start,
-        filePath,
         source: source.value,
+        sourcePath: filePath,
       });
     }
   }
@@ -566,13 +566,13 @@ export const reviseTrailSource = (
       blaze?.value
     )
   );
-  const written = writeLifecycleSourceFile(match.value.filePath, nextSource);
+  const written = writeLifecycleSourceFile(match.value.sourcePath, nextSource);
   if (written.isErr()) {
     return written;
   }
 
   return Result.ok({
-    file: match.value.filePath,
+    filePath: match.value.sourcePath,
     trailId: trail.id,
     updated: true,
     ...(usesForkPlaceholder
@@ -724,18 +724,18 @@ export const setVersionStatusSource = (
         );
   if (nextSource === match.value.source) {
     return Result.ok({
-      file: match.value.filePath,
+      filePath: match.value.sourcePath,
       trailId: target.trailId,
       updated: false,
     });
   }
-  const written = writeLifecycleSourceFile(match.value.filePath, nextSource);
+  const written = writeLifecycleSourceFile(match.value.sourcePath, nextSource);
   if (written.isErr()) {
     return written;
   }
 
   return Result.ok({
-    file: match.value.filePath,
+    filePath: match.value.sourcePath,
     trailId: target.trailId,
     updated: true,
   });
@@ -768,18 +768,18 @@ export const forkVersionEntrySource = (
   const nextSource = rewrite.source;
   if (nextSource === match.value.source) {
     return Result.ok({
-      file: match.value.filePath,
+      filePath: match.value.sourcePath,
       trailId: target.trailId,
       updated: false,
     });
   }
-  const written = writeLifecycleSourceFile(match.value.filePath, nextSource);
+  const written = writeLifecycleSourceFile(match.value.sourcePath, nextSource);
   if (written.isErr()) {
     return written;
   }
 
   return Result.ok({
-    file: match.value.filePath,
+    filePath: match.value.sourcePath,
     trailId: target.trailId,
     updated: true,
     ...(rewrite.usedPlaceholder


### PR DESCRIPTION
## Summary
- rename version lifecycle write outputs to `filePath`
- keep internal source-analysis paths named `sourcePath`
- update revise/deprecate schemas, callers, and tests

## Verification
- `bun test apps/trails/src/__tests__/version-lifecycle.test.ts`
- final stack: `bun run check`, `bun run test`, `bun run build`, `bun run changeset:check`, `bun run publish:check`, `bun run wayfinder:dogfood`
