### PR TITLE
chore(release): clean generated release notes

### DIFF
--- a/.changeset/clean-release-notes.md
+++ b/.changeset/clean-release-notes.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Clean generated release output by suppressing internal dependency cascade noise in package changelogs and rendering generated release PR and GitHub Release notes from the same Highlights, Changes, and Package Versions summary.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.0/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": [
+    "../scripts/changesets/changelog.cjs",
+    { "repo": "outfitter-dev/trails" }
+  ],
   "commit": false,
   "fixed": [["@ontrails/*"]],
   "linked": [],

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: bun run publish:label-release-pr
+      - name: Update version PR body
+        if: steps.changesets.outputs.hasChangesets == 'true'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          git fetch --no-tags origin changeset-release/main
+          git checkout --force FETCH_HEAD
+          bun scripts/release-notes.ts update-release-pr
       - name: Validate version PR
         if: steps.changesets.outputs.hasChangesets == 'true'
         run: |
@@ -142,6 +150,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+      - uses: ./.github/actions/setup
       - name: Create GitHub release
         env:
           DIST_TAG: ${{ needs.publish-policy.outputs.tag }}
@@ -156,7 +165,11 @@ jobs:
           fi
 
           tag="v$VERSION"
-          notes="Published @ontrails/* packages at $VERSION to npm with dist-tag \`$DIST_TAG\`."
+          notes_file="$(mktemp)"
+          bun scripts/release-notes.ts github-release \
+            --version "$VERSION" \
+            --dist-tag "$DIST_TAG" \
+            > "$notes_file"
           version_target="$(git log -n 1 --format=%H -S "\"version\": \"$VERSION\"" -- apps/trails/package.json)"
           if [ -z "$version_target" ]; then
             echo "Could not resolve commit that introduced apps/trails/package.json version $VERSION" >&2
@@ -181,6 +194,6 @@ jobs:
             gh release create "$tag" \
               --verify-tag \
               --title "Trails v$VERSION" \
-              --notes "$notes" \
+              --notes-file "$notes_file" \
               "${create_args[@]}"
           fi

--- a/apps/trails/src/__tests__/release-notes.test.ts
+++ b/apps/trails/src/__tests__/release-notes.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  dedupeReleaseChanges,
+  extractChangelogEntry,
+  renderReleaseNotes,
+} from '../release/notes.js';
+
+describe('release notes rendering', () => {
+  test('extracts the requested changelog version entry', () => {
+    const changelog = `# @ontrails/core
+
+## 1.0.0-beta.32
+
+### Patch Changes
+
+- [\`abc1234\`](https://github.com/outfitter-dev/trails/commit/abc1234): Ship the thing.
+
+## 1.0.0-beta.31
+
+### Patch Changes
+
+- Previous thing.
+`;
+
+    expect(extractChangelogEntry(changelog, '1.0.0-beta.32')).toContain(
+      'Ship the thing.'
+    );
+    expect(extractChangelogEntry(changelog, '1.0.0-beta.31')).toContain(
+      'Previous thing.'
+    );
+    expect(extractChangelogEntry(changelog, '1.0.0-beta.30')).toBeUndefined();
+  });
+
+  test('dedupes changes across packages and keeps package provenance', () => {
+    const changes = dedupeReleaseChanges([
+      {
+        commit: 'abc1234',
+        packageName: '@ontrails/core',
+        summary: 'Export shared helpers.',
+        url: 'https://github.com/outfitter-dev/trails/commit/abc1234',
+      },
+      {
+        commit: 'abc1234',
+        packageName: '@ontrails/warden',
+        summary: 'Export shared helpers.',
+        url: 'https://github.com/outfitter-dev/trails/commit/abc1234',
+      },
+      {
+        commit: 'def5678',
+        packageName: '@ontrails/trails',
+        summary: 'Render release notes.',
+      },
+    ]);
+
+    expect(changes).toEqual([
+      {
+        commit: 'abc1234',
+        packages: ['@ontrails/core', '@ontrails/warden'],
+        summary: 'Export shared helpers.',
+        url: 'https://github.com/outfitter-dev/trails/commit/abc1234',
+      },
+      {
+        commit: 'def5678',
+        packages: ['@ontrails/trails'],
+        summary: 'Render release notes.',
+      },
+    ]);
+  });
+
+  test('renders release PR notes with highlights, changes, and package versions', () => {
+    const notes = renderReleaseNotes({
+      changes: [
+        {
+          commit: 'abc1234',
+          packages: ['@ontrails/core', '@ontrails/warden'],
+          summary: 'Export shared helpers.',
+          url: 'https://github.com/outfitter-dev/trails/commit/abc1234',
+        },
+      ],
+      distTag: 'beta',
+      mode: 'release-pr',
+      packageVersions: [
+        { name: '@ontrails/core', version: '1.0.0-beta.33' },
+        { name: '@ontrails/warden', version: '1.0.0-beta.33' },
+      ],
+      repo: 'outfitter-dev/trails',
+      version: '1.0.0-beta.33',
+    });
+
+    expect(notes).toContain('# Release 1.0.0-beta.33');
+    expect(notes).toContain('## Highlights');
+    expect(notes).toContain('- Export shared helpers.');
+    expect(notes).toContain('## Changes');
+    expect(notes).toContain(
+      '- [`abc1234`](https://github.com/outfitter-dev/trails/commit/abc1234): Export shared helpers. Packages: `@ontrails/core`, `@ontrails/warden`'
+    );
+    expect(notes).toContain('<summary>Package Versions</summary>');
+    expect(notes).toContain('`@ontrails/core@1.0.0-beta.33`');
+  });
+
+  test('renders GitHub Release notes with published dist-tag copy', () => {
+    const notes = renderReleaseNotes({
+      changes: [],
+      distTag: 'beta',
+      mode: 'github-release',
+      packageVersions: [{ name: '@ontrails/core', version: '1.0.0-beta.33' }],
+      version: '1.0.0-beta.33',
+    });
+
+    expect(notes).toContain(
+      'Published the publishable `@ontrails/*` package set at `1.0.0-beta.33` on the `beta` dist-tag.'
+    );
+    expect(notes).toContain(
+      '- No user-facing changes were detected in package changelogs.'
+    );
+  });
+});

