### PR TITLE
feat(regrade): classify vocabulary run dispositions

### DIFF
--- a/.changeset/trl-1122-regrade-dispositions.md
+++ b/.changeset/trl-1122-regrade-dispositions.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/regrade": patch
+"@ontrails/trails": patch
+---
+
+Expose vocabulary Regrade occurrence dispositions and disposition summary counts alongside mechanical verdicts.
+
+Accept explicit preserve-rule dispositions through the `trails regrade` CLI/MCP contract.

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -180,6 +180,10 @@ describe('Trails MCP surface shaping', () => {
       },
       type: 'object',
     });
+    expect(JSON.stringify(regrade.inputSchema)).toContain('disposition');
+    expect(JSON.stringify(regrade.inputSchema)).toContain(
+      'preserve-current-live-api'
+    );
 
     expect(warden.description).toBe('Run governance checks (lint + drift)');
     expect(warden.annotations).toEqual({
@@ -227,30 +231,77 @@ describe('Trails MCP surface shaping', () => {
   test('executes regrade through the MCP tool handler', async () => {
     const dir = makeTempDir();
     try {
-      writeFile(dir, 'src/surface.ts', 'export const facet = "facet";\n');
+      writeFile(
+        dir,
+        'src/surface.ts',
+        'export const facet = "facet";\nexport const facetId = facet;\n'
+      );
       const tools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
       const regrade = requireTool(tools, 'trails_regrade');
 
       const result = await regrade.handler(
-        { from: 'facet', rootDir: dir, to: 'trailhead' },
+        {
+          from: 'facet',
+          preserve: [
+            {
+              disposition: 'preserve-current-live-api',
+              pattern: '^facetId$',
+              reason: 'live-api-identifier',
+            },
+          ],
+          rootDir: dir,
+          to: 'trailhead',
+        },
         {}
       );
 
       expect(result.isError).toBeUndefined();
+      const structured = result.structuredContent as {
+        readonly run?: {
+          readonly ledger?: {
+            readonly occurrences?: readonly {
+              readonly disposition?: string;
+              readonly form?: string;
+              readonly verdict?: string;
+            }[];
+          };
+        };
+      };
       expect(result.structuredContent).toMatchObject({
         run: {
           plan: { from: 'facet', to: 'trailhead' },
           report: {
-            modified: 2,
-            open: 2,
+            dispositions: {
+              'in-family-modified': 3,
+              'preserve-current-live-api': 1,
+            },
+            gate: {
+              remainingByDisposition: { 'in-family-modified': 3 },
+            },
+            modified: 3,
+            open: 3,
           },
         },
         scan: {
-          byDirectory: [{ files: 1, occurrences: 2, path: 'src' }],
-          byExtension: [{ extension: '.ts', files: 1, occurrences: 2 }],
+          byDirectory: [{ files: 1, occurrences: 4, path: 'src' }],
+          byExtension: [{ extension: '.ts', files: 1, occurrences: 4 }],
           files: { matched: 1, scanned: 1, skipped: 0 },
         },
       });
+      expect(structured.run?.ledger?.occurrences).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            disposition: 'in-family-modified',
+            form: 'facet',
+            verdict: 'modified',
+          }),
+          expect.objectContaining({
+            disposition: 'preserve-current-live-api',
+            form: 'facetId',
+            verdict: 'skipped',
+          }),
+        ])
+      );
       expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
         'facet'
       );

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -138,26 +138,60 @@ describe('trails regrade', () => {
       });
       expect(
         result.value.run?.ledger.occurrences.map((occurrence) => ({
+          disposition: occurrence.disposition,
           form: occurrence.form,
           replacement: occurrence.replacement,
           verdict: occurrence.verdict,
         }))
       ).toEqual([
-        { form: 'facet', replacement: 'trailhead', verdict: 'modified' },
-        { form: 'facet', replacement: 'trailhead', verdict: 'modified' },
-        { form: 'facet', replacement: 'trailhead', verdict: 'modified' },
-        { form: 'facets', replacement: 'trailheads', verdict: 'modified' },
-        { form: 'facetId', replacement: undefined, verdict: 'deferred' },
+        {
+          disposition: 'in-family-modified',
+          form: 'facet',
+          replacement: 'trailhead',
+          verdict: 'modified',
+        },
+        {
+          disposition: 'in-family-modified',
+          form: 'facet',
+          replacement: 'trailhead',
+          verdict: 'modified',
+        },
+        {
+          disposition: 'in-family-modified',
+          form: 'facet',
+          replacement: 'trailhead',
+          verdict: 'modified',
+        },
+        {
+          disposition: 'in-family-modified',
+          form: 'facets',
+          replacement: 'trailheads',
+          verdict: 'modified',
+        },
+        {
+          disposition: 'in-family-unresolved',
+          form: 'facetId',
+          replacement: undefined,
+          verdict: 'deferred',
+        },
       ]);
       expect(result.value.run?.report).toMatchObject({
         applied: 0,
         deferred: 1,
+        dispositions: {
+          'in-family-modified': 4,
+          'in-family-unresolved': 1,
+        },
         gate: {
           reasons: [
             'safe-modifications-not-yet-applied',
             'deferred-forms-or-occurrences',
           ],
           remaining: 5,
+          remainingByDisposition: {
+            'in-family-modified': 4,
+            'in-family-unresolved': 1,
+          },
           status: 'open',
         },
         modified: 4,
@@ -359,6 +393,7 @@ describe('trails regrade', () => {
         include: ['src/**', 'docs/**'],
         preserve: [
           {
+            disposition: 'preserve-current-live-api',
             paths: ['src/**'],
             pattern: '^facetId$',
             reason: 'live-api-identifier',
@@ -381,6 +416,7 @@ describe('trails regrade', () => {
         readonly run?: {
           readonly ledger?: {
             readonly occurrences?: readonly {
+              readonly disposition: string;
               readonly form: string;
               readonly path: string;
               readonly reason: string;
@@ -389,6 +425,7 @@ describe('trails regrade', () => {
           };
           readonly plan?: {
             readonly preserve?: readonly {
+              readonly disposition?: string;
               readonly paths?: readonly string[];
               readonly pattern?: string;
               readonly reason?: string;
@@ -396,6 +433,7 @@ describe('trails regrade', () => {
           };
           readonly report?: {
             readonly deferred?: number;
+            readonly dispositions?: Readonly<Record<string, number>>;
             readonly modified?: number;
             readonly skipped?: number;
           };
@@ -403,6 +441,7 @@ describe('trails regrade', () => {
       };
       expect(parsed.run?.plan?.preserve).toEqual([
         {
+          disposition: 'preserve-current-live-api',
           paths: ['src/**'],
           pattern: '^facetId$',
           reason: 'live-api-identifier',
@@ -410,6 +449,7 @@ describe('trails regrade', () => {
       ]);
       expect(
         parsed.run?.ledger?.occurrences?.map((occurrence) => ({
+          disposition: occurrence.disposition,
           form: occurrence.form,
           path: occurrence.path,
           reason: occurrence.reason,
@@ -417,12 +457,14 @@ describe('trails regrade', () => {
         }))
       ).toEqual([
         {
+          disposition: 'in-family-unresolved',
           form: 'facetId',
           path: 'docs/surface.md',
           reason: 'unclassified-neighbor',
           verdict: 'deferred',
         },
         {
+          disposition: 'preserve-current-live-api',
           form: 'facetId',
           path: 'src/surface.ts',
           reason: 'live-api-identifier',
@@ -431,6 +473,10 @@ describe('trails regrade', () => {
       ]);
       expect(parsed.run?.report).toMatchObject({
         deferred: 1,
+        dispositions: {
+          'in-family-unresolved': 1,
+          'preserve-current-live-api': 1,
+        },
         modified: 0,
         skipped: 1,
       });
@@ -717,6 +763,17 @@ describe('trails regrade', () => {
     expect(parsed.command?.input?.properties).toHaveProperty('configPath');
     expect(parsed.command?.input?.properties).toHaveProperty('exclude');
     expect(parsed.command?.output?.properties).toHaveProperty('scan');
+    expect(JSON.stringify(parsed.command?.input)).toContain('disposition');
+    expect(JSON.stringify(parsed.command?.input)).toContain(
+      'preserve-current-live-api'
+    );
+    expect(JSON.stringify(parsed.command?.output)).toContain('dispositions');
+    expect(JSON.stringify(parsed.command?.output)).toContain(
+      'remainingByDisposition'
+    );
+    expect(JSON.stringify(parsed.command?.output)).toContain(
+      'in-family-unresolved'
+    );
     expect(parsed.command?.flags).toContainEqual(
       expect.objectContaining({
         name: 'config-path',

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -17,6 +17,7 @@ import {
   regradeReportOutput,
   runRegrade,
   runVocabularyRegrade,
+  vocabularyDispositionValues,
 } from '@ontrails/regrade';
 import type {
   RegradeReport,
@@ -41,6 +42,10 @@ const regradePathScopeInputSchema = pathScopeSchema.extend({
 });
 
 const regradePreserveRuleInputSchema = z.object({
+  disposition: z
+    .enum(vocabularyDispositionValues)
+    .optional()
+    .describe('Classification to assign to occurrences this rule preserves'),
   paths: z
     .array(z.string())
     .optional()
@@ -166,6 +171,9 @@ const vocabularyPreserveFromInput = (
     }
 
     return {
+      ...(rule.disposition === undefined
+        ? {}
+        : { disposition: rule.disposition }),
       ...(rule.paths === undefined ? {} : { paths: rule.paths }),
       pattern: rule.pattern,
       ...(rule.reason === undefined ? {} : { reason: rule.reason }),

--- a/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
+++ b/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
@@ -823,8 +823,14 @@ describe('runVocabularyRegrade', () => {
         'legacy facetId\nactive facetId\n'
       );
       expect(result.value?.run?.ledger.occurrences).toMatchObject([
-        { form: 'facetId', reason: 'legacy API name', verdict: 'skipped' },
         {
+          disposition: 'explicit-preserve',
+          form: 'facetId',
+          reason: 'legacy API name',
+          verdict: 'skipped',
+        },
+        {
+          disposition: 'in-family-unresolved',
           form: 'facetId',
           reason: 'unclassified-neighbor',
           verdict: 'deferred',
@@ -832,7 +838,15 @@ describe('runVocabularyRegrade', () => {
       ]);
       expect(result.value?.run?.report).toMatchObject({
         deferred: 1,
-        gate: { reasons: ['deferred-forms-or-occurrences'], status: 'open' },
+        dispositions: {
+          'explicit-preserve': 1,
+          'in-family-unresolved': 1,
+        },
+        gate: {
+          reasons: ['deferred-forms-or-occurrences'],
+          remainingByDisposition: { 'in-family-unresolved': 1 },
+          status: 'open',
+        },
         open: 1,
         skipped: 1,
       });
@@ -952,6 +966,25 @@ describe('runVocabularyRegrade', () => {
       expect(emptyPreserve.isErr()).toBe(true);
       if (emptyPreserve.isErr()) {
         expect(emptyPreserve.error.constructor.name).toBe('ValidationError');
+      }
+
+      const invalidDisposition = runVocabularyRegrade({
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          preserve: [{ disposition: 'bogus', pattern: 'facet' }],
+          to: 'trailhead',
+        } as Parameters<typeof runVocabularyRegrade>[0]['plan'],
+        root: dir,
+      });
+      expect(invalidDisposition.isErr()).toBe(true);
+      if (invalidDisposition.isErr()) {
+        expect(invalidDisposition.error.constructor.name).toBe(
+          'ValidationError'
+        );
+        expect(invalidDisposition.error.message).toContain(
+          'preserve disposition "bogus" is not supported'
+        );
       }
     } finally {
       rmSync(dir, { force: true, recursive: true });

--- a/packages/regrade/src/downstream/vocabulary.ts
+++ b/packages/regrade/src/downstream/vocabulary.ts
@@ -19,7 +19,25 @@ import { buildRegradeScanSummary } from './scan-summary.js';
 
 export type VocabularyVerdict = 'deferred' | 'modified' | 'skipped';
 
+export const vocabularyDispositionValues = [
+  'code-context-out-of-engine',
+  'docs-only',
+  'explicit-preserve',
+  'forward-pointer',
+  'ignored-by-scope',
+  'in-family-modified',
+  'in-family-unresolved',
+  'out-of-family',
+  'preserve-current-live-api',
+] as const;
+
+export type VocabularyDisposition =
+  (typeof vocabularyDispositionValues)[number];
+
+const vocabularyDispositions = new Set<string>(vocabularyDispositionValues);
+
 export interface VocabularyPreserveRule {
+  readonly disposition?: VocabularyDisposition;
   readonly pattern: string;
   readonly reason?: string;
   readonly paths?: readonly string[];
@@ -53,6 +71,7 @@ export interface VocabularyRegradePlan {
 export interface VocabularyOccurrence {
   readonly column: number;
   readonly context: string;
+  readonly disposition: VocabularyDisposition;
   readonly end: number;
   readonly form: string;
   readonly line: number;
@@ -71,6 +90,9 @@ export interface VocabularyRunLedger {
 
 export interface VocabularyRunGate {
   readonly remaining: number;
+  readonly remainingByDisposition: Partial<
+    Readonly<Record<VocabularyDisposition, number>>
+  >;
   readonly reasons: readonly string[];
   readonly status: 'green' | 'open';
 }
@@ -78,6 +100,9 @@ export interface VocabularyRunGate {
 export interface VocabularyRunReport {
   readonly applied: number;
   readonly deferred: number;
+  readonly dispositions: Partial<
+    Readonly<Record<VocabularyDisposition, number>>
+  >;
   readonly filesChanged: number;
   readonly gate: VocabularyRunGate;
   readonly modified: number;
@@ -101,7 +126,10 @@ interface SourceOccurrence extends VocabularyOccurrence {
   readonly absolutePath: string;
 }
 
-type SourceOccurrenceDraft = Omit<SourceOccurrence, 'reason' | 'verdict'>;
+type SourceOccurrenceDraft = Omit<
+  SourceOccurrence,
+  'disposition' | 'reason' | 'verdict'
+>;
 
 interface VocabularyEvaluation {
   readonly entries: readonly RegradeReportEntry[];
@@ -128,6 +156,23 @@ const VOCABULARY_SOURCE_EXTENSIONS = Object.freeze([
 
 const uniqueSorted = (values: readonly string[]): readonly string[] =>
   [...new Set(values)].toSorted((a, b) => a.localeCompare(b));
+
+const vocabularyDispositionCounts = (
+  occurrences: readonly VocabularyOccurrence[]
+): Partial<Readonly<Record<VocabularyDisposition, number>>> => {
+  const counts = new Map<VocabularyDisposition, number>();
+  for (const occurrence of occurrences) {
+    counts.set(
+      occurrence.disposition,
+      (counts.get(occurrence.disposition) ?? 0) + 1
+    );
+  }
+  return Object.fromEntries(
+    [...counts.entries()].toSorted(([left], [right]) =>
+      left.localeCompare(right)
+    )
+  );
+};
 
 const isVocabularyTokenCharacter = (value: string): boolean =>
   /[A-Za-z0-9_$-]/.test(value);
@@ -296,6 +341,23 @@ const capturedVocabularyVerdict = (
   return 'modified';
 };
 
+const vocabularyOccurrenceDisposition = (
+  verdict: VocabularyVerdict,
+  preserveRule: VocabularyPreserveRule | undefined,
+  markdownCodeContext: boolean
+): VocabularyDisposition => {
+  if (preserveRule !== undefined) {
+    return preserveRule.disposition ?? 'explicit-preserve';
+  }
+  if (markdownCodeContext) {
+    return 'code-context-out-of-engine';
+  }
+  if (verdict === 'modified') {
+    return 'in-family-modified';
+  }
+  return 'in-family-unresolved';
+};
+
 const preserveCase = (sourceForm: string, replacement: string): string => {
   if (sourceForm.toUpperCase() === sourceForm) {
     return replacement.toUpperCase();
@@ -384,6 +446,16 @@ const validateVocabularyPlan = (
         )
       );
     }
+    if (
+      rule.disposition !== undefined &&
+      !vocabularyDispositions.has(rule.disposition)
+    ) {
+      return Result.err(
+        new ValidationError(
+          `Vocabulary Regrade plan preserve disposition "${rule.disposition}" is not supported.`
+        )
+      );
+    }
   }
   return Result.ok();
 };
@@ -460,14 +532,25 @@ const deferredOccurrenceFromDraft = (
   reason = 'unclassified-neighbor'
 ): SourceOccurrence => {
   const preserveRule = preserveRuleForOccurrence(baseOccurrence, plan);
+  const markdownCodeContext = isMarkdownCodeContext(
+    file,
+    baseOccurrence.start,
+    baseOccurrence.end
+  );
+  const verdict = preserveRule === undefined ? 'deferred' : 'skipped';
   return {
     ...baseOccurrence,
+    disposition: vocabularyOccurrenceDisposition(
+      verdict,
+      preserveRule,
+      markdownCodeContext
+    ),
     reason: vocabularyOccurrenceReason(
       preserveRule,
-      isMarkdownCodeContext(file, baseOccurrence.start, baseOccurrence.end),
+      markdownCodeContext,
       reason
     ),
-    verdict: preserveRule === undefined ? 'deferred' : 'skipped',
+    verdict,
   };
 };
 
@@ -537,8 +620,17 @@ const occurrencesForFile = (
       };
       const preserveRule = preserveRuleForOccurrence(baseOccurrence, plan);
       const markdownCodeContext = isMarkdownCodeContext(file, start, end);
+      const verdict = capturedVocabularyVerdict(
+        preserveRule,
+        markdownCodeContext
+      );
       candidates.push({
         ...baseOccurrence,
+        disposition: vocabularyOccurrenceDisposition(
+          verdict,
+          preserveRule,
+          markdownCodeContext
+        ),
         reason: vocabularyOccurrenceReason(
           preserveRule,
           markdownCodeContext,
@@ -547,7 +639,7 @@ const occurrencesForFile = (
         ...(preserveRule === undefined && !markdownCodeContext
           ? { replacement: preserveCase(match[0], replacement) }
           : {}),
-        verdict: capturedVocabularyVerdict(preserveRule, markdownCodeContext),
+        verdict,
       });
     }
   }
@@ -791,6 +883,10 @@ const buildVocabularyEvaluation = (params: {
   const deferredOccurrences = occurrences.filter(
     (occurrence) => occurrence.verdict === 'deferred'
   );
+  const unresolvedOccurrences = occurrences.filter(
+    (occurrence) =>
+      occurrence.verdict === 'modified' || occurrence.verdict === 'deferred'
+  );
   const forms: Record<string, VocabularyVerdict> = {};
   for (const occurrence of occurrences) {
     const current = forms[occurrence.form];
@@ -817,7 +913,7 @@ const buildVocabularyEvaluation = (params: {
   if (deferredForms.length > 0) {
     gateReasons.push('deferred-forms-or-occurrences');
   }
-  const open = modifiedOccurrences.length + deferredOccurrences.length;
+  const open = unresolvedOccurrences.length;
 
   return {
     entries: [
@@ -846,10 +942,14 @@ const buildVocabularyEvaluation = (params: {
       report: {
         applied: params.apply === true ? modifiedOccurrences.length : 0,
         deferred: deferredOccurrences.length,
+        dispositions: vocabularyDispositionCounts(occurrences),
         filesChanged: params.apply === true ? rewrittenPaths.size : 0,
         gate: {
           reasons: gateReasons,
           remaining: open,
+          remainingByDisposition: vocabularyDispositionCounts(
+            unresolvedOccurrences
+          ),
           status: gateReasons.length === 0 ? 'green' : 'open',
         },
         modified: modifiedOccurrences.length,
@@ -1057,6 +1157,10 @@ export const runVocabularyRegrade = (params: {
 };
 
 const vocabularyPreserveRuleSchema = z.object({
+  disposition: z
+    .enum(vocabularyDispositionValues)
+    .optional()
+    .describe('Classification for occurrences preserved by this rule'),
   paths: z
     .array(z.string())
     .optional()
@@ -1064,6 +1168,15 @@ const vocabularyPreserveRuleSchema = z.object({
   pattern: z.string().describe('Regex or literal pattern to preserve'),
   reason: z.string().optional().describe('Why this form is preserved'),
 });
+
+const vocabularyDispositionCountSchema = z.object(
+  Object.fromEntries(
+    vocabularyDispositionValues.map((disposition) => [
+      disposition,
+      z.number().optional(),
+    ])
+  ) as Record<VocabularyDisposition, z.ZodOptional<z.ZodNumber>>
+);
 
 const vocabularyRegradeScopeSchema = z.object({
   exclude: z
@@ -1125,6 +1238,9 @@ export const vocabularyRegradeRunOutput = z.object({
           z.object({
             column: z.number().describe('One-based source column'),
             context: z.string().describe('Source-line context'),
+            disposition: z
+              .enum(vocabularyDispositionValues)
+              .describe('Occurrence-level classification beside the verdict'),
             end: z.number().describe('Source end offset'),
             form: z.string().describe('Matched vocabulary form'),
             line: z.number().describe('One-based source line'),
@@ -1148,11 +1264,17 @@ export const vocabularyRegradeRunOutput = z.object({
     .object({
       applied: z.number().describe('Modified occurrences applied to disk'),
       deferred: z.number().describe('Deferred occurrence count'),
+      dispositions: z
+        .object(vocabularyDispositionCountSchema.shape)
+        .describe('Occurrence counts grouped by disposition'),
       filesChanged: z.number().describe('Distinct files changed on disk'),
       gate: z
         .object({
           reasons: z.array(z.string()).describe('Open-gate reasons'),
           remaining: z.number().describe('Unresolved occurrence count'),
+          remainingByDisposition: z
+            .object(vocabularyDispositionCountSchema.shape)
+            .describe('Unresolved occurrence counts grouped by disposition'),
           status: z
             .enum(['green', 'open'])
             .describe('Whether the run is complete'),

--- a/packages/regrade/src/index.ts
+++ b/packages/regrade/src/index.ts
@@ -15,6 +15,7 @@ export {
 } from './downstream/report.js';
 export {
   runVocabularyRegrade,
+  vocabularyDispositionValues,
   vocabularyRegradePlanSchema,
   vocabularyRegradeRunOutput,
 } from './downstream/vocabulary.js';
@@ -42,6 +43,7 @@ export type {
   RegradeScanSummary,
 } from './downstream/scan-summary.js';
 export type {
+  VocabularyDisposition,
   VocabularyOccurrence,
   VocabularyPreserveRule,
   VocabularyRegradePlan,


### PR DESCRIPTION
## Summary

Fixes [TRL-1122](https://linear.app/outfitter/issue/TRL-1122/).

- Adds occurrence-level vocabulary dispositions beside mechanical Regrade verdicts.
- Reports disposition counts and gate remaining counts for CLI and MCP consumers.
- Exposes preserve dispositions through the public `trails regrade` input schema.

## Verification

- `bun test packages/regrade/src/downstream/__tests__/vocabulary.test.ts apps/trails/src/__tests__/regrade.test.ts apps/trails/src/__tests__/mcp.test.ts`
- `bun run --cwd packages/regrade typecheck`
- `bun run --cwd apps/trails typecheck`
- `bun run changeset:check`
- Full stack: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`

## Notes

Local review reached clean state on round 2 after exposing preserve dispositions and replacing sparse `partialRecord` output maps with finite optional-key schemas.