### PR TITLE
fix(scope): fold remaining path scope surfaces

### DIFF
--- a/.changeset/trl-1104-path-scope-surfaces.md
+++ b/.changeset/trl-1104-path-scope-surfaces.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/core": patch
+"@ontrails/regrade": patch
+"@ontrails/trails": patch
+"@ontrails/warden": patch
+---
+
+Fold remaining Regrade and Warden scan-target surfaces onto the shared path-scope vocabulary.

--- a/apps/trails/src/regrade/config.ts
+++ b/apps/trails/src/regrade/config.ts
@@ -1,17 +1,16 @@
 import { loadTrailsConfigValue } from '@ontrails/config';
-import { InternalError, Result, ValidationError } from '@ontrails/core';
+import {
+  InternalError,
+  Result,
+  ValidationError,
+  pathScopeSchema,
+} from '@ontrails/core';
 import type { Result as TrailsResult } from '@ontrails/core';
 import { z } from 'zod';
 
-const regradeScopeConfigSchema = z.object({
-  exclude: z.array(z.string()).optional(),
-  extensions: z.array(z.string()).optional(),
-  include: z.array(z.string()).optional(),
-});
-
 export const regradeConfigSchema = z
   .object({
-    scope: regradeScopeConfigSchema.optional(),
+    scope: pathScopeSchema.optional(),
   })
   .default({});
 

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -7,10 +7,11 @@ import {
   NotFoundError,
   Result,
   ValidationError,
+  pathScopeSchema,
   trail,
   validateOutput,
 } from '@ontrails/core';