--- a/apps/trails/src/release/index.ts
+++ b/apps/trails/src/release/index.ts
@@ -90,6 +90,18 @@ export {
   type RegistryWorkspace,
 } from './native-bun-registry.js';
 export {
+  collectReleaseNotesInput,
+  dedupeReleaseChanges,
+  extractChangelogEntry,
+  renderReleaseNotes,
+  type ReleaseNotesCollectOptions,
+  type ReleaseNotesChange,
+  type ReleaseNotesInput,
+  type ReleaseNotesPackageVersion,
+  type ReleaseNotesParsedChange,
+} from './notes.js';
+export { runReleaseNotesCli } from './notes-cli.js';
+export {
   channelIntentForDistTag,
   evaluateReleasePolicy,
   labelsForReleasePullRequest,

--- a/apps/trails/src/release/notes-cli.ts
+++ b/apps/trails/src/release/notes-cli.ts
@@ -1,0 +1,171 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+import { collectReleaseNotesInput, renderReleaseNotes } from './notes.js';
+import type { ReleaseNotesCollectOptions } from './notes.js';
+
+const RELEASE_BRANCH = 'changeset-release/main';
+
+type CliOptions = Omit<ReleaseNotesCollectOptions, 'mode'>;
+
+const runText = async (cmd: readonly string[]): Promise<string> => {
+  const proc = Bun.spawn([...cmd], { stderr: 'pipe', stdout: 'pipe' });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(
+      `Command failed (${exitCode}): ${cmd.join(' ')}\n${stderr.trim()}`
+    );
+  }
+  return stdout.trim();
+};
+
+const readRepository = async (): Promise<string> =>
+  process.env['GITHUB_REPOSITORY'] ??
+  (await runText([
+    'gh',
+    'repo',
+    'view',
+    '--json',
+    'nameWithOwner',
+    '--jq',
+    '.nameWithOwner',
+  ]));
+
+const findReleasePullRequestNumber = async (
+  repo: string
+): Promise<string | undefined> => {
+  const output = await runText([
+    'gh',
+    'pr',
+    'list',
+    '--repo',
+    repo,
+    '--head',
+    RELEASE_BRANCH,
+    '--base',
+    'main',
+    '--state',
+    'open',
+    '--json',
+    'number',
+    '--jq',
+    '.[0].number // empty',
+  ]);
+  return output || undefined;
+};
+
+const parseArgs = (args: readonly string[]): CliOptions => {
+  let distTag: string | undefined;
+  let repo: string | undefined;
+  let repoRoot = resolve(process.cwd());
+  let version: string | undefined;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--dist-tag') {
+      index += 1;
+      distTag = args[index];
+      continue;
+    }
+    if (arg === '--repo') {
+      index += 1;
+      repo = args[index];
+      continue;
+    }
+    if (arg === '--repo-root') {
+      index += 1;
+      repoRoot = resolve(args[index] ?? repoRoot);
+      continue;
+    }
+    if (arg === '--version') {
+      index += 1;
+      version = args[index];
+      continue;
+    }
+    throw new Error(`Unknown release-notes option: ${arg}`);
+  }
+
+  return {
+    ...(distTag === undefined ? {} : { distTag }),
+    ...(repo === undefined ? {} : { repo }),
+    repoRoot,
+    ...(version === undefined ? {} : { version }),
+  };
+};
+
+const commandGithubRelease = async (args: readonly string[]): Promise<void> => {
+  const input = await collectReleaseNotesInput({
+    ...parseArgs(args),
+    mode: 'github-release',
+  });
+  process.stdout.write(renderReleaseNotes(input));
+};
+
+const commandReleasePr = async (args: readonly string[]): Promise<void> => {
+  const input = await collectReleaseNotesInput({
+    ...parseArgs(args),
+    mode: 'release-pr',
+  });
+  process.stdout.write(renderReleaseNotes(input));
+};
+
+const commandUpdateReleasePr = async (
+  args: readonly string[]
+): Promise<void> => {
+  const options = parseArgs(args);
+  const repo = options.repo ?? (await readRepository());
+  const number = await findReleasePullRequestNumber(repo);
+  if (!number) {
+    throw new Error(`No open ${RELEASE_BRANCH} pull request found`);
+  }
+  const input = await collectReleaseNotesInput({
+    ...options,
+    mode: 'release-pr',
+    repo,
+  });
+  const dir = await mkdtemp(join(tmpdir(), 'trails-release-notes-'));
+  const bodyPath = join(dir, 'body.md');
+  await writeFile(bodyPath, renderReleaseNotes(input));
+  await runText([
+    'gh',
+    'pr',
+    'edit',
+    number,
+    '--repo',
+    repo,
+    '--body-file',
+    bodyPath,
+  ]);
+  console.error(`trails: updated release PR #${number} body`);
+};
+
+export const runReleaseNotesCli = async (
+  args: readonly string[] = process.argv.slice(2)
+): Promise<number> => {
+  try {
+    const [command, ...rest] = args;
+    if (command === 'github-release') {
+      await commandGithubRelease(rest);
+      return 0;
+    }
+    if (command === 'release-pr') {
+      await commandReleasePr(rest);
+      return 0;
+    }
+    if (command === 'update-release-pr') {
+      await commandUpdateReleasePr(rest);
+      return 0;
+    }
+    throw new Error(
+      'Usage: bun scripts/release-notes.ts <github-release|release-pr|update-release-pr> [--version <version>] [--dist-tag <tag>] [--repo <owner/name>] [--repo-root <path>]'
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+};

--- a/apps/trails/src/release/notes.ts
+++ b/apps/trails/src/release/notes.ts
@@ -1,0 +1,390 @@
+/* oxlint-disable max-lines-per-function, max-statements -- release-note parsing keeps source extraction explicit. */
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const DEFAULT_REPO = 'outfitter-dev/trails';
+
+interface PackageJson {
+  readonly name?: string;
+  readonly private?: boolean;
+  readonly version?: string;
+}
+
+interface ReleaseNotesWorkspace {
+  readonly isPrivate: boolean;
+  readonly name: string;
+  readonly path: string;
+  readonly version: string;
+}
+
+export interface ReleaseNotesChange {
+  readonly commit?: string | undefined;
+  readonly packages: readonly string[];
+  readonly summary: string;
+  readonly url?: string | undefined;
+}
+
+export interface ReleaseNotesPackageVersion {
+  readonly name: string;
+  readonly version: string;
+}
+
+export interface ReleaseNotesInput {
+  readonly changes: readonly ReleaseNotesChange[];
+  readonly distTag: string;
+  readonly mode: 'github-release' | 'release-pr';
+  readonly packageVersions: readonly ReleaseNotesPackageVersion[];
+  readonly repo?: string | undefined;
+  readonly version: string;
+}
+
+interface ChangelogEntryInput {
+  readonly changelog: string;
+  readonly packageName: string;
+  readonly version: string;
+}
+
+export interface ReleaseNotesParsedChange {
+  readonly commit?: string | undefined;
+  readonly packageName: string;
+  readonly summary: string;
+  readonly url?: string | undefined;
+}
+
+export interface ReleaseNotesCollectOptions {
+  readonly distTag?: string | undefined;
+  readonly mode: ReleaseNotesInput['mode'];
+  readonly repo?: string | undefined;
+  readonly repoRoot: string;
+  readonly version?: string | undefined;
+}
+
+interface CurrentParsedChange {
+  readonly commit?: string | undefined;
+  readonly packageName: string;
+  readonly summaryLines: string[];
+  readonly url?: string | undefined;
+}
+
+const readJson = async <T>(path: string): Promise<T> =>
+  (await Bun.file(path).json()) as T;
+
+const discoverWorkspaceDirs = async (
+  repoRoot: string,
+  patterns: readonly string[]
+): Promise<string[]> => {
+  const dirs: string[] = [];
+
+  for (const pattern of patterns) {
+    if (pattern.endsWith('/*')) {
+      const parent = join(repoRoot, pattern.slice(0, -2));
+      const entries = await readdir(parent, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) {
+          continue;
+        }
+        const dir = join(parent, entry.name);
+        if (await Bun.file(join(dir, 'package.json')).exists()) {
+          dirs.push(dir);
+        }
+      }
+      continue;
+    }
+
+    const dir = join(repoRoot, pattern);
+    if (await Bun.file(join(dir, 'package.json')).exists()) {
+      dirs.push(dir);
+    }
+  }
+
+  return dirs;
+};
+
+const discoverReleaseNotesWorkspaces = async (
+  repoRoot: string,
+  { includePrivate }: { readonly includePrivate: boolean }
+): Promise<ReleaseNotesWorkspace[]> => {
+  const root = await readJson<{ workspaces?: string[] }>(
+    join(repoRoot, 'package.json')
+  );
+  const dirs = await discoverWorkspaceDirs(repoRoot, root.workspaces ?? []);
+  const workspaces: ReleaseNotesWorkspace[] = [];
+
+  for (const dir of dirs) {
+    const pkg = await readJson<PackageJson>(join(dir, 'package.json'));
+    if (
+      typeof pkg.name !== 'string' ||
+      !pkg.name.startsWith('@ontrails/') ||
+      typeof pkg.version !== 'string' ||
+      (pkg.private === true && !includePrivate)
+    ) {
+      continue;
+    }
+    workspaces.push({
+      isPrivate: pkg.private === true,
+      name: pkg.name,
+      path: dir.slice(repoRoot.length + 1),
+      version: pkg.version,
+    });
+  }
+
+  return workspaces.toSorted((a, b) => a.name.localeCompare(b.name));
+};
+
+const readTrailsVersion = async (repoRoot: string): Promise<string> => {
+  const pkg = await readJson<PackageJson>(
+    join(repoRoot, 'apps', 'trails', 'package.json')
+  );
+  if (!pkg.version) {
+    throw new Error('Missing version in apps/trails/package.json');
+  }
+  return pkg.version;
+};
+
+const distTagForVersion = (version: string): string =>
+  version.includes('-')
+    ? (version.split('-')[1]?.split('.')[0] ?? 'beta')
+    : 'latest';
+
+export const extractChangelogEntry = (
+  changelog: string,
+  version: string
+): string | undefined => {
+  const lines = changelog.split('\n');
+  const heading = `## ${version}`;
+  const start = lines.findIndex((line) => line.trim() === heading);
+  if (start === -1) {
+    return undefined;
+  }
+
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (/^##\s+\S/u.test(lines[index] ?? '')) {
+      end = index;
+      break;
+    }
+  }
+
+  return lines
+    .slice(start + 1, end)
+    .join('\n')
+    .trim();
+};
+
+const normalizeSummary = (lines: readonly string[]): string =>
+  lines.join(' ').replaceAll(/\s+/gu, ' ').trim();
+
+const parseChangeStart = (
+  line: string
+): Omit<ReleaseNotesParsedChange, 'packageName'> | undefined => {
+  if (
+    !line.startsWith('- ') ||
+    line.startsWith('- Updated dependencies') ||
+    line.startsWith('- @ontrails/')
+  ) {
+    return undefined;
+  }
+
+  const linked = line.match(/^- \[`?([0-9a-f]{7,40})`?\]\(([^)]+)\):\s*(.*)$/u);
+  if (linked) {
+    return {
+      commit: linked[1],
+      summary: linked[3] ?? '',
+      url: linked[2],
+    };
+  }
+
+  const raw = line.match(/^- ([0-9a-f]{7,40}):\s*(.*)$/u);
+  if (raw) {
+    return {
+      commit: raw[1],
+      summary: raw[2] ?? '',
+    };
+  }
+
+  return { summary: line.slice(2) };
+};
+
+const parseChangelogEntryChanges = ({
+  changelog,
+  packageName,
+  version,
+}: ChangelogEntryInput): ReleaseNotesParsedChange[] => {
+  const entry = extractChangelogEntry(changelog, version);
+  if (!entry) {
+    return [];
+  }
+
+  const changes: ReleaseNotesParsedChange[] = [];
+  let current: CurrentParsedChange | undefined;
+
+  const flush = () => {
+    if (!current) {
+      return;
+    }
+    const summary = normalizeSummary(current.summaryLines);
+    if (summary) {
+      changes.push({
+        ...(current.commit === undefined ? {} : { commit: current.commit }),
+        packageName: current.packageName,
+        summary,
+        ...(current.url === undefined ? {} : { url: current.url }),
+      });
+    }
+  };
+
+  for (const line of entry.split('\n')) {
+    const start = parseChangeStart(line);
+    if (start) {
+      flush();
+      current = {
+        ...(start.commit === undefined ? {} : { commit: start.commit }),
+        packageName,
+        summaryLines: [start.summary],
+        ...(start.url === undefined ? {} : { url: start.url }),
+      };
+      continue;
+    }
+
+    if (current && line.startsWith('  ') && line.trim()) {
+      current.summaryLines.push(line.trim());
+      continue;
+    }
+
+    if (line.startsWith('- ')) {
+      flush();
+      current = undefined;
+    }
+  }
+
+  flush();
+  return changes;
+};
+
+export const dedupeReleaseChanges = (
+  changes: readonly ReleaseNotesParsedChange[]
+): ReleaseNotesChange[] => {
+  const byKey = new Map<string, ReleaseNotesChange>();
+
+  for (const change of changes) {
+    const key = `${change.commit ?? ''}\n${change.summary}`;
+    const existing = byKey.get(key);
+    if (existing) {
+      byKey.set(key, {
+        ...existing,
+        packages: [
+          ...new Set([...existing.packages, change.packageName]),
+        ].toSorted(),
+      });
+      continue;
+    }
+
+    byKey.set(key, {
+      ...(change.commit === undefined ? {} : { commit: change.commit }),
+      packages: [change.packageName],
+      summary: change.summary,
+      ...(change.url === undefined ? {} : { url: change.url }),
+    });
+  }
+
+  return [...byKey.values()];
+};
+
+const renderCommitLink = (change: ReleaseNotesChange, repo: string): string => {
+  if (!change.commit) {
+    return '';
+  }
+  const short = change.commit.slice(0, 7);
+  const url =
+    change.url ?? `https://github.com/${repo}/commit/${change.commit}`;
+  return `[\`${short}\`](${url}): `;
+};
+
+const renderPackages = (packages: readonly string[]): string =>
+  packages.map((name) => `\`${name}\``).join(', ');
+
+export const renderReleaseNotes = ({
+  changes,
+  distTag,
+  mode,
+  packageVersions,
+  repo = DEFAULT_REPO,
+  version,
+}: ReleaseNotesInput): string => {
+  const intro =
+    mode === 'release-pr'
+      ? `${packageVersions.length} \`@ontrails/*\` packages will be bumped to \`${version}\`.`
+      : `Published the publishable \`@ontrails/*\` package set at \`${version}\` on the \`${distTag}\` dist-tag.`;
+  const highlights = changes.slice(0, 5);
+  const lines = [`# Release ${version}`, '', intro, '', '## Highlights', ''];
+
+  if (highlights.length === 0) {
+    lines.push('- No user-facing changes were detected in package changelogs.');
+  } else {
+    lines.push(...highlights.map((change) => `- ${change.summary}`));
+  }
+
+  lines.push('', '## Changes', '');
+  if (changes.length === 0) {
+    lines.push('- No user-facing changes were detected in package changelogs.');
+  } else {
+    lines.push(
+      ...changes.map(
+        (change) =>
+          `- ${renderCommitLink(change, repo)}${change.summary} Packages: ${renderPackages(change.packages)}`
+      )
+    );
+  }
+
+  lines.push(
+    '',
+    '<details>',
+    '<summary>Package Versions</summary>',
+    '',
+    ...packageVersions.map((pkg) => `- \`${pkg.name}@${pkg.version}\``),
+    '',
+    '</details>',
+    ''
+  );
+
+  return lines.join('\n');
+};
+
+export const collectReleaseNotesInput = async ({
+  distTag,
+  mode,
+  repo,
+  repoRoot,
+  version,
+}: ReleaseNotesCollectOptions): Promise<ReleaseNotesInput> => {
+  const resolvedVersion = version ?? (await readTrailsVersion(repoRoot));
+  const resolvedDistTag = distTag ?? distTagForVersion(resolvedVersion);
+  const workspaces = await discoverReleaseNotesWorkspaces(repoRoot, {
+    includePrivate: mode === 'release-pr',
+  });
+  const packageVersions = workspaces.map((workspace) => ({
+    name: workspace.name,
+    version: workspace.version,
+  }));
+  const parsedChangesByPackage = await Promise.all(
+    workspaces.map(async (workspace: ReleaseNotesWorkspace) =>
+      parseChangelogEntryChanges({
+        changelog: await Bun.file(
+          join(repoRoot, workspace.path, 'CHANGELOG.md')
+        ).text(),
+        packageName: workspace.name,
+        version: resolvedVersion,
+      })
+    )
+  );
+  const parsedChanges = parsedChangesByPackage.flat();
+
+  return {
+    changes: dedupeReleaseChanges(parsedChanges),
+    distTag: resolvedDistTag,
+    mode,
+    packageVersions,
+    ...(repo === undefined ? {} : { repo }),
+    version: resolvedVersion,
+  };
+};

