### PR TITLE
feat(regrade): harden governed symbol renames

### DIFF
--- a/.agents/skills/clark/references/warden-guide.md
+++ b/.agents/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 68
+- Rule count: 69
 
 ## Agent Instructions
 
@@ -59,6 +59,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `draft-file-marking` (error, source/source-static, external): Draft-authored state is visibly marked in filenames.
 - `draft-visible-debt` (warn, source/source-static, external): Draft-authored IDs remain visible debt.
 - `fork-without-preserved-blaze` (error, source/source-static, external): Fork version entries preserve their historical blaze.
+- `governed-symbol-residue` (error, source/source-static, external): Active governed vocabulary symbol renames do not leave retired identifiers in source.
 - `marker-schema-unsupported` (error, source/source-static, external): Versioned schemas stay inside the supported marker projection subset.
 - `pending-force` (warn, topo/topo-aware, external): Forced topo break audit events do not remain pending indefinitely.
 - `scheduled-destroy-intent` (warn, topo/topo-aware, external): Schedule-activated destroy trails make unattended destructive work visible for review.

--- a/.changeset/trl-1120-governed-symbol-rename.md
+++ b/.changeset/trl-1120-governed-symbol-rename.md
@@ -1,0 +1,7 @@
+---
+'@ontrails/regrade': patch
+'@ontrails/warden': patch
+---
+
+Add governed AST identifier rename helpers and Warden residue detection for
+active vocabulary symbol transitions.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 68
+- Rule count: 69
 
 ## Agent Instructions
 
@@ -59,6 +59,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `draft-file-marking` (error, source/source-static, external): Draft-authored state is visibly marked in filenames.
 - `draft-visible-debt` (warn, source/source-static, external): Draft-authored IDs remain visible debt.
 - `fork-without-preserved-blaze` (error, source/source-static, external): Fork version entries preserve their historical blaze.
+- `governed-symbol-residue` (error, source/source-static, external): Active governed vocabulary symbol renames do not leave retired identifiers in source.
 - `marker-schema-unsupported` (error, source/source-static, external): Versioned schemas stay inside the supported marker projection subset.
 - `pending-force` (warn, topo/topo-aware, external): Forced topo break audit events do not remain pending indefinitely.
 - `scheduled-destroy-intent` (warn, topo/topo-aware, external): Schedule-activated destroy trails make unattended destructive work visible for review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ See [ADR-0050](docs/adr/0050-surface-accommodations-preserve-trail-identity.md) 
 This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
-- Rule count: 68
+- Rule count: 69
 
 ### Rule Index
 
@@ -154,6 +154,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `draft-file-marking` (error, source/source-static, external): Draft-authored state is visibly marked in filenames.
 - `draft-visible-debt` (warn, source/source-static, external): Draft-authored IDs remain visible debt.
 - `fork-without-preserved-blaze` (error, source/source-static, external): Fork version entries preserve their historical blaze.
+- `governed-symbol-residue` (error, source/source-static, external): Active governed vocabulary symbol renames do not leave retired identifiers in source.
 - `marker-schema-unsupported` (error, source/source-static, external): Versioned schemas stay inside the supported marker projection subset.
 - `pending-force` (warn, topo/topo-aware, external): Forced topo break audit events do not remain pending indefinitely.
 - `scheduled-destroy-intent` (warn, topo/topo-aware, external): Schedule-activated destroy trails make unattended destructive work visible for review.

