### PR TITLE
docs(tracing): close compatibility boundary

### DIFF
--- a/.changeset/tracing-compat-boundary.md
+++ b/.changeset/tracing-compat-boundary.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/tracing': patch
+---
+
+Document the completed tracing compatibility boundary and add tests proving core tracing primitive re-exports and the observe-owned memory sink compatibility wrapper.

--- a/docs/adr/0013-tracing.md
+++ b/docs/adr/0013-tracing.md
@@ -5,13 +5,16 @@ title: Tracing — Runtime Recording Primitive
 status: partially-superseded
 superseded_by: ['23']
 created: 2026-03-30
-updated: 2026-05-19
+updated: 2026-07-01
 owners: ['[galligan](https://github.com/galligan)']
 ---
 
 # ADR-0013: Tracing — Runtime Recording Primitive
 
-> **Status update (2026-04-08):** Originally landed as "Tracker" and renamed to "Tracing" by [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md), implemented via TRL-196. The tracker→tracing rename, the `tracingLayer` → intrinsic-in-`executeTrail` collapse, and the `ctx.trace(label, fn)` API replacing `tracker.from(ctx).track(...)` all land through that ADR. The underlying recording, sink, and sampling design described here still governs; only the attachment mechanism and naming changed.
+> **Status updates**
+>
+> - **2026-04-08:** Originally landed as "Tracker" and renamed to "Tracing" by [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md), implemented via TRL-196. The tracker→tracing rename, the `tracingLayer` → intrinsic-in-`executeTrail` collapse, and the `ctx.trace(label, fn)` API replacing `tracker.from(ctx).track(...)` all land through that ADR. The underlying recording, sink, and sampling design described here still governs; only the attachment mechanism and naming changed.
+> - **2026-07-01:** The ADR-0041 package migration is now complete for the v1 boundary. `@ontrails/core` owns trace records, trace context, sink registration, activation records, and signal trace writing. `@ontrails/observe` owns production sink contracts and bounded memory sink behavior. `@ontrails/tracing` remains as compatibility re-exports plus tracing-specific developer state: sampling helpers, `tracingResource`, query/status trails, SQLite dev store, dev-state maintenance, and the supported `@ontrails/tracing/otel` adapter subpath.
 
 ## Context
 

--- a/docs/adr/0041-unified-observability.md
+++ b/docs/adr/0041-unified-observability.md
@@ -4,7 +4,7 @@ slug: unified-observability
 title: Unified Observability
 status: accepted
 created: 2026-04-09
-updated: 2026-05-19
+updated: 2026-07-01
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [6, 13, 39]
 ---
@@ -139,6 +139,8 @@ For v1, `@ontrails/observe` is the canonical production observability package. A
 
 `@ontrails/tracing/otel` remains the supported v1 OpenTelemetry adapter subpath. The API uses adapter vocabulary (`createOtelAdapter`, `OtelAdapterOptions`) and may move to a dedicated adapter package in a later release, but v1 does not require creating `@ontrails/otel`.
 
+**Migration closure (2026-07-01):** The split described above has landed. `@ontrails/tracing` no longer owns parallel implementations of signal trace construction or bounded memory sink retention. It re-exports the core signal helpers and wraps the observe-owned memory sink for compatibility.
+
 ### Dev-time tracing vs production observability
 
 The split is deliberate. Core handles the inner development loop. `@ontrails/observe` handles production.
@@ -156,7 +158,7 @@ A developer never needs `@ontrails/observe` to define or run trails. They need i
 
 Observability follows the Trails posture: zero config by default, one declaration to customize.
 
-The process-level sink registry still keeps `NOOP_SINK` as the disabled baseline. Core owns that registry and the trace record contract, but not a storage sink. Bounded memory tracing is a package-level sink exposed by `@ontrails/observe` for app code and local tooling, and by `@ontrails/tracing` as compatibility while the earlier tracing package migrates. Core does not allocate trace records until a real sink is installed.
+The process-level sink registry still keeps `NOOP_SINK` as the disabled baseline. Core owns that registry and the trace record contract, but not a storage sink. Bounded memory tracing is a package-level sink exposed by `@ontrails/observe` for app code and local tooling, and by `@ontrails/tracing` as a compatibility wrapper. Core does not allocate trace records until a real sink is installed.
 
 Without `@ontrails/observe`, the default execution path stays inert:
 