--- a/scripts/__tests__/changesets-changelog.test.ts
+++ b/scripts/__tests__/changesets-changelog.test.ts
@@ -1,0 +1,60 @@
+import { createRequire } from 'node:module';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+const require = createRequire(import.meta.url);
+const changelog = require(
+  join(import.meta.dir, '..', 'changesets', 'changelog.cjs')
+) as {
+  getDependencyReleaseLine: (
+    changesets: unknown[],
+    dependenciesUpdated: { name: string; newVersion: string }[]
+  ) => Promise<string>;
+  getReleaseLine: (
+    changeset: { commit?: string; summary: string },
+    type: string,
+    options?: { repo?: string }
+  ) => Promise<string>;
+};
+
+describe('changesets changelog formatter', () => {
+  test('links release line commits when repo is configured', async () => {
+    await expect(
+      changelog.getReleaseLine(
+        {
+          commit: 'abcdef1234567890',
+          summary: 'Render cleaner release notes.\nWith a continuation.',
+        },
+        'patch',
+        { repo: 'outfitter-dev/trails' }
+      )
+    ).resolves.toBe(
+      '- [`abcdef1`](https://github.com/outfitter-dev/trails/commit/abcdef1234567890): Render cleaner release notes.\n  With a continuation.'
+    );
+  });
+
+  test('suppresses internal dependency cascade lines', async () => {
+    await expect(
+      changelog.getDependencyReleaseLine(
+        [],
+        [
+          { name: '@ontrails/core', newVersion: '1.0.0-beta.33' },
+          { name: '@ontrails/warden', newVersion: '1.0.0-beta.33' },
+        ]
+      )
+    ).resolves.toBe('');
+  });
+
+  test('keeps external dependency updates visible', async () => {
+    await expect(
+      changelog.getDependencyReleaseLine(
+        [],
+        [
+          { name: '@ontrails/core', newVersion: '1.0.0-beta.33' },
+          { name: 'zod', newVersion: '4.3.7' },
+        ]
+      )
+    ).resolves.toBe('- Updated dependency zod@4.3.7');
+  });
+});