-import type { Result as TrailsResult } from '@ontrails/core';
+import type { PathScope, Result as TrailsResult } from '@ontrails/core';
 import {
   loadWardenTermRewriteClasses,
   regradeReportOutput,
@@ -23,7 +24,19 @@ import { z } from 'zod';
 import { loadRegradeConfig } from '../regrade/config.js';
 import { resolveTrailRootDir } from './root-dir.js';
 
-const regradeInputSchema = z.object({
+const regradePathScopeInputSchema = pathScopeSchema.extend({
+  exclude: pathScopeSchema.shape.exclude.describe(
+    'Root-relative path globs to exclude during Regrade collection'
+  ),
+  extensions: pathScopeSchema.shape.extensions.describe(
+    'Source file extensions to scan during Regrade collection'
+  ),
+  include: pathScopeSchema.shape.include.describe(
+    'Root-relative path patterns to include in vocabulary regrade mode'
+  ),
+});
+
+const regradeInputSchema = regradePathScopeInputSchema.extend({
   apply: z
     .boolean()
     .default(false)
@@ -36,25 +49,11 @@ const regradeInputSchema = z.object({
     .string()
     .optional()
     .describe('Path to a Trails config file with regrade defaults'),
-  exclude: z
-    .array(z.string())
-    .optional()
-    .describe('Root-relative path globs to exclude during Regrade collection'),
-  extensions: z
-    .array(z.string())
-    .optional()
-    .describe('Source file extensions to scan during Regrade collection'),
   from: z
     .string()
     .min(1)
     .optional()
     .describe('Source vocabulary term for a vocabulary regrade'),
-  include: z
-    .array(z.string())
-    .optional()
-    .describe(
-      'Root-relative path patterns to include in vocabulary regrade mode'
-    ),
   includeEntries: z
     .enum(['actionable', 'all'])
     .default('actionable')
@@ -122,9 +121,9 @@ const classModeCollection = (
 };
 
 interface RegradeConfigScope {
-  readonly exclude?: readonly string[] | undefined;
-  readonly extensions?: readonly string[] | undefined;
-  readonly include?: readonly string[] | undefined;
+  readonly exclude?: PathScope['exclude'] | undefined;
+  readonly extensions?: PathScope['extensions'] | undefined;
+  readonly include?: PathScope['include'] | undefined;
 }
 
 const vocabularyScopeFromConfig = (

--- a/apps/trails/src/trails/warden-guide.ts
+++ b/apps/trails/src/trails/warden-guide.ts
@@ -39,8 +39,8 @@ const wardenRuleGuideEntrySchema = z.object({
       safety: z.enum(wardenFixSafeties),
       scanTargets: z
         .object({
+          exclude: z.array(z.string()).readonly().optional(),
           extensions: z.array(z.string()).readonly().optional(),
-          ignoredDirectories: z.array(z.string()).readonly().optional(),
         })
         .optional(),
     })

--- a/packages/core/src/__tests__/derive.test.ts
+++ b/packages/core/src/__tests__/derive.test.ts
@@ -222,6 +222,19 @@ describe('derive', () => {
       });
     });
 
+    test('readonly z.array(z.string()) derives from the inner field shape', () => {
+      const schema = z.object({
+        tags: z.array(z.string()).readonly().optional().describe('Tags'),
+      });
+      const fields = deriveFields(schema);
+      expect(fields[0]).toMatchObject({
+        label: 'Tags',
+        name: 'tags',
+        required: false,
+        type: 'string[]',
+      });
+    });
+
     test('z.array(z.string()) with default sets default value', () => {
       const schema = z.object({
         items: z.array(z.string()).default(['a', 'b']),

--- a/packages/core/src/derive.ts
+++ b/packages/core/src/derive.ts
@@ -145,7 +145,7 @@ const propagateDescription = (
   }
 };
 
-/** Step one level of optional/default unwrapping. Returns null if not a wrapper type. */
+/** Step one level of transparent wrapper unwrapping. Returns null if not a wrapper type. */
 const unwrapStep = (
   current: ZodInternals,
   state: {
@@ -155,10 +155,16 @@ const unwrapStep = (
   }
 ): ZodInternals | null => {
   const defType = current._zod.def['type'] as string;
-  if (defType !== 'optional' && defType !== 'default') {
+  if (
+    defType !== 'optional' &&
+    defType !== 'default' &&
+    defType !== 'readonly'
+  ) {
     return null;
   }
-  state.required = false;
+  if (defType !== 'readonly') {
+    state.required = false;
+  }
   if (defType === 'default') {
     state.defaultValue = current._zod.def['defaultValue'];
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -132,7 +132,7 @@ export {
   normalizePathScopePath,
   pathScopeSchema,
 } from './path-scope.js';
-export type { PathGlob, PathScope } from './path-scope.js';
+export type { PathGlob, PathScope, ScanTargets } from './path-scope.js';
 export { matchesAnyTrailIdGlob, matchesTrailIdGlob } from './trail-id-glob.js';
 export type { TrailIdGlob } from './trail-id-glob.js';
 

--- a/packages/core/src/path-scope.ts
+++ b/packages/core/src/path-scope.ts
@@ -38,6 +38,8 @@ export const pathScopeSchema = z
 
 export type PathScope = z.output<typeof pathScopeSchema>;
 
+export type ScanTargets = Pick<PathScope, 'exclude' | 'extensions'>;
+
 const extensionOf = (path: string): string => {
   const normalized = normalizePathScopePath(path);
   const name = normalized.slice(normalized.lastIndexOf('/') + 1);

--- a/packages/regrade/src/downstream/__tests__/collect.test.ts
+++ b/packages/regrade/src/downstream/__tests__/collect.test.ts
@@ -61,10 +61,22 @@ describe('classifyDownstreamEntry', () => {
       classifyDownstreamEntry('app.js', 'file', { extensions: ['.js'] })
     ).toEqual({ action: 'collect' });
     expect(
+      classifyDownstreamEntry('app.md', 'file', { extensions: ['md'] })
+    ).toEqual({ action: 'collect' });
+    expect(
       classifyDownstreamEntry('build', 'directory', {
         ignoredDirectories: ['build'],
       })
     ).toEqual({ action: 'skip', reason: 'ignored-directory' });
+  });
+
+  test('treats an empty extension list as no extension filter', () => {
+    expect(
+      classifyDownstreamEntry('README.md', 'file', { extensions: [] })
+    ).toEqual({ action: 'collect' });
+    expect(
+      classifyDownstreamEntry('Makefile', 'file', { extensions: [] })
+    ).toEqual({ action: 'collect' });
   });
 });
 
@@ -172,6 +184,27 @@ describe('collectDownstreamSources', () => {
       expect(skippedReasons.get('.agents/plans')).toBe('ignored-glob');
       expect(skippedReasons.get('.agents/goals')).toBe('ignored-glob');
       expect(skippedReasons.get('.scratch')).toBe('ignored-glob');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('empty extension lists collect every otherwise-scoped file', () => {
+    const root = writeFixture();
+    try {
+      const collection = collectDownstreamSources(root, { extensions: [] });
+      expect(collection).not.toBeNull();
+      const result = collection as NonNullable<typeof collection>;
+
+      expect(result.files.map((file) => file.path)).toEqual([
+        'src/nested/ping.ts',
+        'src/README.md',
+        'src/signal.ts',
+        'src/view.tsx',
+      ]);
+      expect(
+        result.skipped.some((entry) => entry.path === 'src/README.md')
+      ).toBe(false);
     } finally {
       rmSync(root, { force: true, recursive: true });
     }

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -322,7 +322,7 @@ describe('wardenTermRewriteClasses', () => {
         fix: {
           class: 'term-rewrite',
           safety: 'safe',
-          scanTargets: { extensions: ['.md'] },
+          scanTargets: { extensions: ['.md'], ignoredDirectories: [] },
         },
         invariant: 'Project-local Warden term rewrites can feed Regrade.',
         lifecycle: { retireWhen: 'migration completes', state: 'temporary' },
@@ -336,7 +336,10 @@ describe('wardenTermRewriteClasses', () => {
     const cls = createWardenTermRewriteClass(rule);
 
     expect(cls?.id).toBe('term-rewrite:project-local-term-rewrite');
-    expect(cls?.scanTargets).toEqual({ extensions: ['.md'] });
+    expect(cls?.scanTargets).toEqual({
+      extensions: ['.md'],
+      ignoredDirectories: [],
+    });
   });
 
   test('preserves Warden scan-target filtering for Warden-backed classes', () => {
@@ -648,6 +651,348 @@ describe('runRegrade', () => {
     }
   });
 
+  test('all-extension classes widen multi-class collection', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-all-extension-class-'));
+    try {
+      mkdirSync(join(root, 'src'), { recursive: true });
+      writeFileSync(join(root, 'README.md'), 'sourceTerm\n');
+      writeFileSync(
+        join(root, 'src', 'sourceTerm.ts'),
+        'export const sourceTerm = 1;\n'
+      );
+
+      const allExtensionTerm = {
+        ...createTermRewriteClass({
+          from: 'sourceTerm',
+          id: 'all-extension-term',
+          to: 'targetTerm',
+        }),
+        scanTargets: { extensions: [] },
+      } satisfies RegradeClass;
+
+      const report = expectRunRegradeOk({
+        classes: [
+          {
+            apply: (source) =>
+              source.includes('sourceTerm')
+                ? {
+                    kind: 'rewrite',
+                    nextSource: source.replaceAll('sourceTerm', 'targetTerm'),
+                    notes: ['Rewrote docs term.'],
+                  }
+                : { kind: 'no-op', notes: [] },
+            describe: 'Rewrite docs vocabulary.',
+            id: 'docs-term',
+            scanTargets: { extensions: ['.md'] },
+          },
+          allExtensionTerm,
+        ],
+        includeEntries: 'all',
+        root,
+        selection: { classIds: ['docs-term', 'all-extension-term'] },
+      });
+
+      expect(report?.entries.map((entry) => entry.path)).toEqual([
+        'README.md',
+        'src/sourceTerm.ts',
+      ]);
+      expect(
+        report?.entries.find((entry) => entry.path === 'src/sourceTerm.ts')
+      ).toMatchObject({
+        classId: 'all-extension-term',
+        outcome: 'rewrite',
+      });
+      expect(report?.rewritten).toBe(2);
+      expect(report?.scanned).toBe(2);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('all-extension classes do not widen default class targets', () => {
+    const root = mkdtempSync(
+      join(tmpdir(), 'regrade-default-extension-class-')
+    );
+    try {
+      mkdirSync(join(root, 'src'), { recursive: true });
+      writeFileSync(join(root, 'README.md'), 'defaultTerm\n');
+      writeFileSync(
+        join(root, 'src', 'defaultTerm.ts'),
+        'export const defaultTerm = 1;\n'
+      );
+
+      const defaultTerm = createTermRewriteClass({
+        from: 'defaultTerm',
+        id: 'default-term',
+        to: 'targetTerm',
+      });
+      const allExtensionNoop = {
+        apply: () => ({ kind: 'no-op', notes: [] }),
+        describe: 'Inspect every extension without rewriting.',
+        id: 'all-extension-noop',
+        scanTargets: { extensions: [] },
+      } satisfies RegradeClass;
+
+      const report = expectRunRegradeOk({
+        classes: [defaultTerm, allExtensionNoop],
+        includeEntries: 'all',
+        root,
+        selection: { classIds: ['default-term', 'all-extension-noop'] },
+      });
+
+      expect(
+        report?.entries.find((entry) => entry.path === 'README.md')
+      ).toMatchObject({
+        outcome: 'no-op',
+      });
+      expect(
+        report?.entries.find((entry) => entry.path === 'src/defaultTerm.ts')
+      ).toMatchObject({
+        classId: 'default-term',
+        outcome: 'rewrite',
+      });
+      expect(report?.rewritten).toBe(1);
+      expect(report?.scanned).toBe(2);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('class scan excludes do not hide files from other selected classes', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-class-exclude-'));
+    try {
+      mkdirSync(join(root, 'src', 'generated'), { recursive: true });
+      writeFileSync(
+        join(root, 'src', 'generated', 'a.ts'),
+        'export const signal = 1;\n'
+      );
+
+      const excludingClass = {
+        ...createTermRewriteClass({
+          from: 'signal',
+          id: 'class-a',
+          to: 'blocked',
+        }),
+        scanTargets: { exclude: ['src/generated/**'] },
+      } satisfies RegradeClass;
+      const rewriteClass = createTermRewriteClass({
+        from: 'signal',
+        id: 'class-b',
+        to: 'ping',
+      });
+
+      const report = expectRunRegradeOk({
+        classes: [excludingClass, rewriteClass],
+        includeEntries: 'all',
+        root,
+      });
+
+      expect(report?.scanned).toBe(1);
+      expect(report?.skipped).toBe(0);
+      expect(report?.rewritten).toBe(1);
+      expect(report?.entries).toContainEqual(
+        expect.objectContaining({
+          classId: 'class-b',
+          outcome: 'rewrite',
+          path: 'src/generated/a.ts',
+        })
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('later class no-ops still count as scanned after an earlier class skip', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-class-skip-noop-'));
+    try {
+      mkdirSync(join(root, 'src', 'generated'), { recursive: true });
+      writeFileSync(
+        join(root, 'src', 'generated', 'a.ts'),
+        'export const value = 1;\n'
+      );
+
+      const excludingClass = {
+        ...createTermRewriteClass({
+          from: 'signal',
+          id: 'class-a',
+          to: 'blocked',
+        }),
+        scanTargets: { exclude: ['src/generated/**'] },
+      } satisfies RegradeClass;
+      const noOpClass = createTermRewriteClass({
+        from: 'missingTerm',
+        id: 'class-b',
+        to: 'replacement',
+      });
+
+      const report = expectRunRegradeOk({
+        classes: [excludingClass, noOpClass],
+        includeEntries: 'all',
+        root,
+      });
+
+      expect(report?.scanned).toBe(1);
+      expect(report?.skipped).toBe(0);
+      expect(report?.entries).toContainEqual(
+        expect.objectContaining({
+          outcome: 'no-op',
+          path: 'src/generated/a.ts',
+        })
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('legacy class ignored-directory overrides can scan default-pruned directories', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-class-ignored-dirs-'));
+    try {
+      mkdirSync(join(root, 'dist', 'generated'), { recursive: true });
+      writeFileSync(
+        join(root, 'dist', 'generated', 'a.ts'),
+        'export const signal = 1;\n'
+      );
+
+      const report = expectRunRegradeOk({
+        classes: [
+          {
+            ...signalToPing,
+            scanTargets: { ignoredDirectories: [] },
+          },
+        ],
+        includeEntries: 'all',
+        root,
+      });
+
+      expect(report?.scanned).toBe(1);
+      expect(report?.skipped).toBe(0);
+      expect(report?.entries).toContainEqual(
+        expect.objectContaining({
+          classId: 'term-rewrite:signal->ping',
+          outcome: 'rewrite',
+          path: 'dist/generated/a.ts',
+        })
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('legacy ignored-directory opt-outs stay scoped to the owning class', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-class-ignored-scope-'));
+    try {
+      mkdirSync(join(root, 'dist', 'generated'), { recursive: true });
+      writeFileSync(
+        join(root, 'dist', 'generated', 'a.ts'),
+        'export const signal = 1;\n'
+      );
+
+      const optInNoOpClass = {
+        ...createTermRewriteClass({
+          from: 'missingTerm',
+          id: 'class-a',
+          to: 'replacement',
+        }),
+        scanTargets: { ignoredDirectories: [] },
+      } satisfies RegradeClass;
+      const defaultScopedClass = createTermRewriteClass({
+        from: 'signal',
+        id: 'class-b',
+        to: 'ping',
+      });
+
+      const report = expectRunRegradeOk({
+        classes: [optInNoOpClass, defaultScopedClass],
+        includeEntries: 'all',
+        root,
+      });
+
+      expect(report?.rewritten).toBe(0);
+      expect(report?.scanned).toBe(1);
+      expect(report?.entries).toContainEqual(
+        expect.objectContaining({
+          outcome: 'no-op',
+          path: 'dist/generated/a.ts',
+        })
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('run-level ignored-directory overrides apply to every selected class', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-run-ignored-dirs-'));
+    try {
+      mkdirSync(join(root, 'dist', 'generated'), { recursive: true });
+      writeFileSync(
+        join(root, 'dist', 'generated', 'a.ts'),
+        'export const signal = 1;\n'
+      );
+
+      const defaultScopedClass = createTermRewriteClass({
+        from: 'signal',
+        id: 'class-b',
+        to: 'ping',
+      });
+
+      const report = expectRunRegradeOk({
+        classes: [defaultScopedClass],
+        collection: { ignoredDirectories: [] },
+        includeEntries: 'all',
+        root,
+      });
+
+      expect(report?.rewritten).toBe(1);
+      expect(report?.entries).toContainEqual(
+        expect.objectContaining({
+          classId: 'class-b',
+          outcome: 'rewrite',
+          path: 'dist/generated/a.ts',
+        })
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('run-level ignored-directory overrides beat legacy class targets', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-run-ignored-wins-'));
+    try {
+      mkdirSync(join(root, 'dist', 'generated'), { recursive: true });
+      writeFileSync(
+        join(root, 'dist', 'generated', 'a.ts'),
+        'export const signal = 1;\n'
+      );
+
+      const legacyScopedClass = {
+        ...createTermRewriteClass({
+          from: 'signal',
+          id: 'class-b',
+          to: 'ping',
+        }),
+        scanTargets: { ignoredDirectories: ['dist'] },
+      } satisfies RegradeClass;
+
+      const report = expectRunRegradeOk({
+        classes: [legacyScopedClass],
+        collection: { ignoredDirectories: [] },
+        includeEntries: 'all',
+        root,
+      });
+
+      expect(report?.rewritten).toBe(1);
+      expect(report?.entries).toContainEqual(
+        expect.objectContaining({
+          classId: 'class-b',
+          outcome: 'rewrite',
+          path: 'dist/generated/a.ts',
+        })
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test('unknown-only selection reports ids without collecting sources', () => {
     const root = mkdtempSync(join(tmpdir(), 'regrade-run-unknown-only-'));
     try {
@@ -780,6 +1125,41 @@ describe('runRegrade', () => {
       );
       expect(readFileSync(join(root, 'src', 'a.ts'), 'utf8')).toBe(
         'export const ping = 2;\n'
+      );
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('single class scan excludes are reported as class skips', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-single-class-exclude-'));
+    try {
+      mkdirSync(join(root, 'src', 'generated'), { recursive: true });
+      writeFileSync(
+        join(root, 'src', 'generated', 'a.ts'),
+        'export const signal = 1;\n'
+      );
+
+      const report = expectRunRegradeOk({
+        classes: [
+          {
+            ...signalToPing,
+            scanTargets: { exclude: ['src/generated/**'] },
+          },
+        ],
+        includeEntries: 'all',
+        root,
+      });
+
+      expect(report?.scanned).toBe(0);
+      expect(report?.skipped).toBe(1);
+      expect(report?.entries).toContainEqual(
+        expect.objectContaining({
+          classId: 'term-rewrite:signal->ping',
+          outcome: 'skip',
+          path: 'src/generated/a.ts',
+          reason: 'regrade-scan-target-filtered',
+        })
       );
     } finally {
       rmSync(root, { force: true, recursive: true });

--- a/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
+++ b/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
@@ -9,7 +9,10 @@ import {
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 
-import { runVocabularyRegrade } from '../vocabulary.js';
+import {
+  runVocabularyRegrade,
+  vocabularyRegradePlanSchema,
+} from '../vocabulary.js';
 
 const makeTempDir = (): string =>
   mkdtempSync(join(tmpdir(), `trails-vocabulary-regrade-${Date.now()}-`));
@@ -212,6 +215,36 @@ describe('runVocabularyRegrade', () => {
         skippedByReason: { 'ignored-glob': 2 },
       });
       expect(result.value?.scanned).toBe(2);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('preserves legacy ignored-directory overrides during collection', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'dist/generated.md', 'facet in generated output\n');
+      const plan = vocabularyRegradePlanSchema.parse({
+        from: 'facet',
+        kind: 'vocabulary',
+        scope: { ignoredDirectories: [] },
+        to: 'trailhead',
+      });
+
+      const result = runVocabularyRegrade({
+        plan,
+        root: dir,
+      });
+
+      expect(plan.scope?.ignoredDirectories).toEqual([]);
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value?.scanned).toBe(1);
+      expect(result.value?.run?.ledger.occurrences.map((o) => o.path)).toEqual([
+        'dist/generated.md',
+      ]);
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/regrade/src/downstream/collect.ts
+++ b/packages/regrade/src/downstream/collect.ts
@@ -86,6 +86,16 @@ const extensionOf = (name: string): string => {
   return dot <= 0 ? '' : name.slice(dot);
 };
 
+const normalizeExtension = (extension: string): string =>
+  extension === '' || extension.startsWith('.') ? extension : `.${extension}`;
+
+const collectionExtensions = (
+  extensions: readonly string[] | undefined
+): readonly string[] =>
+  extensions === undefined
+    ? DEFAULT_SOURCE_EXTENSIONS
+    : extensions.map(normalizeExtension);
+
 /**
  * Decide what to do with a single directory entry. Pure: no filesystem access,
  * so collection policy can be tested directly with synthetic entries.
@@ -97,7 +107,7 @@ export const classifyDownstreamEntry = (
 ): DownstreamEntryClassification => {
   const ignoredDirectories =
     options.ignoredDirectories ?? DEFAULT_IGNORED_DIRECTORIES;
-  const extensions = options.extensions ?? DEFAULT_SOURCE_EXTENSIONS;
+  const extensions = collectionExtensions(options.extensions);
 
   if (kind === 'directory') {
     return ignoredDirectories.includes(name)
@@ -107,7 +117,7 @@ export const classifyDownstreamEntry = (
   if (kind === 'other') {
     return { action: 'skip', reason: 'unsupported-entry' };
   }
-  return extensions.includes(extensionOf(name))
+  return extensions.length === 0 || extensions.includes(extensionOf(name))
     ? { action: 'collect' }
     : { action: 'skip', reason: 'unsupported-extension' };
 };

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -1,4 +1,10 @@
-import { InternalError, Result, escapeRegExp } from '@ontrails/core';
+import {
+  InternalError,
+  Result,
+  escapeRegExp,
+  includedByPathScope,
+} from '@ontrails/core';
+import type { ScanTargets } from '@ontrails/core';
 import type {
   WardenDiagnostic,
   WardenFixEdit,
@@ -75,12 +81,14 @@ export interface RegradeClassContext {
 }
 
 /** Files a regrade class knows how to inspect. */
-export interface RegradeScanTargets {
-  /** Source extensions the class can inspect. */
-  readonly extensions?: readonly string[];
-  /** Directory names to skip during collection. */
+export type RegradeScanTargets = ScanTargets & {
+  /**
+   * @deprecated Use collection-level `exclude` globs. Preserved so existing
+   * Regrade classes can explicitly opt into directories the default collector
+   * prunes, such as `dist`, while migrating to PathScope.
+   */
   readonly ignoredDirectories?: readonly string[];
-}
+};
 
 /** One named, contract-aware transform. */
 export interface RegradeClass {
@@ -222,6 +230,9 @@ const regradeScanTargetsFromWardenFix = (
     return undefined;
   }
   return {
+    ...(scanTargets.exclude === undefined
+      ? {}
+      : { exclude: scanTargets.exclude }),
     ...(scanTargets.extensions === undefined
       ? {}
       : { extensions: scanTargets.extensions }),
@@ -514,32 +525,53 @@ export const selectRegradeClasses = (
 const uniqueSorted = (values: readonly string[]): readonly string[] =>
   [...new Set(values)].toSorted((a, b) => a.localeCompare(b));
 
+const intersectValues = (
+  left: readonly string[],
+  right: readonly string[]
+): readonly string[] => left.filter((value) => right.includes(value));
+
+const deriveClassIgnoredDirectories = (
+  classes: readonly RegradeClass[]
+): readonly string[] | undefined => {
+  const explicitTargets = classes
+    .map((cls) => cls.scanTargets?.ignoredDirectories)
+    .filter((value): value is readonly string[] => value !== undefined);
+  if (explicitTargets.length === 0) {
+    return undefined;
+  }
+
+  let common = explicitTargets[0] ?? [];
+  for (const target of explicitTargets.slice(1)) {
+    common = intersectValues(common, target);
+  }
+  return uniqueSorted(common);
+};
+
 const deriveCollectionOptions = (
   classes: readonly RegradeClass[],
   collection: DownstreamCollectionOptions | undefined
 ): DownstreamCollectionOptions => {
-  const targetExtensions = uniqueSorted(
-    classes.length === 0
-      ? DEFAULT_SOURCE_EXTENSIONS
-      : classes.flatMap(
-          (cls) => cls.scanTargets?.extensions ?? DEFAULT_SOURCE_EXTENSIONS
-        )
+  const allExtensions = classes.some(
+    (cls) => cls.scanTargets?.extensions?.length === 0
   );
-  const ignoredDirectories = uniqueSorted(
-    classes.length === 0
-      ? DEFAULT_IGNORED_DIRECTORIES
-      : classes.flatMap(
-          (cls) =>
-            cls.scanTargets?.ignoredDirectories ?? DEFAULT_IGNORED_DIRECTORIES
-        )
-  );
-
+  const targetExtensions = allExtensions
+    ? []
+    : uniqueSorted(
+        classes.length === 0
+          ? DEFAULT_SOURCE_EXTENSIONS
+          : classes.flatMap(
+              (cls) => cls.scanTargets?.extensions ?? DEFAULT_SOURCE_EXTENSIONS
+            )
+      );
   return {
     ...(collection?.exclude === undefined
       ? {}
       : { exclude: collection.exclude }),
     extensions: collection?.extensions ?? targetExtensions,
-    ignoredDirectories: collection?.ignoredDirectories ?? ignoredDirectories,
+    ignoredDirectories:
+      collection?.ignoredDirectories ??
+      deriveClassIgnoredDirectories(classes) ??
+      DEFAULT_IGNORED_DIRECTORIES,
   };
 };
 
@@ -601,20 +633,76 @@ interface RegradeClassifiedFile {
   readonly rewrite?: RegradeRewriteCandidate;
 }
 
+const isIgnoredByClassDirectories = (
+  path: string,
+  ignoredDirectories: readonly string[] | undefined
+): boolean => {
+  if (ignoredDirectories === undefined || ignoredDirectories.length === 0) {
+    return false;
+  }
+  return path
+    .split('/')
+    .slice(0, -1)
+    .some((segment) => ignoredDirectories.includes(segment));
+};
+
+const classScanTargetSkip = (
+  cls: RegradeClass,
+  path: string,
+  collection: DownstreamCollectionOptions | undefined
+): RegradeClassResult | undefined => {
+  const ignoredDirectories =
+    collection?.ignoredDirectories ??
+    cls.scanTargets?.ignoredDirectories ??
+    DEFAULT_IGNORED_DIRECTORIES;
+  if (isIgnoredByClassDirectories(path, ignoredDirectories)) {
+    return {
+      kind: 'skipped',
+      notes: [`Skipped by ${cls.id} scan-target filtering.`],
+      reason: 'regrade-scan-target-filtered',
+    };
+  }
+  const effectiveScanTargets: ScanTargets | undefined =
+    cls.scanTargets?.extensions === undefined &&
+    collection?.extensions === undefined
+      ? {
+          ...cls.scanTargets,
+          extensions: DEFAULT_SOURCE_EXTENSIONS,
+        }
+      : cls.scanTargets;
+  if (
+    effectiveScanTargets === undefined ||
+    includedByPathScope(path, effectiveScanTargets)
+  ) {
+    return undefined;
+  }
+  return {
+    kind: 'skipped',
+    notes: [`Skipped by ${cls.id} scan-target filtering.`],
+    reason: 'regrade-scan-target-filtered',
+  };
+};
+
 const classifyFile = (
   path: string,
   source: string,
   context: RegradeClassContext,
-  selected: readonly RegradeClass[]
+  selected: readonly RegradeClass[],
+  collection?: DownstreamCollectionOptions
 ): RegradeClassifiedFile => {
   // First selected class that matches (rewrite or review) wins, mirroring the
-  // "run one class" emphasis. A scan-target skip is remembered so the file is
-  // accounted as skipped rather than a scanned/clean no-op. No-ops fall through.
+  // "run one class" emphasis. Scan-target skips only own the file when no
+  // selected class inspects it; a later no-op still counts as a clean scan.
   let skipped:
     | { readonly classId: string; readonly result: RegradeClassResult }
     | undefined;
+  let inspected = false;
   for (const cls of selected) {
-    const result = cls.apply(source, context);
+    const result =
+      classScanTargetSkip(cls, path, collection) ?? cls.apply(source, context);
+    if (result.kind !== 'skipped') {
+      inspected = true;
+    }
     if (result.kind === 'rewrite') {
       if (typeof result.nextSource !== 'string') {
         return {
@@ -667,7 +755,7 @@ const classifyFile = (
       skipped = { classId: cls.id, result };
     }
   }
-  if (skipped !== undefined) {
+  if (!inspected && skipped !== undefined) {
     return {
       entry: {
         classId: skipped.classId,
@@ -726,6 +814,7 @@ const buildRegradeEvaluation = (params: {
   readonly skipped: readonly SkippedSource[];
   readonly classes: readonly RegradeClass[];
   readonly selection?: RegradeSelection;
+  readonly collection?: DownstreamCollectionOptions;
   readonly includeEntries?: RegradeReportEntrySelection;
 }): RegradeEvaluation => {
   const entrySelection = params.includeEntries ?? 'actionable';
@@ -744,7 +833,8 @@ const buildRegradeEvaluation = (params: {
           : { absolutePath: file.absolutePath }),
         path: file.path,
       },
-      selected
+      selected,
+      params.collection
     )
   );
   const fileEntries = classifiedFiles.map((file) => file.entry);
@@ -813,6 +903,7 @@ export const buildRegradeReport = (params: {
   readonly skipped: readonly SkippedSource[];
   readonly classes: readonly RegradeClass[];
   readonly selection?: RegradeSelection;
+  readonly collection?: DownstreamCollectionOptions;
   readonly includeEntries?: RegradeReportEntrySelection;
 }): RegradeReport => buildRegradeEvaluation(params).report;
 
@@ -897,6 +988,9 @@ const runRegradeEvaluation = (params: {
     }
     return buildRegradeEvaluation({
       classes: params.classes,
+      ...(params.collection === undefined
+        ? {}
+        : { collection: params.collection }),
       files: [],
       root: params.root,
       skipped: [],
@@ -933,6 +1027,9 @@ const runRegradeEvaluation = (params: {
 
   return buildRegradeEvaluation({
     classes: params.classes,
+    ...(params.collection === undefined
+      ? {}
+      : { collection: params.collection }),
     files,
     root: params.root,
     skipped,

--- a/packages/regrade/src/downstream/vocabulary.ts
+++ b/packages/regrade/src/downstream/vocabulary.ts
@@ -8,10 +8,7 @@ import {
 import { readFileSync, writeFileSync } from 'node:fs';
 import { z } from 'zod';
 
-import {
-  DEFAULT_IGNORED_DIRECTORIES,
-  collectDownstreamSources,
-} from './collect.js';
+import { collectDownstreamSources } from './collect.js';
 import type { DownstreamCollectionOptions, SkippedSource } from './collect.js';
 import type {
   RegradeApplySummary,
@@ -31,6 +28,11 @@ export interface VocabularyPreserveRule {
 export interface VocabularyRegradeScope {
   readonly exclude?: readonly string[];
   readonly extensions?: readonly string[];
+  /**
+   * @deprecated Use `exclude` path globs for new plans. This remains as a
+   * compatibility bridge for pre-path-scope plans that intentionally disabled
+   * the collector's default directory pruning.
+   */
   readonly ignoredDirectories?: readonly string[];
   readonly include?: readonly string[];
 }
@@ -758,8 +760,9 @@ export const runVocabularyRegrade = (params: {
     ...(params.plan.scope?.exclude === undefined
       ? {}
       : { exclude: params.plan.scope.exclude }),
-    ignoredDirectories:
-      params.plan.scope?.ignoredDirectories ?? DEFAULT_IGNORED_DIRECTORIES,
+    ...(params.plan.scope?.ignoredDirectories === undefined
+      ? {}
+      : { ignoredDirectories: params.plan.scope.ignoredDirectories }),
   } satisfies DownstreamCollectionOptions);
   if (collected === null) {
     return Result.ok(null);
@@ -877,7 +880,9 @@ const vocabularyRegradeScopeSchema = z.object({
   ignoredDirectories: z
     .array(z.string())
     .optional()
-    .describe('Directory names to skip during collection'),
+    .describe(
+      'Deprecated compatibility override for legacy plans. Use exclude globs for new plans.'
+    ),
   include: z
     .array(z.string())
     .optional()

--- a/packages/warden/src/rules/public-internal-deep-imports.ts
+++ b/packages/warden/src/rules/public-internal-deep-imports.ts
@@ -1,6 +1,6 @@
 import { existsSync, realpathSync } from 'node:fs';
 import { resolve, sep } from 'node:path';
-import { escapeRegExp } from '@ontrails/core';
+import { matchesPathGlob } from '@ontrails/core';
 
 import {
   extractStringLiteral,
@@ -304,47 +304,6 @@ const rootBarrelDiagnostics = (
 const stripLeadingDotSlash = (path: string): string =>
   path.startsWith('./') ? path.slice(2) : path;
 
-const wildcardPatternSource = (pattern: string): string => {
-  let regexSource = '';
-  for (let index = 0; index < pattern.length; index += 1) {
-    const char = pattern[index];
-    if (char === '*') {
-      if (pattern[index + 1] === '*') {
-        regexSource += '.*';
-        index += 1;
-      } else {
-        regexSource += '[^/]*';
-      }
-      continue;
-    }
-    regexSource += escapeRegExp(char ?? '');
-  }
-  return regexSource;
-};
-
-const segmentWildcardPatternCovers = (
-  filePath: string,
-  pattern: string
-): boolean => new RegExp(`^${wildcardPatternSource(pattern)}$`).test(filePath);
-
-const deepWildcardPatternCovers = (
-  filePath: string,
-  pattern: string,
-  globIndex: number
-): boolean => {
-  const prefix = pattern.slice(0, globIndex + 1);
-  if (!filePath.startsWith(prefix)) {
-    return false;
-  }
-  const suffixPattern = pattern.slice(globIndex + '/**/'.length);
-  if (suffixPattern.length === 0) {
-    return true;
-  }
-  const remainingPath = filePath.slice(prefix.length);
-  const regexSource = `^(?:.*/)?${wildcardPatternSource(suffixPattern)}$`;
-  return new RegExp(regexSource).test(remainingPath);
-};
-
 const filePatternCovers = (filePath: string, pattern: string): boolean => {
   const normalizedFilePath = normalizePath(stripLeadingDotSlash(filePath));
   const normalizedPattern = normalizePath(stripLeadingDotSlash(pattern));
@@ -357,27 +316,10 @@ const filePatternCovers = (filePath: string, pattern: string): boolean => {
   if (normalizedPattern === '**') {
     return true;
   }
-  if (normalizedPattern.endsWith('/**')) {
-    const prefix = normalizedPattern.slice(0, -2);
-    return normalizedFilePath.startsWith(prefix);
-  }
-
-  const globIndex = normalizedPattern.indexOf('/**/');
-  if (globIndex === -1) {
-    if (normalizedPattern.includes('*')) {
-      return segmentWildcardPatternCovers(
-        normalizedFilePath,
-        normalizedPattern
-      );
-    }
+  if (!normalizedPattern.includes('*') && !normalizedPattern.includes('?')) {
     return normalizedFilePath.startsWith(`${normalizedPattern}/`);
   }
-
-  return deepWildcardPatternCovers(
-    normalizedFilePath,
-    normalizedPattern,
-    globIndex
-  );
+  return matchesPathGlob(normalizedFilePath, normalizedPattern);
 };
 
 const filesCoverTarget = (

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -2,6 +2,7 @@ import type {
   DiagnosticSeverity,
   Intent,
   RuleDiagnosticBase,
+  ScanTargets,
   Topo,
 } from '@ontrails/core';
 import type { TopoGraph } from '@ontrails/topographer';
@@ -142,12 +143,13 @@ export interface WardenFixEdit {
  * consumers such as Regrade that need to derive a narrower collection before
  * invoking the rule against an explicit downstream root.
  */
-export interface WardenFixScanTargets {
-  /** Source extensions the fix class can inspect. */
-  readonly extensions?: readonly string[] | undefined;
-  /** Directory names to skip during downstream collection. */
-  readonly ignoredDirectories?: readonly string[] | undefined;
-}
+export type WardenFixScanTargets = ScanTargets & {
+  /**
+   * @deprecated Compatibility bridge for Warden-backed Regrade classes that
+   * predate PathScope. Prefer Regrade collection scope for new callers.
+   */
+  readonly ignoredDirectories?: readonly string[];
+};
 
 /**
  * Per-finding fix metadata attached to a diagnostic.


### PR DESCRIPTION
## Context

Finishes [TRL-1104](https://linear.app/outfitter/issue/TRL-1104) by folding remaining path-scope-ish surfaces into the shared `PathScope` vocabulary while preserving compatibility where old Regrade plans/classes may still exist.

## What changed

- Added shared `ScanTargets` from `PathScope` for scan-only include/exclude/extensions surfaces.
- Regrade class-mode and vocabulary-mode inputs now use `exclude` / `extensions`; deprecated `ignoredDirectories` remains as a compatibility bridge.
- Regrade preserves legacy per-class `scanTargets.ignoredDirectories`, including explicit `[]` opt-outs for default-pruned directories such as `dist`.
- Class scan excludes no longer hide files from later selected classes; a later no-op now counts as a clean scan instead of becoming a skipped file.
- Warden guide/deep-import scan targets use the shared path glob helpers.
- CLI field derivation handles readonly array wrappers so `include`, `exclude`, and `extensions` stay visible in schema/CLI projection.

## Verification

- `bun test packages/regrade/src/downstream/__tests__/report.test.ts packages/regrade/src/downstream/__tests__/vocabulary.test.ts apps/trails/src/__tests__/regrade.test.ts`
- `bun run --filter @ontrails/regrade typecheck`
- `bun run --filter @ontrails/trails typecheck`
- Full stack verification: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`, `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`, and real Graphite submit pre-push stable checks.

## Risks

Medium-low. The main compatibility risk was existing Regrade classes/plans relying on `ignoredDirectories`; this branch keeps that bridge and adds focused regressions for it.