### PR TITLE
feat(core): expose typed topo diagnostics

### DIFF
--- a/.changeset/trl-1063-typed-topo-diagnostics.md
+++ b/.changeset/trl-1063-typed-topo-diagnostics.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/core": patch
+---
+
+Expose stable typed topo diagnostics for missing references so downstream
+migration tooling can consume validation results without parsing human messages.

--- a/packages/core/src/__tests__/validate-topo.test.ts
+++ b/packages/core/src/__tests__/validate-topo.test.ts
@@ -10,7 +10,7 @@ import { Result } from '../result.js';
 import { trail } from '../trail.js';
 import { topo } from '../topo.js';
 import type { TopoDiagnostic } from '../validate-topo.js';
-import { validateTopo } from '../validate-topo.js';
+import { getTopoDiagnostics, validateTopo } from '../validate-topo.js';
 import { webhook } from '../webhook.js';
 
 // ---------------------------------------------------------------------------
@@ -89,6 +89,22 @@ describe('validateTopo', () => {
     expect(result.isOk()).toBe(true);
   });
 
+  test('exposes structured diagnostics without parsing messages', () => {
+    const app = topo('app', {
+      exportTrail: mockTrail('entity.export', {
+        composes: ['entity.missing'],
+      }),
+    });
+
+    const result = validateTopo(app);
+    expect(result.isErr()).toBe(true);
+
+    const diagnostics = result.isErr() ? getTopoDiagnostics(result.error) : [];
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.code).toBe('topo.missing-reference');
+    expect(diagnostics[0]?.reference?.missingId).toBe('entity.missing');
+  });
+
   describe('trail composing', () => {
     test('draft compositions are allowed in the authored graph', () => {
       const app = topo('app', {
@@ -115,6 +131,14 @@ describe('validateTopo', () => {
       expect(issues).toHaveLength(1);
       expect(issues[0]?.rule).toBe('compose-exists');
       expect(issues[0]?.message).toContain('entity.missing');
+      expect(issues[0]?.code).toBe('topo.missing-reference');
+      expect(issues[0]?.reference).toEqual({
+        fromId: 'entity.onboard',
+        fromKind: 'trail',
+        fromTrailId: 'entity.onboard',
+        missingId: 'entity.missing',
+        referenceKind: 'compose',
+      });
     });
 
     test('live fork version composing a non-existent trail fails', () => {
@@ -145,6 +169,15 @@ describe('validateTopo', () => {
       expect(issues[0]?.trailId).toBe('entity.versioned');
       expect(issues[0]?.message).toContain('Version 1');
       expect(issues[0]?.message).toContain('entity.missing');
+      expect(issues[0]?.code).toBe('topo.missing-reference');
+      expect(issues[0]?.reference).toEqual({
+        fromId: 'entity.versioned',
+        fromKind: 'trail-version',
+        fromTrailId: 'entity.versioned',
+        missingId: 'entity.missing',
+        referenceKind: 'compose',
+        version: 1,
+      });
     });
 
     test('archived fork version composing a missing trail is not live-validated', () => {
@@ -329,6 +362,14 @@ describe('validateTopo', () => {
       expect(issues).toHaveLength(1);
       expect(issues[0]?.rule).toBe('resource-exists');
       expect(issues[0]?.message).toContain('db.main');
+      expect(issues[0]?.code).toBe('topo.missing-reference');
+      expect(issues[0]?.reference).toEqual({
+        fromId: 'entity.show',
+        fromKind: 'trail',
+        fromTrailId: 'entity.show',
+        missingId: 'db.main',
+        referenceKind: 'resource',
+      });
     });
 
     test('live fork version declaring a missing resource fails', () => {
@@ -360,6 +401,15 @@ describe('validateTopo', () => {
       expect(issues[0]?.trailId).toBe('entity.versioned');
       expect(issues[0]?.message).toContain('Version 1');
       expect(issues[0]?.message).toContain('db.main');
+      expect(issues[0]?.code).toBe('topo.missing-reference');
+      expect(issues[0]?.reference).toEqual({
+        fromId: 'entity.versioned',
+        fromKind: 'trail-version',
+        fromTrailId: 'entity.versioned',
+        missingId: 'db.main',
+        referenceKind: 'resource',
+        version: 1,
+      });
     });
   });
 
@@ -562,6 +612,13 @@ describe('validateTopo', () => {
       expect(issues).toHaveLength(1);
       expect(issues[0]?.rule).toBe('contour-reference-exists');
       expect(issues[0]?.message).toContain('user');
+      expect(issues[0]?.code).toBe('topo.missing-reference');
+      expect(issues[0]?.reference).toEqual({
+        fromId: 'post',
+        fromKind: 'contour',
+        missingId: 'user',
+        referenceKind: 'contour-reference',
+      });
     });
 
     test('draft contour references are allowed', () => {
@@ -596,6 +653,13 @@ describe('validateTopo', () => {
       expect(issues).toHaveLength(1);
       expect(issues[0]?.rule).toBe('signal-origin-exists');
       expect(issues[0]?.message).toContain('entity.ghost');
+      expect(issues[0]?.code).toBe('topo.missing-reference');
+      expect(issues[0]?.reference).toEqual({
+        fromId: 'entity.updated',
+        fromKind: 'signal',
+        missingId: 'entity.ghost',
+        referenceKind: 'signal-origin',
+      });
     });
 
     test('signal without origins is accepted', () => {
@@ -638,6 +702,14 @@ describe('validateTopo', () => {
       expect(issues).toHaveLength(1);
       expect(issues[0]?.rule).toBe('signal-fire-exists');
       expect(issues[0]?.message).toContain('entity.missing');
+      expect(issues[0]?.code).toBe('topo.missing-reference');
+      expect(issues[0]?.reference).toEqual({
+        fromId: 'entity.produce',
+        fromKind: 'trail',
+        fromTrailId: 'entity.produce',
+        missingId: 'entity.missing',
+        referenceKind: 'signal-fire',
+      });
     });
 
     test('trail activating from a missing signal fails', () => {
@@ -654,6 +726,14 @@ describe('validateTopo', () => {
       expect(issues).toHaveLength(1);
       expect(issues[0]?.rule).toBe('signal-on-exists');
       expect(issues[0]?.message).toContain('entity.missing');
+      expect(issues[0]?.code).toBe('topo.missing-reference');
+      expect(issues[0]?.reference).toEqual({
+        fromId: 'entity.consume',
+        fromKind: 'trail',
+        fromTrailId: 'entity.consume',
+        missingId: 'entity.missing',
+        referenceKind: 'signal-on',
+      });
     });
 
     test('draft signal references are allowed in the authored graph', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -447,8 +447,15 @@ export type {
 } from './draft.js';
 
 // Topo validation
-export { validateTopo } from './validate-topo.js';
-export type { TopoDiagnostic, TopoIssue } from './validate-topo.js';
+export { getTopoDiagnostics, validateTopo } from './validate-topo.js';
+export type {
+  TopoDiagnostic,
+  TopoDiagnosticCode,
+  TopoIssue,
+  TopoMissingReference,
+  TopoReferenceKind,
+  TopoReferenceOwnerKind,
+} from './validate-topo.js';
 export { validateEstablishedTopo } from './validate-established-topo.js';
 
 // Layer

--- a/packages/core/src/type-checks.test-d.ts
+++ b/packages/core/src/type-checks.test-d.ts
@@ -29,6 +29,7 @@ import type {
   DraftDiagnostic as BarrelDraftDiagnostic,
   DraftFinding as BarrelDraftFinding,
   TopoDiagnostic as BarrelTopoDiagnostic,
+  TopoMissingReference as BarrelTopoMissingReference,
   TopoIssue as BarrelTopoIssue,
 } from './index.js';
 import { z } from 'zod';
@@ -89,6 +90,16 @@ const augmentedTopoIssue: DirectTopoIssue = {
   trailId: 'example',
 };
 void augmentedTopoIssue;
+
+const topoMissingReference: BarrelTopoMissingReference = {
+  fromId: 'entity.versioned',
+  fromKind: 'trail-version',
+  fromTrailId: 'entity.versioned',
+  missingId: 'entity.missing',
+  referenceKind: 'compose',
+  version: 1,
+};
+void topoMissingReference;
 
 const defaultedTrail = trail('typecheck.defaulted-input', {
   blaze: (input) => {

--- a/packages/core/src/validate-topo.ts
+++ b/packages/core/src/validate-topo.ts
@@ -34,11 +34,49 @@ import { validateWebhookSource } from './webhook.js';
 // Issue shape
 // ---------------------------------------------------------------------------
 
+export type TopoDiagnosticCode = 'topo.missing-reference';
+
+export type TopoReferenceKind =
+  | 'compose'
+  | 'contour-reference'
+  | 'resource'
+  | 'signal-fire'
+  | 'signal-on'
+  | 'signal-origin';
+
+export type TopoReferenceOwnerKind =
+  | 'contour'
+  | 'signal'
+  | 'trail'
+  | 'trail-version';
+
+/**
+ * Stable machine-readable payload for dangling topo references.
+ *
+ * Consumers such as Regrade should branch on `code` and `reference` instead
+ * of parsing `message`, which remains a human-readable diagnostic.
+ */
+export interface TopoMissingReference {
+  readonly fromId: string;
+  readonly fromKind: TopoReferenceOwnerKind;
+  readonly fromTrailId?: string;
+  readonly missingId: string;
+  readonly referenceKind: TopoReferenceKind;
+  readonly version?: number;
+}
+
 export interface TopoDiagnostic {
+  /**
+   * Stable machine-readable code. Human-facing messages may change for
+   * clarity; downstream automation should depend on this code and the typed
+   * payload fields.
+   */
+  readonly code?: TopoDiagnosticCode;
   readonly trailId: string;
   readonly rule: string;
   readonly message: string;
   readonly inputPath?: readonly (string | number)[];
+  readonly reference?: TopoMissingReference;
   readonly schemaIssues?: readonly TopoSchemaIssue[];
   readonly sourceId?: string;
   readonly sourceKind?: string;
@@ -53,6 +91,22 @@ export interface TopoIssue extends TopoDiagnostic {
 }
 
 export type TopoSchemaIssue = ActivationSchemaIssue;
+
+const isTopoDiagnostic = (value: unknown): value is TopoDiagnostic =>
+  typeof value === 'object' &&
+  value !== null &&
+  typeof (value as { message?: unknown }).message === 'string' &&
+  typeof (value as { rule?: unknown }).rule === 'string' &&
+  typeof (value as { trailId?: unknown }).trailId === 'string';
+
+const missingReferenceDiagnostic = (
+  issue: Omit<TopoDiagnostic, 'code' | 'reference'> & {
+    readonly reference: TopoMissingReference;
+  }
+): TopoDiagnostic => ({
+  ...issue,
+  code: 'topo.missing-reference',
+});
 
 // ---------------------------------------------------------------------------
 // Validators
@@ -147,11 +201,20 @@ const checkComposes = (
           trailId: id,
         });
       } else if (!topo.has(composedId) && !isDraftId(composedId)) {
-        issues.push({
-          message: `Composes "${composedId}" which is not in the topo`,
-          rule: 'compose-exists',
-          trailId: id,
-        });
+        issues.push(
+          missingReferenceDiagnostic({
+            message: `Composes "${composedId}" which is not in the topo`,
+            reference: {
+              fromId: id,
+              fromKind: 'trail',
+              fromTrailId: id,
+              missingId: composedId,
+              referenceKind: 'compose',
+            },
+            rule: 'compose-exists',
+            trailId: id,
+          })
+        );
       }
     }
     for (const [rawVersion, entry] of Object.entries(trail.versions ?? {})) {
@@ -174,11 +237,21 @@ const checkComposes = (
             trailId: id,
           });
         } else if (!topo.has(composedId) && !isDraftId(composedId)) {
-          issues.push({
-            message: `Version ${version} composes "${composedId}" which is not in the topo`,
-            rule: 'compose-exists',
-            trailId: id,
-          });
+          issues.push(
+            missingReferenceDiagnostic({
+              message: `Version ${version} composes "${composedId}" which is not in the topo`,
+              reference: {
+                fromId: id,
+                fromKind: 'trail-version',
+                fromTrailId: id,
+                missingId: composedId,
+                referenceKind: 'compose',
+                version,
+              },
+              rule: 'compose-exists',
+              trailId: id,
+            })
+          );
         }
       }
     }
@@ -199,11 +272,20 @@ const checkResources = (
         !topo.hasResource(declaredResource.id) &&
         !isDraftId(declaredResource.id)
       ) {
-        issues.push({
-          message: `Resource "${declaredResource.id}" is not in the topo`,
-          rule: 'resource-exists',
-          trailId: id,
-        });
+        issues.push(
+          missingReferenceDiagnostic({
+            message: `Resource "${declaredResource.id}" is not in the topo`,
+            reference: {
+              fromId: id,
+              fromKind: 'trail',
+              fromTrailId: id,
+              missingId: declaredResource.id,
+              referenceKind: 'resource',
+            },
+            rule: 'resource-exists',
+            trailId: id,
+          })
+        );
       }
     }
     for (const [rawVersion, entry] of Object.entries(trail.versions ?? {})) {
@@ -221,11 +303,21 @@ const checkResources = (
           !topo.hasResource(declaredResource.id) &&
           !isDraftId(declaredResource.id)
         ) {
-          issues.push({
-            message: `Version ${version} resource "${declaredResource.id}" is not in the topo`,
-            rule: 'resource-exists',
-            trailId: id,
-          });
+          issues.push(
+            missingReferenceDiagnostic({
+              message: `Version ${version} resource "${declaredResource.id}" is not in the topo`,
+              reference: {
+                fromId: id,
+                fromKind: 'trail-version',
+                fromTrailId: id,
+                missingId: declaredResource.id,
+                referenceKind: 'resource',
+                version,
+              },
+              rule: 'resource-exists',
+              trailId: id,
+            })
+          );
         }
       }
     }
@@ -310,11 +402,19 @@ const checkSignalOrigins = (
     }
     for (const originId of evt.from) {
       if (!topo.has(originId) && !isDraftId(originId)) {
-        issues.push({
-          message: `Signal origin "${originId}" is not in the topo`,
-          rule: 'signal-origin-exists',
-          trailId: id,
-        });
+        issues.push(
+          missingReferenceDiagnostic({
+            message: `Signal origin "${originId}" is not in the topo`,
+            reference: {
+              fromId: id,
+              fromKind: 'signal',
+              missingId: originId,
+              referenceKind: 'signal-origin',
+            },
+            rule: 'signal-origin-exists',
+            trailId: id,
+          })
+        );
       }
     }
   }
@@ -330,21 +430,39 @@ const checkSignalReferences = (
   for (const [id, trail] of trails) {
     for (const signalId of trail.fires ?? []) {
       if (!signals.has(signalId) && !isDraftId(signalId)) {
-        issues.push({
-          message: `Trail fires signal "${signalId}" which is not in the topo`,
-          rule: 'signal-fire-exists',
-          trailId: id,
-        });
+        issues.push(
+          missingReferenceDiagnostic({
+            message: `Trail fires signal "${signalId}" which is not in the topo`,
+            reference: {
+              fromId: id,
+              fromKind: 'trail',
+              fromTrailId: id,
+              missingId: signalId,
+              referenceKind: 'signal-fire',
+            },
+            rule: 'signal-fire-exists',
+            trailId: id,
+          })
+        );
       }
     }
 
     for (const signalId of trail.on ?? []) {
       if (!signals.has(signalId) && !isDraftId(signalId)) {
-        issues.push({
-          message: `Trail declares on signal "${signalId}" which is not in the topo`,
-          rule: 'signal-on-exists',
-          trailId: id,
-        });
+        issues.push(
+          missingReferenceDiagnostic({
+            message: `Trail declares on signal "${signalId}" which is not in the topo`,
+            reference: {
+              fromId: id,
+              fromKind: 'trail',
+              fromTrailId: id,
+              missingId: signalId,
+              referenceKind: 'signal-on',
+            },
+            rule: 'signal-on-exists',
+            trailId: id,
+          })
+        );
       }
     }
   }
@@ -517,11 +635,19 @@ const checkContourReferences = (
   for (const [name, contourDef] of contours) {
     for (const ref of getContourReferences(contourDef)) {
       if (!topo.hasContour(ref.contour) && !isDraftId(ref.contour)) {
-        issues.push({
-          message: `Contour "${name}" references "${ref.contour}" which is not in the topo`,
-          rule: 'contour-reference-exists',
-          trailId: name,
-        });
+        issues.push(
+          missingReferenceDiagnostic({
+            message: `Contour "${name}" references "${ref.contour}" which is not in the topo`,
+            reference: {
+              fromId: name,
+              fromKind: 'contour',
+              missingId: ref.contour,
+              referenceKind: 'contour-reference',
+            },
+            rule: 'contour-reference-exists',
+            trailId: name,
+          })
+        );
       }
     }
   }
@@ -532,6 +658,21 @@ const checkContourReferences = (
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+
+/**
+ * Extract structured topo diagnostics from a validation error.
+ *
+ * `validateTopo` keeps source compatibility by returning `Result<void,
+ * ValidationError>`. Consumers that need machine-readable diagnostics should
+ * use this helper instead of parsing the human `message` text.
+ */
+export const getTopoDiagnostics = (
+  error: ValidationError
+): readonly TopoDiagnostic[] => {
+  const context = error.context as { issues?: unknown } | undefined;
+  const issues = context?.issues;
+  return Array.isArray(issues) ? issues.filter(isTopoDiagnostic) : [];
+};
 
 /**
  * Validate the structural integrity of a Topo graph.


### PR DESCRIPTION
## Context

Closes [TRL-1063](https://linear.app/outfitter/issue/TRL-1063/add-typed-topo-diagnostics-for-regrade-consumable-dangling-references). Regrade needs topo validation failures it can consume structurally instead of parsing message text.

## Changes

- Adds typed missing-reference diagnostics to topo validation for compose, resource, contour, and signal references.
- Exposes `getTopoDiagnostics()` and exports the new diagnostic/reference types from `@ontrails/core`.
- Adds regression coverage for missing trail, resource, contour, and signal references plus public type checks.

## Verification

- `bun test packages/core/src/__tests__/validate-topo.test.ts`
- `bun run --cwd packages/core typecheck`
- Full stack verification before submit: `bun run typecheck`, `bun run lint`, `bun run lint:ast-grep`, focused Regrade/MCP tests, `bun run test`, `bun run build`, `bun run check`, `bun run changeset:check`, `bun run wayfinder:dogfood`, `bun run publish:check`, `git diff --check`
- Graphite pre-push hook passed.

## Risk

Additive API surface. Existing `validateTopo` pass/fail behavior and message text remain intact; consumers that only read `rule` keep working.