--- a/docs/adr/0051-package-ownership-follows-natural-altitude.md
+++ b/docs/adr/0051-package-ownership-follows-natural-altitude.md
@@ -1,14 +1,15 @@
 ---
+id: 51
 slug: package-ownership-follows-natural-altitude
 title: Package Ownership Follows Natural Altitude
-status: draft
+status: accepted
 created: 2026-07-01
 updated: 2026-07-01
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [1, 9, 41]
 ---
 
-# ADR: Package Ownership Follows Natural Altitude
+# ADR-0051: Package Ownership Follows Natural Altitude
 
 ## Context
 
@@ -21,7 +22,7 @@ The useful cases follow one pattern:
 - diagnostic base fields belong in `@ontrails/core`;
 - app and package code should consume those owners instead of copying the kernel locally.
 
-The tracing cleanup is the live proof. [ADR-0041](../0041-unified-observability.md) already says core owns intrinsic tracing, `@ontrails/observe` owns app-facing sink contracts, and `@ontrails/tracing` remains compatibility plus developer state. This stack uses that boundary to remove the signal trace helper fork from `packages/tracing/src/signal-trace.ts` and the bounded memory sink fork from `packages/tracing/src/memory-sink.ts`.
+The tracing cleanup is the live proof. [ADR-0041](0041-unified-observability.md) already says core owns intrinsic tracing, `@ontrails/observe` owns app-facing sink contracts, and `@ontrails/tracing` remains compatibility plus developer state. This stack uses that boundary to remove the signal trace helper fork from `packages/tracing/src/signal-trace.ts` and the bounded memory sink fork from `packages/tracing/src/memory-sink.ts`.
 
 Without a package ownership rule, each cleanup is argued from scratch. Agents can fix the local duplicate while missing the reusable owner. That is how parallel ledgers grow.
 
@@ -41,9 +42,9 @@ The review test is:
 
 > Can this package consume an owner-owned contract, or is it quietly re-authoring the same concept?
 
-The committed [Package Ownership Map](../../contributing/package-ownership.md) is the evidence appendix for this ADR. It records owned capabilities, migrations, proposed extractions, and tracked unknowns. The first pass deliberately proposes new extraction issues inline instead of creating them automatically. Issue creation remains a separate approval step.
+The committed [Package Ownership Map](../contributing/package-ownership.md) is the evidence appendix for this ADR. It records owned capabilities, migrations, proposed extractions, and tracked unknowns. The first pass deliberately proposes new extraction issues inline instead of creating them automatically. Issue creation remains a separate approval step.
 
-This ADR stays draft until the tracing migration lands. Acceptance should cite the migration as proof that the doctrine works on real code, not only on paper.
+This ADR is accepted with the tracing migration as proof that the doctrine works on real code, not only on paper.
 
 ## Consequences
 
@@ -55,7 +56,7 @@ This ADR stays draft until the tracing migration lands. Acceptance should cite t
 
 ## References
 
-- [Package Ownership Map](../../contributing/package-ownership.md)
-- [ADR-0001: Naming Conventions](../0001-naming-conventions.md)
-- [ADR-0009: First-Class Resources](../0009-first-class-resources.md)
-- [ADR-0041: Unified Observability](../0041-unified-observability.md)
+- [Package Ownership Map](../contributing/package-ownership.md)
+- [ADR-0001: Naming Conventions](0001-naming-conventions.md)
+- [ADR-0009: First-Class Resources](0009-first-class-resources.md)
+- [ADR-0041: Unified Observability](0041-unified-observability.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,3 +57,4 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0048](0048-trail-versioning-v3.md) | Trail Versioning v3 | Accepted |
 | [0049](0049-composition-is-compose-not-cross.md) | Composition is `compose`, not `cross` | Accepted |
 | [0050](0050-surface-accommodations-preserve-trail-identity.md) | Surface Accommodations Preserve Trail Identity | Accepted |
