### PR TITLE
docs: map package ownership doctrine

### DIFF
--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -284,9 +284,19 @@
           "fromPath": "docs/adr/drafts/20260612-verdicts-run-on-stable-ground.md"
         },
         {
+          "context": "- [ADR-0001: Naming Conventions](../0001-naming-conventions.md)",
+          "from": "20260701",
+          "fromPath": "docs/adr/drafts/20260701-package-ownership-follows-natural-altitude.md"
+        },
+        {
           "context": "Canonical public surface-facing reference. For naming conventions and decision history, see [ADR-0001](./adr/0001-naming-conventions.md).",
           "from": "api-reference",
           "fromPath": "docs/api-reference.md"
+        },
+        {
+          "context": "- [ADR-0001: Naming Conventions](../adr/0001-naming-conventions.md)",
+          "from": "package-ownership",
+          "fromPath": "docs/contributing/package-ownership.md"
         },
         {
           "context": "- **[ADR-0001: Naming Conventions](./adr/0001-naming-conventions.md)** — How and why we chose every term",
@@ -939,6 +949,16 @@
           "context": "[adr-0009]: ../0009-first-class-resources.md",
           "from": "20260612",
           "fromPath": "docs/adr/drafts/20260612-library-surface-and-compiler.md"
+        },
+        {
+          "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md)",
+          "from": "20260701",
+          "fromPath": "docs/adr/drafts/20260701-package-ownership-follows-natural-altitude.md"
+        },
+        {
+          "context": "- [ADR-0009: First-Class Resources](../adr/0009-first-class-resources.md)",
+          "from": "package-ownership",
+          "fromPath": "docs/contributing/package-ownership.md"
         },
         {
           "context": "- **[ADR-0009: First-Class Resources](./adr/0009-first-class-resources.md)** — Dependency declarations, lifecycle, testing, governance",
@@ -2486,6 +2506,16 @@
           "context": "- docs/adr/0041-unified-observability.md",
           "from": "20260503",
           "fromPath": "docs/adr/drafts/20260503-wayfinding.md"
+        },
+        {
+          "context": "The tracing cleanup is the live proof. [ADR-0041](../0041-unified-observability.md) already says core owns intrinsic tracing, `@ontrails/observe` owns app-facing sink contracts, and `@ontrails/tracing",
+          "from": "20260701",
+          "fromPath": "docs/adr/drafts/20260701-package-ownership-follows-natural-altitude.md"
+        },
+        {
+          "context": "- [ADR-0041: Unified Observability](../adr/0041-unified-observability.md)",
+          "from": "package-ownership",
+          "fromPath": "docs/contributing/package-ownership.md"
         },
         {
           "context": "- [ADR-0041: Unified Observability](../adr/0041-unified-observability.md)",

--- a/docs/adr/drafts/20260701-package-ownership-follows-natural-altitude.md
+++ b/docs/adr/drafts/20260701-package-ownership-follows-natural-altitude.md
@@ -1,0 +1,61 @@
+---
+slug: package-ownership-follows-natural-altitude
+title: Package Ownership Follows Natural Altitude
+status: draft
+created: 2026-07-01
+updated: 2026-07-01
+owners: ['[galligan](https://github.com/galligan)']
+depends_on: [1, 9, 41]
+---
+
+# ADR: Package Ownership Follows Natural Altitude
+
+## Context
+
+Trails has been cleaning up repeated helper logic across packages. The repeated shape was not the root problem. The root problem was missing ownership.
+
+The useful cases follow one pattern:
+
+- glob and path-scope logic belongs in `@ontrails/core`;
+- activation graph facts belong in `@ontrails/topographer`;
+- diagnostic base fields belong in `@ontrails/core`;
+- app and package code should consume those owners instead of copying the kernel locally.
+
+The tracing cleanup is the live proof. [ADR-0041](../0041-unified-observability.md) already says core owns intrinsic tracing, `@ontrails/observe` owns app-facing sink contracts, and `@ontrails/tracing` remains compatibility plus developer state. The code still carries two forks: signal trace helpers in `packages/tracing/src/signal-trace.ts` and a bounded memory sink in `packages/tracing/src/memory-sink.ts`.
+
+Without a package ownership rule, each cleanup is argued from scratch. Agents can fix the local duplicate while missing the reusable owner. That is how parallel ledgers grow.
+
+## Decision
+
+Each reusable capability has one canonical owner. The owner is the lowest package where the concept is still coherent and reusable. That is the capability's natural altitude.
+
+This means:
+
+- The owner exports the smallest stable contract other packages need.
+- Consumers compose the owner contract instead of reimplementing it.
+- Higher packages may render, configure, or adapt the owner contract for their domain, but they do not own the kernel.
+- If a consumer needs a different behavior, the choice is explicit: add an extension point to the owner, or declare a distinct capability.
+- Similarity alone is not debt. The ownership test cares about duplicate authority, not repeated scaffolding.
+
+The review test is:
+
+> Can this package consume an owner-owned contract, or is it quietly re-authoring the same concept?
+
+The committed [Package Ownership Map](../../contributing/package-ownership.md) is the evidence appendix for this ADR. It records owned capabilities, migrations, proposed extractions, and tracked unknowns. The first pass deliberately proposes new extraction issues inline instead of creating them automatically. Issue creation remains a separate approval step.
+
+This ADR stays draft until the tracing migration lands. Acceptance should cite the migration as proof that the doctrine works on real code, not only on paper.
+
+## Consequences
+
+- Contributors get a repeatable test for extraction work.
+- Future cleanup can separate true ownership debt from similar-but-valid code.
+- Docs, PRs, and review comments can name natural altitude instead of arguing package boundaries ad hoc.
+- Warden hardening rules should land after the code is clean enough for the rule to encode a real boundary.
+- The ownership map must stay honest about unknowns. A bounded map with tracked unknowns is better than a broad claim that silently under-audits the repo.
+
+## References
+
+- [Package Ownership Map](../../contributing/package-ownership.md)
+- [ADR-0001: Naming Conventions](../0001-naming-conventions.md)
+- [ADR-0009: First-Class Resources](../0009-first-class-resources.md)
+- [ADR-0041: Unified Observability](../0041-unified-observability.md)

--- a/docs/adr/drafts/README.md
+++ b/docs/adr/drafts/README.md
@@ -56,3 +56,8 @@ Draft map: `docs/adr/drafts/decision-map.json`; numbered map: `docs/adr/decision
   - depends on [ADR-0008: Deterministic Surface Derivation](../0008-deterministic-trailhead-derivation.md), [ADR-0019: Hierarchical Command Trees from Trail IDs](../0019-hierarchical-command-trees-from-trail-ids.md), [ADR-0035: Surface APIs Render the Graph](../0035-surface-apis-render-the-graph.md), [ADR-0047: Stable Release Line Discipline](../0047-stable-release-line-discipline.md), [ADR-0050: Surface Accommodations Preserve Trail Identity](../0050-surface-accommodations-preserve-trail-identity.md)
 - [Project Substrate Names Its Truth](20260622-project-substrate-names-its-truth.md)
   - depends on [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md), [ADR-0042: Core/Topographer Boundary Doctrine](../0042-core-topographer-boundary-doctrine.md), [ADR-0046: Lock v3 Artifact Family](../0046-lock-v3-artifact-family.md), [ADR-0050: Surface Accommodations Preserve Trail Identity](../0050-surface-accommodations-preserve-trail-identity.md)
+
+## 2026-07
+
+- [Package Ownership Follows Natural Altitude](20260701-package-ownership-follows-natural-altitude.md)
+  - depends on [ADR-0001: Naming Conventions — Guessable API Through Structural Rules](../0001-naming-conventions.md), [ADR-0009: First-Class Resources](../0009-first-class-resources.md), [ADR-0041: Unified Observability](../0041-unified-observability.md)

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -325,6 +325,19 @@
       "superseded_by": null,
       "title": "Project Substrate Names Its Truth",
       "updated": "2026-06-22"
+    },
+    {
+      "created": "2026-07-01",
+      "depends_on": ["1", "9", "41"],
+      "inbound": [],
+      "number": null,
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/drafts/20260701-package-ownership-follows-natural-altitude.md",
+      "slug": "package-ownership-follows-natural-altitude",
+      "status": "draft",
+      "superseded_by": null,
+      "title": "Package Ownership Follows Natural Altitude",
+      "updated": "2026-07-01"
     }
   ],
   "version": 1

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -10,6 +10,8 @@ If you are building an app with Trails, start with the user-facing docs in [`doc
   criteria, and code shape conventions.
 - [Codebase Navigation](./codebase-navigation.md) — repository orientation,
   source-of-truth locations, generated files, and symbol navigation.
+- [Package Ownership Map](./package-ownership.md) — current natural-altitude
+  map for cross-cutting capabilities and proposed extractions.
 - [Warden Rules](./warden-rules.md) — how to author and audit durable Warden
   and repo-local correctness rules.
 - [Script Graduation](./script-graduation.md) — when root-script behavior must

--- a/docs/contributing/package-ownership.md
+++ b/docs/contributing/package-ownership.md
@@ -1,0 +1,97 @@
+# Package Ownership Map
+
+This map is a bounded first pass for [TRL-1110](https://linear.app/outfitter/issue/TRL-1110/). It records where cross-cutting capabilities naturally belong, where current code already follows that ownership, and where code still carries duplicate or mis-parked kernels.
+
+Use this as a contributor guide, not as a complete archaeology ledger. When a capability is not audited yet, this document says so directly instead of letting broad language imply certainty.
+
+## Ownership Test
+
+Every reusable kernel should have one owner.
+
+The owner is the lowest package where the concept is still coherent and reusable. Call that the capability's natural altitude.
+
+This means:
+
+- Put the kernel where its domain lives.
+- Export the smallest stable contract other packages need.
+- Let higher packages compose or render the owner contract.
+- Do not copy logic into a consumer because importing the owner feels inconvenient.
+- If a consumer needs a different behavior, decide whether the owner contract is missing a real extension point or whether this is a distinct capability.
+
+The review question:
+
+> Can this package consume an owner-owned contract, or is it quietly re-authoring the same concept?
+
+## Status Vocabulary
+
+| Status | Meaning |
+| --- | --- |
+| `owned` | The owner is clear and consumers already import from it. |
+| `migration` | The owner is clear, but consumers still carry duplicate logic. |
+| `proposal` | The owner is likely, but the extraction still needs a focused issue or implementation plan. |
+| `distinct` | Similar shape is intentional and should not be merged. |
+| `unknown` | Not audited in this first pass. |
+
+## Current Map
+
+| Capability | Natural owner | Consumers | Status | Evidence and next move |
+| --- | --- | --- | --- | --- |
+| Glob-to-regexp escaping and matching | `@ontrails/core` | Warden, Regrade, adapter-kit, release tooling | `owned` | `escapeRegExp` and glob helpers already live in `packages/core/src/glob.ts`; prior cleanup moved consumers to core. |
+| Path-scope grammar | `@ontrails/core` | Warden, Regrade, Trails CLI | `owned` | `PathScope` and `pathScopeSchema` live in `packages/core/src/path-scope.ts`. Consumers should use `include`, `exclude`, and `extensions`; do not reintroduce Regrade `ignore` or Warden `jurisdiction`. |
+| Workspace package discovery | `@ontrails/core` | adapter-kit, Warden, app loading | `owned` | `listWorkspacePackages` belongs beside workspace-root discovery in `packages/core/src/workspace.ts`; this is the owner for workspace manifest expansion. |
+| Diagnostic base shape | `@ontrails/core` | Warden, permits, adapter-kit, future diagnostics | `owned` | `DiagnosticBase` and `DiagnosticSeverity` live in `packages/core/src/diagnostics.ts`. Location-specific diagnostic shapes stay with their domains. |
+| Surface error projection | `@ontrails/core` | CLI, MCP, HTTP, Warden coverage | `owned` | `packages/core/src/transport-error-map.ts` owns surface error mapping. Surfaces consume it. |
+| Schema-derived fields | `@ontrails/core` | CLI, MCP, docs, examples | `owned` | Field derivation belongs with schema and trail contract logic, not individual surfaces. |
+| Config merge and resolution primitive | `@ontrails/config` today | Trails app config, future adopter config | `owned` | `@ontrails/config` is the current package owner for schema-validated config loading. Future work may revisit package placement, but consumers should not reimplement merge and file loading. |
+| Signal trace record construction and writing | `@ontrails/core` | `@ontrails/tracing`, signal runtime | `migration` | Core already owns `createSignalTraceRecord` and `writeSignalTraceRecord` internally in `packages/core/src/tracing.ts`; `packages/tracing/src/signal-trace.ts` still forks them. Proposed extraction: export the core helpers and make tracing re-export them for compatibility. |
+| Bounded memory trace sink | `@ontrails/observe` | `@ontrails/tracing`, CLI trace rendering, tests | `migration` | Observe owns `createMemorySink` in `packages/observe/src/memory.ts`. Tracing still carries a duplicate `memory-sink.ts` with a different accessor shape. Proposed extraction: make observe the canonical memory sink and keep tracing compatibility without a second implementation. |
+| Tracing dev-state store | `@ontrails/tracing` | tracing query/status trails, local dev tooling | `owned` | SQLite dev store, trace store registry, cleanup helpers, and query/status trails remain tracing-owned because they are developer-state tooling, not production sink contracts. |
+| OpenTelemetry trace adapter | `@ontrails/tracing/otel` for v1 | users exporting traces | `owned` | ADR-0041 keeps the v1 OTel adapter at the current `@ontrails/tracing/otel` subpath. It is an adapter boundary, not an observe memory-sink contract. |
+| Activation graph derived facts | `@ontrails/topographer` | Trails app topo reports | `owned` | Prior cleanup moved activation-derived facts to Topographer so app reports do not re-project the activation graph. |
+| Stable topo hashing | `@ontrails/topographer` | watch mode, topo artifacts | `proposal` | `apps/trails/src/run-watch.ts` has carried stable JSON hashing parallel to `packages/topographer/src/hash.ts`. Proposed extraction: expose the Topographer-owned stable hash needed by watch mode. |
+| Adapter source scanning | `@ontrails/adapter-kit` | adapter generator, adapter checks/catalog | `proposal` | `apps/trails/src/trails/create-adapter.ts` duplicates source masking and import/export scans from adapter-kit. Proposed extraction: adapter-kit owns reusable scanning helpers; CLI consumes them. |
+| Public/internal export-map boundary checks | `@ontrails/warden` plus source facts from packages | repo governance | `proposal` | Warden should encode the durable rule, but packages own their export maps. Do not move package export truth into Warden. |
+| Topo summary facts for read/report trails | likely Trails app or Topographer, depending on fact | Trails CLI reports, Wayfinder | `unknown` | `buildCurrentTopo*` naming drift was identified, but the ownership split still needs a focused pass: pure graph facts belong lower; presentation-specific summaries may remain app-owned. |
+| Serialization and lock IO | Topographer and Trails app split | compile, validate, Wayfinder | `unknown` | Not audited in this first pass. Future map update should separate lock schema ownership from CLI file IO. |
+| Markdown rendering | package that owns the content domain | docs, Warden guide, release notes | `unknown` | Not audited in this first pass. Do not extract until a real duplicate has evidence and a clear owner. |
+| CLI argument parsing | Trails app CLI surface | CLI routes and commands | `unknown` | Not audited in this first pass. Parsing can stay surface-owned unless it reimplements contract derivation. |
+
+## Proposed Extractions
+
+These are findings from the map. They are not newly created Linear issues in this branch.
+
+| Finding | Proposed extraction | Why it belongs there |
+| --- | --- | --- |
+| Tracing signal helpers fork | Export `createSignalTraceRecord` and `writeSignalTraceRecord` from `@ontrails/core`; make `@ontrails/tracing` re-export them. | Core owns intrinsic trace context, sink registry, signal lifecycle writing, and the runtime call sites. |
+| Tracing memory sink fork | Make `@ontrails/observe` the canonical bounded memory sink; keep `@ontrails/tracing` compatibility without a second implementation. | Observe owns app-facing sink contracts and sink implementations. |
+| Stable topo hash duplicate | Expose or consume the Topographer-owned stable hash from watch mode. | Topographer owns topo artifact identity. |
+| Adapter source scan duplicate | Move reusable source masking and import/export scans to adapter-kit; let `create-adapter` consume it. | Adapter-kit owns adapter authoring conformance. |
+
+## Tracked Unknowns
+
+These were named in [TRL-1110](https://linear.app/outfitter/issue/TRL-1110/) or the audit notes but are not fully decomposed in this first pass:
+
+- serialization and lock IO;
+- markdown rendering;
+- CLI argument parsing beyond route derivation;
+- detailed topo summary/report fact ownership;
+- future config-package placement if `@ontrails/config` is folded into a core-facing API;
+- broader public/internal export ownership beyond Warden rule shape.
+
+Do not treat these as settled. Treat them as explicit follow-up slots for the next ownership-map revision.
+
+## Distinct On Purpose
+
+Do not merge these just because the code shape looks similar:
+
+- `get`, `read`, `find`, and `list` have distinct meanings documented in the language styleguide.
+- Path globs and trail-id globs are different grammars.
+- Warden rule scaffolding can repeat when the repeated shape makes each rule easier to inspect.
+- HTTP and MCP surface rendering can look symmetrical without being duplicate ownership.
+
+## References
+
+- [ADR-0001: Naming Conventions](../adr/0001-naming-conventions.md)
+- [ADR-0009: First-Class Resources](../adr/0009-first-class-resources.md)
+- [ADR-0041: Unified Observability](../adr/0041-unified-observability.md)
+- [Code Standards](./code-standards.md)


### PR DESCRIPTION
## Context

Part of the Coherence Cleanup ownership/tracing stack. This branch addresses [TRL-1110](https://linear.app/outfitter/issue/TRL-1110/) and supports [TRL-1111](https://linear.app/outfitter/issue/TRL-1111/) by making package ownership reviewable before more cleanup work lands.

## What changed

- Added `docs/contributing/package-ownership.md` as the first committed ownership map.
- Linked the map from `docs/contributing/README.md`.
- Added the package ownership ADR as a draft on this lower branch; it is promoted to ADR-0051 upstack after the tracing proof lands.
- Regenerated ADR maps and draft indexes.

## Verification

- `bun scripts/adr.ts check`
- `bun run docs:wrap-check`
- `git diff --check`
- Full-stack verification on the top branch: `bun run changeset:check`, `bun run wayfinder:dogfood`, `bun run check`, `bun run test`, `bun run build`, `bun run publish:check`, `git diff --check`

## Local review

- In-thread local review by Avicenna: 5/5, no P0-P2 findings.
- Fixed two P3 wording suggestions before submit.

## Risks

- This branch intentionally proposes extraction issues in the map but does not create those issues during this stack.
- The ADR remains draft here and is accepted upstack once tracing proves the ownership doctrine.