### PR TITLE
feat(regrade): run governed symbols from command path

### DIFF
--- a/.agents/memory/decisions.md
+++ b/.agents/memory/decisions.md
@@ -244,3 +244,15 @@ Merit aside: a *gate* is a point (binary allow/deny on a path); the job is a *br
 **Basis (tenets):** regressions-harden-the-trail (the dogfood to substrate loop is the v1 posture); derive-by-default + the-contract-is-queryable (preserve derivation); one-schema / surfaces-are-peers (input precedence); kind-by-coverage (code vs prose engines).
 
 **Confidence:** High. RETRO: `.agents/goals/2026-06-30-regrade-vocab-tracer/RETRO.md`. Follow-ups teed up: CLI precedence, derived-preserve substrate, phase-2 gated slice — all relate to TRL-1116.
+
+### 2026-07-01 Issue-writing fall-down: components captured, seams orphaned (from the TRL-1125 miss)
+
+**Question:** The one-command governed-code invocation (TRL-1125) escaped V0 planning even though every component — engine (1120), registry (1121), classification (1122), derived-preserve (1118) — had an issue and V0 was declared done. It was found only by *running* the engine by hand. Matt: "tells me there's a fall down in how we write issues." Root cause + fix?
+
+**Decision (diagnosis):** We decompose issues by **component (noun/capability)** and define "done" at the **component level** ("this piece compiles and its tests pass"). Nothing forces the parts to *compose* into a usable end-to-end flow, so the **seam** — the verb that wires the nouns into a one-command journey — gets no issue and no owner, and hides inside a per-consumer execution issue. A milestone then reads 100% done while the thing it's for can't be run. Sharpest form: **the substrate had no surface.** We'd never ship a public trail without its surface+docs, but we shipped a substrate without its invocation because internally "compiles + tests" counted as done — i.e. **internal substrate escaped our own distribution-ready-done bar.** Compounded by building **bottom-up/parts-first** with no top-down tracer to force the seams.
+
+**Fix (how to write issues):** (1) A milestone isn't done until there's a **usable end-to-end proof** (a tracer / one-command demo), not just "each component works." (2) Write the **seam/integration issue explicitly, at its shared altitude** — never folded into a per-consumer execution issue. (3) Run a **thin top-down tracer first** to force seams before building parts thick. (4) Apply **distribution-ready-done to substrate** (invocation + docs are part of substrate done), not just public features.
+
+**Other same-class gaps found:** v1-workflow docs/agent-guidance (no issue at all); the `reviewDeclarationTypes` public-API auto-rename-vs-review policy (confirm it's inside TRL-1123's "review gates" or capture it).
+
+**Basis (tenets):** "ship the whole developer experience" / done-means-usable-teachable-releasable — applied to substrate, not just features; natural-altitude (seams live at shared altitude). **Confidence:** High. Fourth run-exposed gap in the loop (structured-preserve, md-code-shield, `--input-json`, now TRL-1125) — the pattern is that *running* finds seams that *reading/planning* cannot.

--- a/.changeset/trl-1125-governed-symbol-command.md
+++ b/.changeset/trl-1125-governed-symbol-command.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/regrade": patch
+"@ontrails/trails": patch
+---
+
+Run governed AST symbol renames from the registry-backed `trails regrade` command path, including MCP parity, while preserving derived live API forms.

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -280,44 +280,21 @@ describe('Trails MCP surface shaping', () => {
               source: 'derived-live-api',
             }),
           ]),
-          report: {
-            dispositions: {
-              'in-family-modified': 3,
-              'preserve-current-live-api': 1,
-            },
-            gate: {
-              remainingByDisposition: { 'in-family-modified': 3 },
-            },
-            modified: 3,
-            open: 3,
-          },
+          report: { modified: 0, open: 0 },
         },
         scan: {
-          byDirectory: [{ files: 1, occurrences: 4, path: 'src' }],
-          byExtension: [{ extension: '.ts', files: 1, occurrences: 4 }],
-          files: { matched: 1, scanned: 1, skipped: 0 },
+          byDirectory: [{ files: 1, path: 'src' }],
+          byExtension: [{ extension: '.ts', files: 1 }],
+          files: { matched: 1, scanned: 1, skipped: 1 },
         },
       });
       expect(structured.selectedClassIds).toContain(
         'ast-symbol-rename:v1-facet-trailhead:facet->trailhead'
       );
-      expect(structured.selectedClassIds).not.toContain(
+      expect(structured.selectedClassIds).toContain(
         'ast-symbol-rename:v1-facet-trailhead:facetId->trailheadId'
       );
-      expect(structured.run?.ledger?.occurrences).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            disposition: 'in-family-modified',
-            form: 'facet',
-            verdict: 'modified',
-          }),
-          expect.objectContaining({
-            disposition: 'preserve-current-live-api',
-            form: 'facetId',
-            verdict: 'skipped',
-          }),
-        ])
-      );
+      expect(structured.run?.ledger?.occurrences).toEqual([]);
       expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
         'facet'
       );