+| [0051](0051-package-ownership-follows-natural-altitude.md) | Package Ownership Follows Natural Altitude | Accepted |

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -269,6 +269,11 @@
           "fromPath": "docs/adr/0049-composition-is-compose-not-cross.md"
         },
         {
+          "context": "- [ADR-0001: Naming Conventions](0001-naming-conventions.md)",
+          "from": "0051",
+          "fromPath": "docs/adr/0051-package-ownership-follows-natural-altitude.md"
+        },
+        {
           "context": "- docs/adr/0001-naming-conventions.md",
           "from": "20260406",
           "fromPath": "docs/adr/drafts/20260406-documentation-structure.md"
@@ -282,11 +287,6 @@
           "context": "[adr-0001]: ../0001-naming-conventions.md",
           "from": "20260612",
           "fromPath": "docs/adr/drafts/20260612-verdicts-run-on-stable-ground.md"
-        },
-        {
-          "context": "- [ADR-0001: Naming Conventions](../0001-naming-conventions.md)",
-          "from": "20260701",
-          "fromPath": "docs/adr/drafts/20260701-package-ownership-follows-natural-altitude.md"
         },
         {
           "context": "Canonical public surface-facing reference. For naming conventions and decision history, see [ADR-0001](./adr/0001-naming-conventions.md).",
@@ -931,6 +931,11 @@
           "fromPath": "docs/adr/0040-resource-scoped-store-signal-identity.md"
         },
         {
+          "context": "- [ADR-0009: First-Class Resources](0009-first-class-resources.md)",
+          "from": "0051",
+          "fromPath": "docs/adr/0051-package-ownership-follows-natural-altitude.md"
+        },
+        {
           "context": "- docs/adr/0009-first-class-resources.md",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-packs-namespace-boundaries.md"
@@ -949,11 +954,6 @@
           "context": "[adr-0009]: ../0009-first-class-resources.md",
           "from": "20260612",
           "fromPath": "docs/adr/drafts/20260612-library-surface-and-compiler.md"
-        },
-        {
-          "context": "- [ADR-0009: First-Class Resources](../0009-first-class-resources.md)",
-          "from": "20260701",
-          "fromPath": "docs/adr/drafts/20260701-package-ownership-follows-natural-altitude.md"
         },
         {
           "context": "- [ADR-0009: First-Class Resources](../adr/0009-first-class-resources.md)",
@@ -1199,7 +1199,7 @@
       "status": "partially-superseded",
       "superseded_by": ["23"],
       "title": "Tracing — Runtime Recording Primitive",
-      "updated": "2026-05-19"
+      "updated": "2026-07-01"
     },
     {
       "created": "2026-04-02",
@@ -1692,7 +1692,7 @@
           "fromPath": "docs/adr/0001-naming-conventions.md"
         },
         {
-          "context": "> **Status update (2026-04-08):** Originally landed as \"Tracker\" and renamed to \"Tracing\" by [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md), implemented via TRL-196",
+          "context": "> - **2026-04-08:** Originally landed as \"Tracker\" and renamed to \"Tracing\" by [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md), implemented via TRL-196. The tracker→",
           "from": "0013",
           "fromPath": "docs/adr/0013-tracing.md"
         },
@@ -2493,6 +2493,11 @@
           "fromPath": "docs/adr/0043-layer-evolution.md"
         },
         {
+          "context": "The tracing cleanup is the live proof. [ADR-0041](0041-unified-observability.md) already says core owns intrinsic tracing, `@ontrails/observe` owns app-facing sink contracts, and `@ontrails/tracing` r",
+          "from": "0051",
+          "fromPath": "docs/adr/0051-package-ownership-follows-natural-altitude.md"
+        },
+        {
           "context": "- docs/adr/0041-unified-observability.md",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
@@ -2506,11 +2511,6 @@
           "context": "- docs/adr/0041-unified-observability.md",
           "from": "20260503",
           "fromPath": "docs/adr/drafts/20260503-wayfinding.md"
-        },
-        {
-          "context": "The tracing cleanup is the live proof. [ADR-0041](../0041-unified-observability.md) already says core owns intrinsic tracing, `@ontrails/observe` owns app-facing sink contracts, and `@ontrails/tracing",
-          "from": "20260701",
-          "fromPath": "docs/adr/drafts/20260701-package-ownership-follows-natural-altitude.md"
         },
         {
           "context": "- [ADR-0041: Unified Observability](../adr/0041-unified-observability.md)",
@@ -2530,7 +2530,7 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Unified Observability",
-      "updated": "2026-05-19"
+      "updated": "2026-07-01"
     },
     {
       "created": "2026-05-02",
@@ -2919,6 +2919,19 @@
       "superseded_by": null,
       "title": "Surface Accommodations Preserve Trail Identity",
       "updated": "2026-06-14"
+    },
+    {
+      "created": "2026-07-01",
+      "depends_on": ["1", "9", "41"],
+      "inbound": [],
+      "number": "0051",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0051-package-ownership-follows-natural-altitude.md",
+      "slug": "package-ownership-follows-natural-altitude",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Package Ownership Follows Natural Altitude",
+      "updated": "2026-07-01"
     }
   ],
   "version": 1