--- a/scripts/changesets/changelog.cjs
+++ b/scripts/changesets/changelog.cjs
@@ -1,0 +1,45 @@
+const renderCommit = (commit, repo) => {
+  if (!commit) {
+    return '';
+  }
+  const short = commit.slice(0, 7);
+  if (!repo) {
+    return `${short}: `;
+  }
+  return `[\`${short}\`](https://github.com/${repo}/commit/${commit}): `;
+};
+
+const getReleaseLine = async (changeset, _type, options = {}) => {
+  const [firstLine = '', ...rest] = changeset.summary
+    .split('\n')
+    .map((line) => line.trimEnd());
+  let output = `- ${renderCommit(changeset.commit, options.repo)}${firstLine}`;
+
+  if (rest.length > 0) {
+    output += `\n${rest.map((line) => `  ${line}`).join('\n')}`;
+  }
+
+  return output;
+};
+
+const getDependencyReleaseLine = async (_changesets, dependenciesUpdated) => {
+  const externalDependencies = dependenciesUpdated.filter(
+    (dependency) => !dependency.name.startsWith('@ontrails/')
+  );
+
+  if (externalDependencies.length === 0) {
+    return '';
+  }
+
+  return externalDependencies
+    .map(
+      (dependency) =>
+        `- Updated dependency ${dependency.name}@${dependency.newVersion}`
+    )
+    .join('\n');
+};
+
+module.exports = {
+  getDependencyReleaseLine,
+  getReleaseLine,
+};