--- a/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
+++ b/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import { createSourceEdit, getNodeName } from '@ontrails/warden/ast';
+import { getGovernedVocabularyTransition } from '@ontrails/warden';
 
 import {
   createAstIdentifierRenameClass,
   createAstRewriteClass,
+  createGovernedAstIdentifierRenameClasses,
 } from '../ast-rewrite.js';
 
 describe('createAstRewriteClass', () => {
@@ -149,6 +151,62 @@ describe('createAstIdentifierRenameClass', () => {
     );
   });
 
+  test('renames representative type-position symbols', () => {
+    const cls = createAstIdentifierRenameClass({
+      from: 'SourceType',
+      to: 'TargetType',
+    });
+    const result = cls.apply(
+      [
+        'type SourceAlias = SourceType;',
+        'interface Box extends SourceType {',
+        '  value: SourceType;',
+        '}',
+        'const value = {} as SourceType;',
+        '',
+      ].join('\n'),
+      { path: 'src/types.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        'type SourceAlias = TargetType;',
+        'interface Box extends TargetType {',
+        '  value: TargetType;',
+        '}',
+        'const value = {} as TargetType;',
+        '',
+      ].join('\n')
+    );
+  });
+
+  test('does not rewrite comments or string literal text', () => {
+    const cls = createAstIdentifierRenameClass({
+      from: 'sourceTerm',
+      to: 'targetTerm',
+    });
+    const result = cls.apply(
+      [
+        '// sourceTerm remains prose',
+        'const label = "sourceTerm remains a string";',
+        'const sourceTerm = 1;',
+        '',
+      ].join('\n'),
+      { path: 'src/sourceTerm.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        '// sourceTerm remains prose',
+        'const label = "sourceTerm remains a string";',
+        'const targetTerm = 1;',
+        '',
+      ].join('\n')
+    );
+  });
+
   test('routes configured shadowed declarations to review', () => {
     const cls = createAstIdentifierRenameClass({
       from: 'sourceTerm',
@@ -178,7 +236,7 @@ describe('createAstIdentifierRenameClass', () => {
         expectedTarget: 'Rename identifier "sourceTerm" to "targetTerm".',
         nodeKind: 'Identifier',
         reason: 'ast-identifier-review-declaration',
-        span: { column: 16, end: 118, line: 3, start: 96 },
+        span: { column: 16, end: 106, line: 3, start: 96 },
         suggestedValidation: 'bun run typecheck',
         symbol: 'sourceTerm',
       },
@@ -190,6 +248,94 @@ describe('createAstIdentifierRenameClass', () => {
         span: { column: 10, end: 141, line: 4, start: 131 },
         suggestedValidation: 'bun run typecheck',
         symbol: 'sourceTerm',
+      },
+    ]);
+  });
+
+  test('creates governed identifier rename classes from registry symbols', () => {
+    const transition = getGovernedVocabularyTransition('v1-facet-trailhead');
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected facet vocabulary transition.');
+    }
+
+    const classes = createGovernedAstIdentifierRenameClasses(transition);
+    const facetIdClass = classes.find((cls) =>
+      cls.id.includes('facetId->trailheadId')
+    );
+    expect(facetIdClass).toBeDefined();
+    if (facetIdClass === undefined) {
+      throw new Error('Expected facetId rename class.');
+    }
+
+    const result = facetIdClass.apply(
+      [
+        'export interface FacetRecord { facetId: string }',
+        'export const current = { facetId: "manual" };',
+        '',
+      ].join('\n'),
+      { path: 'src/facets.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        'export interface FacetRecord { trailheadId: string }',
+        'export const current = { trailheadId: "manual" };',
+        '',
+      ].join('\n')
+    );
+  });
+
+  test('routes governed registry shadow declarations to review', () => {
+    const transition = getGovernedVocabularyTransition('cross-compose');
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected cross vocabulary transition.');
+    }
+
+    const classes = createGovernedAstIdentifierRenameClasses(transition);
+    const crossInputClass = classes.find((cls) =>
+      cls.id.includes('crossInput->composeInput')
+    );
+    expect(crossInputClass).toBeDefined();
+    if (crossInputClass === undefined) {
+      throw new Error('Expected crossInput rename class.');
+    }
+
+    const result = crossInputClass.apply(
+      [
+        "import { crossInput } from './composition';",
+        'export const current = crossInput;',
+        'function local(crossInput: string) {',
+        '  return crossInput;',
+        '}',
+        '',
+      ].join('\n'),
+      { path: 'src/composition.ts' }
+    );
+
+    expect(result.kind).toBe('needs-review');
+    expect(result.reason).toBe('ast-identifier-review-declaration');
+    expect(result.nextSource).toBeUndefined();
+    expect(result.reviewDetails).toEqual([
+      {
+        classId: 'ast-symbol-rename:cross-compose:crossInput->composeInput',
+        expectedTarget: 'Rename identifier "crossInput" to "composeInput".',
+        nodeKind: 'Identifier',
+        reason: 'ast-identifier-review-declaration',
+        span: { column: 16, end: 104, line: 3, start: 94 },
+        suggestedValidation: 'bun run typecheck',
+        symbol: 'crossInput',
+      },
+      {
+        classId: 'ast-symbol-rename:cross-compose:crossInput->composeInput',
+        expectedTarget: 'Rename identifier "crossInput" to "composeInput".',
+        nodeKind: 'Identifier',
+        reason: 'ast-identifier-review-declaration',
+        span: { column: 10, end: 135, line: 4, start: 125 },
+        suggestedValidation: 'bun run typecheck',
+        symbol: 'crossInput',
       },
     ]);
   });

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -256,6 +256,7 @@ describe('wardenTermRewriteClasses', () => {
     });
 
     expect(report.selectedClassIds).toEqual([
+      'term-rewrite:governed-symbol-residue',
       'term-rewrite:no-legacy-layer-imports',
       'term-rewrite:no-retired-cross-vocabulary',
     ]);

--- a/packages/regrade/src/downstream/ast-rewrite.ts
+++ b/packages/regrade/src/downstream/ast-rewrite.ts
@@ -12,6 +12,7 @@ import {
   validateSourceEdits,
   walkWithScopeContext,
 } from '@ontrails/warden/ast';
+import type { GovernedVocabularyTransition } from '@ontrails/warden';
 
 import type {
   RegradeClass,
@@ -237,6 +238,17 @@ export interface AstIdentifierRenameClassOptions {
 const isIdentifierNamed = (node: AstNode, name: string): boolean =>
   node.type === 'Identifier' && identifierName(node) === name;
 
+const identifierTokenSpan = (
+  node: AstNode,
+  source: string,
+  name: string
+): { readonly end: number; readonly start: number } | null => {
+  const end = node.start + name.length;
+  return source.slice(node.start, end) === name
+    ? { end, start: node.start }
+    : null;
+};
+
 export const createAstIdentifierRenameClass = (
   options: AstIdentifierRenameClassOptions
 ): RegradeClass => {
@@ -253,9 +265,32 @@ export const createAstIdentifierRenameClass = (
         return null;
       }
 
+      const span = identifierTokenSpan(node, context.source, options.from);
+      if (span === null) {
+        const location = offsetToLineColumn(context.source, node.start);
+        return {
+          detail: {
+            expectedTarget: `Rename identifier "${options.from}" to "${options.to}".`,
+            nodeKind: node.type,
+            reason: 'ast-identifier-token-span-unverified',
+            span: {
+              column: location.column,
+              end: node.end,
+              line: location.line,
+              start: node.start,
+            },
+            suggestedValidation: 'bun run typecheck',
+            symbol: options.from,
+          },
+          kind: 'review',
+          note: `Identifier "${options.from}" token span could not be verified; routed to review.`,
+          reason: 'ast-identifier-token-span-unverified',
+        };
+      }
+
       const declaration = context.getDeclaration(options.from);
       if (declaration && reviewDeclarationTypes.has(declaration.type)) {
-        const location = offsetToLineColumn(context.source, node.start);
+        const location = offsetToLineColumn(context.source, span.start);
         return {
           detail: {
             expectedTarget: `Rename identifier "${options.from}" to "${options.to}".`,
@@ -263,9 +298,9 @@ export const createAstIdentifierRenameClass = (
             reason: 'ast-identifier-review-declaration',
             span: {
               column: location.column,
-              end: node.end,
+              end: span.end,
               line: location.line,
-              start: node.start,
+              start: span.start,
             },
             suggestedValidation: 'bun run typecheck',
             symbol: options.from,
@@ -277,10 +312,23 @@ export const createAstIdentifierRenameClass = (
       }
 
       return {
-        edit: createSourceEdit(node.start, node.end, options.to),
+        edit: createSourceEdit(span.start, span.end, options.to),
         kind: 'edit',
         note: `Renamed identifier "${options.from}" to "${options.to}".`,
       };
     },
   });
 };
+
+export const createGovernedAstIdentifierRenameClasses = (
+  transition: GovernedVocabularyTransition
+): readonly RegradeClass[] =>
+  transition.symbolRenames.map((rename) =>
+    createAstIdentifierRenameClass({
+      describe: `Rename governed symbol "${rename.from}" to "${rename.to}" for ${transition.id}.`,
+      from: rename.from,
+      id: `ast-symbol-rename:${transition.id}:${rename.from}->${rename.to}`,
+      reviewDeclarationTypes: new Set(rename.reviewDeclarationTypes),
+      to: rename.to,
+    })
+  );

--- a/packages/regrade/src/index.ts
+++ b/packages/regrade/src/index.ts
@@ -55,6 +55,7 @@ export type {
 export {
   createAstIdentifierRenameClass,
   createAstRewriteClass,
+  createGovernedAstIdentifierRenameClasses,
 } from './downstream/ast-rewrite.js';
 export type {
   AstIdentifierRenameClassOptions,

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -1326,6 +1326,47 @@ describe('applySafeFixesToFiles', () => {
     }
   });
 
+  test('dedupes identical safe edits from multiple diagnostics', async () => {
+    const dir = makeTempDir();
+    try {
+      const filePath = join(dir, 'entity.ts');
+      writeFileSync(filePath, 'const signal = 1;');
+      const first: WardenDiagnostic = {
+        filePath,
+        fix: {
+          class: 'term-rewrite',
+          edits: [{ end: 12, replacement: 'ping', start: 6 }],
+          reason: 'rename signal to ping',
+          safety: 'safe',
+        },
+        line: 1,
+        message: 'rename signal',
+        rule: 'synthetic-safe-fix',
+        severity: 'warn',
+      };
+      const second: WardenDiagnostic = {
+        ...first,
+        message: 'rename signal from another rule',
+        rule: 'synthetic-overlapping-safe-fix',
+      };
+
+      const summary = await applySafeFixesToFiles([first, second], {
+        allowedFilePaths: [filePath],
+        rootDir: dir,
+      });
+
+      expect(summary).toMatchObject({
+        applied: 2,
+        filesChanged: 1,
+        skipped: 0,
+      });
+      expect(summary.appliedDiagnostics).toEqual([first, second]);
+      expect(readFileSync(filePath, 'utf8')).toBe('const ping = 1;');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('leaves review-only and edit-less fixes unapplied and counted as skipped', async () => {
     const dir = makeTempDir();
     try {

--- a/packages/warden/src/__tests__/governed-symbol-residue.test.ts
+++ b/packages/warden/src/__tests__/governed-symbol-residue.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+
+import { governedSymbolResidue } from '../rules/governed-symbol-residue.js';
+
+const check = (sourceCode: string) =>
+  governedSymbolResidue.check(sourceCode, '/repo/src/example.ts');
+
+describe('governed-symbol-residue', () => {
+  test('does not duplicate cross-compose fixes owned by the beta.19 rule', () => {
+    const diagnostics = check(
+      [
+        'const crossInput = { id: "track" };',
+        'export const run = () => ctx.cross(loadTrack, crossInput);',
+        '',
+      ].join('\n')
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('does not flag prose, strings, or planned v1 symbols before activation', () => {
+    const diagnostics = check(
+      [
+        'const message = "crossInput and ctx.cross in prose";',
+        'const facet = "planned but not active yet";',
+        'const facets = ["still planned"];',
+        '',
+      ].join('\n')
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('allows the governed vocabulary registry to name retired symbols', () => {
+    const diagnostics = governedSymbolResidue.check(
+      [
+        'const safeRewriteForms = [{ from: "crossInput", to: "composeInput" }];',
+        'const reviewForms = [{ from: "crosses", to: "composes" }];',
+        '',
+      ].join('\n'),
+      '/repo/packages/warden/src/rules/retired-vocabulary.ts'
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('ignores parse failures because parser diagnostics belong elsewhere', () => {
+    expect(check('export const = ;')).toEqual([]);
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -9,8 +9,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 68 rule trails', () => {
-    expect(wardenTopo.count).toBe(68);
+  test('contains all 69 rule trails', () => {
+    expect(wardenTopo.count).toBe(69);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/fix.ts
+++ b/packages/warden/src/fix.ts
@@ -95,16 +95,22 @@ export const applySafeFixesToSource = (
   const applied: WardenDiagnostic[] = [];
   const skipped: WardenDiagnostic[] = [];
   const edits: ResolvedEdit[] = [];
+  const seenEdits = new Set<string>();
 
   for (const diagnostic of diagnostics) {
     if (hasSafeFixEdits(diagnostic)) {
       applied.push(diagnostic);
       for (const edit of diagnostic.fix.edits) {
-        edits.push({
+        const resolvedEdit = {
           end: edit.end,
           replacement: edit.replacement,
           start: edit.start,
-        });
+        };
+        const key = `${String(resolvedEdit.start)}\0${String(resolvedEdit.end)}\0${resolvedEdit.replacement}`;
+        if (!seenEdits.has(key)) {
+          seenEdits.add(key);
+          edits.push(resolvedEdit);
+        }
       }
     } else {
       skipped.push(diagnostic);

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -39,6 +39,7 @@ export {
   getGovernedVocabularyTransition,
   governedVocabularyPreserveRuleSchema,
   governedVocabularyRegistrySchema,
+  governedVocabularySymbolRenameSchema,
   governedVocabularyTargetSchema,
   governedVocabularyTransitionSchema,
   governedVocabularyTransitionStatuses,
@@ -58,6 +59,7 @@ export {
 } from './rules/index.js';
 export type {
   GovernedVocabularyPreserveRule,
+  GovernedVocabularySymbolRename,
   GovernedVocabularyTarget,
   GovernedVocabularyTransition,
   GovernedVocabularyTransitionInput,
@@ -199,6 +201,7 @@ export {
   exampleValidTrail,
   firesDeclarationsTrail,
   forkWithoutPreservedBlazeTrail,
+  governedSymbolResidueTrail,
   implementationReturnsResultTrail,
   incompleteAccessorForStandardOpTrail,
   incompleteCrudTrail,

--- a/packages/warden/src/rules/governed-symbol-residue.ts
+++ b/packages/warden/src/rules/governed-symbol-residue.ts
@@ -1,0 +1,131 @@
+import {
+  identifierName,
+  offsetToLine,
+  parseWithDiagnostics,
+  walk,
+} from './ast.js';
+import type { AstNode } from './ast.js';
+import { listGovernedVocabularyTransitions } from './retired-vocabulary.js';
+import type {
+  GovernedVocabularySymbolRename,
+  GovernedVocabularyTransition,
+} from './retired-vocabulary.js';
+import type { WardenDiagnostic, WardenFix, WardenRule } from './types.js';
+
+const RULE_NAME = 'governed-symbol-residue';
+
+const ACTIVE_STATUSES = new Set<GovernedVocabularyTransition['status']>([
+  'active',
+  'complete',
+]);
+
+const FIX_OWNED_TRANSITION_IDS = new Set(['cross-compose']);
+
+const ALLOWED_SOURCE_PATH_SUFFIXES = [
+  '/packages/warden/src/rules/governed-symbol-residue.ts',
+  '/packages/warden/src/rules/retired-vocabulary.ts',
+] as const;
+
+const normalizePath = (filePath: string): string =>
+  filePath.replaceAll('\\', '/');
+
+const isAllowedSourcePath = (filePath: string): boolean =>
+  ALLOWED_SOURCE_PATH_SUFFIXES.some((suffix) =>
+    normalizePath(filePath).endsWith(suffix)
+  );
+
+const activeSymbolRenames = (): readonly GovernedVocabularySymbolRename[] =>
+  listGovernedVocabularyTransitions()
+    .filter(
+      (transition) =>
+        ACTIVE_STATUSES.has(transition.status) &&
+        !FIX_OWNED_TRANSITION_IDS.has(transition.id)
+    )
+    .flatMap((transition) => transition.symbolRenames);
+
+const renameBySourceSymbol = (): ReadonlyMap<
+  string,
+  GovernedVocabularySymbolRename
+> =>
+  new Map(
+    activeSymbolRenames().map((rename) => [rename.from, rename] as const)
+  );
+
+const safeFixFor = (
+  sourceCode: string,
+  node: AstNode,
+  rename: GovernedVocabularySymbolRename
+): WardenFix | undefined => {
+  const end = node.start + rename.from.length;
+  if (sourceCode.slice(node.start, end) !== rename.from) {
+    return undefined;
+  }
+  return {
+    class: 'term-rewrite',
+    edits: [
+      {
+        end,
+        replacement: rename.to,
+        start: node.start,
+      },
+    ],
+    reason: `Retired governed symbol '${rename.from}' has a mechanical replacement '${rename.to}'.`,
+    safety: 'safe',
+  };
+};
+
+const diagnosticFor = (
+  sourceCode: string,
+  filePath: string,
+  node: AstNode,
+  rename: GovernedVocabularySymbolRename
+): WardenDiagnostic => {
+  const fix = safeFixFor(sourceCode, node, rename);
+  return {
+    filePath,
+    ...(fix === undefined ? {} : { fix }),
+    line: offsetToLine(sourceCode, node.start),
+    message: `Retired governed symbol '${rename.from}' should migrate to '${rename.to}'.`,
+    rule: RULE_NAME,
+    severity: 'error',
+  };
+};
+
+export const governedSymbolResidue: WardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    if (isAllowedSourcePath(filePath)) {
+      return [];
+    }
+
+    const renames = renameBySourceSymbol();
+    if (renames.size === 0) {
+      return [];
+    }
+
+    const parsed = parseWithDiagnostics(filePath, sourceCode);
+    if (!parsed.ast || parsed.diagnostics.length > 0) {
+      return [];
+    }
+
+    const diagnostics: WardenDiagnostic[] = [];
+    walk(parsed.ast, (node) => {
+      const name = identifierName(node);
+      if (name === null) {
+        return;
+      }
+
+      const rename = renames.get(name);
+      if (rename === undefined) {
+        return;
+      }
+
+      diagnostics.push(diagnosticFor(sourceCode, filePath, node, rename));
+    });
+
+    return diagnostics;
+  },
+  description:
+    'Detect active governed vocabulary symbols that remain in source code.',
+  name: RULE_NAME,
+  severity: 'error',
+};

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -12,6 +12,7 @@ import { duplicatePublicContract } from './duplicate-public-contract.js';
 import { errorMappingCompleteness } from './error-mapping-completeness.js';
 import { exampleValid } from './example-valid.js';
 import { firesDeclarations } from './fires-declarations.js';
+import { governedSymbolResidue } from './governed-symbol-residue.js';
 import { implementationReturnsResult } from './implementation-returns-result.js';
 import { incompleteAccessorForStandardOp } from './incomplete-accessor-for-standard-op.js';
 import { incompleteCrud } from './incomplete-crud.js';
@@ -100,6 +101,7 @@ export {
   getGovernedVocabularyTransition,
   governedVocabularyPreserveRuleSchema,
   governedVocabularyRegistrySchema,
+  governedVocabularySymbolRenameSchema,
   governedVocabularyTargetSchema,
   governedVocabularyTransitionSchema,
   governedVocabularyTransitionStatuses,
@@ -109,6 +111,7 @@ export {
 } from './retired-vocabulary.js';
 export type {
   GovernedVocabularyPreserveRule,
+  GovernedVocabularySymbolRename,
   GovernedVocabularyTarget,
   GovernedVocabularyTransition,
   GovernedVocabularyTransitionInput,
@@ -141,6 +144,7 @@ export { duplicatePublicContract } from './duplicate-public-contract.js';
 export { errorMappingCompleteness } from './error-mapping-completeness.js';
 export { exampleValid } from './example-valid.js';
 export { firesDeclarations } from './fires-declarations.js';
+export { governedSymbolResidue } from './governed-symbol-residue.js';
 export { incompleteAccessorForStandardOp } from './incomplete-accessor-for-standard-op.js';
 export { incompleteCrud } from './incomplete-crud.js';
 export { intentPropagation } from './intent-propagation.js';
@@ -213,6 +217,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [errorMappingCompleteness.name, errorMappingCompleteness],
   [exampleValid.name, exampleValid],
   [firesDeclarations.name, firesDeclarations],
+  [governedSymbolResidue.name, governedSymbolResidue],
   [incompleteCrud.name, incompleteCrud],
   [intentPropagation.name, intentPropagation],
   [layerFieldNameDrift.name, layerFieldNameDrift],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -80,6 +80,7 @@ const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
   'error-mapping-completeness': 'results',
   'fires-declarations': 'signals',
   'fork-without-preserved-blaze': 'lifecycle',
+  'governed-symbol-residue': 'lifecycle',
   'implementation-returns-result': 'results',
   'intent-propagation': 'composition',
   'library-projection-coherence': 'meta',
@@ -263,6 +264,13 @@ const builtinWardenRuleMetadataInput = {
   'fork-without-preserved-blaze': {
     ...durableExternal,
     invariant: 'Fork version entries preserve their historical blaze.',
+    tier: 'source-static',
+  },
+  'governed-symbol-residue': {
+    ...durableExternal,
+    fix: { class: 'term-rewrite', safety: 'safe' },
+    invariant:
+      'Active governed vocabulary symbol renames do not leave retired identifiers in source.',
     tier: 'source-static',
   },
   'implementation-returns-result': {

--- a/packages/warden/src/rules/no-retired-cross-vocabulary.ts
+++ b/packages/warden/src/rules/no-retired-cross-vocabulary.ts
@@ -37,6 +37,7 @@ const ALLOWED_PATH_SUFFIXES: readonly string[] = [
   '/packages/warden/src/rules/no-retired-cross-vocabulary.ts',
   '/packages/warden/src/rules/metadata.ts',
   '/packages/warden/src/rules/retired-vocabulary.ts',
+  '/packages/warden/src/trails/governed-symbol-residue.trail.ts',
   '/packages/warden/src/trails/no-retired-cross-vocabulary.trail.ts',
   '/scripts/vocab-cutover-rewrite.ts',
 ];

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -20,6 +20,7 @@ import { duplicatePublicContract } from './duplicate-public-contract.js';
 import { errorMappingCompleteness } from './error-mapping-completeness.js';
 import { exampleValid } from './example-valid.js';
 import { firesDeclarations } from './fires-declarations.js';
+import { governedSymbolResidue } from './governed-symbol-residue.js';
 import { implementationReturnsResult } from './implementation-returns-result.js';
 import { incompleteAccessorForStandardOp } from './incomplete-accessor-for-standard-op.js';
 import { incompleteCrud } from './incomplete-crud.js';
@@ -100,6 +101,7 @@ export const registeredRuleNames: readonly string[] = [
   errorMappingCompleteness.name,
   exampleValid.name,
   firesDeclarations.name,
+  governedSymbolResidue.name,
   forkWithoutPreservedBlaze.name,
   implementationReturnsResult.name,
   incompleteAccessorForStandardOp.name,

--- a/packages/warden/src/rules/retired-vocabulary.ts
+++ b/packages/warden/src/rules/retired-vocabulary.ts
@@ -35,6 +35,12 @@ export const governedVocabularyPreserveRuleSchema = z.object({
   reason: z.string().min(1),
 });
 
+export const governedVocabularySymbolRenameSchema = z.object({
+  from: z.string().min(1),
+  reviewDeclarationTypes: z.array(z.string().min(1)).default([]),
+  to: z.string().min(1),
+});
+
 export const governedVocabularyTransitionSchema = z.object({
   codeIdentifiers: z.array(z.string().min(1)).default([]),
   docs: z.object({
@@ -51,6 +57,7 @@ export const governedVocabularyTransitionSchema = z.object({
   reviewForms: z.array(z.string().min(1)).default([]),
   safeRewriteForms: z.record(z.string().min(1), z.string().min(1)).default({}),
   status: z.enum(governedVocabularyTransitionStatuses),
+  symbolRenames: z.array(governedVocabularySymbolRenameSchema).default([]),
   target: governedVocabularyTargetSchema,
 });
 
@@ -87,6 +94,9 @@ export type GovernedVocabularyPreserveRule = z.output<
 export type GovernedVocabularyTarget = z.output<
   typeof governedVocabularyTargetSchema
 >;
+export type GovernedVocabularySymbolRename = z.output<
+  typeof governedVocabularySymbolRenameSchema
+>;
 export type GovernedVocabularyTransition = z.output<
   typeof governedVocabularyTransitionSchema
 >;
@@ -98,6 +108,10 @@ const defineTransition = (
   input: GovernedVocabularyTransitionInput
 ): GovernedVocabularyTransition =>
   governedVocabularyTransitionSchema.parse(input);
+
+const reviewFunctionParamDeclarations = {
+  reviewDeclarationTypes: ['FunctionParam'],
+};
 
 export const governedVocabularyTransitions =
   governedVocabularyRegistrySchema.parse([
@@ -124,6 +138,15 @@ export const governedVocabularyTransitions =
         'ctx.cross': 'ctx.compose',
       },
       status: 'complete',
+      symbolRenames: [
+        { ...reviewFunctionParamDeclarations, from: 'cross', to: 'compose' },
+        {
+          ...reviewFunctionParamDeclarations,
+          from: 'crossInput',
+          to: 'composeInput',
+        },
+        { ...reviewFunctionParamDeclarations, from: 'crosses', to: 'composes' },
+      ],
       target: { kind: 'single', to: 'compose' },
     }),
     defineTransition({
@@ -148,6 +171,18 @@ export const governedVocabularyTransitions =
         blazes: 'implementations',
       },
       status: 'planned',
+      symbolRenames: [
+        {
+          ...reviewFunctionParamDeclarations,
+          from: 'blaze',
+          to: 'implementation',
+        },
+        {
+          ...reviewFunctionParamDeclarations,
+          from: 'blazes',
+          to: 'implementations',
+        },
+      ],
       target: { kind: 'single', to: 'implementation' },
     }),
     defineTransition({
@@ -171,6 +206,14 @@ export const governedVocabularyTransitions =
         contours: 'entities',
       },
       status: 'planned',
+      symbolRenames: [
+        { ...reviewFunctionParamDeclarations, from: 'contour', to: 'entity' },
+        {
+          ...reviewFunctionParamDeclarations,
+          from: 'contours',
+          to: 'entities',
+        },
+      ],
       target: { kind: 'single', to: 'entity' },
     }),
     defineTransition({
@@ -201,6 +244,24 @@ export const governedVocabularyTransitions =
         facets: 'trailheads',
       },
       status: 'planned',
+      symbolRenames: [
+        { ...reviewFunctionParamDeclarations, from: 'facet', to: 'trailhead' },
+        {
+          ...reviewFunctionParamDeclarations,
+          from: 'facets',
+          to: 'trailheads',
+        },
+        {
+          ...reviewFunctionParamDeclarations,
+          from: 'facetId',
+          to: 'trailheadId',
+        },
+        {
+          ...reviewFunctionParamDeclarations,
+          from: 'McpSurfaceFacetMap',
+          to: 'McpSurfaceTrailheadMap',
+        },
+      ],
       target: { kind: 'single', to: 'trailhead' },
     }),
     defineTransition({

--- a/packages/warden/src/trails/governed-symbol-residue.trail.ts
+++ b/packages/warden/src/trails/governed-symbol-residue.trail.ts
@@ -1,0 +1,24 @@
+import { governedSymbolResidue } from '../rules/governed-symbol-residue.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const governedSymbolResidueTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'packages/example/src/trails/play.ts',
+        sourceCode: 'const composeInput = { id: "track" };\n',
+      },
+      name: 'Current governed symbol vocabulary is clean',
+    },
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'packages/example/src/trails/play.ts',
+        sourceCode: 'const crossInput = { id: "track" };\n',
+      },
+      name: 'Cross-compose vocabulary is owned by the beta.19 rule',
+    },
+  ],
+  rule: governedSymbolResidue,
+});

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -14,6 +14,7 @@ export { errorMappingCompletenessTrail } from './error-mapping-completeness.trai
 export { exampleValidTrail } from './example-valid.trail.js';
 export { firesDeclarationsTrail } from './fires-declarations.trail.js';
 export { forkWithoutPreservedBlazeTrail } from './fork-without-preserved-blaze.trail.js';
+export { governedSymbolResidueTrail } from './governed-symbol-residue.trail.js';
 export { implementationReturnsResultTrail } from './implementation-returns-result.trail.js';
 export { incompleteAccessorForStandardOpTrail } from './incomplete-accessor-for-standard-op.trail.js';
 export { incompleteCrudTrail } from './incomplete-crud.trail.js';

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 68
+- Rule count: 69
 
 ## Agent Instructions
 
@@ -59,6 +59,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `draft-file-marking` (error, source/source-static, external): Draft-authored state is visibly marked in filenames.
 - `draft-visible-debt` (warn, source/source-static, external): Draft-authored IDs remain visible debt.
 - `fork-without-preserved-blaze` (error, source/source-static, external): Fork version entries preserve their historical blaze.
+- `governed-symbol-residue` (error, source/source-static, external): Active governed vocabulary symbol renames do not leave retired identifiers in source.
 - `marker-schema-unsupported` (error, source/source-static, external): Versioned schemas stay inside the supported marker projection subset.
 - `pending-force` (warn, topo/topo-aware, external): Forced topo break audit events do not remain pending indefinitely.
 - `scheduled-destroy-intent` (warn, topo/topo-aware, external): Schedule-activated destroy trails make unattended destructive work visible for review.


### PR DESCRIPTION
## Summary

Fixes [TRL-1120](https://linear.app/outfitter/issue/TRL-1120/).

- Hardens AST symbol rewrite edits to verified identifier token spans.
- Adds governed symbol rename classes derived from the vocabulary registry.
- Adds Warden `governed-symbol-residue` detection and regenerated Warden guides.

## Verification

- `bun test packages/warden/src/__tests__/governed-symbol-residue.test.ts packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts packages/warden/src/__tests__/retired-vocabulary.test.ts packages/regrade/src/downstream/__tests__/vocabulary.test.ts`
- `bun run warden:agents:check`
- `bun run warden:skills:check`
- `bun run changeset:check`
- Full stack: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`

## Notes

Local review reached clean state on round 2 after routing registry-owned function-parameter shadows to review instead of mechanical rewrite.