### PR TITLE
feat(regrade): harden vocabulary transition substrate

### DIFF
--- a/.changeset/regrade-vocabulary-substrate.md
+++ b/.changeset/regrade-vocabulary-substrate.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/regrade": patch
+"@ontrails/trails": patch
+---
+
+Harden vocabulary regrades by deferring Markdown code contexts for review and
+exposing structured preserve rules through the Trails `regrade` command.

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -348,6 +348,97 @@ describe('trails regrade', () => {
     }
   });
 
+  test('CLI accepts structured preserve rules through input json', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'export const facetId = "preserved";\n');
+      writeFile(dir, 'docs/surface.md', 'The facetId field needs review.\n');
+
+      const input = {
+        from: 'facet',
+        include: ['src/**', 'docs/**'],
+        preserve: [
+          {
+            paths: ['src/**'],
+            pattern: '^facetId$',
+            reason: 'live-api-identifier',
+          },
+        ],
+        to: 'trailhead',
+      };
+
+      const result = runRawCli([
+        'regrade',
+        '--root-dir',
+        dir,
+        '--input-json',
+        JSON.stringify(input),
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        readonly run?: {
+          readonly ledger?: {
+            readonly occurrences?: readonly {
+              readonly form: string;
+              readonly path: string;
+              readonly reason: string;
+              readonly verdict: string;
+            }[];
+          };
+          readonly plan?: {
+            readonly preserve?: readonly {
+              readonly paths?: readonly string[];
+              readonly pattern?: string;
+              readonly reason?: string;
+            }[];
+          };
+          readonly report?: {
+            readonly deferred?: number;
+            readonly modified?: number;
+            readonly skipped?: number;
+          };
+        };
+      };
+      expect(parsed.run?.plan?.preserve).toEqual([
+        {
+          paths: ['src/**'],
+          pattern: '^facetId$',
+          reason: 'live-api-identifier',
+        },
+      ]);
+      expect(
+        parsed.run?.ledger?.occurrences?.map((occurrence) => ({
+          form: occurrence.form,
+          path: occurrence.path,
+          reason: occurrence.reason,
+          verdict: occurrence.verdict,
+        }))
+      ).toEqual([
+        {
+          form: 'facetId',
+          path: 'docs/surface.md',
+          reason: 'unclassified-neighbor',
+          verdict: 'deferred',
+        },
+        {
+          form: 'facetId',
+          path: 'src/surface.ts',
+          reason: 'live-api-identifier',
+          verdict: 'skipped',
+        },
+      ]);
+      expect(parsed.run?.report).toMatchObject({
+        deferred: 1,
+        modified: 0,
+        skipped: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('CLI accepts path-scope exclude globs for class-mode apply', () => {
     const dir = makeTempDir();
     try {

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -18,7 +18,11 @@ import {
   runRegrade,
   runVocabularyRegrade,
 } from '@ontrails/regrade';
-import type { RegradeReport, VocabularyRegradePlan } from '@ontrails/regrade';
+import type {
+  RegradeReport,
+  VocabularyPreserveRule,
+  VocabularyRegradePlan,
+} from '@ontrails/regrade';
 import { z } from 'zod';
 
 import { loadRegradeConfig } from '../regrade/config.js';
@@ -35,6 +39,20 @@ const regradePathScopeInputSchema = pathScopeSchema.extend({
     'Root-relative path patterns to include in vocabulary regrade mode'
   ),
 });
+
+const regradePreserveRuleInputSchema = z.object({
+  paths: z
+    .array(z.string())
+    .optional()
+    .describe('Root-relative path globs where this preserve rule applies'),
+  pattern: z.string().min(1).describe('Regex or literal pattern to preserve'),
+  reason: z.string().optional().describe('Why this form is preserved'),
+});
+
+const regradePreserveInputSchema = z.union([
+  z.string().min(1),
+  regradePreserveRuleInputSchema,
+]);
 
 const regradeInputSchema = regradePathScopeInputSchema.extend({
   apply: z
@@ -69,10 +87,10 @@ const regradeInputSchema = regradePathScopeInputSchema.extend({
     .optional()
     .describe('Explicit source-form to target-form mappings'),
   preserve: z
-    .array(z.string().min(1))
+    .array(regradePreserveInputSchema)
     .optional()
     .describe(
-      'Regex or literal contexts to preserve during a vocabulary regrade'
+      'Regex or literal contexts, or structured preserve rules, for a vocabulary regrade'
     ),
   rootDir: z.string().optional().describe('Workspace root directory'),
   to: z
@@ -139,6 +157,21 @@ const vocabularyScopeFromConfig = (
         ...(scope.include === undefined ? {} : { include: scope.include }),
       };
 
+const vocabularyPreserveFromInput = (
+  preserve: z.output<typeof regradeInputSchema>['preserve']
+): readonly VocabularyPreserveRule[] | undefined =>
+  preserve?.map((rule) => {
+    if (typeof rule === 'string') {
+      return { pattern: rule, reason: 'preserved-by-operator-input' };
+    }
+
+    return {
+      ...(rule.paths === undefined ? {} : { paths: rule.paths }),
+      pattern: rule.pattern,
+      ...(rule.reason === undefined ? {} : { reason: rule.reason }),
+    };
+  });
+
 const buildVocabularyPlan = (
   input: z.output<typeof regradeInputSchema>,
   configScope?: VocabularyRegradePlan['scope']
@@ -156,20 +189,15 @@ const buildVocabularyPlan = (
     );
   }
 
+  const preserve = vocabularyPreserveFromInput(input.preserve);
+
   return Result.ok({
     from: input.from,
     id: `vocabulary:${input.from}->${input.to}`,
     kind: 'vocabulary',
     ...(input.intent === undefined ? {} : { intent: input.intent }),
     ...(input.overrides === undefined ? {} : { overrides: input.overrides }),
-    ...(input.preserve === undefined
-      ? {}
-      : {
-          preserve: input.preserve.map((pattern) => ({
-            pattern,
-            reason: 'preserved-by-operator-input',
-          })),
-        }),
+    ...(preserve === undefined ? {} : { preserve }),
     scope: {
       ...configScope,
       ...(input.exclude === undefined ? {} : { exclude: input.exclude }),

--- a/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
+++ b/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
@@ -133,6 +133,172 @@ describe('runVocabularyRegrade', () => {
     }
   });
 
+  test('defers markdown code contexts instead of treating them as safe prose', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'docs/surface.md',
+        [
+          'facet prose should move.',
+          'Inline `facet` should be reviewed.',
+          '',
+          '```ts',
+          'facets: {',
+          '  inspect: ["facet"],',
+          '}',
+          '```',
+          '',
+        ].join('\n')
+      );
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          scope: { extensions: ['.md'] },
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(readFileSync(join(dir, 'docs', 'surface.md'), 'utf8')).toBe(
+        [
+          'trailhead prose should move.',
+          'Inline `facet` should be reviewed.',
+          '',
+          '```ts',
+          'facets: {',
+          '  inspect: ["facet"],',
+          '}',
+          '```',
+          '',
+        ].join('\n')
+      );
+      expect(
+        result.value?.run?.ledger.occurrences.map((occurrence) => ({
+          form: occurrence.form,
+          reason: occurrence.reason,
+          replacement: occurrence.replacement,
+          verdict: occurrence.verdict,
+        }))
+      ).toEqual([
+        {
+          form: 'facet',
+          reason: 'markdown-code-context',
+          replacement: undefined,
+          verdict: 'deferred',
+        },
+        {
+          form: 'facets',
+          reason: 'markdown-code-context',
+          replacement: undefined,
+          verdict: 'deferred',
+        },
+        {
+          form: 'facet',
+          reason: 'markdown-code-context',
+          replacement: undefined,
+          verdict: 'deferred',
+        },
+      ]);
+      expect(result.value?.apply).toMatchObject({
+        applied: 1,
+        filesChanged: 1,
+        review: 1,
+      });
+      expect(result.value?.run?.report).toMatchObject({
+        applied: 1,
+        deferred: 3,
+        gate: {
+          reasons: ['deferred-forms-or-occurrences'],
+          remaining: 3,
+          status: 'open',
+        },
+        modified: 0,
+        open: 3,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('defers multi-backtick and blockquoted markdown code contexts', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'docs/surface.md',
+        [
+          'Use ``facet`` as a literal.',
+          '',
+          '> ```ts',
+          '> facet',
+          '> ```',
+          '',
+        ].join('\n')
+      );
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          scope: { extensions: ['.md'] },
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(readFileSync(join(dir, 'docs', 'surface.md'), 'utf8')).toBe(
+        [
+          'Use ``facet`` as a literal.',
+          '',
+          '> ```ts',
+          '> facet',
+          '> ```',
+          '',
+        ].join('\n')
+      );
+      expect(
+        result.value?.run?.ledger.occurrences.map((occurrence) => ({
+          form: occurrence.form,
+          reason: occurrence.reason,
+          verdict: occurrence.verdict,
+        }))
+      ).toEqual([
+        {
+          form: 'facet',
+          reason: 'markdown-code-context',
+          verdict: 'deferred',
+        },
+        {
+          form: 'facet',
+          reason: 'markdown-code-context',
+          verdict: 'deferred',
+        },
+      ]);
+      expect(result.value?.run?.report).toMatchObject({
+        applied: 0,
+        deferred: 2,
+        gate: { status: 'open' },
+        modified: 0,
+        open: 2,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('scopes path discovery before judging occurrences', () => {
     const dir = makeTempDir();
     try {

--- a/packages/regrade/src/downstream/vocabulary.ts
+++ b/packages/regrade/src/downstream/vocabulary.ts
@@ -192,6 +192,106 @@ const contextForOffset = (
   return source.slice(lineStart, lineEnd).trim();
 };
 
+const isMarkdownPath = (path: string): boolean =>
+  path.endsWith('.md') || path.endsWith('.mdx');
+
+const sourceLineBoundsForOffset = (
+  source: string,
+  start: number,
+  end: number
+): { readonly lineEnd: number; readonly lineStart: number } => {
+  const lineStart = source.lastIndexOf('\n', start - 1) + 1;
+  const nextLine = source.indexOf('\n', end);
+  return { lineEnd: nextLine === -1 ? source.length : nextLine, lineStart };
+};
+
+const markdownBacktickRuns = (value: string): readonly RegExpMatchArray[] => [
+  ...value.matchAll(/(?<!\\)`+/g),
+];
+
+const isMarkdownInlineCodeContext = (
+  source: string,
+  start: number,
+  end: number
+): boolean => {
+  const { lineEnd, lineStart } = sourceLineBoundsForOffset(source, start, end);
+  const line = source.slice(lineStart, lineEnd);
+  const relativeStart = start - lineStart;
+  const relativeEnd = end - lineStart;
+  let openRun: { readonly length: number; readonly start: number } | undefined;
+
+  for (const run of markdownBacktickRuns(line)) {
+    const runStart = run.index ?? 0;
+    const [value] = run;
+    const runLength = value.length;
+    if (openRun === undefined) {
+      openRun = { length: runLength, start: runStart };
+      continue;
+    }
+    if (runLength !== openRun.length) {
+      continue;
+    }
+    if (
+      openRun.start + openRun.length <= relativeStart &&
+      relativeEnd <= runStart
+    ) {
+      return true;
+    }
+    openRun = undefined;
+  }
+
+  return false;
+};
+
+const markdownFenceLinePattern = /^\s*(?:>\s*){0,8}(```|~~~)/;
+
+const isMarkdownFenceContext = (source: string, start: number): boolean => {
+  const before = source.slice(0, start);
+  let fenced = false;
+  for (const line of before.split('\n')) {
+    if (markdownFenceLinePattern.test(line)) {
+      fenced = !fenced;
+    }
+  }
+  return fenced;
+};
+
+const isMarkdownCodeContext = (
+  file: SourceFile,
+  start: number,
+  end: number
+): boolean =>
+  isMarkdownPath(file.path) &&
+  (isMarkdownInlineCodeContext(file.source, start, end) ||
+    isMarkdownFenceContext(file.source, start));
+
+const vocabularyOccurrenceReason = (
+  preserveRule: VocabularyPreserveRule | undefined,
+  markdownCodeContext: boolean,
+  defaultReason: string
+): string => {
+  if (preserveRule !== undefined) {
+    return preserveRule.reason ?? 'preserved-by-plan';
+  }
+  if (markdownCodeContext) {
+    return 'markdown-code-context';
+  }
+  return defaultReason;
+};
+
+const capturedVocabularyVerdict = (
+  preserveRule: VocabularyPreserveRule | undefined,
+  markdownCodeContext: boolean
+): VocabularyVerdict => {
+  if (preserveRule !== undefined) {
+    return 'skipped';
+  }
+  if (markdownCodeContext) {
+    return 'deferred';
+  }
+  return 'modified';
+};
+
 const preserveCase = (sourceForm: string, replacement: string): string => {
   if (sourceForm.toUpperCase() === sourceForm) {
     return replacement.toUpperCase();
@@ -337,15 +437,18 @@ const occurrencesForFile = (
         start,
       };
       const preserveRule = preserveRuleForOccurrence(baseOccurrence, plan);
+      const markdownCodeContext = isMarkdownCodeContext(file, start, end);
       candidates.push({
         ...baseOccurrence,
-        reason:
-          preserveRule?.reason ??
-          (preserveRule === undefined ? 'captured-form' : 'preserved-by-plan'),
-        ...(preserveRule === undefined
+        reason: vocabularyOccurrenceReason(
+          preserveRule,
+          markdownCodeContext,
+          'captured-form'
+        ),
+        ...(preserveRule === undefined && !markdownCodeContext
           ? { replacement: preserveCase(match[0], replacement) }
           : {}),
-        verdict: preserveRule === undefined ? 'modified' : 'skipped',
+        verdict: capturedVocabularyVerdict(preserveRule, markdownCodeContext),
       });
     }
   }
@@ -388,11 +491,11 @@ const deferredOccurrencesForFile = (
     const preserveRule = preserveRuleForOccurrence(baseOccurrence, plan);
     occurrences.push({
       ...baseOccurrence,
-      reason:
-        preserveRule?.reason ??
-        (preserveRule === undefined
-          ? 'unclassified-neighbor'
-          : 'preserved-by-plan'),
+      reason: vocabularyOccurrenceReason(
+        preserveRule,
+        isMarkdownCodeContext(file, baseOccurrence.start, baseOccurrence.end),
+        'unclassified-neighbor'
+      ),
       verdict: preserveRule === undefined ? 'deferred' : 'skipped',
     });
   };


### PR DESCRIPTION
## Context

This is the lower branch for the Regrade/v1 vocabulary tracer. It hardens the transition substrate before applying any `facet` to `trailhead` dogfood changes.

## What Changed

- Allows `trails regrade` structured preserve rules through CLI `--input-json`, file input, and MCP-style structured input.
- Keeps string preserve rules backward-compatible while preserving optional `paths` and `reason` metadata for object rules.
- Routes Markdown inline code spans, multi-backtick inline spans, fenced code, and blockquoted fenced code to review inventory instead of safe rewrites.
- Adds focused Regrade and Trails operator tests.

## Verification

- `bun test packages/regrade/src/downstream/__tests__/vocabulary.test.ts`
- `bun test apps/trails/src/__tests__/regrade.test.ts`
- `bun run lint --filter @ontrails/regrade --filter @ontrails/trails`
- `bun run typecheck --filter @ontrails/regrade --filter @ontrails/trails`
- `bun run changeset:check`
- `bun run docs:wrap-check`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `git diff --check`
- `gt submit --stack --draft --restack --no-edit --no-interactive --dry-run`

## Review

Local in-thread review ran twice. Initial P2s around multi-backtick and blockquoted Markdown code shielding were fixed; re-review found no remaining P0-P2 issues.

## Notes

The dogfood branch above intentionally leaves live API/code `facet` inventory for later code/API migration. This branch only makes the safe prose tracer honest.
