### PR TITLE
feat(regrade): add governed vocabulary registry

### DIFF
--- a/.changeset/trl-1121-governed-vocabulary-registry.md
+++ b/.changeset/trl-1121-governed-vocabulary-registry.md
@@ -1,0 +1,7 @@
+---
+'@ontrails/regrade': patch
+'@ontrails/warden': patch
+---
+
+Add a typed governed-vocabulary transition registry that Warden owns and Regrade
+can consume for migration planning.

--- a/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
+++ b/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
@@ -8,11 +8,16 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { getGovernedVocabularyTransition } from '@ontrails/warden';
 
 import {
   runVocabularyRegrade,
   vocabularyRegradePlanSchema,
 } from '../vocabulary.js';
+import {
+  listVocabularyRegradePlansFromRegistry,
+  vocabularyRegradePlanFromTransition,
+} from '../vocabulary-registry.js';
 
 const makeTempDir = (): string =>
   mkdtempSync(join(tmpdir(), `trails-vocabulary-regrade-${Date.now()}-`));
@@ -24,6 +29,173 @@ const writeFile = (root: string, path: string, value: string): void => {
 };
 
 describe('runVocabularyRegrade', () => {
+  test('runs single-target governed vocabulary transitions from the registry', () => {
+    const transition = getGovernedVocabularyTransition('v1-facet-trailhead');
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected facet vocabulary transition.');
+    }
+    const plan = vocabularyRegradePlanFromTransition(transition);
+    expect(plan).toMatchObject({
+      from: 'facet',
+      id: 'v1-facet-trailhead',
+      kind: 'vocabulary',
+      to: 'trailhead',
+    });
+    if (plan === null) {
+      throw new Error('Expected single-target transition to produce a plan.');
+    }
+
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/surface.ts',
+        'export const facets = ["facet"];\nexport const Facet = "review";\nexport const facetId = "manual";\n'
+      );
+
+      const result = runVocabularyRegrade({
+        plan: { ...plan, scope: { include: ['src/**/*.ts'] } },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.run.ledger.forms).toMatchObject({
+        Facet: 'deferred',
+        facet: 'modified',
+        facetId: 'deferred',
+        facets: 'modified',
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('does not turn classified vocabulary transitions into unsafe plans', () => {
+    const transition = getGovernedVocabularyTransition(
+      'v1-projection-derive-render'
+    );
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected projection vocabulary transition.');
+    }
+
+    expect(vocabularyRegradePlanFromTransition(transition)).toBeNull();
+  });
+
+  test('does not turn review-only registry defaults into unsafe plans', () => {
+    const transition = getGovernedVocabularyTransition('cross-compose');
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected cross vocabulary transition.');
+    }
+
+    expect(vocabularyRegradePlanFromTransition(transition)).toBeNull();
+    expect(
+      listVocabularyRegradePlansFromRegistry().map((plan) => plan.id)
+    ).not.toContain('cross-compose');
+  });
+
+  test('registry-generated plans preserve review forms as deferred inventory', () => {
+    const transition = getGovernedVocabularyTransition(
+      'v1-blaze-implementation'
+    );
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected blaze vocabulary transition.');
+    }
+    const plan = vocabularyRegradePlanFromTransition(transition);
+    if (plan === null) {
+      throw new Error(
+        'Expected blaze vocabulary transition to produce a plan.'
+      );
+    }
+    expect(plan).toMatchObject({
+      from: 'blaze',
+      id: 'v1-blaze-implementation',
+      kind: 'vocabulary',
+      to: 'implementation',
+    });
+    expect(plan.deferForms).toContain('blazing');
+
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/blaze.ts',
+        'export const blaze = "safe";\nexport const blazing = "review";\n'
+      );
+
+      const result = runVocabularyRegrade({
+        plan: { ...plan, scope: { include: ['src/**/*.ts'] } },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.run.ledger.forms).toMatchObject({
+        blaze: 'modified',
+        blazing: 'deferred',
+      });
+      expect(result.value.run.report.gate.status).toBe('open');
+      expect(result.value.run.report.gate.reasons).toContain(
+        'deferred-forms-or-occurrences'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('lets deferred forms take precedence over safe rewrite targets', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'export const facet = "facet";\n');
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          deferForms: ['facet'],
+          from: 'facet',
+          kind: 'vocabulary',
+          scope: { include: ['src/**/*.ts'] },
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.run.ledger.forms).toEqual({ facet: 'deferred' });
+      expect(
+        result.value.run.ledger.occurrences.every(
+          (occurrence) => occurrence.verdict === 'deferred'
+        )
+      ).toBe(true);
+      expect(result.value.run.report).toMatchObject({
+        deferred: 2,
+        gate: {
+          reasons: ['deferred-forms-or-occurrences'],
+          remaining: 2,
+          status: 'open',
+        },
+        modified: 0,
+        open: 2,
+      });
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toBe(
+        'export const facet = "facet";\n'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('dry-runs authored vocabulary plans into plan ledger report shape', () => {
     const dir = makeTempDir();
     try {

--- a/packages/regrade/src/downstream/vocabulary-registry.ts
+++ b/packages/regrade/src/downstream/vocabulary-registry.ts
@@ -1,0 +1,68 @@
+import type { GovernedVocabularyTransition } from '@ontrails/warden';
+import { listGovernedVocabularyTransitions } from '@ontrails/warden';
+
+import type {
+  VocabularyPreserveRule,
+  VocabularyRegradePlan,
+} from './vocabulary.js';
+
+const pluralizeVocabularyForm = (value: string): string =>
+  value.endsWith('s') || value.endsWith('x') || value.endsWith('ch')
+    ? `${value}es`
+    : `${value}s`;
+
+const preserveRulesFromTransition = (
+  transition: GovernedVocabularyTransition
+): readonly VocabularyPreserveRule[] =>
+  transition.preserve.map((rule) => ({
+    ...(rule.paths === undefined ? {} : { paths: rule.paths }),
+    pattern: rule.pattern,
+    reason: rule.reason,
+  }));
+
+const defaultFormsAreRegistrySafe = (
+  transition: GovernedVocabularyTransition
+): boolean => {
+  if (transition.target.kind !== 'single') {
+    return false;
+  }
+
+  const defaultForms = [
+    transition.from,
+    pluralizeVocabularyForm(transition.from),
+  ];
+
+  return defaultForms.every((form) => {
+    const replacement = transition.safeRewriteForms[form];
+    return replacement !== undefined && !transition.reviewForms.includes(form);
+  });
+};
+
+export const vocabularyRegradePlanFromTransition = (
+  transition: GovernedVocabularyTransition
+): VocabularyRegradePlan | null => {
+  if (
+    transition.target.kind !== 'single' ||
+    !defaultFormsAreRegistrySafe(transition)
+  ) {
+    return null;
+  }
+
+  return {
+    caseSensitive: true,
+    deferForms: transition.reviewForms,
+    from: transition.from,
+    id: transition.id,
+    intent: transition.intent,
+    kind: 'vocabulary',
+    overrides: transition.safeRewriteForms,
+    preserve: preserveRulesFromTransition(transition),
+    to: transition.target.to,
+  };
+};
+
+export const listVocabularyRegradePlansFromRegistry =
+  (): readonly VocabularyRegradePlan[] =>
+    listGovernedVocabularyTransitions()
+      .map(vocabularyRegradePlanFromTransition)
+      .filter((plan): plan is VocabularyRegradePlan => plan !== null);

--- a/packages/regrade/src/downstream/vocabulary.ts
+++ b/packages/regrade/src/downstream/vocabulary.ts
@@ -38,6 +38,8 @@ export interface VocabularyRegradeScope {
 }
 
 export interface VocabularyRegradePlan {
+  readonly caseSensitive?: boolean;
+  readonly deferForms?: readonly string[];
   readonly from: string;
   readonly id?: string;
   readonly intent?: string;
@@ -98,6 +100,8 @@ interface SourceFile {
 interface SourceOccurrence extends VocabularyOccurrence {
   readonly absolutePath: string;
 }
+
+type SourceOccurrenceDraft = Omit<SourceOccurrence, 'reason' | 'verdict'>;
 
 interface VocabularyEvaluation {
   readonly entries: readonly RegradeReportEntry[];
@@ -331,6 +335,9 @@ const targetFormsForPlan = (
   return forms;
 };
 
+const deferFormsForPlan = (plan: VocabularyRegradePlan): readonly string[] =>
+  Array.isArray(plan.deferForms) ? uniqueSorted(plan.deferForms) : [];
+
 const validateVocabularyPlan = (
   plan: VocabularyRegradePlan
 ): Result<void, ValidationError> => {
@@ -360,6 +367,15 @@ const validateVocabularyPlan = (
       );
     }
   }
+  for (const form of deferFormsForPlan(plan)) {
+    if (form.trim().length === 0) {
+      return Result.err(
+        new ValidationError(
+          'Vocabulary Regrade plan deferForms entries cannot be empty.'
+        )
+      );
+    }
+  }
   for (const rule of plan.preserve ?? []) {
     if (rule.pattern.trim().length === 0) {
       return Result.err(
@@ -371,6 +387,9 @@ const validateVocabularyPlan = (
   }
   return Result.ok();
 };
+
+const vocabularyScanFlags = (plan: VocabularyRegradePlan): string =>
+  plan.caseSensitive === true ? 'g' : 'gi';
 
 const includedByScope = (
   path: string,
@@ -390,7 +409,7 @@ const compilePreservePattern = (pattern: string): RegExp => {
 };
 
 const preserveRuleForOccurrence = (
-  occurrence: Omit<SourceOccurrence, 'reason' | 'verdict'>,
+  occurrence: SourceOccurrenceDraft,
   plan: VocabularyRegradePlan
 ): VocabularyPreserveRule | undefined =>
   plan.preserve?.find((rule) => {
@@ -406,10 +425,87 @@ const preserveRuleForOccurrence = (
     );
   });
 
+const occurrenceOverlaps = (
+  occurrences: readonly SourceOccurrence[],
+  start: number,
+  end: number
+): boolean =>
+  occurrences.some(
+    (occurrence) => start < occurrence.end && occurrence.start < end
+  );
+
+const occurrenceDraftForSpan = (
+  file: SourceFile,
+  start: number,
+  end: number,
+  form = file.source.slice(start, end)
+): SourceOccurrenceDraft => {
+  const { column, line } = lineColumnForOffset(file.source, start);
+  return {
+    absolutePath: file.absolutePath,
+    column,
+    context: contextForOffset(file.source, start, end),
+    end,
+    form,
+    line,
+    path: file.path,
+    start,
+  };
+};
+
+const deferredOccurrenceFromDraft = (
+  file: SourceFile,
+  plan: VocabularyRegradePlan,
+  baseOccurrence: SourceOccurrenceDraft,
+  reason = 'unclassified-neighbor'
+): SourceOccurrence => {
+  const preserveRule = preserveRuleForOccurrence(baseOccurrence, plan);
+  return {
+    ...baseOccurrence,
+    reason: vocabularyOccurrenceReason(
+      preserveRule,
+      isMarkdownCodeContext(file, baseOccurrence.start, baseOccurrence.end),
+      reason
+    ),
+    verdict: preserveRule === undefined ? 'deferred' : 'skipped',
+  };
+};
+
+const exactDeferredFormOccurrencesForFile = (
+  file: SourceFile,
+  plan: VocabularyRegradePlan,
+  deferForms: readonly string[]
+): readonly SourceOccurrence[] => {
+  const occurrences: SourceOccurrence[] = [];
+  for (const form of deferForms) {
+    const pattern = new RegExp(escapeRegExp(form), vocabularyScanFlags(plan));
+    for (const match of file.source.matchAll(pattern)) {
+      const start = match.index ?? 0;
+      const end = start + match[0].length;
+      if (
+        !hasWordBoundary(file.source, start, end) ||
+        occurrenceOverlaps(occurrences, start, end)
+      ) {
+        continue;
+      }
+      occurrences.push(
+        deferredOccurrenceFromDraft(
+          file,
+          plan,
+          occurrenceDraftForSpan(file, start, end, match[0]),
+          'deferred-form'
+        )
+      );
+    }
+  }
+  return occurrences;
+};
+
 const occurrencesForFile = (
   file: SourceFile,
   plan: VocabularyRegradePlan,
-  targetForms: Map<string, string>
+  targetForms: Map<string, string>,
+  deferredOccurrences: readonly SourceOccurrence[]
 ): readonly SourceOccurrence[] => {
   const occurrences: SourceOccurrence[] = [];
   const candidates: SourceOccurrence[] = [];
@@ -418,11 +514,14 @@ const occurrencesForFile = (
   );
 
   for (const [form, replacement] of forms) {
-    const pattern = new RegExp(escapeRegExp(form), 'gi');
+    const pattern = new RegExp(escapeRegExp(form), vocabularyScanFlags(plan));
     for (const match of file.source.matchAll(pattern)) {
       const start = match.index ?? 0;
       const end = start + match[0].length;
-      if (!hasWordBoundary(file.source, start, end)) {
+      if (
+        !hasWordBoundary(file.source, start, end) ||
+        occurrenceOverlaps(deferredOccurrences, start, end)
+      ) {
         continue;
       }
       const { column, line } = lineColumnForOffset(file.source, start);
@@ -479,29 +578,23 @@ const deferredOccurrencesForFile = (
   plan: VocabularyRegradePlan,
   targetForms: Map<string, string>
 ): readonly SourceOccurrence[] => {
+  const deferForms = deferFormsForPlan(plan);
   const knownForms = new Set(
-    [...targetForms.keys()].flatMap((form) => [form, form.toLowerCase()])
+    plan.caseSensitive === true
+      ? [...targetForms.keys(), ...deferForms]
+      : [...targetForms.keys(), ...deferForms].flatMap((form) => [
+          form,
+          form.toLowerCase(),
+        ])
   );
   const lowerFrom = plan.from.toLowerCase();
   const tokenPattern = /[A-Za-z_$][A-Za-z0-9_$-]*/g;
-  const occurrences: SourceOccurrence[] = [];
-  const pushOccurrence = (
-    baseOccurrence: Omit<SourceOccurrence, 'reason' | 'verdict'>
-  ): void => {
-    const preserveRule = preserveRuleForOccurrence(baseOccurrence, plan);
-    occurrences.push({
-      ...baseOccurrence,
-      reason: vocabularyOccurrenceReason(
-        preserveRule,
-        isMarkdownCodeContext(file, baseOccurrence.start, baseOccurrence.end),
-        'unclassified-neighbor'
-      ),
-      verdict: preserveRule === undefined ? 'deferred' : 'skipped',
-    });
-  };
+  const occurrences = [
+    ...exactDeferredFormOccurrencesForFile(file, plan, deferForms),
+  ];
 
   for (const form of targetForms.keys()) {
-    const pattern = new RegExp(escapeRegExp(form), 'gi');
+    const pattern = new RegExp(escapeRegExp(form), vocabularyScanFlags(plan));
     for (const match of file.source.matchAll(pattern)) {
       const matchStart = match.index ?? 0;
       const matchEnd = matchStart + match[0].length;
@@ -515,35 +608,31 @@ const deferredOccurrencesForFile = (
       );
       const matchedForm = file.source.slice(start, end);
       const lowerMatchedForm = matchedForm.toLowerCase();
-      const overlaps = occurrences.some(
-        (occurrence) => start < occurrence.end && occurrence.start < end
-      );
       if (
-        overlaps ||
+        occurrenceOverlaps(occurrences, start, end) ||
         knownForms.has(matchedForm) ||
-        knownForms.has(lowerMatchedForm) ||
+        (plan.caseSensitive !== true && knownForms.has(lowerMatchedForm)) ||
         !lowerMatchedForm.includes(lowerFrom)
       ) {
         continue;
       }
-      const { column, line } = lineColumnForOffset(file.source, start);
-      pushOccurrence({
-        absolutePath: file.absolutePath,
-        column,
-        context: contextForOffset(file.source, start, end),
-        end,
-        form: matchedForm,
-        line,
-        path: file.path,
-        start,
-      });
+      occurrences.push(
+        deferredOccurrenceFromDraft(
+          file,
+          plan,
+          occurrenceDraftForSpan(file, start, end, matchedForm)
+        )
+      );
     }
   }
 
   for (const match of file.source.matchAll(tokenPattern)) {
     const [form] = match;
     const lower = form.toLowerCase();
-    if (knownForms.has(form) || knownForms.has(lower)) {
+    if (
+      knownForms.has(form) ||
+      (plan.caseSensitive !== true && knownForms.has(lower))
+    ) {
       continue;
     }
     if (!lower.includes(lowerFrom)) {
@@ -551,23 +640,16 @@ const deferredOccurrencesForFile = (
     }
     const start = match.index ?? 0;
     const end = start + form.length;
-    const overlaps = occurrences.some(
-      (occurrence) => start < occurrence.end && occurrence.start < end
-    );
-    if (overlaps) {
+    if (occurrenceOverlaps(occurrences, start, end)) {
       continue;
     }
-    const { column, line } = lineColumnForOffset(file.source, start);
-    pushOccurrence({
-      absolutePath: file.absolutePath,
-      column,
-      context: contextForOffset(file.source, start, end),
-      end,
-      form,
-      line,
-      path: file.path,
-      start,
-    });
+    occurrences.push(
+      deferredOccurrenceFromDraft(
+        file,
+        plan,
+        occurrenceDraftForSpan(file, start, end, form)
+      )
+    );
   }
   return occurrences.toSorted((left, right) =>
     left.path === right.path
@@ -663,10 +745,22 @@ const buildVocabularyEvaluation = (params: {
   const scopeSkipped: SkippedSource[] = params.files
     .filter((file) => !includedByScope(file.path, params.plan.scope))
     .map((file) => ({ path: file.path, reason: 'excluded-by-regrade-scope' }));
-  const occurrences = scopedFiles.flatMap((file) => [
-    ...occurrencesForFile(file, params.plan, targetForms),
-    ...deferredOccurrencesForFile(file, params.plan, targetForms),
-  ]);
+  const occurrences = scopedFiles.flatMap((file) => {
+    const deferredOccurrences = deferredOccurrencesForFile(
+      file,
+      params.plan,
+      targetForms
+    );
+    return [
+      ...occurrencesForFile(
+        file,
+        params.plan,
+        targetForms,
+        deferredOccurrences
+      ),
+      ...deferredOccurrences,
+    ];
+  });
   const occurrencesByPath = new Map<string, SourceOccurrence[]>();
   for (const occurrence of occurrences) {
     const existing = occurrencesByPath.get(occurrence.path) ?? [];
@@ -993,6 +1087,14 @@ const vocabularyRegradeScopeSchema = z.object({
 });
 
 export const vocabularyRegradePlanSchema = z.object({
+  caseSensitive: z
+    .boolean()
+    .optional()
+    .describe('Whether source form scanning preserves case exactly'),
+  deferForms: z
+    .array(z.string().min(1))
+    .optional()
+    .describe('Known forms that must be inventoried for review, not rewritten'),
   from: z.string().min(1).describe('Source vocabulary term or phrase'),
   id: z.string().optional().describe('Stable authored regrade plan id'),
   intent: z.string().optional().describe('Human-authored migration intent'),

--- a/packages/regrade/src/index.ts
+++ b/packages/regrade/src/index.ts
@@ -18,6 +18,10 @@ export {
   vocabularyRegradePlanSchema,
   vocabularyRegradeRunOutput,
 } from './downstream/vocabulary.js';
+export {
+  listVocabularyRegradePlansFromRegistry,
+  vocabularyRegradePlanFromTransition,
+} from './downstream/vocabulary-registry.js';
 export type {
   RegradeApplySummary,
   RegradeClass,

--- a/packages/warden/src/__tests__/no-retired-cross-vocabulary.test.ts
+++ b/packages/warden/src/__tests__/no-retired-cross-vocabulary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { noRetiredCrossVocabulary } from '../rules/no-retired-cross-vocabulary.js';
+import { requireGovernedVocabularyTransition } from '../rules/retired-vocabulary.js';
 
 const RULE_NAME = 'no-retired-cross-vocabulary';
 
@@ -53,6 +54,29 @@ describe('no-retired-cross-vocabulary', () => {
         },
       ]
     );
+  });
+
+  test('safe rewrites come from the governed vocabulary registry', () => {
+    const transition = requireGovernedVocabularyTransition('cross-compose');
+    const source = [
+      'const a = ctx.cross(loadTrack, input);',
+      'const b = crossInput;',
+      'const c = crosses;',
+    ].join('\n');
+
+    const diagnostics = check(source);
+
+    const replacementsBySourceForm = Object.fromEntries(
+      diagnostics.map((diagnostic) => {
+        const edit = diagnostic.fix?.edits?.[0];
+        if (edit === undefined) {
+          throw new Error('Expected safe rewrite edit.');
+        }
+        return [source.slice(edit.start, edit.end), edit.replacement];
+      })
+    );
+
+    expect(replacementsBySourceForm).toEqual(transition.safeRewriteForms);
   });
 
   test('routes Cross type prefixes and partial identifiers to review', () => {
@@ -121,6 +145,7 @@ describe('no-retired-cross-vocabulary', () => {
       '/repo/docs/adr/0049-composition-is-compose-not-cross.md',
       '/repo/packages/warden/src/rules/no-retired-cross-vocabulary.ts',
       '/repo/packages/warden/src/rules/metadata.ts',
+      '/repo/packages/warden/src/rules/retired-vocabulary.ts',
       '/repo/packages/warden/src/trails/no-retired-cross-vocabulary.trail.ts',
     ]) {
       const diagnostics = noRetiredCrossVocabulary.check(

--- a/packages/warden/src/__tests__/retired-vocabulary.test.ts
+++ b/packages/warden/src/__tests__/retired-vocabulary.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+import { ZodError } from 'zod';
+
+import {
+  formatGovernedVocabularyTransitionGuide,
+  getGovernedVocabularyTransition,
+  governedVocabularyRegistrySchema,
+  governedVocabularyTransitions,
+  listGovernedVocabularyTransitions,
+} from '../rules/retired-vocabulary.js';
+
+describe('governed vocabulary registry', () => {
+  test('accounts for current pending v1 lexicon families', () => {
+    const transitions = listGovernedVocabularyTransitions();
+
+    expect(transitions.map((transition) => transition.id)).toEqual([
+      'cross-compose',
+      'v1-blaze-implementation',
+      'v1-contour-entity',
+      'v1-facet-trailhead',
+      'v1-projection-derive-render',
+    ]);
+    expect(transitions.map((transition) => transition.from)).toEqual([
+      'cross',
+      'blaze',
+      'contour',
+      'facet',
+      'projection',
+    ]);
+
+    const projection = getGovernedVocabularyTransition(
+      'v1-projection-derive-render'
+    );
+    expect(projection?.oldForms).toContain('project');
+    expect(projection?.target.kind).toBe('classified');
+  });
+
+  test('validates registry shape and rejects incomplete entries', () => {
+    expect(() =>
+      governedVocabularyRegistrySchema.parse([
+        {
+          docs: { summary: 'missing target' },
+          from: 'old',
+          id: 'bad',
+          intent: 'bad entry',
+          kind: 'vocabulary',
+          oldForms: ['old'],
+          status: 'planned',
+        },
+      ])
+    ).toThrow(ZodError);
+  });
+
+  test('rejects duplicate ids and duplicate source terms', () => {
+    const [transition] = governedVocabularyTransitions;
+    if (transition === undefined) {
+      throw new Error('Expected governed vocabulary registry fixture.');
+    }
+
+    expect(() =>
+      governedVocabularyRegistrySchema.parse([transition, transition])
+    ).toThrow(ZodError);
+  });
+
+  test('renders a documentation guide without making markdown the source of truth', () => {
+    const guide = formatGovernedVocabularyTransitionGuide();
+
+    expect(guide).toContain('v1-facet-trailhead: facet -> trailhead');
+    expect(guide).toContain('v1-projection-derive-render: projection ->');
+    expect(guide).toContain('Status: planned');
+  });
+});

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -35,8 +35,18 @@ export type {
 // Rule registry
 export {
   builtinWardenRuleMetadata,
+  formatGovernedVocabularyTransitionGuide,
+  getGovernedVocabularyTransition,
+  governedVocabularyPreserveRuleSchema,
+  governedVocabularyRegistrySchema,
+  governedVocabularyTargetSchema,
+  governedVocabularyTransitionSchema,
+  governedVocabularyTransitionStatuses,
+  governedVocabularyTransitions,
   getWardenRuleMetadata,
   listWardenRuleMetadata,
+  listGovernedVocabularyTransitions,
+  requireGovernedVocabularyTransition,
   wardenFixClasses,
   wardenFixSafeties,
   wardenRuleConcerns,
@@ -45,6 +55,12 @@ export {
   wardenRuleTiers,
   wardenRules,
   wardenTopoRules,
+} from './rules/index.js';
+export type {
+  GovernedVocabularyPreserveRule,
+  GovernedVocabularyTarget,
+  GovernedVocabularyTransition,
+  GovernedVocabularyTransitionInput,
 } from './rules/index.js';
 
 // Rule-scoped cache controls for long-lived consumers (watch mode, LSPs).

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -96,6 +96,24 @@ export type {
 } from './types.js';
 
 export {
+  formatGovernedVocabularyTransitionGuide,
+  getGovernedVocabularyTransition,
+  governedVocabularyPreserveRuleSchema,
+  governedVocabularyRegistrySchema,
+  governedVocabularyTargetSchema,
+  governedVocabularyTransitionSchema,
+  governedVocabularyTransitionStatuses,
+  governedVocabularyTransitions,
+  listGovernedVocabularyTransitions,
+  requireGovernedVocabularyTransition,
+} from './retired-vocabulary.js';
+export type {
+  GovernedVocabularyPreserveRule,
+  GovernedVocabularyTarget,
+  GovernedVocabularyTransition,
+  GovernedVocabularyTransitionInput,
+} from './retired-vocabulary.js';
+export {
   builtinWardenRuleMetadata,
   getWardenRuleMetadata,
   listWardenRuleMetadata,

--- a/packages/warden/src/rules/no-retired-cross-vocabulary.ts
+++ b/packages/warden/src/rules/no-retired-cross-vocabulary.ts
@@ -8,17 +8,25 @@
  */
 import { resolve, sep } from 'node:path';
 
+import { requireGovernedVocabularyTransition } from './retired-vocabulary.js';
 import type { WardenDiagnostic, WardenFix, WardenRule } from './types.js';
 
 const RULE_NAME = 'no-retired-cross-vocabulary';
 
-const SAFE_REWRITES = [
-  { from: 'ctx.cross', to: 'ctx.compose' },
-  { from: 'crossInput', to: 'composeInput' },
-  { from: 'crosses', to: 'composes' },
-] as const;
+const CROSS_COMPOSE_TRANSITION =
+  requireGovernedVocabularyTransition('cross-compose');
 
-const REVIEW_TERMS = ['Cross', 'cross'] as const;
+if (CROSS_COMPOSE_TRANSITION.target.kind !== 'single') {
+  throw new Error('cross-compose transition must have a single target.');
+}
+
+const COMPOSE_TARGET = CROSS_COMPOSE_TRANSITION.target.to;
+
+const SAFE_REWRITES = Object.entries(
+  CROSS_COMPOSE_TRANSITION.safeRewriteForms
+).map(([from, to]) => ({ from, to }));
+
+const REVIEW_TERMS = CROSS_COMPOSE_TRANSITION.reviewForms;
 
 const IDENTIFIER_CHAR = /[$0-9A-Z_a-z]/u;
 
@@ -28,6 +36,7 @@ const ALLOWED_PATH_SUFFIXES: readonly string[] = [
   '/docs/adr/0049-composition-is-compose-not-cross.md',
   '/packages/warden/src/rules/no-retired-cross-vocabulary.ts',
   '/packages/warden/src/rules/metadata.ts',
+  '/packages/warden/src/rules/retired-vocabulary.ts',
   '/packages/warden/src/trails/no-retired-cross-vocabulary.trail.ts',
   '/scripts/vocab-cutover-rewrite.ts',
 ];
@@ -40,7 +49,7 @@ interface SafeRewriteMatch {
 
 interface ReviewMatch {
   readonly index: number;
-  readonly term: (typeof REVIEW_TERMS)[number];
+  readonly term: string;
 }
 
 const normalizePath = (filePath: string): string =>
@@ -150,7 +159,7 @@ const safeFix = (match: SafeRewriteMatch): WardenFix => ({
 
 const reviewFix = (term: string): WardenFix => ({
   class: 'term-rewrite',
-  reason: `Retired composition vocabulary '${term}' appears in a larger or ambiguous form. Review before migrating to compose vocabulary.`,
+  reason: `Retired composition vocabulary '${term}' appears in a larger or ambiguous form. Review before migrating to ${COMPOSE_TARGET} vocabulary.`,
   safety: 'review',
 });
 
@@ -158,7 +167,7 @@ const safeMessage = (match: SafeRewriteMatch): string =>
   `Retired composition vocabulary '${match.from}' should be '${match.to}' after the beta.19 compose cutover.`;
 
 const reviewMessage = (term: string): string =>
-  `Retired composition vocabulary '${term}' needs review before migrating to compose vocabulary.`;
+  `Retired composition vocabulary '${term}' needs review before migrating to ${COMPOSE_TARGET} vocabulary.`;
 
 export const noRetiredCrossVocabulary: WardenRule = {
   check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {

--- a/packages/warden/src/rules/retired-vocabulary.ts
+++ b/packages/warden/src/rules/retired-vocabulary.ts
@@ -1,0 +1,281 @@
+import { z } from 'zod';
+
+export const governedVocabularyTransitionStatuses = [
+  'planned',
+  'active',
+  'complete',
+] as const;
+
+const governedVocabularySingleTargetSchema = z.object({
+  kind: z.literal('single'),
+  to: z.string().min(1),
+});
+
+const governedVocabularyClassifiedTargetSchema = z.object({
+  guidance: z.string().min(1),
+  kind: z.literal('classified'),
+  options: z
+    .array(
+      z.object({
+        to: z.string().min(1),
+        when: z.string().min(1),
+      })
+    )
+    .min(1),
+});
+
+export const governedVocabularyTargetSchema = z.discriminatedUnion('kind', [
+  governedVocabularySingleTargetSchema,
+  governedVocabularyClassifiedTargetSchema,
+]);
+
+export const governedVocabularyPreserveRuleSchema = z.object({
+  paths: z.array(z.string().min(1)).optional(),
+  pattern: z.string().min(1),
+  reason: z.string().min(1),
+});
+
+export const governedVocabularyTransitionSchema = z.object({
+  codeIdentifiers: z.array(z.string().min(1)).default([]),
+  docs: z.object({
+    guidance: z.array(z.string().min(1)).default([]),
+    summary: z.string().min(1),
+  }),
+  from: z.string().min(1),
+  id: z.string().min(1),
+  intent: z.string().min(1),
+  kind: z.literal('vocabulary'),
+  oldForms: z.array(z.string().min(1)).min(1),
+  overrides: z.record(z.string().min(1), z.string().min(1)).default({}),
+  preserve: z.array(governedVocabularyPreserveRuleSchema).default([]),
+  reviewForms: z.array(z.string().min(1)).default([]),
+  safeRewriteForms: z.record(z.string().min(1), z.string().min(1)).default({}),
+  status: z.enum(governedVocabularyTransitionStatuses),
+  target: governedVocabularyTargetSchema,
+});
+
+export const governedVocabularyRegistrySchema = z
+  .array(governedVocabularyTransitionSchema)
+  .superRefine((transitions, ctx) => {
+    const seenIds = new Set<string>();
+    const seenFrom = new Set<string>();
+
+    for (const [index, transition] of transitions.entries()) {
+      if (seenIds.has(transition.id)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Duplicate governed vocabulary transition id "${transition.id}".`,
+          path: [index, 'id'],
+        });
+      }
+      seenIds.add(transition.id);
+
+      if (seenFrom.has(transition.from)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Duplicate governed vocabulary source "${transition.from}".`,
+          path: [index, 'from'],
+        });
+      }
+      seenFrom.add(transition.from);
+    }
+  });
+
+export type GovernedVocabularyPreserveRule = z.output<
+  typeof governedVocabularyPreserveRuleSchema
+>;
+export type GovernedVocabularyTarget = z.output<
+  typeof governedVocabularyTargetSchema
+>;
+export type GovernedVocabularyTransition = z.output<
+  typeof governedVocabularyTransitionSchema
+>;
+export type GovernedVocabularyTransitionInput = z.input<
+  typeof governedVocabularyTransitionSchema
+>;
+
+const defineTransition = (
+  input: GovernedVocabularyTransitionInput
+): GovernedVocabularyTransition =>
+  governedVocabularyTransitionSchema.parse(input);
+
+export const governedVocabularyTransitions =
+  governedVocabularyRegistrySchema.parse([
+    defineTransition({
+      codeIdentifiers: ['ctx.cross', 'crossInput', 'crosses'],
+      docs: {
+        guidance: [
+          'Exact ctx.cross, crossInput, and crosses forms are mechanically rewritten.',
+          'Broader cross or Cross forms route to review because a text rule cannot prove the intended symbol boundary.',
+        ],
+        summary:
+          'Beta.19 retired cross composition vocabulary in favor of compose.',
+      },
+      from: 'cross',
+      id: 'cross-compose',
+      intent:
+        'Retire beta.19 cross composition vocabulary in favor of compose.',
+      kind: 'vocabulary',
+      oldForms: ['cross', 'Cross', 'crosses', 'crossInput', 'ctx.cross'],
+      reviewForms: ['Cross', 'cross'],
+      safeRewriteForms: {
+        crossInput: 'composeInput',
+        crosses: 'composes',
+        'ctx.cross': 'ctx.compose',
+      },
+      status: 'complete',
+      target: { kind: 'single', to: 'compose' },
+    }),
+    defineTransition({
+      codeIdentifiers: ['blaze', 'blazes'],
+      docs: {
+        guidance: [
+          'Treat code/API identifiers as governed symbols, not prose-only vocabulary.',
+          'Review inflected forms such as blazed or blazing instead of forcing a mechanical rewrite.',
+        ],
+        summary:
+          'The authored trail behavior field is moving from blaze to implementation.',
+      },
+      from: 'blaze',
+      id: 'v1-blaze-implementation',
+      intent:
+        'Move the authored trail behavior field from blaze to implementation for v1.',
+      kind: 'vocabulary',
+      oldForms: ['blaze', 'blazes', 'Blaze'],
+      reviewForms: ['Blaze', 'blazing', 'blazed', 'trailblaze'],
+      safeRewriteForms: {
+        blaze: 'implementation',
+        blazes: 'implementations',
+      },
+      status: 'planned',
+      target: { kind: 'single', to: 'implementation' },
+    }),
+    defineTransition({
+      codeIdentifiers: ['contour', 'contours'],
+      docs: {
+        guidance: [
+          'Keep domain-object semantics distinct from entities in app data until the occurrence is classified.',
+        ],
+        summary:
+          'The domain object declaration term is moving from contour to entity.',
+      },
+      from: 'contour',
+      id: 'v1-contour-entity',
+      intent:
+        'Move the domain object declaration vocabulary from contour to entity for v1.',
+      kind: 'vocabulary',
+      oldForms: ['contour', 'contours', 'Contour'],
+      reviewForms: ['Contour'],
+      safeRewriteForms: {
+        contour: 'entity',
+        contours: 'entities',
+      },
+      status: 'planned',
+      target: { kind: 'single', to: 'entity' },
+    }),
+    defineTransition({
+      codeIdentifiers: [
+        'facets',
+        'facetId',
+        'McpSurfaceFacetMap',
+        'surface-facet-coherence',
+        'wayfind.facets',
+      ],
+      docs: {
+        guidance: [
+          'A trailhead is one grouped surface entry fronting several trails while preserving member identity.',
+          'Code/API identifiers remain governed symbols and need structured preservation before broad application.',
+        ],
+        summary:
+          'The grouped surface entry term is moving from facet to trailhead.',
+      },
+      from: 'facet',
+      id: 'v1-facet-trailhead',
+      intent:
+        'Move grouped surface entry vocabulary from facet to trailhead for v1.',
+      kind: 'vocabulary',
+      oldForms: ['facet', 'facets', 'Facet'],
+      reviewForms: ['Facet'],
+      safeRewriteForms: {
+        facet: 'trailhead',
+        facets: 'trailheads',
+      },
+      status: 'planned',
+      target: { kind: 'single', to: 'trailhead' },
+    }),
+    defineTransition({
+      codeIdentifiers: [],
+      docs: {
+        guidance: [
+          'Use derive for contract-owned fact production.',
+          'Use render for surface- or operator-facing presentation.',
+          'Route every occurrence to review until the stage is classified.',
+        ],
+        summary: 'Projection vocabulary splits by stage into derive or render.',
+      },
+      from: 'projection',
+      id: 'v1-projection-derive-render',
+      intent:
+        'Split projection vocabulary into derive/render by lifecycle stage for v1.',
+      kind: 'vocabulary',
+      oldForms: ['projection', 'projections', 'project', 'projected'],
+      reviewForms: ['projection', 'projections', 'project', 'projected'],
+      safeRewriteForms: {},
+      status: 'planned',
+      target: {
+        guidance:
+          'No single replacement is safe. Classify by whether the occurrence produces contract facts or presents derived facts.',
+        kind: 'classified',
+        options: [
+          {
+            to: 'derive',
+            when: 'The occurrence describes producing contract-owned facts or inferred data from authored inputs.',
+          },
+          {
+            to: 'render',
+            when: 'The occurrence describes presenting derived facts through a surface, report, guide, or operator output.',
+          },
+        ],
+      },
+    }),
+  ]);
+
+export const listGovernedVocabularyTransitions =
+  (): readonly GovernedVocabularyTransition[] => governedVocabularyTransitions;
+
+export const getGovernedVocabularyTransition = (
+  id: string
+): GovernedVocabularyTransition | undefined =>
+  governedVocabularyTransitions.find((transition) => transition.id === id);
+
+export const requireGovernedVocabularyTransition = (
+  id: string
+): GovernedVocabularyTransition => {
+  const transition = getGovernedVocabularyTransition(id);
+  if (transition === undefined) {
+    throw new Error(`Unknown governed vocabulary transition "${id}".`);
+  }
+  return transition;
+};
+
+export const formatGovernedVocabularyTransitionGuide = (
+  transitions: readonly GovernedVocabularyTransition[] = governedVocabularyTransitions
+): string =>
+  transitions
+    .map((transition) => {
+      const target =
+        transition.target.kind === 'single'
+          ? transition.target.to
+          : transition.target.options
+              .map((option) => `${option.to} (${option.when})`)
+              .join(' or ');
+      const lines = [
+        `- ${transition.id}: ${transition.from} -> ${target}`,
+        `  - Status: ${transition.status}`,
+        `  - Intent: ${transition.intent}`,
+        `  - Safe rewrites: ${Object.keys(transition.safeRewriteForms).length}`,
+        `  - Review forms: ${transition.reviewForms.join(', ') || 'none'}`,
+      ];
+      return lines.join('\n');
+    })
+    .join('\n');


### PR DESCRIPTION
## Summary

Fixes [TRL-1121](https://linear.app/outfitter/issue/TRL-1121/).

- Adds Warden-owned governed retired vocabulary transitions.
- Derives Regrade vocabulary plans from safe single-target registry transitions.
- Keeps classified transitions, such as `projection -> derive/render`, out of unsafe automatic rewrite plans.

## Verification

- `bun test packages/warden/src/__tests__/retired-vocabulary.test.ts packages/warden/src/__tests__/no-retired-cross-vocabulary.test.ts packages/regrade/src/downstream/__tests__/vocabulary.test.ts`
- `bun run --cwd packages/warden typecheck`
- `bun run --cwd packages/regrade typecheck`
- `bun run changeset:check`
- Full stack: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`

## Notes

Local review reached clean state on round 3 after tightening safe-plan derivation and exact-case rewrite behavior.