### PR TITLE
fix(cli): honor structured input over flag defaults

### DIFF
--- a/.changeset/trl-1117-cli-input-json-precedence.md
+++ b/.changeset/trl-1117-cli-input-json-precedence.md
@@ -1,0 +1,10 @@
+---
+'@ontrails/cli': patch
+'@ontrails/commander': patch
+---
+
+Honor explicit structured input values over CLI flag defaults when commands merge
+`--input-json` or `--input` payloads.
+
+Commander now forwards user-supplied flag metadata so explicit flag values that
+match a default still keep normal CLI precedence over structured input.

--- a/adapters/commander/src/__tests__/to-commander.test.ts
+++ b/adapters/commander/src/__tests__/to-commander.test.ts
@@ -1182,6 +1182,37 @@ describe('toCommander option wiring', () => {
     expect(received).toEqual({ format: 'text' });
   });
 
+  test('default-valued aliases override structured input', async () => {
+    let observed: unknown;
+    const t = trail('render', {
+      blaze: (input) => {
+        observed = input;
+        return Result.ok(input);
+      },
+      fields: {
+        outputFormat: { aliases: true },
+      },
+      input: z.object({
+        outputFormat: z.enum(['json', 'text']).default('text'),
+      }),
+    });
+    const app = makeApp(t);
+    const commands = buildCommands(app, { onResult: noopResult });
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+
+    await program.parseAsync([
+      'node',
+      'test',
+      'render',
+      '--input-json',
+      '{"outputFormat":"json"}',
+      '--text',
+    ]);
+
+    expect(observed).toEqual({ outputFormat: 'text' });
+  });
+
   test('value aliases reject simultaneous canonical enum flags', async () => {
     let received: Record<string, unknown> | undefined;
     const commands: CliCommand[] = [
@@ -1300,6 +1331,38 @@ describe('toCommander option wiring', () => {
 
       await program.parseAsync(['node', 'test', 'check', '--strict']);
       expect(spy.received['strict']).toBe(true);
+    });
+
+    test('explicit --no-<flag> overrides structured input through Commander', async () => {
+      let observed: unknown;
+      const t = trail('regrade-like', {
+        blaze: (input) => {
+          observed = input;
+          return Result.ok(input);
+        },
+        input: z.object({
+          apply: z.boolean().default(false),
+          query: z.string(),
+        }),
+      });
+      const app = makeApp(t);
+      const commands = buildCommands(app, { onResult: noopResult });
+      const program = toCommander(commands, { name: 'test' });
+      program.exitOverride();
+
+      await program.parseAsync([
+        'node',
+        'test',
+        'regrade-like',
+        '--input-json',
+        '{"apply":true,"query":"from json"}',
+        '--no-apply',
+      ]);
+
+      expect(observed).toEqual({
+        apply: false,
+        query: 'from json',
+      });
     });
 
     test('omitted --dry-run preserves a createContext dryRun default through Commander', async () => {

--- a/adapters/commander/src/to-commander.ts
+++ b/adapters/commander/src/to-commander.ts
@@ -581,7 +581,12 @@ const wireAction = (
         action.parsedFlags,
         action.userSuppliedFlagKeys
       );
-      await action.command.execute(action.parsedArgs, parsedFlags);
+      await action.command.execute(action.parsedArgs, parsedFlags, undefined, {
+        userSuppliedFlagKeys: getCanonicalUserSuppliedFlagKeys(
+          action.command.flags,
+          action.userSuppliedFlagKeys
+        ),
+      });
     } catch (error: unknown) {
       handleError(
         error,

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -439,6 +439,56 @@ describe('trails regrade', () => {
     }
   });
 
+  test('CLI honors apply mode from input json without --apply', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'docs/surface.md', 'The facet docs are ready.\n');
+
+      const result = runRawCli([
+        'regrade',
+        '--root-dir',
+        dir,
+        '--input-json',
+        JSON.stringify({
+          apply: true,
+          from: 'facet',
+          include: ['docs/**'],
+          to: 'trailhead',
+        }),
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        readonly apply?: {
+          readonly applied?: number;
+          readonly filesChanged?: number;
+        };
+        readonly run?: {
+          readonly report?: {
+            readonly applied?: number;
+            readonly gate?: {
+              readonly status?: string;
+            };
+          };
+        };
+      };
+      expect(parsed.apply).toMatchObject({
+        applied: 1,
+        filesChanged: 1,
+      });
+      expect(parsed.run?.report).toMatchObject({
+        applied: 1,
+        gate: { status: 'green' },
+      });
+      expect(readFileSync(join(dir, 'docs/surface.md'), 'utf8')).toBe(
+        'The trailhead docs are ready.\n'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('CLI accepts path-scope exclude globs for class-mode apply', () => {
     const dir = makeTempDir();
     try {

--- a/packages/cli/src/__tests__/build.test.ts
+++ b/packages/cli/src/__tests__/build.test.ts
@@ -594,6 +594,97 @@ describe('buildCommands execution', () => {
     });
   });
 
+  test('structured input beats parsed flag defaults', async () => {
+    let receivedInput: unknown;
+    const t = trail('regrade-like', {
+      blaze: (input) => {
+        receivedInput = input;
+        return Result.ok(input);
+      },
+      input: z.object({
+        apply: z.boolean().default(false),
+        query: z.string(),
+      }),
+    });
+    const app = makeApp(t);
+    const commands = buildCommands(app);
+
+    await commands[0]?.execute(
+      {},
+      {
+        apply: false,
+        'input-json': '{"apply":true,"query":"from json"}',
+      },
+      undefined,
+      { userSuppliedFlagKeys: new Set() }
+    );
+
+    expect(receivedInput).toEqual({
+      apply: true,
+      query: 'from json',
+    });
+  });
+
+  test('explicit same-as-default flags beat structured input', async () => {
+    let receivedInput: unknown;
+    const t = trail('regrade-explicit', {
+      blaze: (input) => {
+        receivedInput = input;
+        return Result.ok(input);
+      },
+      input: z.object({
+        apply: z.boolean().default(false),
+        query: z.string(),
+      }),
+    });
+    const app = makeApp(t);
+    const commands = buildCommands(app);
+
+    await commands[0]?.execute(
+      {},
+      {
+        apply: false,
+        'input-json': '{"apply":true,"query":"from json"}',
+      },
+      undefined,
+      { userSuppliedFlagKeys: new Set(['apply']) }
+    );
+
+    expect(receivedInput).toEqual({
+      apply: false,
+      query: 'from json',
+    });
+  });
+
+  test('direct default-valued flags without provenance beat structured input', async () => {
+    let receivedInput: unknown;
+    const t = trail('regrade-direct-explicit', {
+      blaze: (input) => {
+        receivedInput = input;
+        return Result.ok(input);
+      },
+      input: z.object({
+        apply: z.boolean().default(false),
+        query: z.string(),
+      }),
+    });
+    const app = makeApp(t);
+    const commands = buildCommands(app);
+
+    await commands[0]?.execute(
+      {},
+      {
+        apply: false,
+        'input-json': '{"apply":true,"query":"from json"}',
+      }
+    );
+
+    expect(receivedInput).toEqual({
+      apply: false,
+      query: 'from json',
+    });
+  });
+
   test('resolveInput only fills missing values and never overwrites explicit input', async () => {
     let receivedInput: unknown;
     const t = trail('prompted', {

--- a/packages/cli/src/build.ts
+++ b/packages/cli/src/build.ts
@@ -32,7 +32,13 @@ import {
   withSurfaceLayerNames,
 } from '@ontrails/core';
 
-import type { AnyTrail, CliArg, CliCommand, CliFlag } from './command.js';
+import type {
+  AnyTrail,
+  CliArg,
+  CliCommand,
+  CliCommandExecuteOptions,
+  CliFlag,
+} from './command.js';
 import {
   detectDateFieldKinds,
   detectDateFields,
@@ -252,9 +258,65 @@ const paginatePreset = (): CliFlag[] => [
   },
 ];
 
+const isJsonLikeDefault = (
+  value: unknown
+): value is readonly unknown[] | object =>
+  Array.isArray(value) ||
+  (value !== null &&
+    typeof value === 'object' &&
+    Object.getPrototypeOf(value) === Object.prototype);
+
+const defaultValuesEqual = (actual: unknown, expected: unknown): boolean => {
+  if (Object.is(actual, expected)) {
+    return true;
+  }
+  if (!isJsonLikeDefault(actual) || !isJsonLikeDefault(expected)) {
+    return false;
+  }
+  try {
+    return JSON.stringify(actual) === JSON.stringify(expected);
+  } catch {
+    return false;
+  }
+};
+
+const isParsedDefaultValue = (
+  defaultFlagValues: ReadonlyMap<string, unknown>,
+  userSuppliedFlagKeys: ReadonlySet<string>,
+  key: string,
+  value: unknown
+): boolean =>
+  !userSuppliedFlagKeys.has(key) &&
+  defaultFlagValues.has(key) &&
+  defaultValuesEqual(value, defaultFlagValues.get(key));
+
+const collectDefaultFlagValues = (
+  flags: readonly CliFlag[]
+): ReadonlyMap<string, unknown> => {
+  const defaults = new Map<string, unknown>();
+  for (const flag of flags) {
+    if (flag.default !== undefined) {
+      defaults.set(kebabToCamel(flag.name), flag.default);
+    }
+  }
+  return defaults;
+};
+
+const normalizeFlagKeySet = (
+  keys?: ReadonlySet<string> | undefined
+): ReadonlySet<string> => {
+  const normalized = new Set<string>();
+  for (const key of keys ?? []) {
+    normalized.add(kebabToCamel(key));
+  }
+  return normalized;
+};
+
 /** Merge parsed args and flags into a camelCase input record. */
 const mergeArgsAndFlags = (
   metaFlagNames: ReadonlySet<string>,
+  defaultFlagValues: ReadonlyMap<string, unknown>,
+  userSuppliedFlagKeys: ReadonlySet<string>,
   structuredInput: Record<string, unknown>,
   parsedArgs: Record<string, unknown>,
   parsedFlags: Record<string, unknown>
@@ -268,9 +330,18 @@ const mergeArgsAndFlags = (
     mergedInput[key] = value;
   }
   for (const [key, value] of Object.entries(parsedFlags)) {
-    if (!metaFlagNames.has(key) && value !== undefined) {
-      mergedInput[key] = value;
+    if (metaFlagNames.has(key) || value === undefined) {
+      continue;
     }
+    if (
+      isParsedDefaultValue(defaultFlagValues, userSuppliedFlagKeys, key, value)
+    ) {
+      if (mergedInput[key] === undefined) {
+        mergedInput[key] = value;
+      }
+      continue;
+    }
+    mergedInput[key] = value;
   }
   return mergedInput;
 };
@@ -359,6 +430,8 @@ const applyDateShortcutsInPlace = (
 const resolveMergedInput = async (
   fields: readonly Field[],
   metaFlagNames: ReadonlySet<string>,
+  defaultFlagValues: ReadonlyMap<string, unknown>,
+  userSuppliedFlagKeys: ReadonlySet<string>,
   dateFields: readonly string[],
   dateFieldKinds: Readonly<Record<string, DateShortcutKind>>,
   parsedArgs: Record<string, unknown>,
@@ -382,6 +455,8 @@ const resolveMergedInput = async (
   );
   const mergedInput = mergeArgsAndFlags(
     metaFlagNames,
+    defaultFlagValues,
+    userSuppliedFlagKeys,
     structuredInput.payload ?? {},
     trailArgs,
     normalizedFlags
@@ -422,6 +497,8 @@ const maybeAddStructuredInputHint = (
 const safeMergeInput = async (
   fields: readonly Field[],
   metaFlagNames: ReadonlySet<string>,
+  defaultFlagValues: ReadonlyMap<string, unknown>,
+  userSuppliedFlagKeys: ReadonlySet<string>,
   dateFields: readonly string[],
   dateFieldKinds: Readonly<Record<string, DateShortcutKind>>,
   parsedArgs: Record<string, unknown>,
@@ -438,6 +515,8 @@ const safeMergeInput = async (
       await resolveMergedInput(
         fields,
         metaFlagNames,
+        defaultFlagValues,
+        userSuppliedFlagKeys,
         dateFields,
         dateFieldKinds,
         parsedArgs,
@@ -940,6 +1019,7 @@ const createExecute =
     t: AnyTrail,
     fields: readonly Field[],
     trailInputExcludeKeys: ReadonlySet<string>,
+    defaultFlagValues: ReadonlyMap<string, unknown>,
     dateFields: readonly string[],
     dateFieldKinds: Readonly<Record<string, DateShortcutKind>>,
     shouldHintStructuredInput: boolean,
@@ -949,11 +1029,17 @@ const createExecute =
   async (
     parsedArgs: Record<string, unknown>,
     parsedFlags: Record<string, unknown>,
-    ctxOverrides?: Partial<TrailContext>
+    ctxOverrides?: Partial<TrailContext>,
+    executeOptions?: CliCommandExecuteOptions
   ): Promise<Result<unknown, Error>> => {
+    const userSuppliedFlagKeys = normalizeFlagKeySet(
+      executeOptions?.userSuppliedFlagKeys ?? new Set(Object.keys(parsedFlags))
+    );
     const merged = await safeMergeInput(
       fields,
       trailInputExcludeKeys,
+      defaultFlagValues,
+      userSuppliedFlagKeys,
       dateFields,
       dateFieldKinds,
       parsedArgs,
@@ -1191,6 +1277,7 @@ const toCliCommand = (
     claimedFlagKebabs
   );
   const flags = [...trailFlags, ...layerProjection.flags];
+  const defaultFlagValues = collectDefaultFlagValues(flags);
   const layerMappedKeys = collectLayerMappedKeys(layerProjection.projections);
   // The executor strips both meta flags and layer-mapped flag values from
   // the trail input so layer-only flags never reach trail validation.
@@ -1224,6 +1311,7 @@ const toCliCommand = (
       t,
       fields,
       trailInputExcludeKeys,
+      defaultFlagValues,
       dateFields,
       dateFieldKinds,
       shouldHintStructuredInput,

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -57,6 +57,17 @@ export interface CliArg {
 // CliCommand
 // ---------------------------------------------------------------------------
 
+export interface CliCommandExecuteOptions {
+  /**
+   * CamelCase or kebab-case parsed flag keys that came directly from argv.
+   *
+   * Adapters that preserve framework-defaulted parsed flag values should pass
+   * this set so default-valued but explicitly supplied flags keep normal flag
+   * precedence over structured input.
+   */
+  readonly userSuppliedFlagKeys?: ReadonlySet<string> | undefined;
+}
+
 /** A framework-agnostic representation of a CLI command. */
 export interface CliCommand {
   readonly path: readonly string[];
@@ -82,10 +93,14 @@ export interface CliCommand {
    * @param ctxOverrides - Optional per-invocation overrides merged into the
    *   TrailContext before execution. The CLI surface marker is always
    *   applied on top of these overrides.
+   * @param executeOptions - Optional adapter metadata about parsed argv
+   *   provenance. Callers may omit it when parsed flags contain only explicit
+   *   values.
    */
   execute(
     parsedArgs: Record<string, unknown>,
     parsedFlags: Record<string, unknown>,
-    ctxOverrides?: Partial<TrailContext>
+    ctxOverrides?: Partial<TrailContext>,
+    executeOptions?: CliCommandExecuteOptions
   ): Promise<Result<unknown, Error>>;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@
 export type {
   AnyTrail,
   CliCommand,
+  CliCommandExecuteOptions,
   CliFlag,
   CliArg,
   CliFlagValueAlias,


### PR DESCRIPTION
## Summary

Fixes [TRL-1117](https://linear.app/outfitter/issue/TRL-1117/).

- Tracks CLI flag defaults separately from user-supplied flags.
- Lets structured `--input-json` values beat adapter-injected defaults.
- Preserves explicit same-as-default flags, including `--no-*` and value aliases, as real user input.

## Verification

- `bun run --cwd packages/cli typecheck`
- `bun run --cwd adapters/commander typecheck`
- `bun test packages/cli/src/__tests__/build.test.ts adapters/commander/src/__tests__/to-commander.test.ts apps/trails/src/__tests__/regrade.test.ts`
- `bun run changeset:check`
- Full stack: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`

## Notes

Local review reached clean state on round 3 after fixing explicit default and canonical alias provenance.