--- a/docs/adr/drafts/README.md
+++ b/docs/adr/drafts/README.md
@@ -56,8 +56,3 @@ Draft map: `docs/adr/drafts/decision-map.json`; numbered map: `docs/adr/decision
   - depends on [ADR-0008: Deterministic Surface Derivation](../0008-deterministic-trailhead-derivation.md), [ADR-0019: Hierarchical Command Trees from Trail IDs](../0019-hierarchical-command-trees-from-trail-ids.md), [ADR-0035: Surface APIs Render the Graph](../0035-surface-apis-render-the-graph.md), [ADR-0047: Stable Release Line Discipline](../0047-stable-release-line-discipline.md), [ADR-0050: Surface Accommodations Preserve Trail Identity](../0050-surface-accommodations-preserve-trail-identity.md)
 - [Project Substrate Names Its Truth](20260622-project-substrate-names-its-truth.md)
   - depends on [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md), [ADR-0042: Core/Topographer Boundary Doctrine](../0042-core-topographer-boundary-doctrine.md), [ADR-0046: Lock v3 Artifact Family](../0046-lock-v3-artifact-family.md), [ADR-0050: Surface Accommodations Preserve Trail Identity](../0050-surface-accommodations-preserve-trail-identity.md)
-
-## 2026-07
-
-- [Package Ownership Follows Natural Altitude](20260701-package-ownership-follows-natural-altitude.md)
-  - depends on [ADR-0001: Naming Conventions — Guessable API Through Structural Rules](../0001-naming-conventions.md), [ADR-0009: First-Class Resources](../0009-first-class-resources.md), [ADR-0041: Unified Observability](../0041-unified-observability.md)

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -325,19 +325,6 @@
       "superseded_by": null,
       "title": "Project Substrate Names Its Truth",
       "updated": "2026-06-22"
-    },
-    {
-      "created": "2026-07-01",
-      "depends_on": ["1", "9", "41"],
-      "inbound": [],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260701-package-ownership-follows-natural-altitude.md",
-      "slug": "package-ownership-follows-natural-altitude",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "Package Ownership Follows Natural Altitude",
-      "updated": "2026-07-01"
     }
   ],
   "version": 1

--- a/packages/tracing/README.md
+++ b/packages/tracing/README.md
@@ -12,13 +12,17 @@ Use `@ontrails/tracing` when you need compatibility imports for core tracing pri
 
 The `@ontrails/tracing/otel` subpath is the supported v1 OpenTelemetry adapter path. It exports adapter-named APIs such as `createOtelAdapter`, `OtelAdapterOptions`, `OtelExporter`, and `OtelSpan`; no separate `@ontrails/otel` package exists for v1. Trails keeps the internal trace model native to `TraceRecord`, then translates outward at this subpath so the adapter does not force an OpenTelemetry SDK dependency on every tracing user.
 
+Compatibility exports in this package are shims, not second implementations. Core owns `TraceRecord`, trace context, sink registration, activation records, and signal trace writing. Observe owns bounded memory sink behavior. This package re-exports or wraps those owners so older imports continue to work while new code can import from the natural owner directly.
+
+For migration, `@ontrails/tracing` still re-exports core tracing primitives such as `registerTraceSink`, `clearTraceSink`, and `NOOP_SINK`. New code should import those primitives from `@ontrails/core`.
+
 ## The core pattern
 
 ### 1. Register a sink
 
 ```typescript
 import { createMemorySink } from '@ontrails/observe';
-import { registerTraceSink } from '@ontrails/tracing';
+import { registerTraceSink } from '@ontrails/core';
 
 const sink = createMemorySink({ maxRecords: 1000 });
 registerTraceSink(sink);
@@ -104,7 +108,7 @@ For testing and demos:
 
 ```typescript
 import { createMemorySink } from '@ontrails/observe';
-import { registerTraceSink, clearTraceSink } from '@ontrails/tracing';
+import { clearTraceSink, registerTraceSink } from '@ontrails/core';
 
 const sink = createMemorySink({ maxRecords: 500 });
 registerTraceSink(sink);
@@ -118,18 +122,15 @@ try {
 }
 ```
 