--- a/scripts/release-notes.ts
+++ b/scripts/release-notes.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env bun
+import { runReleaseNotesCli } from '@ontrails/trails/release';
+
+if (import.meta.main) {
+  process.exit(await runReleaseNotesCli(process.argv.slice(2)));
+}


### PR DESCRIPTION
## Context

The generated Changesets release PR and GitHub Release notes were hard to scan because the fixed `@ontrails/*` release group repeated the same internal dependency cascade under every package. This keeps lockstep versioning, but changes the generated output to lead with the actual changes.

## What Changed

- Added a custom Changesets changelog formatter that links commit hashes and suppresses internal `@ontrails/*` dependency cascade lines while keeping external dependency updates visible.
- Added shared release-note rendering for generated release PRs and GitHub Releases with `Highlights`, `Changes`, and collapsed `Package Versions`.
- Wired the release workflow to rewrite the version PR body after `changesets/action` and to create GitHub Releases from the same release-note renderer.
- Added focused tests and a patch changeset for `@ontrails/trails`.

## Verification

- `bun test apps/trails/src/__tests__/release-notes.test.ts scripts/__tests__/changesets-changelog.test.ts`
- `bun run --cwd apps/trails typecheck`
- `bun run --cwd apps/trails build`
- `bun run --cwd apps/trails lint`
- `bunx ultracite check <touched release files>`
- `bun run changeset:check -- --changed-files /tmp/trails-release-notes-changed-files.txt --base-ref main`
- `bun scripts/release-notes.ts release-pr --version 1.0.0-beta.32 --dist-tag beta`
- `bun scripts/release-notes.ts github-release --version 1.0.0-beta.32 --dist-tag beta`
- `bun run check`
- `bun run publish:check`
- Graphite pre-push hook on submit

## Notes

Draft until CI is green, per repo policy. Warden warnings seen locally are existing warning-only findings unrelated to this release-note change.