@@ -331,8 +308,8 @@ describe('Trails MCP surface shaping', () => {
     try {
       writeFile(
         dir,
-        'src/blaze.ts',
-        'export const blaze = "safe";\nexport const blazing = "review";\n'
+        'docs/blaze.md',
+        'The blaze path is safe.\nThe blazing path needs review.\n'
       );
       const tools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
       const regrade = requireTool(tools, 'trails_regrade');

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -251,6 +251,7 @@ describe('Trails MCP surface shaping', () => {
 
       expect(result.isError).toBeUndefined();
       const structured = result.structuredContent as {
+        readonly selectedClassIds?: readonly string[];
         readonly run?: {
           readonly ledger?: {
             readonly occurrences?: readonly {
@@ -297,6 +298,12 @@ describe('Trails MCP surface shaping', () => {
           files: { matched: 1, scanned: 1, skipped: 0 },
         },
       });
+      expect(structured.selectedClassIds).toContain(
+        'ast-symbol-rename:v1-facet-trailhead:facet->trailhead'
+      );
+      expect(structured.selectedClassIds).not.toContain(
+        'ast-symbol-rename:v1-facet-trailhead:facetId->trailheadId'
+      );
       expect(structured.run?.ledger?.occurrences).toEqual(
         expect.arrayContaining([
           expect.objectContaining({

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -103,11 +103,10 @@ describe('trails regrade', () => {
     try {
       writeFile(
         dir,
-        'src/surface.ts',
+        'docs/surface.md',
         [
-          'export const facet = "facet";',
-          'export const facetId = facet;',
-          'export const facets = ["inspect"];',
+          'The facet docs mention facetId.',
+          'The facets docs mention grouping.',
           '',
         ].join('\n')
       );
@@ -115,7 +114,7 @@ describe('trails regrade', () => {
       const result = await regradeTrail.blaze(
         {
           from: 'facet',
-          include: ['src/**/*.ts'],
+          include: ['docs/**/*.md'],
           rootDir: dir,
           to: 'trailhead',
         },
@@ -141,15 +140,15 @@ describe('trails regrade', () => {
           }),
           expect.objectContaining({
             pattern: expect.stringContaining('wayfind\\.facets'),
-            reason: 'current-live-trail-id',
+            reason: 'current-live-trail-compose-input',
             source: 'derived-live-api',
           }),
         ])
       );
       expect(result.value.run?.ledger.forms).toEqual({
         facet: 'modified',
-        facetId: 'skipped',
-        facets: 'skipped',
+        facetId: 'deferred',
+        facets: 'modified',
       });
       expect(
         result.value.run?.ledger.occurrences.map((occurrence) => ({
@@ -167,52 +166,44 @@ describe('trails regrade', () => {
             verdict: 'modified',
           },
           {
-            disposition: 'in-family-modified',
-            form: 'facet',
-            replacement: 'trailhead',
-            verdict: 'modified',
-          },
-          {
-            disposition: 'in-family-modified',
-            form: 'facet',
-            replacement: 'trailhead',
-            verdict: 'modified',
-          },
-          {
-            disposition: 'preserve-current-live-api',
+            disposition: 'in-family-unresolved',
             form: 'facetId',
             replacement: undefined,
-            verdict: 'skipped',
+            verdict: 'deferred',
           },
           {
-            disposition: 'preserve-current-live-api',
+            disposition: 'in-family-modified',
             form: 'facets',
-            replacement: undefined,
-            verdict: 'skipped',
+            replacement: 'trailheads',
+            verdict: 'modified',
           },
         ])
       );
-      expect(result.value.run?.ledger.occurrences).toHaveLength(5);
+      expect(result.value.run?.ledger.occurrences).toHaveLength(3);
       expect(result.value.run?.report).toMatchObject({
         applied: 0,
-        deferred: 0,
+        deferred: 1,
         dispositions: {
-          'in-family-modified': 3,
-          'preserve-current-live-api': 2,
+          'in-family-modified': 2,
+          'in-family-unresolved': 1,
         },
         gate: {
-          reasons: ['safe-modifications-not-yet-applied'],
+          reasons: [
+            'safe-modifications-not-yet-applied',
+            'deferred-forms-or-occurrences',
+          ],
           remaining: 3,
           remainingByDisposition: {
-            'in-family-modified': 3,
+            'in-family-modified': 2,
+            'in-family-unresolved': 1,
           },
           status: 'open',
         },
-        modified: 3,
+        modified: 2,
         open: 3,
-        skipped: 2,
+        skipped: 0,
       });
-      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
+      expect(readFileSync(join(dir, 'docs', 'surface.md'), 'utf8')).toContain(
         'facet'
       );
     } finally {
@@ -250,13 +241,13 @@ describe('trails regrade', () => {
         throw result.error;
       }
       expect(result.value.apply).toMatchObject({
-        applied: 4,
+        applied: 3,
         filesChanged: 2,
         review: 1,
         skipped: 1,
       });
       expect(result.value.run?.report).toMatchObject({
-        applied: 4,
+        applied: 2,
         deferred: 1,
         gate: {
           reasons: ['deferred-forms-or-occurrences'],
@@ -265,13 +256,16 @@ describe('trails regrade', () => {
         },
         modified: 0,
         open: 1,
-        skipped: 1,
+        skipped: 0,
       });
       expect(readFileSync(join(dir, 'docs', 'surface.md'), 'utf8')).toBe(
         'Facet docs mention trailhead and trailheads.\n'
       );
       expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
         'facetId'
+      );
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
+        'export const trailhead = "facet";'
       );
     } finally {
       rmSync(dir, { force: true, recursive: true });
@@ -281,7 +275,7 @@ describe('trails regrade', () => {
   test('CLI accepts regrade source and target as positional arguments', () => {
     const dir = makeTempDir();
     try {
-      writeFile(dir, 'src/surface.ts', 'export const facet = "facet";\n');
+      writeFile(dir, 'docs/surface.md', 'The facet docs mention facet.\n');
 
       const result = runRawCli([
         'regrade',
@@ -308,7 +302,7 @@ describe('trails regrade', () => {
       });
       expect(parsed.run?.report?.modified).toBe(2);
       expect(parsed.run?.report?.open).toBe(2);
-      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
+      expect(readFileSync(join(dir, 'docs', 'surface.md'), 'utf8')).toContain(
         'facet'
       );
     } finally {
@@ -355,7 +349,7 @@ describe('trails regrade', () => {
       expect(parsed.selectedClassIds).toContain(
         'ast-symbol-rename:v1-facet-trailhead:facet->trailhead'
       );
-      expect(parsed.selectedClassIds).not.toContain(
+      expect(parsed.selectedClassIds).toContain(
         'ast-symbol-rename:v1-facet-trailhead:facetId->trailheadId'
       );
       expect(parsed.entries).toEqual(
@@ -369,6 +363,54 @@ describe('trails regrade', () => {
       );
       expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
         'facet'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI applies governed symbol include scope before rewriting', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'other/surface.ts', 'export const facet = 1;\n');
+      writeFile(dir, 'src/surface.ts', 'export const facet = 1;\n');
+
+      const result = runRawCli([
+        'regrade',
+        'facet',
+        'trailhead',
+        '--include',
+        'src/**',
+        '--include-entries',
+        'all',
+        '--root-dir',
+        dir,
+        '--apply',
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        readonly entries?: readonly {
+          readonly outcome?: string;
+          readonly path?: string;
+          readonly reason?: string;
+        }[];
+      };
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
+        'trailhead'
+      );
+      expect(readFileSync(join(dir, 'other', 'surface.ts'), 'utf8')).toContain(
+        'facet'
+      );
+      expect(parsed.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            outcome: 'skip',
+            path: 'other/surface.ts',
+            reason: 'not-included-glob',
+          }),
+        ])
       );
     } finally {
       rmSync(dir, { force: true, recursive: true });
@@ -417,8 +459,8 @@ describe('trails regrade', () => {
     try {
       writeFile(
         dir,
-        'src/blaze.ts',
-        'export const blaze = "safe";\nexport const blazing = "review";\n'
+        'docs/blaze.md',
+        'The blaze path is safe.\nThe blazing path needs review.\n'
       );
 
       const result = runRawCli([
@@ -470,21 +512,88 @@ describe('trails regrade', () => {
     }
   });
 
+  test('CLI keeps path-scoped symbol preserves local to matching occurrences', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/internal.ts', 'export const blaze = 1;\n');
+      writeFile(dir, 'src/public-api.ts', 'export const blaze = 1;\n');
+
+      const result = runRawCli([
+        'regrade',
+        '--root-dir',
+        dir,
+        '--input-json',
+        JSON.stringify({
+          apply: true,
+          extensions: ['.ts'],
+          from: 'blaze',
+          preserve: [
+            {
+              forms: ['blaze'],
+              paths: ['src/public-api.ts'],
+              pattern: String.raw`\bblaze\b\s*=`,
+              reason: 'public-api-field',
+            },
+          ],
+          to: 'implementation',
+        }),
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(readFileSync(join(dir, 'src', 'internal.ts'), 'utf8')).toContain(
+        'implementation'
+      );
+      expect(readFileSync(join(dir, 'src', 'public-api.ts'), 'utf8')).toContain(
+        'blaze'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI merged vocabulary reports count prose and code scanned files', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'docs/blaze.md', 'The blaze docs are ready.\n');
+      writeFile(dir, 'src/blaze.ts', 'export const blaze = 1;\n');
+
+      const result = runRawCli([
+        'regrade',
+        'blaze',
+        'implementation',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        readonly scan?: {
+          readonly files?: {
+            readonly matched?: number;
+            readonly scanned?: number;
+          };
+        };
+        readonly scanned?: number;
+      };
+      expect(parsed.scanned).toBe(2);
+      expect(parsed.scan?.files).toMatchObject({
+        matched: 2,
+        scanned: 2,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('CLI accepts path-scope exclude globs for vocabulary regrades', () => {
     const dir = makeTempDir();
     try {
-      writeFile(dir, '.agents/notes/history.ts', 'export const facet = 1;\n');
-      writeFile(
-        dir,
-        '.agents/skills/trails/SKILL.ts',
-        'export const facet = 1;\n'
-      );
-      writeFile(dir, '.scratch/history.ts', 'export const facet = 1;\n');
-      writeFile(
-        dir,
-        'plugin/skills/trails/SKILL.ts',
-        'export const facet = 1;\n'
-      );
+      writeFile(dir, '.agents/notes/history.md', 'facet\n');
+      writeFile(dir, '.agents/skills/trails/SKILL.md', 'facet\n');
+      writeFile(dir, '.scratch/history.md', 'facet\n');
+      writeFile(dir, 'plugin/skills/trails/SKILL.md', 'facet\n');
 
       const result = runRawCli([
         'regrade',
@@ -531,20 +640,20 @@ describe('trails regrade', () => {
         '.agents/notes/**',
       ]);
       expect(parsed.run?.ledger?.occurrences?.map((o) => o.path)).toEqual([
-        '.agents/skills/trails/SKILL.ts',
-        'plugin/skills/trails/SKILL.ts',
+        '.agents/skills/trails/SKILL.md',
+        'plugin/skills/trails/SKILL.md',
       ]);
       expect(parsed.scan?.files).toEqual({
         matched: 2,
         scanned: 2,
-        skipped: 2,
+        skipped: 4,
       });
       expect(parsed.scan?.byDirectory).toEqual([
         { files: 1, occurrences: 1, path: '.agents' },
         { files: 1, occurrences: 1, path: 'plugin' },
       ]);
       expect(parsed.scan?.byExtension).toEqual([
-        { extension: '.ts', files: 2, occurrences: 2 },
+        { extension: '.md', files: 2, occurrences: 2 },
       ]);
       expect(parsed.skipsByReason).toMatchObject({ 'ignored-glob': 2 });
     } finally {
@@ -649,22 +758,14 @@ describe('trails regrade', () => {
           reason: 'unclassified-neighbor',
           verdict: 'deferred',
         },
-        {
-          disposition: 'preserve-current-live-api',
-          form: 'facetId',
-          path: 'src/surface.ts',
-          reason: 'live-api-identifier',
-          verdict: 'skipped',
-        },
       ]);
       expect(parsed.run?.report).toMatchObject({
         deferred: 1,
         dispositions: {
           'in-family-unresolved': 1,
-          'preserve-current-live-api': 1,
         },
         modified: 0,
-        skipped: 1,
+        skipped: 0,
       });
     } finally {
       rmSync(dir, { force: true, recursive: true });
@@ -699,9 +800,7 @@ describe('trails regrade', () => {
 
       expect(result.exitCode).toBe(0);
       const source = readFileSync(join(dir, 'src', 'surface.ts'), 'utf8');
-      expect(source).toContain(
-        "ctx.compose('wayfind.facets', { trailheads });"
-      );
+      expect(source).toContain("ctx.compose('wayfind.facets', { facets });");
       expect(source).toContain(
         'readonly facets?: McpSurfaceFacetMap | undefined;'
       );
@@ -716,8 +815,28 @@ describe('trails regrade', () => {
               readonly verdict: string;
             }[];
           };
+          readonly preserveInventory?: readonly {
+            readonly forms?: readonly string[];
+            readonly reason?: string;
+          }[];
         };
       };
+      expect(parsed.run?.preserveInventory).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            forms: expect.arrayContaining(['facets']),
+            reason: 'current-live-trail-compose-input',
+          }),
+          expect.objectContaining({
+            forms: expect.arrayContaining(['facets']),
+            reason: 'current-live-mcp-facets-property',
+          }),
+          expect.objectContaining({
+            forms: expect.arrayContaining(['McpSurfaceFacetMap']),
+            reason: 'current-live-mcp-facet-type',
+          }),
+        ])
+      );
       const liveApiOccurrences = parsed.run?.ledger?.occurrences
         ?.filter(
           (occurrence) =>
@@ -730,40 +849,49 @@ describe('trails regrade', () => {
           reason: occurrence.reason,
           verdict: occurrence.verdict,
         }));
-      expect(liveApiOccurrences).toEqual(
-        expect.arrayContaining([
-          {
-            context: "ctx.compose('wayfind.facets', { trailheads });",
-            form: 'facets',
-            reason: 'current-live-trail-id',
-            verdict: 'skipped',
-          },
-          {
-            context:
-              'export type McpSurfaceFacetMap = Record<string, unknown>;',
-            form: 'McpSurfaceFacetMap',
-            reason: 'current-live-mcp-facet-type',
-            verdict: 'skipped',
-          },
-          {
-            context: 'readonly facets?: McpSurfaceFacetMap | undefined;',
-            form: 'facets',
-            reason: 'current-live-mcp-facets-property',
-            verdict: 'skipped',
-          },
-          {
-            context: 'readonly facets?: McpSurfaceFacetMap | undefined;',
-            form: 'McpSurfaceFacetMap',
-            reason: 'current-live-mcp-facet-type',
-            verdict: 'skipped',
-          },
-        ])
+      expect(liveApiOccurrences).toEqual([]);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI apply keeps prose rewrites out of code strings and comments', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/surface.ts',
+        [
+          'const label = "the facets string must not change";',
+          '// the facets comment must not change',
+          'export const facets = 1;',
+          'export const useFacets = facets;',
+          'export const facet = 1;',
+          'export const useFacet = facet;',
+          '',
+        ].join('\n')
       );
-      expect(
-        liveApiOccurrences?.every(
-          (occurrence) => occurrence.verdict === 'skipped'
-        )
-      ).toBe(true);
+
+      const result = runRawCli([
+        'regrade',
+        '--root-dir',
+        dir,
+        'facet',
+        'trailhead',
+        '--apply',
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const source = readFileSync(join(dir, 'src', 'surface.ts'), 'utf8');
+      expect(source).toContain('"the facets string must not change"');
+      expect(source).toContain('// the facets comment must not change');
+      expect(source).toContain('export const facets = 1;');
+      expect(source).toContain('export const useFacets = facets;');
+      expect(source).toContain('export const trailhead = 1;');
+      expect(source).toContain('export const useFacet = trailhead;');
+      expect(source).not.toContain('the trailheads string must not change');
+      expect(source).not.toContain('// the trailheads comment must not change');
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }
@@ -772,7 +900,7 @@ describe('trails regrade', () => {
   test('CLI forwards form-scoped preserve rules from input json', () => {
     const dir = makeTempDir();
     try {
-      writeFile(dir, 'src/api.ts', 'export const legacyId = legacy;\n');
+      writeFile(dir, 'docs/api.md', 'legacyId = legacy\n');
 
       const result = runRawCli([
         'regrade',
@@ -781,7 +909,7 @@ describe('trails regrade', () => {
         '--input-json',
         JSON.stringify({
           from: 'legacy',
-          include: ['src/**'],
+          include: ['docs/**'],
           preserve: [
             {
               disposition: 'preserve-current-live-api',
@@ -1023,18 +1151,10 @@ describe('trails regrade', () => {
           },
         })
       );
-      writeFile(dir, '.agents/notes/history.ts', 'export const facet = 1;\n');
-      writeFile(
-        dir,
-        '.agents/skills/trails/SKILL.ts',
-        'export const facet = 1;\n'
-      );
-      writeFile(dir, '.scratch/history.ts', 'export const facet = 1;\n');
-      writeFile(
-        dir,
-        'plugin/skills/trails/SKILL.ts',
-        'export const facet = 1;\n'
-      );
+      writeFile(dir, '.agents/notes/history.md', 'facet\n');
+      writeFile(dir, '.agents/skills/trails/SKILL.md', 'facet\n');
+      writeFile(dir, '.scratch/history.md', 'facet\n');
+      writeFile(dir, 'plugin/skills/trails/SKILL.md', 'facet\n');
 
       const result = runRawCli([
         'regrade',
@@ -1060,8 +1180,8 @@ describe('trails regrade', () => {
         '.agents/notes/**',
       ]);
       expect(parsed.run?.ledger?.occurrences?.map((o) => o.path)).toEqual([
-        '.agents/skills/trails/SKILL.ts',
-        'plugin/skills/trails/SKILL.ts',
+        '.agents/skills/trails/SKILL.md',
+        'plugin/skills/trails/SKILL.md',
       ]);
       expect(parsed.skipsByReason).toMatchObject({ 'ignored-glob': 2 });
     } finally {
@@ -1081,9 +1201,9 @@ describe('trails regrade', () => {
           },
         })
       );
-      writeFile(dir, '.agents/notes/history.ts', 'export const facet = 1;\n');
-      writeFile(dir, '.scratch/history.ts', 'export const facet = 1;\n');
-      writeFile(dir, 'src/keep.ts', 'export const facet = 1;\n');
+      writeFile(dir, '.agents/notes/history.md', 'facet\n');
+      writeFile(dir, '.scratch/history.md', 'facet\n');
+      writeFile(dir, 'docs/keep.md', 'facet\n');
 
       const result = await regradeTrail.blaze(
         {
@@ -1101,8 +1221,8 @@ describe('trails regrade', () => {
       }
       expect(result.value.run?.plan.scope?.exclude).toEqual(['.scratch/**']);
       expect(result.value.run?.ledger.occurrences.map((o) => o.path)).toEqual([
-        '.agents/notes/history.ts',
-        'src/keep.ts',
+        '.agents/notes/history.md',
+        'docs/keep.md',
       ]);
       expect(result.value.skipsByReason).toMatchObject({ 'ignored-glob': 1 });
     } finally {
@@ -1204,6 +1324,126 @@ describe('trails regrade', () => {
         name: 'ValidationError',
       });
       expect(parsed.error?.message).toContain('requires both `from` and `to`');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI reports no applicable regrade engine for unsupported vocabulary extensions', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'data/surface.json', '{"facet": true}\n');
+
+      const result = runRawCli([
+        'regrade',
+        '--root-dir',
+        dir,
+        '--input-json',
+        JSON.stringify({
+          extensions: ['.json'],
+          from: 'facet',
+          to: 'trailhead',
+        }),
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(1);
+      const parsed = JSON.parse(result.stderr) as {
+        readonly error?: {
+          readonly category?: string;
+          readonly message?: string;
+          readonly name?: string;
+        };
+        readonly ok?: boolean;
+      };
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toMatchObject({
+        category: 'validation',
+        name: 'ValidationError',
+      });
+      expect(parsed.error?.message).toContain(
+        'no prose or governed symbol engine'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI preserves missing-root diagnostics for unsupported vocabulary extensions', () => {
+    const dir = makeTempDir();
+    const missingRoot = join(dir, 'missing');
+    try {
+      const result = runRawCli([
+        'regrade',
+        '--root-dir',
+        missingRoot,
+        '--input-json',
+        JSON.stringify({
+          extensions: ['.json'],
+          from: 'facet',
+          to: 'trailhead',
+        }),
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(2);
+      const parsed = JSON.parse(result.stderr) as {
+        readonly error?: {
+          readonly category?: string;
+          readonly message?: string;
+          readonly name?: string;
+        };
+        readonly ok?: boolean;
+      };
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toMatchObject({
+        category: 'not_found',
+        name: 'NotFoundError',
+      });
+      expect(parsed.error?.message).toContain('could not be read');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI treats fully preserved governed symbol transitions as successful no-ops', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/surface.ts', 'export const facet = 1;\n');
+
+      const result = runRawCli([
+        'regrade',
+        '--root-dir',
+        dir,
+        '--input-json',
+        JSON.stringify({
+          extensions: ['.ts'],
+          from: 'facet',
+          preserve: [
+            {
+              forms: ['facet'],
+              pattern: 'facet',
+              reason: 'operator-preserved-symbol',
+            },
+          ],
+          to: 'trailhead',
+        }),
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        readonly matched?: number;
+        readonly rewritten?: number;
+        readonly selectedClassIds?: readonly string[];
+      };
+      expect(parsed).toMatchObject({ matched: 0, rewritten: 0 });
+      expect(parsed.selectedClassIds).toContain(
+        'ast-symbol-rename:v1-facet-trailhead:facet->trailhead'
+      );
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toBe(
+        'export const facet = 1;\n'
+      );
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -316,6 +316,102 @@ describe('trails regrade', () => {
     }
   });
 
+  test('CLI runs governed symbol renames from the registry-backed command path', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/surface.ts',
+        [
+          'export const facet = "facet";',
+          'export const facetId = facet;',
+          'export const facets = ["inspect"];',
+          '',
+        ].join('\n')
+      );
+
+      const result = runRawCli([
+        'regrade',
+        'facet',
+        'trailhead',
+        '--include',
+        'src/**/*.ts',
+        '--include-entries',
+        'all',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        readonly entries?: readonly {
+          readonly classId?: string;
+          readonly outcome?: string;
+          readonly path?: string;
+        }[];
+        readonly selectedClassIds?: readonly string[];
+      };
+      expect(parsed.selectedClassIds).toContain(
+        'ast-symbol-rename:v1-facet-trailhead:facet->trailhead'
+      );
+      expect(parsed.selectedClassIds).not.toContain(
+        'ast-symbol-rename:v1-facet-trailhead:facetId->trailheadId'
+      );
+      expect(parsed.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            classId: 'ast-symbol-rename:v1-facet-trailhead:facet->trailhead',
+            outcome: 'rewrite',
+            path: 'src/surface.ts',
+          }),
+        ])
+      );
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toContain(
+        'facet'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI skips governed symbol renames when explicit extensions exclude source code', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/surface.ts',
+        [
+          'export const facet = "facet";',
+          'export const facetId = facet;',
+          'export const facets = ["inspect"];',
+          '',
+        ].join('\n')
+      );
+
+      const result = runRawCli([
+        'regrade',
+        'facet',
+        'trailhead',
+        '--extensions',
+        '.md',
+        '--include-entries',
+        'all',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        readonly selectedClassIds?: readonly string[];
+      };
+      expect(parsed.selectedClassIds).toEqual(['v1-facet-trailhead']);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('CLI regrade uses governed registry review forms', () => {
     const dir = makeTempDir();
     try {

--- a/apps/trails/src/regrade/live-api-preserve.ts
+++ b/apps/trails/src/regrade/live-api-preserve.ts
@@ -1,4 +1,3 @@
-import { escapeRegExp } from '@ontrails/core';
 import type {
   VocabularyPreserveInventoryEntry,
   VocabularyRegradePlan,
@@ -10,9 +9,6 @@ import { getGovernedVocabularyTransition } from '@ontrails/warden';
 import { trailsMcpFacets } from '../mcp-options.js';
 
 const facetTransitionId = 'v1-facet-trailhead';
-
-const containedPattern = (value: string): string =>
-  `\\b${escapeRegExp(value)}\\b`;
 
 const sourceCodePaths = [
   '**/*.cjs',
@@ -84,8 +80,8 @@ export const deriveLiveApiPreserveInventory = async (
     addInventoryEntry(inventory, {
       evidence: ['topo.entry:wayfind.facets'],
       forms: ['facets'],
-      pattern: containedPattern('wayfind.facets'),
-      reason: 'current-live-trail-id',
+      pattern: String.raw`\bwayfind\.facets\b['"],\s*\{\s*facets\b`,
+      reason: 'current-live-trail-compose-input',
     });
   }
 

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -7,6 +7,7 @@ import {
   NotFoundError,
   Result,
   ValidationError,
+  matchesAnyPathGlob,
   pathScopeSchema,
   trail,
   validateOutput,
@@ -32,6 +33,7 @@ import type {
   VocabularyRegradePlan,
   VocabularyPreserveInventoryEntry,
 } from '@ontrails/regrade';
+import { readdirSync } from 'node:fs';
 import { z } from 'zod';
 
 import { loadRegradeConfig } from '../regrade/config.js';
@@ -181,8 +183,92 @@ const symbolSourceExtensions: readonly string[] = [
   '.tsx',
 ] as const;
 
+const vocabularyProseExtensions: readonly string[] = [
+  '.md',
+  '.mdx',
+  '.txt',
+] as const;
+
 const normalizeExtension = (extension: string): string =>
   extension === '' || extension.startsWith('.') ? extension : `.${extension}`;
+
+const compileVocabularyPreservePattern = (pattern: string): RegExp => {
+  try {
+    return new RegExp(pattern);
+  } catch {
+    return new RegExp(pattern.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  }
+};
+
+const globalVocabularyPreservePattern = (pattern: RegExp): RegExp => {
+  const flags = pattern.flags.includes('g')
+    ? pattern.flags
+    : `${pattern.flags}g`;
+  return new RegExp(pattern.source, flags);
+};
+
+const preservePatternOverlapsSpan = (
+  pattern: RegExp,
+  source: string,
+  start: number,
+  end: number
+): boolean => {
+  for (const match of source.matchAll(
+    globalVocabularyPreservePattern(pattern)
+  )) {
+    const matchStart = match.index ?? 0;
+    const matchEnd = matchStart + match[0].length;
+    if (matchStart !== matchEnd && start < matchEnd && matchStart < end) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const preserveRuleMatchesSymbolOccurrence = (
+  rule: VocabularyPreserveRule,
+  occurrence: {
+    readonly form: string;
+    readonly path: string;
+    readonly source: string;
+    readonly start: number;
+    readonly end: number;
+  }
+): boolean => {
+  if (rule.forms !== undefined && !rule.forms.includes(occurrence.form)) {
+    return false;
+  }
+  if (
+    rule.paths !== undefined &&
+    !matchesAnyPathGlob(occurrence.path, rule.paths)
+  ) {
+    return false;
+  }
+  const pattern = compileVocabularyPreservePattern(rule.pattern);
+  return (
+    pattern.test(occurrence.form) ||
+    preservePatternOverlapsSpan(
+      pattern,
+      occurrence.source,
+      occurrence.start,
+      occurrence.end
+    )
+  );
+};
+
+const symbolOccurrenceIsPreserved = (
+  rules: readonly VocabularyPreserveRule[] | undefined,
+  occurrence: {
+    readonly form: string;
+    readonly path: string;
+    readonly source: string;
+    readonly start: number;
+    readonly end: number;
+  }
+): boolean =>
+  rules?.some((rule) =>
+    preserveRuleMatchesSymbolOccurrence(rule, occurrence)
+  ) ?? false;
 
 const vocabularyScopeFromConfig = (
   scope: RegradeConfigScope | undefined
@@ -401,6 +487,7 @@ const mergeRegradeReports = (
     symbolReport.skipsByReason
   );
   const apply = mergeApplySummary(vocabularyReport.apply, symbolReport.apply);
+  const scanned = vocabularyReport.scanned + symbolReport.scanned;
 
   return {
     ...vocabularyReport,
@@ -414,12 +501,12 @@ const mergeRegradeReports = (
       byExtension: mergedExtensionBuckets(matchedPaths, occurrencePaths),
       files: {
         matched: new Set(matchedPaths).size,
-        scanned: Math.max(vocabularyReport.scanned, symbolReport.scanned),
+        scanned,
         skipped: Math.max(vocabularyReport.skipped, symbolReport.skipped),
       },
       skippedByReason,
     },
-    scanned: Math.max(vocabularyReport.scanned, symbolReport.scanned),
+    scanned,
     selectedClassIds: uniqueSorted([
       ...vocabularyReport.selectedClassIds,
       ...symbolReport.selectedClassIds,
@@ -432,20 +519,6 @@ const mergeRegradeReports = (
     ]),
   };
 };
-
-const preservedFormsFromRules = (
-  rules: readonly VocabularyPreserveRule[] | undefined
-): ReadonlySet<string> => new Set(rules?.flatMap((rule) => rule.forms ?? []));
-
-const preservedFormsFromInventory = (
-  inventory: readonly VocabularyPreserveInventoryEntry[]
-): ReadonlySet<string> =>
-  new Set(inventory.flatMap((rule) => rule.forms ?? []));
-
-const combinePreservedForms = (
-  left: ReadonlySet<string>,
-  right: ReadonlySet<string>
-): ReadonlySet<string> => new Set([...left, ...right]);
 
 const vocabularySymbolCollection = (
   scope: VocabularyRegradePlan['scope'] | undefined
@@ -477,6 +550,46 @@ const vocabularySymbolCollection = (
     ...(codeExtensions.length === 0 ? {} : { extensions: codeExtensions }),
     ...(include === undefined ? {} : { include }),
   };
+};
+
+const vocabularyProseScope = (
+  scope: VocabularyRegradePlan['scope'] | undefined
+): NonNullable<VocabularyRegradePlan['scope']> | null => {
+  const explicitExtensions = scope?.extensions !== undefined;
+  const extensions =
+    scope?.extensions === undefined
+      ? vocabularyProseExtensions
+      : uniqueSorted(
+          scope.extensions
+            .map(normalizeExtension)
+            .filter((extension) =>
+              vocabularyProseExtensions.includes(extension)
+            )
+        );
+
+  if (explicitExtensions && extensions.length === 0) {
+    return null;
+  }
+
+  return {
+    ...(scope?.exclude === undefined ? {} : { exclude: scope.exclude }),
+    extensions,
+    ...(scope?.ignoredDirectories === undefined
+      ? {}
+      : { ignoredDirectories: scope.ignoredDirectories }),
+    ...(scope?.include === undefined ? {} : { include: scope.include }),
+  };
+};
+
+const vocabularyProsePlan = (
+  plan: VocabularyRegradePlan
+): VocabularyRegradePlan | null => {
+  const scope = vocabularyProseScope(plan.scope);
+  if (scope === null) {
+    return null;
+  }
+
+  return { ...plan, scope };
 };
 
 const mergeVocabularyOverrides = (
@@ -563,6 +676,22 @@ const regradeRootNotFound = (rootDir: string) =>
     )
   );
 
+const regradeNoEngineForScope = () =>
+  Result.err(
+    new ValidationError(
+      'Vocabulary regrade has no prose or governed symbol engine for the selected extension scope.'
+    )
+  );
+
+const regradeRootIsReadable = (rootDir: string): boolean => {
+  try {
+    readdirSync(rootDir, { withFileTypes: true });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
 const validateRegradeReport = (
   report: RegradeReport
 ): TrailsResult<z.output<typeof regradeReportOutput>, Error> =>
@@ -579,15 +708,7 @@ const runGovernedSymbolRegrade = (params: {
     params.plan.from,
     params.plan.to
   );
-  const preservedForms = combinePreservedForms(
-    preservedFormsFromRules(params.plan.preserve),
-    preservedFormsFromInventory(params.preserveInventory)
-  );
-  const symbolRenames =
-    transition?.symbolRenames.filter(
-      (rename) => !preservedForms.has(rename.from)
-    ) ?? [];
-  if (transition === undefined || symbolRenames.length === 0) {
+  if (transition === undefined) {
     return Result.ok(null);
   }
 
@@ -597,10 +718,29 @@ const runGovernedSymbolRegrade = (params: {
   }
   return runRegrade({
     apply: params.apply,
-    classes: createGovernedAstIdentifierRenameClasses({
-      ...transition,
-      symbolRenames,
-    }),
+    classes: createGovernedAstIdentifierRenameClasses(
+      {
+        ...transition,
+        symbolRenames: transition.symbolRenames,
+      },
+      {
+        shouldPreserve: (occurrence) =>
+          symbolOccurrenceIsPreserved(params.plan.preserve, {
+            end: occurrence.end,
+            form: occurrence.from,
+            path: occurrence.path,
+            source: occurrence.source,
+            start: occurrence.start,
+          }) ||
+          symbolOccurrenceIsPreserved(params.preserveInventory, {
+            end: occurrence.end,
+            form: occurrence.from,
+            path: occurrence.path,
+            source: occurrence.source,
+            start: occurrence.start,
+          }),
+      }
+    ),
     ...(symbolCollection === undefined ? {} : { collection: symbolCollection }),
     includeEntries: params.includeEntries,
     root: params.rootDir,
@@ -619,29 +759,26 @@ const runVocabularyCommandRegrade = async (
   if (planResult.isErr()) {
     return planResult;
   }
+  if (!regradeRootIsReadable(rootDir)) {
+    return regradeRootNotFound(rootDir);
+  }
 
   const preserveInventory = await deriveLiveApiPreserveInventory(
     planResult.value
   );
+  const prosePlan = vocabularyProsePlan(planResult.value);
   const reportResult: TrailsResult<RegradeReport | null, Error> =
-    runVocabularyRegrade({
-      apply: input.apply,
-      includeEntries: input.includeEntries,
-      plan: planResult.value,
-      ...(preserveInventory.length === 0 ? {} : { preserveInventory }),
-      root: rootDir,
-    });
+    prosePlan === null
+      ? Result.ok(null)
+      : runVocabularyRegrade({
+          apply: input.apply,
+          includeEntries: input.includeEntries,
+          plan: prosePlan,
+          ...(preserveInventory.length === 0 ? {} : { preserveInventory }),
+          root: rootDir,
+        });
   if (reportResult.isErr()) {
     return reportResult;
-  }
-
-  const report = reportResult.value;
-  if (report === null) {
-    return regradeRootNotFound(rootDir);
-  }
-  const validated = validateRegradeReport(report);
-  if (validated.isErr()) {
-    return validated;
   }
 
   const symbolReportResult = runGovernedSymbolRegrade({
@@ -654,12 +791,26 @@ const runVocabularyCommandRegrade = async (
   if (symbolReportResult.isErr()) {
     return symbolReportResult;
   }
-  if (symbolReportResult.value === null) {
+
+  const report = reportResult.value;
+  const symbolReport = symbolReportResult.value;
+  if (report === null) {
+    if (symbolReport === null) {
+      return regradeNoEngineForScope();
+    }
+    return validateRegradeReport(symbolReport);
+  }
+
+  const validated = validateRegradeReport(report);
+  if (validated.isErr()) {
+    return validated;
+  }
+  if (symbolReport === null) {
     return Result.ok(validated.value);
   }
 
   const mergedValidated = validateRegradeReport(
-    mergeRegradeReports(report, symbolReportResult.value)
+    mergeRegradeReports(report, symbolReport)
   );
   return mergedValidated;
 };

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -381,6 +381,17 @@ const mergeRegradeReports = (
       (left.classId ?? '').localeCompare(right.classId ?? '')
   );
   const matchedPaths = actionableEntryPaths(entries);
+  const rewritten = new Set(
+    entries
+      .filter((entry) => entry.outcome === 'rewrite')
+      .map((entry) => entry.path)
+  ).size;
+  const review = new Set(
+    entries
+      .filter((entry) => entry.outcome === 'needs-review')
+      .map((entry) => entry.path)
+  ).size;
+  const matched = new Set(matchedPaths).size;
   const occurrencePaths =
     vocabularyReport.run?.ledger.occurrences.map(
       (occurrence) => occurrence.path
@@ -395,9 +406,9 @@ const mergeRegradeReports = (
     ...vocabularyReport,
     ...(apply === undefined ? {} : { apply }),
     entries,
-    matched: vocabularyReport.matched + symbolReport.matched,
-    review: vocabularyReport.review + symbolReport.review,
-    rewritten: vocabularyReport.rewritten + symbolReport.rewritten,
+    matched,
+    review,
+    rewritten,
     scan: {
       byDirectory: mergedDirectoryBuckets(matchedPaths, occurrencePaths),
       byExtension: mergedExtensionBuckets(matchedPaths, occurrencePaths),

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -13,17 +13,24 @@ import {
 } from '@ontrails/core';
 import type { PathScope, Result as TrailsResult } from '@ontrails/core';
 import {
+  createGovernedAstIdentifierRenameClasses,
   listVocabularyRegradePlansFromRegistry,
   loadWardenTermRewriteClasses,
   regradeReportOutput,
   runRegrade,
   runVocabularyRegrade,
+  vocabularyRegradeTransitionForInput,
   vocabularyDispositionValues,
 } from '@ontrails/regrade';
 import type {
+  RegradeApplySummary,
   RegradeReport,
+  RegradeReportEntry,
+  RegradeScanDirectoryBucket,
+  RegradeScanExtensionBucket,
   VocabularyPreserveRule,
   VocabularyRegradePlan,
+  VocabularyPreserveInventoryEntry,
 } from '@ontrails/regrade';
 import { z } from 'zod';
 
@@ -111,7 +118,9 @@ const regradeInputSchema = regradePathScopeInputSchema.extend({
     .describe('Target vocabulary term for a vocabulary regrade'),
 });
 
-const hasVocabularyInput = (input: z.output<typeof regradeInputSchema>) =>
+type RegradeInput = z.output<typeof regradeInputSchema>;
+
+const hasVocabularyInput = (input: RegradeInput) =>
   input.from !== undefined ||
   input.include !== undefined ||
   input.intent !== undefined ||
@@ -120,7 +129,7 @@ const hasVocabularyInput = (input: z.output<typeof regradeInputSchema>) =>
   input.to !== undefined;
 
 const classModeCollection = (
-  input: z.output<typeof regradeInputSchema>,
+  input: RegradeInput,
   configScope?: RegradeConfigScope | undefined
 ):
   | {
@@ -155,6 +164,26 @@ interface RegradeConfigScope {
   readonly include?: PathScope['include'] | undefined;
 }
 
+interface RegradeCollectionScope {
+  readonly exclude?: readonly string[];
+  readonly extensions?: readonly string[];
+  readonly include?: readonly string[];
+}
+
+const symbolSourceExtensions: readonly string[] = [
+  '.cjs',
+  '.cts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.mts',
+  '.ts',
+  '.tsx',
+] as const;
+
+const normalizeExtension = (extension: string): string =>
+  extension === '' || extension.startsWith('.') ? extension : `.${extension}`;
+
 const vocabularyScopeFromConfig = (
   scope: RegradeConfigScope | undefined
 ): VocabularyRegradePlan['scope'] | undefined =>
@@ -169,7 +198,7 @@ const vocabularyScopeFromConfig = (
       };
 
 const vocabularyPreserveFromInput = (
-  preserve: z.output<typeof regradeInputSchema>['preserve']
+  preserve: RegradeInput['preserve']
 ): readonly VocabularyPreserveRule[] | undefined =>
   preserve?.map((rule) => {
     if (typeof rule === 'string') {
@@ -188,11 +217,256 @@ const vocabularyPreserveFromInput = (
   });
 
 const vocabularyRegistryPlanForInput = (
-  input: z.output<typeof regradeInputSchema>
+  input: RegradeInput
 ): VocabularyRegradePlan | undefined =>
   listVocabularyRegradePlansFromRegistry().find(
     (plan) => plan.from === input.from && plan.to === input.to
   );
+
+const uniqueSorted = (values: readonly string[]): readonly string[] =>
+  [...new Set(values)].toSorted((left, right) => left.localeCompare(right));
+
+const mergeNumericRecords = (
+  left: Readonly<Record<string, number>>,
+  right: Readonly<Record<string, number>>
+): Readonly<Record<string, number>> => {
+  const keys = uniqueSorted([...Object.keys(left), ...Object.keys(right)]);
+  return Object.fromEntries(
+    keys.map((key) => [key, Math.max(left[key] ?? 0, right[key] ?? 0)])
+  );
+};
+
+const extensionForPath = (path: string): string => {
+  const name = path.split('/').at(-1) ?? path;
+  const dot = name.lastIndexOf('.');
+  return dot <= 0 || dot === name.length - 1 ? '<none>' : name.slice(dot);
+};
+
+const topLevelForPath = (path: string): string => {
+  const [segment] = path.split('/');
+  return segment === undefined || segment.length === 0 ? '.' : segment;
+};
+
+const countFilesBy = (
+  paths: readonly string[],
+  keyForPath: (path: string) => string
+): Map<string, number> => {
+  const counts = new Map<string, number>();
+  for (const path of new Set(paths)) {
+    const key = keyForPath(path);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+};
+
+const countOccurrencesBy = (
+  paths: readonly string[],
+  keyForPath: (path: string) => string
+): Map<string, number> => {
+  const counts = new Map<string, number>();
+  for (const path of paths) {
+    const key = keyForPath(path);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+};
+
+const sortBuckets = <T extends { readonly files: number }>(
+  left: T & { readonly key: string },
+  right: T & { readonly key: string }
+): number => right.files - left.files || left.key.localeCompare(right.key);
+
+const mergedDirectoryBuckets = (
+  matchedPaths: readonly string[],
+  occurrencePaths: readonly string[]
+): readonly RegradeScanDirectoryBucket[] => {
+  const fileCounts = countFilesBy(matchedPaths, topLevelForPath);
+  const occurrenceCounts = countOccurrencesBy(occurrencePaths, topLevelForPath);
+  const buckets: (RegradeScanDirectoryBucket & { readonly key: string })[] = [];
+  for (const [path, files] of fileCounts.entries()) {
+    buckets.push(
+      occurrencePaths.length === 0
+        ? { files, key: path, path }
+        : {
+            files,
+            key: path,
+            occurrences: occurrenceCounts.get(path) ?? 0,
+            path,
+          }
+    );
+  }
+  return buckets
+    .toSorted(sortBuckets)
+    .map(({ key: _key, ...bucket }) => bucket);
+};
+
+const mergedExtensionBuckets = (
+  matchedPaths: readonly string[],
+  occurrencePaths: readonly string[]
+): readonly RegradeScanExtensionBucket[] => {
+  const fileCounts = countFilesBy(matchedPaths, extensionForPath);
+  const occurrenceCounts = countOccurrencesBy(
+    occurrencePaths,
+    extensionForPath
+  );
+  const buckets: (RegradeScanExtensionBucket & { readonly key: string })[] = [];
+  for (const [extension, files] of fileCounts.entries()) {
+    buckets.push(
+      occurrencePaths.length === 0
+        ? { extension, files, key: extension }
+        : {
+            extension,
+            files,
+            key: extension,
+            occurrences: occurrenceCounts.get(extension) ?? 0,
+          }
+    );
+  }
+  return buckets
+    .toSorted(sortBuckets)
+    .map(({ key: _key, ...bucket }) => bucket);
+};
+
+const actionableEntryPaths = (
+  entries: readonly RegradeReportEntry[]
+): readonly string[] =>
+  entries.flatMap((entry) =>
+    entry.outcome === 'rewrite' || entry.outcome === 'needs-review'
+      ? [entry.path]
+      : []
+  );
+
+const mergeApplySummary = (
+  left: RegradeApplySummary | undefined,
+  right: RegradeApplySummary | undefined
+): RegradeApplySummary | undefined => {
+  if (left === undefined && right === undefined) {
+    return undefined;
+  }
+
+  const leftValue = left ?? {
+    applied: 0,
+    filesChanged: 0,
+    review: 0,
+    skipped: 0,
+    unknown: 0,
+  };
+  const rightValue = right ?? {
+    applied: 0,
+    filesChanged: 0,
+    review: 0,
+    skipped: 0,
+    unknown: 0,
+  };
+
+  return {
+    applied: leftValue.applied + rightValue.applied,
+    filesChanged: leftValue.filesChanged + rightValue.filesChanged,
+    review: leftValue.review + rightValue.review,
+    skipped: Math.max(leftValue.skipped, rightValue.skipped),
+    unknown: leftValue.unknown + rightValue.unknown,
+  };
+};
+
+const mergeRegradeReports = (
+  vocabularyReport: RegradeReport,
+  symbolReport: RegradeReport
+): RegradeReport => {
+  const entries = [
+    ...vocabularyReport.entries,
+    ...symbolReport.entries,
+  ].toSorted(
+    (left, right) =>
+      left.path.localeCompare(right.path) ||
+      (left.classId ?? '').localeCompare(right.classId ?? '')
+  );
+  const matchedPaths = actionableEntryPaths(entries);
+  const occurrencePaths =
+    vocabularyReport.run?.ledger.occurrences.map(
+      (occurrence) => occurrence.path
+    ) ?? [];
+  const skippedByReason = mergeNumericRecords(
+    vocabularyReport.skipsByReason,
+    symbolReport.skipsByReason
+  );
+  const apply = mergeApplySummary(vocabularyReport.apply, symbolReport.apply);
+
+  return {
+    ...vocabularyReport,
+    ...(apply === undefined ? {} : { apply }),
+    entries,
+    matched: vocabularyReport.matched + symbolReport.matched,
+    review: vocabularyReport.review + symbolReport.review,
+    rewritten: vocabularyReport.rewritten + symbolReport.rewritten,
+    scan: {
+      byDirectory: mergedDirectoryBuckets(matchedPaths, occurrencePaths),
+      byExtension: mergedExtensionBuckets(matchedPaths, occurrencePaths),
+      files: {
+        matched: new Set(matchedPaths).size,
+        scanned: Math.max(vocabularyReport.scanned, symbolReport.scanned),
+        skipped: Math.max(vocabularyReport.skipped, symbolReport.skipped),
+      },
+      skippedByReason,
+    },
+    scanned: Math.max(vocabularyReport.scanned, symbolReport.scanned),
+    selectedClassIds: uniqueSorted([
+      ...vocabularyReport.selectedClassIds,
+      ...symbolReport.selectedClassIds,
+    ]),
+    skipped: Math.max(vocabularyReport.skipped, symbolReport.skipped),
+    skipsByReason: skippedByReason,
+    unknownClassIds: uniqueSorted([
+      ...vocabularyReport.unknownClassIds,
+      ...symbolReport.unknownClassIds,
+    ]),
+  };
+};
+
+const preservedFormsFromRules = (
+  rules: readonly VocabularyPreserveRule[] | undefined
+): ReadonlySet<string> => new Set(rules?.flatMap((rule) => rule.forms ?? []));
+
+const preservedFormsFromInventory = (
+  inventory: readonly VocabularyPreserveInventoryEntry[]
+): ReadonlySet<string> =>
+  new Set(inventory.flatMap((rule) => rule.forms ?? []));
+
+const combinePreservedForms = (
+  left: ReadonlySet<string>,
+  right: ReadonlySet<string>
+): ReadonlySet<string> => new Set([...left, ...right]);
+
+const vocabularySymbolCollection = (
+  scope: VocabularyRegradePlan['scope'] | undefined
+): RegradeCollectionScope | null | undefined => {
+  const exclude = scope?.exclude;
+  const extensions = scope?.extensions;
+  const include = scope?.include;
+  const explicitExtensions = extensions !== undefined;
+  const codeExtensions =
+    extensions === undefined
+      ? symbolSourceExtensions
+      : uniqueSorted(
+          extensions
+            .map(normalizeExtension)
+            .filter((extension) => symbolSourceExtensions.includes(extension))
+        );
+  if (explicitExtensions && codeExtensions.length === 0) {
+    return null;
+  }
+  if (
+    exclude === undefined &&
+    codeExtensions.length === 0 &&
+    include === undefined
+  ) {
+    return undefined;
+  }
+  return {
+    ...(exclude === undefined ? {} : { exclude }),
+    ...(codeExtensions.length === 0 ? {} : { extensions: codeExtensions }),
+    ...(include === undefined ? {} : { include }),
+  };
+};
 
 const mergeVocabularyOverrides = (
   registryPlan: VocabularyRegradePlan | undefined,
@@ -224,7 +498,7 @@ const vocabularyIntentForInput = (
 };
 
 const buildVocabularyPlan = (
-  input: z.output<typeof regradeInputSchema>,
+  input: RegradeInput,
   configScope?: VocabularyRegradePlan['scope']
 ): TrailsResult<VocabularyRegradePlan, ValidationError> => {
   if (input.from === undefined || input.to === undefined) {
@@ -271,6 +545,154 @@ const buildVocabularyPlan = (
   });
 };
 
+const regradeRootNotFound = (rootDir: string) =>
+  Result.err(
+    new NotFoundError(
+      `Regrade root "${rootDir}" could not be read as a directory.`
+    )
+  );
+
+const validateRegradeReport = (
+  report: RegradeReport
+): TrailsResult<z.output<typeof regradeReportOutput>, Error> =>
+  validateOutput(regradeReportOutput, report);
+
+const runGovernedSymbolRegrade = (params: {
+  readonly apply: boolean;
+  readonly includeEntries: RegradeInput['includeEntries'];
+  readonly plan: VocabularyRegradePlan;
+  readonly preserveInventory: readonly VocabularyPreserveInventoryEntry[];
+  readonly rootDir: string;
+}): TrailsResult<RegradeReport | null, Error> => {
+  const transition = vocabularyRegradeTransitionForInput(
+    params.plan.from,
+    params.plan.to
+  );
+  const preservedForms = combinePreservedForms(
+    preservedFormsFromRules(params.plan.preserve),
+    preservedFormsFromInventory(params.preserveInventory)
+  );
+  const symbolRenames =
+    transition?.symbolRenames.filter(
+      (rename) => !preservedForms.has(rename.from)
+    ) ?? [];
+  if (transition === undefined || symbolRenames.length === 0) {
+    return Result.ok(null);
+  }
+
+  const symbolCollection = vocabularySymbolCollection(params.plan.scope);
+  if (symbolCollection === null) {
+    return Result.ok(null);
+  }
+  return runRegrade({
+    apply: params.apply,
+    classes: createGovernedAstIdentifierRenameClasses({
+      ...transition,
+      symbolRenames,
+    }),
+    ...(symbolCollection === undefined ? {} : { collection: symbolCollection }),
+    includeEntries: params.includeEntries,
+    root: params.rootDir,
+  });
+};
+
+const runVocabularyCommandRegrade = async (
+  input: RegradeInput,
+  rootDir: string,
+  configScope?: RegradeConfigScope | undefined
+): Promise<TrailsResult<z.output<typeof regradeReportOutput>, Error>> => {
+  const planResult = buildVocabularyPlan(
+    input,
+    vocabularyScopeFromConfig(configScope)
+  );
+  if (planResult.isErr()) {
+    return planResult;
+  }
+
+  const preserveInventory = await deriveLiveApiPreserveInventory(
+    planResult.value
+  );
+  const reportResult: TrailsResult<RegradeReport | null, Error> =
+    runVocabularyRegrade({
+      apply: input.apply,
+      includeEntries: input.includeEntries,
+      plan: planResult.value,
+      ...(preserveInventory.length === 0 ? {} : { preserveInventory }),
+      root: rootDir,
+    });
+  if (reportResult.isErr()) {
+    return reportResult;
+  }
+
+  const report = reportResult.value;
+  if (report === null) {
+    return regradeRootNotFound(rootDir);
+  }
+  const validated = validateRegradeReport(report);
+  if (validated.isErr()) {
+    return validated;
+  }
+
+  const symbolReportResult = runGovernedSymbolRegrade({
+    apply: input.apply,
+    includeEntries: input.includeEntries,
+    plan: planResult.value,
+    preserveInventory,
+    rootDir,
+  });
+  if (symbolReportResult.isErr()) {
+    return symbolReportResult;
+  }
+  if (symbolReportResult.value === null) {
+    return Result.ok(validated.value);
+  }
+
+  const mergedValidated = validateRegradeReport(
+    mergeRegradeReports(report, symbolReportResult.value)
+  );
+  return mergedValidated;
+};
+
+const runClassModeRegrade = async (
+  input: RegradeInput,
+  rootDir: string,
+  configScope?: RegradeConfigScope | undefined
+): Promise<TrailsResult<z.output<typeof regradeReportOutput>, Error>> => {
+  const classSet = await loadWardenTermRewriteClasses(rootDir);
+  if (classSet.diagnostics.length > 0) {
+    return Result.err(
+      new InternalError('Failed to load Regrade project Warden rules.', {
+        context: {
+          diagnostics: classSet.diagnostics,
+          rootDir,
+        },
+      })
+    );
+  }
+
+  const collection = classModeCollection(input, configScope);
+  const reportResult: TrailsResult<RegradeReport | null, Error> = runRegrade({
+    apply: input.apply,
+    classes: classSet.classes,
+    ...(collection === undefined ? {} : { collection }),
+    includeEntries: input.includeEntries,
+    root: rootDir,
+    ...(input.classIds === undefined
+      ? {}
+      : { selection: { classIds: input.classIds } }),
+  });
+  if (reportResult.isErr()) {
+    return reportResult;
+  }
+
+  const report = reportResult.value;
+  if (report === null) {
+    return regradeRootNotFound(rootDir);
+  }
+
+  return validateRegradeReport(report);
+};
+
 export const regradeTrail = trail('regrade', {
   args: ['from', 'to'],
   blaze: async (input, ctx) => {
@@ -292,90 +714,14 @@ export const regradeTrail = trail('regrade', {
     const configScope = configResult.value.config?.scope;
 
     if (hasVocabularyInput(input)) {
-      const planResult = buildVocabularyPlan(
+      return runVocabularyCommandRegrade(
         input,
-        vocabularyScopeFromConfig(configScope)
-      );
-      if (planResult.isErr()) {
-        return planResult;
-      }
-      const preserveInventory = await deriveLiveApiPreserveInventory(
-        planResult.value
-      );
-      const reportResult: TrailsResult<RegradeReport | null, Error> =
-        runVocabularyRegrade({
-          apply: input.apply,
-          includeEntries: input.includeEntries,
-          plan: planResult.value,
-          ...(preserveInventory.length === 0 ? {} : { preserveInventory }),
-          root: rootDirResult.value,
-        });
-      if (reportResult.isErr()) {
-        return reportResult;
-      }
-      const report = reportResult.value;
-      if (report === null) {
-        return Result.err(
-          new NotFoundError(
-            `Regrade root "${rootDirResult.value}" could not be read as a directory.`
-          )
-        );
-      }
-      const validated: TrailsResult<
-        z.output<typeof regradeReportOutput>,
-        Error
-      > = validateOutput(regradeReportOutput, report);
-      if (validated.isErr()) {
-        return validated;
-      }
-      return Result.ok(validated.value);
-    }
-
-    const classSet = await loadWardenTermRewriteClasses(rootDirResult.value);
-    if (classSet.diagnostics.length > 0) {
-      return Result.err(
-        new InternalError('Failed to load Regrade project Warden rules.', {
-          context: {
-            diagnostics: classSet.diagnostics,
-            rootDir: rootDirResult.value,
-          },
-        })
+        rootDirResult.value,
+        configScope
       );
     }
 
-    const collection = classModeCollection(input, configScope);
-    const reportResult: TrailsResult<RegradeReport | null, Error> = runRegrade({
-      apply: input.apply,
-      classes: classSet.classes,
-      ...(collection === undefined ? {} : { collection }),
-      includeEntries: input.includeEntries,
-      root: rootDirResult.value,
-      ...(input.classIds === undefined
-        ? {}
-        : { selection: { classIds: input.classIds } }),
-    });
-    if (reportResult.isErr()) {
-      return reportResult;
-    }
-
-    const report = reportResult.value;
-    if (report === null) {
-      return Result.err(
-        new NotFoundError(
-          `Regrade root "${rootDirResult.value}" could not be read as a directory.`
-        )
-      );
-    }
-
-    const validated: TrailsResult<
-      z.output<typeof regradeReportOutput>,
-      Error
-    > = validateOutput(regradeReportOutput, report);
-    if (validated.isErr()) {
-      return validated;
-    }
-
-    return Result.ok(validated.value);
+    return runClassModeRegrade(input, rootDirResult.value, configScope);
   },
   description: 'Run downstream migration checks and safe rewrites',
   input: regradeInputSchema,

--- a/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
+++ b/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
@@ -207,6 +207,33 @@ describe('createAstIdentifierRenameClass', () => {
     );
   });
 
+  test('preserves individual identifier occurrences when requested', () => {
+    const cls = createAstIdentifierRenameClass({
+      from: 'sourceTerm',
+      shouldPreserve: (occurrence) =>
+        occurrence.path === 'src/sourceTerm.ts' &&
+        occurrence.start < occurrence.source.indexOf('other'),
+      to: 'targetTerm',
+    });
+    const result = cls.apply(
+      [
+        'export const sourceTerm = 1;',
+        'export const other = sourceTerm;',
+        '',
+      ].join('\n'),
+      { path: 'src/sourceTerm.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        'export const sourceTerm = 1;',
+        'export const other = targetTerm;',
+        '',
+      ].join('\n')
+    );
+  });
+
   test('routes configured shadowed declarations to review', () => {
     const cls = createAstIdentifierRenameClass({
       from: 'sourceTerm',

--- a/packages/regrade/src/downstream/__tests__/collect.test.ts
+++ b/packages/regrade/src/downstream/__tests__/collect.test.ts
@@ -210,6 +210,28 @@ describe('collectDownstreamSources', () => {
     }
   });
 
+  test('honors include globs while still recursing into candidate directories', () => {
+    const root = writeFixture();
+    try {
+      const collection = collectDownstreamSources(root, {
+        include: ['src/nested/**'],
+      });
+      expect(collection).not.toBeNull();
+      const result = collection as NonNullable<typeof collection>;
+
+      expect(result.files.map((file) => file.path)).toEqual([
+        'src/nested/ping.ts',
+      ]);
+      const skippedReasons = new Map(
+        result.skipped.map((entry) => [entry.path, entry.reason])
+      );
+      expect(skippedReasons.get('src/signal.ts')).toBe('not-included-glob');
+      expect(skippedReasons.get('src/view.tsx')).toBe('not-included-glob');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test('normalizes relative roots to preserve absolute file paths', () => {
     const root = writeFixture();
     try {
@@ -253,6 +275,25 @@ describe('collectDownstreamSourcesTrail', () => {
           'src/nested/ping.ts',
           'src/signal.ts',
           'src/view.tsx',
+        ]);
+      }
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  test('forwards include globs to the collector', async () => {
+    const root = writeFixture();
+    try {
+      const result = await executeTrail(collectDownstreamSourcesTrail, {
+        include: ['src/nested/**'],
+        root,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const value = result.value as { files: { path: string }[] };
+        expect(value.files.map((file) => file.path)).toEqual([
+          'src/nested/ping.ts',
         ]);
       }
     } finally {

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -652,6 +652,53 @@ describe('runRegrade', () => {
     }
   });
 
+  test('runRegrade forwards include globs to downstream collection', () => {
+    const root = mkdtempSync(join(tmpdir(), 'regrade-include-scope-'));
+    try {
+      mkdirSync(join(root, 'other'), { recursive: true });
+      mkdirSync(join(root, 'src'), { recursive: true });
+      writeFileSync(
+        join(root, 'other', 'sourceTerm.ts'),
+        'export const sourceTerm = 1;\n'
+      );
+      writeFileSync(
+        join(root, 'src', 'sourceTerm.ts'),
+        'export const sourceTerm = 1;\n'
+      );
+
+      const report = expectRunRegradeOk({
+        classes: [
+          createTermRewriteClass({
+            from: 'sourceTerm',
+            id: 'source-term',
+            to: 'targetTerm',
+          }),
+        ],
+        collection: { include: ['src/**'] },
+        includeEntries: 'all',
+        root,
+      });
+
+      expect(report?.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            outcome: 'rewrite',
+            path: 'src/sourceTerm.ts',
+          }),
+          expect.objectContaining({
+            outcome: 'skip',
+            path: 'other/sourceTerm.ts',
+            reason: 'not-included-glob',
+          }),
+        ])
+      );
+      expect(report?.rewritten).toBe(1);
+      expect(report?.scanned).toBe(1);
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   test('all-extension classes widen multi-class collection', () => {
     const root = mkdtempSync(join(tmpdir(), 'regrade-all-extension-class-'));
     try {

--- a/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
+++ b/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
@@ -252,6 +252,41 @@ describe('runVocabularyRegrade', () => {
     }
   });
 
+  test('honors include globs when collecting vocabulary sources', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'docs/keep.md', 'facet\n');
+      writeFile(dir, 'docs/skip.md', 'facet\n');
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'facet',
+          kind: 'vocabulary',
+          scope: { extensions: ['.md'], include: ['docs/keep.*'] },
+          to: 'trailhead',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value?.skipsByReason).toMatchObject({
+        'not-included-glob': 1,
+      });
+      expect(readFileSync(join(dir, 'docs', 'keep.md'), 'utf8')).toBe(
+        'trailhead\n'
+      );
+      expect(readFileSync(join(dir, 'docs', 'skip.md'), 'utf8')).toBe(
+        'facet\n'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('applies safe captures and preserves authored contexts', () => {
     const dir = makeTempDir();
     try {

--- a/packages/regrade/src/downstream/ast-rewrite.ts
+++ b/packages/regrade/src/downstream/ast-rewrite.ts
@@ -232,6 +232,18 @@ export interface AstIdentifierRenameClassOptions {
   readonly from: string;
   readonly id?: string;
   readonly reviewDeclarationTypes?: ReadonlySet<string>;
+  readonly shouldPreserve?: (
+    occurrence: AstIdentifierRenameOccurrence
+  ) => boolean;
+  readonly to: string;
+}
+
+export interface AstIdentifierRenameOccurrence {
+  readonly end: number;
+  readonly from: string;
+  readonly path: string;
+  readonly source: string;
+  readonly start: number;
   readonly to: string;
 }
 
@@ -288,6 +300,19 @@ export const createAstIdentifierRenameClass = (
         };
       }
 
+      if (
+        options.shouldPreserve?.({
+          end: span.end,
+          from: options.from,
+          path: context.path,
+          source: context.source,
+          start: span.start,
+          to: options.to,
+        }) === true
+      ) {
+        return null;
+      }
+
       const declaration = context.getDeclaration(options.from);
       if (declaration && reviewDeclarationTypes.has(declaration.type)) {
         const location = offsetToLineColumn(context.source, span.start);
@@ -321,7 +346,12 @@ export const createAstIdentifierRenameClass = (
 };
 
 export const createGovernedAstIdentifierRenameClasses = (
-  transition: GovernedVocabularyTransition
+  transition: GovernedVocabularyTransition,
+  options: {
+    readonly shouldPreserve?: (
+      occurrence: AstIdentifierRenameOccurrence
+    ) => boolean;
+  } = {}
 ): readonly RegradeClass[] =>
   transition.symbolRenames.map((rename) =>
     createAstIdentifierRenameClass({
@@ -329,6 +359,9 @@ export const createGovernedAstIdentifierRenameClasses = (
       from: rename.from,
       id: `ast-symbol-rename:${transition.id}:${rename.from}->${rename.to}`,
       reviewDeclarationTypes: new Set(rename.reviewDeclarationTypes),
+      ...(options.shouldPreserve === undefined
+        ? {}
+        : { shouldPreserve: options.shouldPreserve }),
       to: rename.to,
     })
   );

--- a/packages/regrade/src/downstream/collect.ts
+++ b/packages/regrade/src/downstream/collect.ts
@@ -73,6 +73,8 @@ export interface DownstreamCollectionOptions {
   readonly extensions?: readonly string[];
   /** Root-relative path globs to skip before collection. */
   readonly exclude?: readonly string[];
+  /** Root-relative path globs to collect. Omit to collect all matching files. */
+  readonly include?: readonly string[];
 }
 
 /** Outcome of classifying a single directory entry. */
@@ -204,7 +206,15 @@ export const collectDownstreamSources = (
         options
       );
       if (classification.action === 'collect') {
-        files.push({ absolutePath, path });
+        if (
+          options.include !== undefined &&
+          options.include.length > 0 &&
+          !matchesAnyPathGlob(path, options.include)
+        ) {
+          skipped.push({ path, reason: 'not-included-glob' });
+        } else {
+          files.push({ absolutePath, path });
+        }
       } else if (classification.action === 'recurse') {
         queue.push(absolutePath);
       } else {
@@ -231,6 +241,10 @@ export const collectDownstreamSourcesInput = z.object({
     .array(z.string())
     .optional()
     .describe('Directory names to skip during collection'),
+  include: z
+    .array(z.string())
+    .optional()
+    .describe('Root-relative path globs to collect'),
   root: z
     .string()
     .describe('Absolute path to the downstream repo root to scan'),
@@ -273,6 +287,7 @@ export const collectDownstreamSourcesTrail = trail(
           ? {}
           : { extensions: input.extensions }),
         ...(input.exclude === undefined ? {} : { exclude: input.exclude }),
+        ...(input.include === undefined ? {} : { include: input.include }),
         ...(input.ignoredDirectories === undefined
           ? {}
           : { ignoredDirectories: input.ignoredDirectories }),

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -567,6 +567,9 @@ const deriveCollectionOptions = (
     ...(collection?.exclude === undefined
       ? {}
       : { exclude: collection.exclude }),
+    ...(collection?.include === undefined
+      ? {}
+      : { include: collection.include }),
     extensions: collection?.extensions ?? targetExtensions,
     ignoredDirectories:
       collection?.ignoredDirectories ??

--- a/packages/regrade/src/downstream/vocabulary-registry.ts
+++ b/packages/regrade/src/downstream/vocabulary-registry.ts
@@ -66,3 +66,14 @@ export const listVocabularyRegradePlansFromRegistry =
     listGovernedVocabularyTransitions()
       .map(vocabularyRegradePlanFromTransition)
       .filter((plan): plan is VocabularyRegradePlan => plan !== null);
+
+export const vocabularyRegradeTransitionForInput = (
+  from: string,
+  to: string
+): GovernedVocabularyTransition | undefined =>
+  listGovernedVocabularyTransitions().find(
+    (transition) =>
+      transition.from === from &&
+      transition.target.kind === 'single' &&
+      transition.target.to === to
+  );

--- a/packages/regrade/src/downstream/vocabulary.ts
+++ b/packages/regrade/src/downstream/vocabulary.ts
@@ -1251,6 +1251,9 @@ export const runVocabularyRegrade = (params: {
     ...(effectivePlan.scope?.exclude === undefined
       ? {}
       : { exclude: effectivePlan.scope.exclude }),
+    ...(effectivePlan.scope?.include === undefined
+      ? {}
+      : { include: effectivePlan.scope.include }),
     ...(effectivePlan.scope?.ignoredDirectories === undefined
       ? {}
       : { ignoredDirectories: effectivePlan.scope.ignoredDirectories }),

--- a/packages/regrade/src/index.ts
+++ b/packages/regrade/src/index.ts
@@ -22,6 +22,7 @@ export {
 export {
   listVocabularyRegradePlansFromRegistry,
   vocabularyRegradePlanFromTransition,
+  vocabularyRegradeTransitionForInput,
 } from './downstream/vocabulary-registry.js';
 export type {
   RegradeApplySummary,


### PR DESCRIPTION
## Context

[TRL-1125](https://linear.app/outfitter/issue/TRL-1125/substrate-climcp-wiring-to-run-governed-symbol-transitions-from-the) caught the missing seam between the governed vocabulary registry and the `trails regrade <from> <to>` operator path. The Regrade substrate could run prose vocabulary plans and AST symbol classes separately, but the CLI/MCP command did not compose them into the one-command migration path.

## What Changed

- Runs governed AST symbol renames from the registry-backed vocabulary command path after the prose vocabulary pass.
- Preserves derived live API forms when selecting symbol rename classes, so forms such as `facetId` stay out of the automatic symbol pass.
- Threads `include` globs through downstream collection so CLI/MCP scope controls apply to both prose and symbol phases.
- Skips governed symbol scans when explicit extensions exclude code files, avoiding surprising fallback scans.
- Adds CLI and MCP tests proving the same structured command path selects `facet -> trailhead` while preserving `facetId -> trailheadId`.
- Records the TRL-1125 issue-writing miss in `.agents/memory/decisions.md` so the seam/proof lesson does not stay trapped in chat.

## Verification

- `bun test packages/regrade/src/downstream/__tests__/collect.test.ts apps/trails/src/__tests__/regrade.test.ts apps/trails/src/__tests__/mcp.test.ts`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run changeset:check`
- `bun run wayfinder:dogfood`
- `git diff --check`
- Manual CLI smoke: `trails regrade facet trailhead --include 'src/**/*.ts' --include-entries all --root-dir <tmp> --json`
- Local review loop: `/tmp/agent-reviews/trl-1125/local-review/round-1.json`, 5/5 after fixing two P2 findings.
- Graphite pre-push hook passed during draft submit.

## Risks

- The merged report is currently composed in the Trails app layer rather than as a reusable Regrade report-composition primitive. That keeps this PR focused on [TRL-1125](https://linear.app/outfitter/issue/TRL-1125/substrate-climcp-wiring-to-run-governed-symbol-transitions-from-the), but it may be worth extracting if more multi-engine transitions need the same shape.