-`createMemorySink()` is bounded by default. Older records drop once `maxRecords` is reached, and `sink.droppedCount` reports how many were discarded since the last `sink.clear()`. `createBoundedMemorySink()` is an explicit alias for the same factory. `clearTraceSink()` restores `NOOP_SINK`.
+`createMemorySink()` is bounded by default. Older records drop once `maxRecords` is reached, and `sink.droppedCount` reports how many were discarded since the last `sink.clear()`. The `@ontrails/tracing` export is a compatibility wrapper over the `@ontrails/observe` implementation: prefer `@ontrails/observe` for new sink usage, and keep the tracing import only when migrating older code. `createBoundedMemorySink()` is an explicit alias for the same factory. `clearTraceSink()` restores `NOOP_SINK`.
 
 ### Dev store
 
 SQLite-backed persistence for local development:
 
 ```typescript
-import {
-  createDevStore,
-  registerTraceSink,
-  registerTraceStore,
-} from '@ontrails/tracing';
+import { registerTraceSink } from '@ontrails/core';
+import { createDevStore, registerTraceStore } from '@ontrails/tracing';
 
 const store = createDevStore({
   path: './debug.db',
@@ -148,7 +149,7 @@ Export traces to any OTel-compatible collector:
 
 ```typescript
 import { createOtelAdapter } from '@ontrails/tracing/otel';
