### PR TITLE
feat(regrade): derive live api preserve inventory

### DIFF
--- a/.changeset/trl-1118-regrade-live-api-preserve.md
+++ b/.changeset/trl-1118-regrade-live-api-preserve.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/regrade": patch
+"@ontrails/trails": patch
+---
+
+Expose derived live-API preserve inventory in vocabulary Regrade runs and have the Trails operator regrade surface derive current facet API preserves from live topo and MCP surface facts.

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -181,6 +181,7 @@ describe('Trails MCP surface shaping', () => {
       type: 'object',
     });
     expect(JSON.stringify(regrade.inputSchema)).toContain('disposition');
+    expect(JSON.stringify(regrade.inputSchema)).toContain('forms');
     expect(JSON.stringify(regrade.inputSchema)).toContain(
       'preserve-current-live-api'
     );
@@ -242,13 +243,6 @@ describe('Trails MCP surface shaping', () => {
       const result = await regrade.handler(
         {
           from: 'facet',
-          preserve: [
-            {
-              disposition: 'preserve-current-live-api',
-              pattern: '^facetId$',
-              reason: 'live-api-identifier',
-            },
-          ],
           rootDir: dir,
           to: 'trailhead',
         },
@@ -265,11 +259,26 @@ describe('Trails MCP surface shaping', () => {
               readonly verdict?: string;
             }[];
           };
+          readonly preserveInventory?: readonly {
+            readonly evidence?: readonly string[];
+            readonly pattern?: string;
+            readonly reason?: string;
+            readonly source?: string;
+          }[];
         };
       };
       expect(result.structuredContent).toMatchObject({
         run: {
           plan: { from: 'facet', to: 'trailhead' },
+          preserveInventory: expect.arrayContaining([
+            expect.objectContaining({
+              evidence: expect.arrayContaining(['topo.facet:inspect']),
+              paths: expect.arrayContaining(['**/*.ts']),
+              pattern: expect.stringContaining('facetId'),
+              reason: 'current-live-mcp-facet-field',
+              source: 'derived-live-api',
+            }),
+          ]),
           report: {
             dispositions: {
               'in-family-modified': 3,
@@ -304,6 +313,60 @@ describe('Trails MCP surface shaping', () => {
       );
       expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
         'facet'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('executes registry-backed regrade review forms through MCP', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/blaze.ts',
+        'export const blaze = "safe";\nexport const blazing = "review";\n'
+      );
+      const tools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
+      const regrade = requireTool(tools, 'trails_regrade');
+
+      const result = await regrade.handler(
+        {
+          from: 'blaze',
+          rootDir: dir,
+          to: 'implementation',
+        },
+        {}
+      );
+
+      expect(result.isError).toBeUndefined();
+      const structured = result.structuredContent as {
+        readonly run?: {
+          readonly ledger?: {
+            readonly forms?: Record<string, string>;
+            readonly occurrences?: readonly {
+              readonly form?: string;
+              readonly verdict?: string;
+            }[];
+          };
+          readonly plan?: {
+            readonly deferForms?: readonly string[];
+            readonly id?: string;
+          };
+        };
+      };
+      expect(structured.run?.plan).toMatchObject({
+        deferForms: expect.arrayContaining(['blazing']),
+        id: 'v1-blaze-implementation',
+      });
+      expect(structured.run?.ledger?.forms).toMatchObject({
+        blaze: 'modified',
+        blazing: 'deferred',
+      });
+      expect(structured.run?.ledger?.occurrences).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ form: 'blazing', verdict: 'deferred' }),
+        ])
       );
     } finally {
       rmSync(dir, { force: true, recursive: true });

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -131,10 +131,25 @@ describe('trails regrade', () => {
         kind: 'vocabulary',
         to: 'trailhead',
       });
+      expect(result.value.run?.preserveInventory).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            paths: expect.arrayContaining(['**/*.ts']),
+            pattern: expect.stringContaining('facetId'),
+            reason: 'current-live-mcp-facet-field',
+            source: 'derived-live-api',
+          }),
+          expect.objectContaining({
+            pattern: expect.stringContaining('wayfind\\.facets'),
+            reason: 'current-live-trail-id',
+            source: 'derived-live-api',
+          }),
+        ])
+      );
       expect(result.value.run?.ledger.forms).toEqual({
         facet: 'modified',
-        facetId: 'deferred',
-        facets: 'modified',
+        facetId: 'skipped',
+        facets: 'skipped',
       });
       expect(
         result.value.run?.ledger.occurrences.map((occurrence) => ({
@@ -143,60 +158,59 @@ describe('trails regrade', () => {
           replacement: occurrence.replacement,
           verdict: occurrence.verdict,
         }))
-      ).toEqual([
-        {
-          disposition: 'in-family-modified',
-          form: 'facet',
-          replacement: 'trailhead',
-          verdict: 'modified',
-        },
-        {
-          disposition: 'in-family-modified',
-          form: 'facet',
-          replacement: 'trailhead',
-          verdict: 'modified',
-        },
-        {
-          disposition: 'in-family-modified',
-          form: 'facet',
-          replacement: 'trailhead',
-          verdict: 'modified',
-        },
-        {
-          disposition: 'in-family-modified',
-          form: 'facets',
-          replacement: 'trailheads',
-          verdict: 'modified',
-        },
-        {
-          disposition: 'in-family-unresolved',
-          form: 'facetId',
-          replacement: undefined,
-          verdict: 'deferred',
-        },
-      ]);
+      ).toEqual(
+        expect.arrayContaining([
+          {
+            disposition: 'in-family-modified',
+            form: 'facet',
+            replacement: 'trailhead',
+            verdict: 'modified',
+          },
+          {
+            disposition: 'in-family-modified',
+            form: 'facet',
+            replacement: 'trailhead',
+            verdict: 'modified',
+          },
+          {
+            disposition: 'in-family-modified',
+            form: 'facet',
+            replacement: 'trailhead',
+            verdict: 'modified',
+          },
+          {
+            disposition: 'preserve-current-live-api',
+            form: 'facetId',
+            replacement: undefined,
+            verdict: 'skipped',
+          },
+          {
+            disposition: 'preserve-current-live-api',
+            form: 'facets',
+            replacement: undefined,
+            verdict: 'skipped',
+          },
+        ])
+      );
+      expect(result.value.run?.ledger.occurrences).toHaveLength(5);
       expect(result.value.run?.report).toMatchObject({
         applied: 0,
-        deferred: 1,
+        deferred: 0,
         dispositions: {
-          'in-family-modified': 4,
-          'in-family-unresolved': 1,
+          'in-family-modified': 3,
+          'preserve-current-live-api': 2,
         },
         gate: {
-          reasons: [
-            'safe-modifications-not-yet-applied',
-            'deferred-forms-or-occurrences',
-          ],
-          remaining: 5,
+          reasons: ['safe-modifications-not-yet-applied'],
+          remaining: 3,
           remainingByDisposition: {
-            'in-family-modified': 4,
-            'in-family-unresolved': 1,
+            'in-family-modified': 3,
           },
           status: 'open',
         },
-        modified: 4,
-        open: 5,
-        skipped: 0,
+        modified: 3,
+        open: 3,
+        skipped: 2,
       });
       expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
         'facet'
@@ -236,12 +250,13 @@ describe('trails regrade', () => {
         throw result.error;
       }
       expect(result.value.apply).toMatchObject({
-        applied: 5,
+        applied: 4,
         filesChanged: 2,
         review: 1,
+        skipped: 1,
       });
       expect(result.value.run?.report).toMatchObject({
-        applied: 5,
+        applied: 4,
         deferred: 1,
         gate: {
           reasons: ['deferred-forms-or-occurrences'],
@@ -250,9 +265,10 @@ describe('trails regrade', () => {
         },
         modified: 0,
         open: 1,
+        skipped: 1,
       });
       expect(readFileSync(join(dir, 'docs', 'surface.md'), 'utf8')).toBe(
-        'Trailhead docs mention trailhead and trailheads.\n'
+        'Facet docs mention trailhead and trailheads.\n'
       );
       expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
         'facetId'
@@ -294,6 +310,64 @@ describe('trails regrade', () => {
       expect(parsed.run?.report?.open).toBe(2);
       expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
         'facet'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI regrade uses governed registry review forms', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/blaze.ts',
+        'export const blaze = "safe";\nexport const blazing = "review";\n'
+      );
+
+      const result = runRawCli([
+        'regrade',
+        'blaze',
+        'implementation',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        readonly run?: {
+          readonly ledger?: {
+            readonly forms?: Record<string, string>;
+            readonly occurrences?: readonly {
+              readonly form?: string;
+              readonly verdict?: string;
+            }[];
+          };
+          readonly plan?: {
+            readonly deferForms?: readonly string[];
+            readonly id?: string;
+          };
+          readonly report?: {
+            readonly gate?: { readonly reasons?: readonly string[] };
+          };
+        };
+      };
+      expect(parsed.run?.plan).toMatchObject({
+        deferForms: expect.arrayContaining(['blazing']),
+        id: 'v1-blaze-implementation',
+      });
+      expect(parsed.run?.ledger?.forms).toMatchObject({
+        blaze: 'modified',
+        blazing: 'deferred',
+      });
+      expect(parsed.run?.ledger?.occurrences).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ form: 'blazing', verdict: 'deferred' }),
+        ])
+      );
+      expect(parsed.run?.report?.gate?.reasons).toContain(
+        'deferred-forms-or-occurrences'
       );
     } finally {
       rmSync(dir, { force: true, recursive: true });
@@ -431,6 +505,12 @@ describe('trails regrade', () => {
               readonly reason?: string;
             }[];
           };
+          readonly preserveInventory?: readonly {
+            readonly evidence?: readonly string[];
+            readonly pattern?: string;
+            readonly reason?: string;
+            readonly source?: string;
+          }[];
           readonly report?: {
             readonly deferred?: number;
             readonly dispositions?: Readonly<Record<string, number>>;
@@ -447,6 +527,16 @@ describe('trails regrade', () => {
           reason: 'live-api-identifier',
         },
       ]);
+      expect(parsed.run?.preserveInventory).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            paths: expect.arrayContaining(['**/*.ts']),
+            pattern: expect.stringContaining('facetId'),
+            reason: 'current-live-mcp-facet-field',
+            source: 'derived-live-api',
+          }),
+        ])
+      );
       expect(
         parsed.run?.ledger?.occurrences?.map((occurrence) => ({
           disposition: occurrence.disposition,
@@ -478,6 +568,189 @@ describe('trails regrade', () => {
           'preserve-current-live-api': 1,
         },
         modified: 0,
+        skipped: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('derived live API preserves match the occurrence span, not just the line', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/surface.ts',
+        [
+          "ctx.compose('wayfind.facets', { facets });",
+          'export type McpSurfaceFacetMap = Record<string, unknown>;',
+          'export interface Options {',
+          '  readonly facets?: McpSurfaceFacetMap | undefined;',
+          '}',
+          '',
+        ].join('\n')
+      );
+
+      const result = runRawCli([
+        'regrade',
+        '--root-dir',
+        dir,
+        'facet',
+        'trailhead',
+        '--apply',
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const source = readFileSync(join(dir, 'src', 'surface.ts'), 'utf8');
+      expect(source).toContain(
+        "ctx.compose('wayfind.facets', { trailheads });"
+      );
+      expect(source).toContain(
+        'readonly facets?: McpSurfaceFacetMap | undefined;'
+      );
+
+      const parsed = JSON.parse(result.stdout) as {
+        readonly run?: {
+          readonly ledger?: {
+            readonly occurrences?: readonly {
+              readonly context: string;
+              readonly form: string;
+              readonly reason: string;
+              readonly verdict: string;
+            }[];
+          };
+        };
+      };
+      const liveApiOccurrences = parsed.run?.ledger?.occurrences
+        ?.filter(
+          (occurrence) =>
+            occurrence.form === 'facets' ||
+            occurrence.form === 'McpSurfaceFacetMap'
+        )
+        .map((occurrence) => ({
+          context: occurrence.context,
+          form: occurrence.form,
+          reason: occurrence.reason,
+          verdict: occurrence.verdict,
+        }));
+      expect(liveApiOccurrences).toEqual(
+        expect.arrayContaining([
+          {
+            context: "ctx.compose('wayfind.facets', { trailheads });",
+            form: 'facets',
+            reason: 'current-live-trail-id',
+            verdict: 'skipped',
+          },
+          {
+            context:
+              'export type McpSurfaceFacetMap = Record<string, unknown>;',
+            form: 'McpSurfaceFacetMap',
+            reason: 'current-live-mcp-facet-type',
+            verdict: 'skipped',
+          },
+          {
+            context: 'readonly facets?: McpSurfaceFacetMap | undefined;',
+            form: 'facets',
+            reason: 'current-live-mcp-facets-property',
+            verdict: 'skipped',
+          },
+          {
+            context: 'readonly facets?: McpSurfaceFacetMap | undefined;',
+            form: 'McpSurfaceFacetMap',
+            reason: 'current-live-mcp-facet-type',
+            verdict: 'skipped',
+          },
+        ])
+      );
+      expect(
+        liveApiOccurrences?.every(
+          (occurrence) => occurrence.verdict === 'skipped'
+        )
+      ).toBe(true);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI forwards form-scoped preserve rules from input json', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/api.ts', 'export const legacyId = legacy;\n');
+
+      const result = runRawCli([
+        'regrade',
+        '--root-dir',
+        dir,
+        '--input-json',
+        JSON.stringify({
+          from: 'legacy',
+          include: ['src/**'],
+          preserve: [
+            {
+              disposition: 'preserve-current-live-api',
+              forms: ['legacyId'],
+              pattern: String.raw`\blegacyId\b\s*=`,
+              reason: 'current-live-api-field',
+            },
+          ],
+          to: 'current',
+        }),
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        readonly run?: {
+          readonly ledger?: {
+            readonly occurrences?: readonly {
+              readonly disposition: string;
+              readonly form: string;
+              readonly reason: string;
+              readonly verdict: string;
+            }[];
+          };
+          readonly plan?: {
+            readonly preserve?: readonly {
+              readonly forms?: readonly string[];
+              readonly pattern?: string;
+            }[];
+          };
+          readonly report?: {
+            readonly modified?: number;
+            readonly skipped?: number;
+          };
+        };
+      };
+      expect(parsed.run?.plan?.preserve?.[0]).toMatchObject({
+        forms: ['legacyId'],
+        pattern: String.raw`\blegacyId\b\s*=`,
+      });
+      expect(
+        parsed.run?.ledger?.occurrences?.map((occurrence) => ({
+          disposition: occurrence.disposition,
+          form: occurrence.form,
+          reason: occurrence.reason,
+          verdict: occurrence.verdict,
+        }))
+      ).toEqual(
+        expect.arrayContaining([
+          {
+            disposition: 'preserve-current-live-api',
+            form: 'legacyId',
+            reason: 'current-live-api-field',
+            verdict: 'skipped',
+          },
+          {
+            disposition: 'in-family-modified',
+            form: 'legacy',
+            reason: 'captured-form',
+            verdict: 'modified',
+          },
+        ])
+      );
+      expect(parsed.run?.report).toMatchObject({
+        modified: 1,
         skipped: 1,
       });
     } finally {

--- a/apps/trails/src/regrade/live-api-preserve.ts
+++ b/apps/trails/src/regrade/live-api-preserve.ts
@@ -1,0 +1,125 @@
+import { escapeRegExp } from '@ontrails/core';
+import type {
+  VocabularyPreserveInventoryEntry,
+  VocabularyRegradePlan,
+} from '@ontrails/regrade';
+import { deriveTopoGraph } from '@ontrails/topographer';
+import type { TopoGraphFacetDeclaration } from '@ontrails/topographer';
+import { getGovernedVocabularyTransition } from '@ontrails/warden';
+
+import { trailsMcpFacets } from '../mcp-options.js';
+
+const facetTransitionId = 'v1-facet-trailhead';
+
+const containedPattern = (value: string): string =>
+  `\\b${escapeRegExp(value)}\\b`;
+
+const sourceCodePaths = [
+  '**/*.cjs',
+  '**/*.cts',
+  '**/*.js',
+  '**/*.jsx',
+  '**/*.mjs',
+  '**/*.mts',
+  '**/*.ts',
+  '**/*.tsx',
+];
+
+const mcpFacetDeclarations = (): readonly TopoGraphFacetDeclaration[] =>
+  Object.entries(trailsMcpFacets).map(([id, facet]) => ({
+    description: facet.description,
+    id,
+    surfaces: ['mcp'],
+    trails: facet.trails,
+  }));
+
+const addInventoryEntry = (
+  entries: VocabularyPreserveInventoryEntry[],
+  options: Omit<VocabularyPreserveInventoryEntry, 'source'>
+): void => {
+  entries.push({
+    ...options,
+    disposition: options.disposition ?? 'preserve-current-live-api',
+    source: 'derived-live-api',
+  });
+};
+
+const matchesFacetTransition = (plan: VocabularyRegradePlan): boolean => {
+  const transition = getGovernedVocabularyTransition(facetTransitionId);
+  return (
+    transition !== undefined &&
+    transition.from === plan.from &&
+    transition.target.kind === 'single' &&
+    transition.target.to === plan.to
+  );
+};
+
+export const deriveLiveApiPreserveInventory = async (
+  plan: VocabularyRegradePlan
+): Promise<readonly VocabularyPreserveInventoryEntry[]> => {
+  if (!matchesFacetTransition(plan)) {
+    return [];
+  }
+
+  const [{ app }, { trailsMcpApp }] = await Promise.all([
+    import('../app.js'),
+    import('../mcp-app.js'),
+  ]);
+  const cliGraph = deriveTopoGraph(app);
+  const mcpGraph = deriveTopoGraph(trailsMcpApp, {
+    facets: mcpFacetDeclarations(),
+  });
+  const inventory: VocabularyPreserveInventoryEntry[] = [];
+  const transition = getGovernedVocabularyTransition(facetTransitionId);
+  if (transition === undefined) {
+    return [];
+  }
+  const identifiers = new Set(transition.codeIdentifiers);
+  const hasMcpFacetFacts = (mcpGraph.facets ?? []).length > 0;
+
+  if (
+    identifiers.has('wayfind.facets') &&
+    cliGraph.entries.some((entry) => entry.id === 'wayfind.facets')
+  ) {
+    addInventoryEntry(inventory, {
+      evidence: ['topo.entry:wayfind.facets'],
+      forms: ['facets'],
+      pattern: containedPattern('wayfind.facets'),
+      reason: 'current-live-trail-id',
+    });
+  }
+
+  if (hasMcpFacetFacts && identifiers.has('facetId')) {
+    addInventoryEntry(inventory, {
+      evidence: mcpGraph.facets?.map((facet) => `topo.facet:${facet.id}`) ?? [],
+      forms: ['facetId'],
+      paths: sourceCodePaths,
+      pattern: String.raw`\bfacetId\b\s*[:?=]`,
+      reason: 'current-live-mcp-facet-field',
+    });
+  }
+
+  if (hasMcpFacetFacts && identifiers.has('McpSurfaceFacetMap')) {
+    addInventoryEntry(inventory, {
+      evidence: ['mcp.surface.facets', 'topo.facets'],
+      forms: ['McpSurfaceFacetMap'],
+      paths: sourceCodePaths,
+      pattern: String.raw`(?:\b(?:import\s+type\s+\{[^;\n]*|(?:export\s+)?type\s+|satisfies\s+)|:\s*)McpSurfaceFacetMap\b`,
+      reason: 'current-live-mcp-facet-type',
+    });
+  }
+
+  if (hasMcpFacetFacts && identifiers.has('facets')) {
+    addInventoryEntry(inventory, {
+      evidence: ['mcp.surface.facets', 'topo.facets'],
+      forms: ['facets'],
+      paths: sourceCodePaths,
+      pattern: String.raw`\bfacets\b\s*(?:\?:|:)|^(?:\s*export\s+)?\s*const\s+facets\b`,
+      reason: 'current-live-mcp-facets-property',
+    });
+  }
+
+  return inventory.toSorted((left, right) =>
+    left.pattern.localeCompare(right.pattern)
+  );
+};

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -13,6 +13,7 @@ import {
 } from '@ontrails/core';
 import type { PathScope, Result as TrailsResult } from '@ontrails/core';
 import {
+  listVocabularyRegradePlansFromRegistry,
   loadWardenTermRewriteClasses,
   regradeReportOutput,
   runRegrade,
@@ -27,6 +28,7 @@ import type {
 import { z } from 'zod';
 
 import { loadRegradeConfig } from '../regrade/config.js';
+import { deriveLiveApiPreserveInventory } from '../regrade/live-api-preserve.js';
 import { resolveTrailRootDir } from './root-dir.js';
 
 const regradePathScopeInputSchema = pathScopeSchema.extend({
@@ -46,6 +48,10 @@ const regradePreserveRuleInputSchema = z.object({
     .enum(vocabularyDispositionValues)
     .optional()
     .describe('Classification to assign to occurrences this rule preserves'),
+  forms: z
+    .array(z.string().min(1))
+    .optional()
+    .describe('Matched forms this preserve rule applies to'),
   paths: z
     .array(z.string())
     .optional()
@@ -174,11 +180,48 @@ const vocabularyPreserveFromInput = (
       ...(rule.disposition === undefined
         ? {}
         : { disposition: rule.disposition }),
+      ...(rule.forms === undefined ? {} : { forms: rule.forms }),
       ...(rule.paths === undefined ? {} : { paths: rule.paths }),
       pattern: rule.pattern,
       ...(rule.reason === undefined ? {} : { reason: rule.reason }),
     };
   });
+
+const vocabularyRegistryPlanForInput = (
+  input: z.output<typeof regradeInputSchema>
+): VocabularyRegradePlan | undefined =>
+  listVocabularyRegradePlansFromRegistry().find(
+    (plan) => plan.from === input.from && plan.to === input.to
+  );
+
+const mergeVocabularyOverrides = (
+  registryPlan: VocabularyRegradePlan | undefined,
+  input: z.output<typeof regradeInputSchema>
+): VocabularyRegradePlan['overrides'] | undefined => {
+  const overrides = {
+    ...registryPlan?.overrides,
+    ...input.overrides,
+  };
+  return Object.keys(overrides).length === 0 ? undefined : overrides;
+};
+
+const mergeVocabularyPreserveRules = (
+  registryPlan: VocabularyRegradePlan | undefined,
+  preserve: readonly VocabularyPreserveRule[] | undefined
+): readonly VocabularyPreserveRule[] | undefined => {
+  const rules = [...(registryPlan?.preserve ?? []), ...(preserve ?? [])];
+  return rules.length === 0 ? undefined : rules;
+};
+
+const vocabularyIntentForInput = (
+  input: z.output<typeof regradeInputSchema>,
+  registryPlan: VocabularyRegradePlan | undefined
+): string | undefined => {
+  if (input.intent !== undefined) {
+    return input.intent;
+  }
+  return registryPlan?.intent;
+};
 
 const buildVocabularyPlan = (
   input: z.output<typeof regradeInputSchema>,
@@ -198,14 +241,24 @@ const buildVocabularyPlan = (
   }
 
   const preserve = vocabularyPreserveFromInput(input.preserve);
+  const registryPlan = vocabularyRegistryPlanForInput(input);
+  const intent = vocabularyIntentForInput(input, registryPlan);
+  const overrides = mergeVocabularyOverrides(registryPlan, input);
+  const preserveRules = mergeVocabularyPreserveRules(registryPlan, preserve);
 
   return Result.ok({
+    ...(registryPlan?.caseSensitive === undefined
+      ? {}
+      : { caseSensitive: registryPlan.caseSensitive }),
+    ...(registryPlan?.deferForms === undefined
+      ? {}
+      : { deferForms: registryPlan.deferForms }),
     from: input.from,
-    id: `vocabulary:${input.from}->${input.to}`,
+    id: registryPlan?.id ?? `vocabulary:${input.from}->${input.to}`,
     kind: 'vocabulary',
-    ...(input.intent === undefined ? {} : { intent: input.intent }),
-    ...(input.overrides === undefined ? {} : { overrides: input.overrides }),
-    ...(preserve === undefined ? {} : { preserve }),
+    ...(intent === undefined ? {} : { intent }),
+    ...(overrides === undefined ? {} : { overrides }),
+    ...(preserveRules === undefined ? {} : { preserve: preserveRules }),
     scope: {
       ...configScope,
       ...(input.exclude === undefined ? {} : { exclude: input.exclude }),
@@ -246,11 +299,15 @@ export const regradeTrail = trail('regrade', {
       if (planResult.isErr()) {
         return planResult;
       }
+      const preserveInventory = await deriveLiveApiPreserveInventory(
+        planResult.value
+      );
       const reportResult: TrailsResult<RegradeReport | null, Error> =
         runVocabularyRegrade({
           apply: input.apply,
           includeEntries: input.includeEntries,
           plan: planResult.value,
+          ...(preserveInventory.length === 0 ? {} : { preserveInventory }),
           root: rootDirResult.value,
         });
       if (reportResult.isErr()) {

--- a/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
+++ b/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
@@ -764,6 +764,46 @@ describe('runVocabularyRegrade', () => {
     }
   });
 
+  test('keeps context-only preserve markers effective for captured forms', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'const facet = 1; // no-rewrite\n');
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          preserve: [{ pattern: 'no-rewrite', reason: 'operator marker' }],
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toBe(
+        'const facet = 1; // no-rewrite\n'
+      );
+      expect(result.value.run.ledger.occurrences).toMatchObject([
+        {
+          form: 'facet',
+          reason: 'operator marker',
+          verdict: 'skipped',
+        },
+      ]);
+      expect(result.value.run.report).toMatchObject({
+        modified: 0,
+        open: 0,
+        skipped: 1,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('reports form verdicts from observed occurrences only', () => {
     const dir = makeTempDir();
     try {
@@ -984,6 +1024,32 @@ describe('runVocabularyRegrade', () => {
         );
         expect(invalidDisposition.error.message).toContain(
           'preserve disposition "bogus" is not supported'
+        );
+      }
+
+      const invalidInventoryDisposition = runVocabularyRegrade({
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          to: 'trailhead',
+        },
+        preserveInventory: [
+          {
+            disposition: 'bogus',
+            evidence: ['derived proof'],
+            pattern: 'facet',
+            source: 'derived-live-api',
+          },
+        ] as Parameters<typeof runVocabularyRegrade>[0]['preserveInventory'],
+        root: dir,
+      });
+      expect(invalidInventoryDisposition.isErr()).toBe(true);
+      if (invalidInventoryDisposition.isErr()) {
+        expect(invalidInventoryDisposition.error.constructor.name).toBe(
+          'ValidationError'
+        );
+        expect(invalidInventoryDisposition.error.message).toContain(
+          'preserve inventory disposition "bogus" is not supported'
         );
       }
     } finally {

--- a/packages/regrade/src/downstream/vocabulary.ts
+++ b/packages/regrade/src/downstream/vocabulary.ts
@@ -38,9 +38,15 @@ const vocabularyDispositions = new Set<string>(vocabularyDispositionValues);
 
 export interface VocabularyPreserveRule {
   readonly disposition?: VocabularyDisposition;
+  readonly forms?: readonly string[];
   readonly pattern: string;
   readonly reason?: string;
   readonly paths?: readonly string[];
+}
+
+export interface VocabularyPreserveInventoryEntry extends VocabularyPreserveRule {
+  readonly evidence: readonly string[];
+  readonly source: 'derived-live-api';
 }
 
 export interface VocabularyRegradeScope {
@@ -113,6 +119,7 @@ export interface VocabularyRunReport {
 export interface VocabularyRegradeRun {
   readonly ledger: VocabularyRunLedger;
   readonly plan: VocabularyRegradePlan;
+  readonly preserveInventory?: readonly VocabularyPreserveInventoryEntry[];
   readonly report: VocabularyRunReport;
 }
 
@@ -126,10 +133,12 @@ interface SourceOccurrence extends VocabularyOccurrence {
   readonly absolutePath: string;
 }
 
-type SourceOccurrenceDraft = Omit<
+interface SourceOccurrenceDraft extends Omit<
   SourceOccurrence,
   'disposition' | 'reason' | 'verdict'
->;
+> {
+  readonly contextColumn: number;
+}
 
 interface VocabularyEvaluation {
   readonly entries: readonly RegradeReportEntry[];
@@ -230,15 +239,20 @@ const lineColumnForOffset = (
   return { column, line };
 };
 
-const contextForOffset = (
+const contextDetailsForOffset = (
   source: string,
   start: number,
   end: number
-): string => {
+): { readonly context: string; readonly contextColumn: number } => {
   const lineStart = source.lastIndexOf('\n', start - 1) + 1;
   const nextLine = source.indexOf('\n', end);
   const lineEnd = nextLine === -1 ? source.length : nextLine;
-  return source.slice(lineStart, lineEnd).trim();
+  const rawLine = source.slice(lineStart, lineEnd);
+  const leadingTrimmed = rawLine.length - rawLine.trimStart().length;
+  return {
+    context: rawLine.trim(),
+    contextColumn: start - lineStart - leadingTrimmed + 1,
+  };
 };
 
 const isMarkdownPath = (path: string): boolean =>
@@ -456,8 +470,68 @@ const validateVocabularyPlan = (
         )
       );
     }
+    if (rule.forms?.some((form) => form.trim().length === 0) === true) {
+      return Result.err(
+        new ValidationError(
+          'Vocabulary Regrade plan preserve forms cannot be empty.'
+        )
+      );
+    }
   }
   return Result.ok();
+};
+
+const validatePreserveInventory = (
+  inventory: readonly VocabularyPreserveInventoryEntry[] | undefined
+): Result<void, ValidationError> => {
+  for (const entry of inventory ?? []) {
+    if (entry.pattern.trim().length === 0) {
+      return Result.err(
+        new ValidationError(
+          'Vocabulary Regrade preserve inventory patterns cannot be empty.'
+        )
+      );
+    }
+    if (entry.forms?.some((form) => form.trim().length === 0) === true) {
+      return Result.err(
+        new ValidationError(
+          'Vocabulary Regrade preserve inventory forms cannot be empty.'
+        )
+      );
+    }
+    if (
+      entry.disposition !== undefined &&
+      !vocabularyDispositions.has(entry.disposition)
+    ) {
+      return Result.err(
+        new ValidationError(
+          `Vocabulary Regrade preserve inventory disposition "${entry.disposition}" is not supported.`
+        )
+      );
+    }
+    if (entry.evidence.length === 0) {
+      return Result.err(
+        new ValidationError(
+          'Vocabulary Regrade preserve inventory entries need evidence.'
+        )
+      );
+    }
+  }
+  return Result.ok();
+};
+
+const effectivePlanForRun = (
+  plan: VocabularyRegradePlan,
+  preserveInventory: readonly VocabularyPreserveInventoryEntry[] | undefined
+): VocabularyRegradePlan => {
+  if (preserveInventory === undefined || preserveInventory.length === 0) {
+    return plan;
+  }
+
+  return {
+    ...plan,
+    preserve: [...(plan.preserve ?? []), ...preserveInventory],
+  };
 };
 
 const vocabularyScanFlags = (plan: VocabularyRegradePlan): string =>
@@ -480,21 +554,59 @@ const compilePreservePattern = (pattern: string): RegExp => {
   }
 };
 
+const globalPreservePattern = (pattern: RegExp): RegExp => {
+  const flags = pattern.flags.includes('g')
+    ? pattern.flags
+    : `${pattern.flags}g`;
+  return new RegExp(pattern.source, flags);
+};
+
+const patternOverlapsOccurrence = (
+  pattern: RegExp,
+  occurrence: SourceOccurrenceDraft
+): boolean => {
+  const occurrenceStart = occurrence.contextColumn - 1;
+  const occurrenceEnd = occurrenceStart + occurrence.form.length;
+
+  for (const match of occurrence.context.matchAll(
+    globalPreservePattern(pattern)
+  )) {
+    const matchStart = match.index ?? 0;
+    const matchEnd = matchStart + match[0].length;
+    if (
+      matchStart !== matchEnd &&
+      occurrenceStart < matchEnd &&
+      matchStart < occurrenceEnd
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
 const preserveRuleForOccurrence = (
   occurrence: SourceOccurrenceDraft,
   plan: VocabularyRegradePlan
 ): VocabularyPreserveRule | undefined =>
   plan.preserve?.find((rule) => {
+    if (rule.forms !== undefined && !rule.forms.includes(occurrence.form)) {
+      return false;
+    }
     if (
       rule.paths !== undefined &&
       !matchesAnyPathGlob(occurrence.path, rule.paths)
     ) {
       return false;
     }
-    return (
-      compilePreservePattern(rule.pattern).test(occurrence.context) ||
-      compilePreservePattern(rule.pattern).test(occurrence.form)
-    );
+    const pattern = compilePreservePattern(rule.pattern);
+    if (
+      pattern.test(occurrence.form) ||
+      patternOverlapsOccurrence(pattern, occurrence)
+    ) {
+      return true;
+    }
+    return rule.forms === undefined && pattern.test(occurrence.context);
   });
 
 const occurrenceOverlaps = (
@@ -513,10 +625,12 @@ const occurrenceDraftForSpan = (
   form = file.source.slice(start, end)
 ): SourceOccurrenceDraft => {
   const { column, line } = lineColumnForOffset(file.source, start);
+  const context = contextDetailsForOffset(file.source, start, end);
   return {
     absolutePath: file.absolutePath,
     column,
-    context: contextForOffset(file.source, start, end),
+    context: context.context,
+    contextColumn: context.contextColumn,
     end,
     form,
     line,
@@ -539,17 +653,24 @@ const deferredOccurrenceFromDraft = (
   );
   const verdict = preserveRule === undefined ? 'deferred' : 'skipped';
   return {
-    ...baseOccurrence,
+    absolutePath: baseOccurrence.absolutePath,
+    column: baseOccurrence.column,
+    context: baseOccurrence.context,
     disposition: vocabularyOccurrenceDisposition(
       verdict,
       preserveRule,
       markdownCodeContext
     ),
+    end: baseOccurrence.end,
+    form: baseOccurrence.form,
+    line: baseOccurrence.line,
+    path: baseOccurrence.path,
     reason: vocabularyOccurrenceReason(
       preserveRule,
       markdownCodeContext,
       reason
     ),
+    start: baseOccurrence.start,
     verdict,
   };
 };
@@ -608,10 +729,12 @@ const occurrencesForFile = (
         continue;
       }
       const { column, line } = lineColumnForOffset(file.source, start);
+      const context = contextDetailsForOffset(file.source, start, end);
       const baseOccurrence = {
         absolutePath: file.absolutePath,
         column,
-        context: contextForOffset(file.source, start, end),
+        context: context.context,
+        contextColumn: context.contextColumn,
         end,
         form: match[0],
         line,
@@ -625,12 +748,18 @@ const occurrencesForFile = (
         markdownCodeContext
       );
       candidates.push({
-        ...baseOccurrence,
+        absolutePath: baseOccurrence.absolutePath,
+        column: baseOccurrence.column,
+        context: baseOccurrence.context,
         disposition: vocabularyOccurrenceDisposition(
           verdict,
           preserveRule,
           markdownCodeContext
         ),
+        end: baseOccurrence.end,
+        form: baseOccurrence.form,
+        line: baseOccurrence.line,
+        path: baseOccurrence.path,
         reason: vocabularyOccurrenceReason(
           preserveRule,
           markdownCodeContext,
@@ -639,6 +768,7 @@ const occurrencesForFile = (
         ...(preserveRule === undefined && !markdownCodeContext
           ? { replacement: preserveCase(match[0], replacement) }
           : {}),
+        start: baseOccurrence.start,
         verdict,
       });
     }
@@ -825,28 +955,31 @@ const applyOccurrenceRewrites = (
 
 const buildVocabularyEvaluation = (params: {
   readonly apply?: boolean;
+  readonly effectivePlan?: VocabularyRegradePlan | undefined;
   readonly files: readonly SourceFile[];
   readonly plan: VocabularyRegradePlan;
+  readonly preserveInventory?: readonly VocabularyPreserveInventoryEntry[];
   readonly root: string;
   readonly skipped: readonly SkippedSource[];
 }): VocabularyEvaluation => {
-  const targetForms = targetFormsForPlan(params.plan);
+  const effectivePlan = params.effectivePlan ?? params.plan;
+  const targetForms = targetFormsForPlan(effectivePlan);
   const scopedFiles = params.files.filter((file) =>
-    includedByScope(file.path, params.plan.scope)
+    includedByScope(file.path, effectivePlan.scope)
   );
   const scopeSkipped: SkippedSource[] = params.files
-    .filter((file) => !includedByScope(file.path, params.plan.scope))
+    .filter((file) => !includedByScope(file.path, effectivePlan.scope))
     .map((file) => ({ path: file.path, reason: 'excluded-by-regrade-scope' }));
   const occurrences = scopedFiles.flatMap((file) => {
     const deferredOccurrences = deferredOccurrencesForFile(
       file,
-      params.plan,
+      effectivePlan,
       targetForms
     );
     return [
       ...occurrencesForFile(
         file,
-        params.plan,
+        effectivePlan,
         targetForms,
         deferredOccurrences
       ),
@@ -939,6 +1072,10 @@ const buildVocabularyEvaluation = (params: {
         ),
       },
       plan: params.plan,
+      ...(params.preserveInventory === undefined ||
+      params.preserveInventory.length === 0
+        ? {}
+        : { preserveInventory: params.preserveInventory }),
       report: {
         applied: params.apply === true ? modifiedOccurrences.length : 0,
         deferred: deferredOccurrences.length,
@@ -1041,30 +1178,12 @@ const applyVocabularyEvaluation = (
   });
 };
 
-export const runVocabularyRegrade = (params: {
-  readonly apply?: boolean;
-  readonly includeEntries?: 'actionable' | 'all';
-  readonly plan: VocabularyRegradePlan;
-  readonly root: string;
-}): Result<RegradeReport | null, InternalError | ValidationError> => {
-  const planValidation = validateVocabularyPlan(params.plan);
-  if (planValidation.isErr()) {
-    return planValidation;
-  }
-
-  const collected = collectDownstreamSources(params.root, {
-    extensions: params.plan.scope?.extensions ?? VOCABULARY_SOURCE_EXTENSIONS,
-    ...(params.plan.scope?.exclude === undefined
-      ? {}
-      : { exclude: params.plan.scope.exclude }),
-    ...(params.plan.scope?.ignoredDirectories === undefined
-      ? {}
-      : { ignoredDirectories: params.plan.scope.ignoredDirectories }),
-  } satisfies DownstreamCollectionOptions);
-  if (collected === null) {
-    return Result.ok(null);
-  }
-
+const readVocabularySourceFiles = (
+  collected: NonNullable<ReturnType<typeof collectDownstreamSources>>
+): {
+  readonly files: readonly SourceFile[];
+  readonly skipped: readonly SkippedSource[];
+} => {
   const files: SourceFile[] = [];
   const skipped: SkippedSource[] = [...collected.skipped];
   for (const file of collected.files) {
@@ -1078,19 +1197,87 @@ export const runVocabularyRegrade = (params: {
       skipped.push({ path: file.path, reason: 'unreadable-file' });
     }
   }
+  return { files, skipped };
+};
 
-  const dryRunEvaluation = buildVocabularyEvaluation({
+const buildRunVocabularyEvaluation = (params: {
+  readonly apply: boolean;
+  readonly effectivePlan: VocabularyRegradePlan;
+  readonly files: readonly SourceFile[];
+  readonly plan: VocabularyRegradePlan;
+  readonly preserveInventory:
+    | readonly VocabularyPreserveInventoryEntry[]
+    | undefined;
+  readonly root: string;
+  readonly skipped: readonly SkippedSource[];
+}): VocabularyEvaluation =>
+  buildVocabularyEvaluation({
+    apply: params.apply,
+    effectivePlan: params.effectivePlan,
+    files: params.files,
+    plan: params.plan,
+    ...(params.preserveInventory === undefined
+      ? {}
+      : { preserveInventory: params.preserveInventory }),
+    root: params.root,
+    skipped: params.skipped,
+  });
+
+export const runVocabularyRegrade = (params: {
+  readonly apply?: boolean;
+  readonly includeEntries?: 'actionable' | 'all';
+  readonly plan: VocabularyRegradePlan;
+  readonly preserveInventory?: readonly VocabularyPreserveInventoryEntry[];
+  readonly root: string;
+}): Result<RegradeReport | null, InternalError | ValidationError> => {
+  const planValidation = validateVocabularyPlan(params.plan);
+  if (planValidation.isErr()) {
+    return planValidation;
+  }
+  const inventoryValidation = validatePreserveInventory(
+    params.preserveInventory
+  );
+  if (inventoryValidation.isErr()) {
+    return inventoryValidation;
+  }
+
+  const effectivePlan = effectivePlanForRun(
+    params.plan,
+    params.preserveInventory
+  );
+
+  const collected = collectDownstreamSources(params.root, {
+    extensions: effectivePlan.scope?.extensions ?? VOCABULARY_SOURCE_EXTENSIONS,
+    ...(effectivePlan.scope?.exclude === undefined
+      ? {}
+      : { exclude: effectivePlan.scope.exclude }),
+    ...(effectivePlan.scope?.ignoredDirectories === undefined
+      ? {}
+      : { ignoredDirectories: effectivePlan.scope.ignoredDirectories }),
+  } satisfies DownstreamCollectionOptions);
+  if (collected === null) {
+    return Result.ok(null);
+  }
+
+  const { files, skipped } = readVocabularySourceFiles(collected);
+
+  const dryRunEffectiveEvaluation = buildRunVocabularyEvaluation({
     apply: false,
+    effectivePlan,
     files,
     plan: params.plan,
+    preserveInventory: params.preserveInventory,
     root: params.root,
     skipped,
   });
-  let reportEvaluation = dryRunEvaluation;
+  let reportEvaluation = dryRunEffectiveEvaluation;
   let applySummary: RegradeApplySummary | undefined;
 
   if (params.apply === true) {
-    const applyResult = applyVocabularyEvaluation(files, dryRunEvaluation);
+    const applyResult = applyVocabularyEvaluation(
+      files,
+      dryRunEffectiveEvaluation
+    );
     if (applyResult.isErr()) {
       return applyResult;
     }
@@ -1099,10 +1286,12 @@ export const runVocabularyRegrade = (params: {
       ...file,
       source: readFileSync(file.absolutePath, 'utf8'),
     }));
-    reportEvaluation = buildVocabularyEvaluation({
+    reportEvaluation = buildRunVocabularyEvaluation({
       apply: true,
+      effectivePlan,
       files: appliedFiles,
       plan: params.plan,
+      preserveInventory: params.preserveInventory,
       root: params.root,
       skipped,
     });
@@ -1161,6 +1350,10 @@ const vocabularyPreserveRuleSchema = z.object({
     .enum(vocabularyDispositionValues)
     .optional()
     .describe('Classification for occurrences preserved by this rule'),
+  forms: z
+    .array(z.string().min(1))
+    .optional()
+    .describe('Matched forms this preserve rule applies to'),
   paths: z
     .array(z.string())
     .optional()
@@ -1168,6 +1361,14 @@ const vocabularyPreserveRuleSchema = z.object({
   pattern: z.string().describe('Regex or literal pattern to preserve'),
   reason: z.string().optional().describe('Why this form is preserved'),
 });
+
+const vocabularyPreserveInventoryEntrySchema =
+  vocabularyPreserveRuleSchema.extend({
+    evidence: z
+      .array(z.string().min(1))
+      .describe('Graph or surface facts that justify this derived preserve'),
+    source: z.literal('derived-live-api').describe('Derived inventory source'),
+  });
 
 const vocabularyDispositionCountSchema = z.object(
   Object.fromEntries(
@@ -1260,6 +1461,12 @@ export const vocabularyRegradeRunOutput = z.object({
     })
     .describe('Observed run ledger'),
   plan: vocabularyRegradePlanSchema.describe('Authored regrade plan'),
+  preserveInventory: z
+    .array(vocabularyPreserveInventoryEntrySchema)
+    .optional()
+    .describe(
+      'Derived live-API preserve inventory applied at run time without changing the authored plan'
+    ),
   report: z
     .object({
       applied: z.number().describe('Modified occurrences applied to disk'),

--- a/packages/regrade/src/index.ts
+++ b/packages/regrade/src/index.ts
@@ -45,6 +45,7 @@ export type {
 export type {
   VocabularyDisposition,
   VocabularyOccurrence,
+  VocabularyPreserveInventoryEntry,
   VocabularyPreserveRule,
   VocabularyRegradePlan,
   VocabularyRegradeScope,


### PR DESCRIPTION
## Summary

Fixes [TRL-1118](https://linear.app/outfitter/issue/TRL-1118/).

- Adds Regrade preserve inventory as a derived, reported runtime artifact.
- Derives Trails operator live API preserve entries for the `facet -> trailhead` transition from live topo and MCP facet facts.
- Exposes form-scoped preserve rules through CLI and MCP, with structured MCP proof for preserve inventory.

## Verification

- `bun test packages/regrade/src/downstream/__tests__/vocabulary.test.ts apps/trails/src/__tests__/regrade.test.ts apps/trails/src/__tests__/mcp.test.ts`
- `bun run --cwd apps/trails typecheck`
- `bun run --cwd packages/regrade typecheck`
- `bun run changeset:check`
- Full stack: `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `bun run wayfinder:dogfood`, `git diff --check`

## Notes

Local review reached clean state on round 3 after narrowing live API preserves by form/path/context and exposing `forms` in the public input schema.