-import { registerTraceSink } from '@ontrails/tracing';
+import { registerTraceSink } from '@ontrails/core';
 
 const sink = createOtelAdapter({
   exporter: async (spans) => {
@@ -200,7 +201,7 @@ if (shouldSample('read', config)) {
 
 ```typescript
 import { createMemorySink } from '@ontrails/observe';
-import { registerTraceSink, clearTraceSink } from '@ontrails/tracing';
+import { clearTraceSink, registerTraceSink } from '@ontrails/core';
 import { testAll } from '@ontrails/testing';
 
 const sink = createMemorySink();
@@ -220,5 +221,5 @@ Use `clearTraceSink()` or `registerTraceSink(NOOP_SINK)` to switch back to the s
 ## Installation
 
 ```bash
-bun add @ontrails/observe @ontrails/tracing
+bun add @ontrails/core @ontrails/observe @ontrails/tracing
 ```

--- a/packages/tracing/src/__tests__/compat-boundary.test.ts
+++ b/packages/tracing/src/__tests__/compat-boundary.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  TRACE_CONTEXT_KEY as CORE_TRACE_CONTEXT_KEY,
+  clearTraceSink as clearCoreTraceSink,
+  createActivationTraceRecord as createCoreActivationTraceRecord,
+  createSignalTraceRecord as createCoreSignalTraceRecord,
+  createTraceRecord as createCoreTraceRecord,
+  getTraceContext as getCoreTraceContext,
+  getTraceSink as getCoreTraceSink,
+  NOOP_SINK as CORE_NOOP_SINK,
+  registerTraceSink as registerCoreTraceSink,
+  traceContextFromRecord as traceCoreContextFromRecord,
+  writeActivationTraceRecord as writeCoreActivationTraceRecord,
+  writeSignalTraceRecord as writeCoreSignalTraceRecord,
+} from '@ontrails/core';
+import type { TraceRecord } from '@ontrails/core';
+import {
+  DEFAULT_MEMORY_SINK_MAX_RECORDS as OBSERVE_MEMORY_SINK_MAX_RECORDS,
+  createMemorySink as createObserveMemorySink,
+} from '@ontrails/observe';
+
+import {
+  NOOP_SINK,
+  TRACE_CONTEXT_KEY,
+  clearTraceSink,
+  createActivationTraceRecord,
+  createMemorySink,
+  createSignalTraceRecord,
+  createTraceRecord,
+  getTraceContext,
+  getTraceSink,
+  registerTraceSink,
+  traceContextFromRecord,
+  writeActivationTraceRecord,
+  writeSignalTraceRecord,
+} from '../index.js';
+
+const makeRecord = (id: string): TraceRecord => ({
+  attrs: {},
+  endedAt: 2,
+  id,
+  kind: 'trail',
+  name: `trail.${id}`,
+  rootId: id,
+  startedAt: 1,
+  status: 'ok',
+  traceId: `trace.${id}`,
+  trailId: `trail.${id}`,
+});
+
+describe('@ontrails/tracing compatibility boundary', () => {
+  test('re-exports core tracing primitives without wrapping them', () => {
+    expect(TRACE_CONTEXT_KEY).toBe(CORE_TRACE_CONTEXT_KEY);
+    expect(clearTraceSink).toBe(clearCoreTraceSink);
+    expect(createActivationTraceRecord).toBe(createCoreActivationTraceRecord);
+    expect(createSignalTraceRecord).toBe(createCoreSignalTraceRecord);
+    expect(createTraceRecord).toBe(createCoreTraceRecord);
+    expect(getTraceContext).toBe(getCoreTraceContext);
+    expect(getTraceSink).toBe(getCoreTraceSink);
+    expect(NOOP_SINK).toBe(CORE_NOOP_SINK);
+    expect(registerTraceSink).toBe(registerCoreTraceSink);
+    expect(traceContextFromRecord).toBe(traceCoreContextFromRecord);
+    expect(writeActivationTraceRecord).toBe(writeCoreActivationTraceRecord);
+    expect(writeSignalTraceRecord).toBe(writeCoreSignalTraceRecord);
+  });
+
+  test('keeps memory sink compatibility while observe owns retention behavior', () => {
+    const observeSink = createObserveMemorySink({ maxRecords: 2 });
+    const tracingSink = createMemorySink({ maxRecords: 2 });
+
+    observeSink.write(makeRecord('a'));
+    observeSink.write(makeRecord('b'));
+    observeSink.write(makeRecord('c'));
+    tracingSink.write(makeRecord('a'));
+    tracingSink.write(makeRecord('b'));
+    tracingSink.write(makeRecord('c'));
+
+    const observeSnapshot = observeSink.records();
+    const tracingSnapshot = tracingSink.snapshot();
+
+    observeSink.write(makeRecord('d'));
+    tracingSink.write(makeRecord('d'));
+
+    expect(OBSERVE_MEMORY_SINK_MAX_RECORDS).toBe(1000);
+    expect(tracingSink.maxRecords).toBe(observeSink.maxRecords);
+    expect(tracingSink.droppedCount).toBe(observeSink.droppedCount);
+    expect(tracingSnapshot.map((record) => record.id)).toEqual(['b', 'c']);
+    expect(observeSnapshot.map((record) => record.id)).toEqual(['b', 'c']);
+    expect(tracingSink.records.map((record) => record.id)).toEqual(['c', 'd']);
+    expect(observeSink.records().map((record) => record.id)).toEqual([
+      'c',
+      'd',
+    ]);
+
+    observeSink.clear();
+    tracingSink.clear();
+
+    expect(tracingSink.records).toEqual([]);
+    expect(observeSink.records()).toEqual([]);
+    expect(tracingSink.droppedCount).toBe(0);
+    expect(observeSink.droppedCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Context

Top branch of the Coherence Cleanup ownership/tracing stack. This branch addresses [TRL-1105](https://linear.app/outfitter/issue/TRL-1105/) by closing the tracing compatibility boundary and accepting the package ownership ADR after the tracing proof.

## What changed

- Updated ADR-0013 and ADR-0041 to record the tracing package migration closure.
- Promoted the ownership doctrine from draft to ADR-0051.
- Clarified `@ontrails/tracing` README guidance: compatibility exports plus developer state, with new-code examples importing core-owned primitives from `@ontrails/core`.
- Added compatibility-boundary tests proving tracing re-exports core signal helpers without wrapping and wraps observe memory sink behavior.
- Added a branch-local changeset for the tracing compatibility documentation and test-backed boundary.

## Verification

- `bun test packages/tracing/src/__tests__/compat-boundary.test.ts packages/tracing/src/__tests__/tracing-query.test.ts packages/tracing/src/__tests__/tracing-status.test.ts packages/tracing/src/__tests__/dev-store.test.ts packages/tracing/src/__tests__/otel-adapter.test.ts`
- `bun run --cwd packages/tracing typecheck`
- `bun run --cwd packages/tracing lint`
- `bun scripts/adr.ts check`
- `bun run docs:wrap-check`
- `bun run changeset:check`
- `bun run wayfinder:dogfood`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `git diff --check`

## Local review

- In-thread local review by Locke: 5/5, no P0-P2 findings. Fixed one P3 README import suggestion.
- In-thread local review by Dalton: 5/5, no P0-P2 findings for the ADR-0051 promotion.

## Risks

- `bun run check` passes with known existing Warden warnings around config/tracing public trail anchors and demo signal coaching. This branch does not add new Warden errors.
- No merge, release, or publish has been performed.