### PR TITLE
feat(regrade): discover prose morphology

### DIFF
--- a/.changeset/trl-1064-vocabulary-morphology.md
+++ b/.changeset/trl-1064-vocabulary-morphology.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/regrade": patch
+---
+
+Teach vocabulary regrades to discover simple prose morphology as deferred
+review inventory so authored plans surface forms like `blazed` and `blazing`.

--- a/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
+++ b/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
@@ -252,6 +252,272 @@ describe('runVocabularyRegrade', () => {
     }
   });
 
+  test('discovers obvious prose morphology as deferred review inventory', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'docs/blaze.md', 'blaze blazes blazed blazing\n');
+
+      const result = runVocabularyRegrade({
+        plan: {
+          from: 'blaze',
+          kind: 'vocabulary',
+          scope: { extensions: ['.md'] },
+          to: 'implementation',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value?.run?.ledger.forms).toEqual({
+        blaze: 'modified',
+        blazed: 'deferred',
+        blazes: 'modified',
+        blazing: 'deferred',
+      });
+      expect(
+        result.value?.run?.ledger.occurrences.map((occurrence) => ({
+          form: occurrence.form,
+          reason: occurrence.reason,
+          verdict: occurrence.verdict,
+        }))
+      ).toEqual([
+        { form: 'blaze', reason: 'captured-form', verdict: 'modified' },
+        { form: 'blazes', reason: 'captured-form', verdict: 'modified' },
+        { form: 'blazed', reason: 'deferred-form', verdict: 'deferred' },
+        { form: 'blazing', reason: 'deferred-form', verdict: 'deferred' },
+      ]);
+      expect(result.value?.run?.report).toMatchObject({
+        deferred: 2,
+        gate: {
+          reasons: [
+            'safe-modifications-not-yet-applied',
+            'deferred-forms-or-occurrences',
+          ],
+          status: 'open',
+        },
+        modified: 2,
+        open: 4,
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('discovers derived morphology case-insensitively', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'docs/blaze.md', 'Blaze Blazes Blazed Blazing\n');
+
+      const result = runVocabularyRegrade({
+        plan: {
+          from: 'Blaze',
+          kind: 'vocabulary',
+          scope: { extensions: ['.md'] },
+          to: 'Implementation',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value?.run?.ledger.forms).toEqual({
+        Blaze: 'modified',
+        Blazed: 'deferred',
+        Blazes: 'modified',
+        Blazing: 'deferred',
+      });
+      expect(result.value?.run?.report.gate.status).toBe('open');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('discovers stem-changing prose morphology as deferred review inventory', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'docs/try.md', 'try tries tried trying\n');
+      writeFile(dir, 'docs/die.md', 'die dies died dying\n');
+
+      const tryResult = runVocabularyRegrade({
+        plan: {
+          from: 'try',
+          kind: 'vocabulary',
+          scope: { include: ['docs/try.md'] },
+          to: 'attempt',
+        },
+        root: dir,
+      });
+      const dieResult = runVocabularyRegrade({
+        plan: {
+          from: 'die',
+          kind: 'vocabulary',
+          scope: { include: ['docs/die.md'] },
+          to: 'expire',
+        },
+        root: dir,
+      });
+
+      expect(tryResult.isOk()).toBe(true);
+      expect(dieResult.isOk()).toBe(true);
+      if (tryResult.isErr()) {
+        throw tryResult.error;
+      }
+      if (dieResult.isErr()) {
+        throw dieResult.error;
+      }
+      expect(tryResult.value.run.ledger.forms).toEqual({
+        tried: 'deferred',
+        tries: 'modified',
+        try: 'modified',
+        trying: 'deferred',
+      });
+      expect(dieResult.value.run.ledger.forms).toEqual({
+        die: 'modified',
+        died: 'deferred',
+        dies: 'modified',
+        dying: 'deferred',
+      });
+      expect(tryResult.value.run.report.gate.status).toBe('open');
+      expect(dieResult.value.run.report.gate.status).toBe('open');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('lets explicit overrides resolve derived deferred morphology', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'docs/blaze.md',
+        'blaze belongs here\nblazed belongs here\nblazing needs review\n'
+      );
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'blaze',
+          kind: 'vocabulary',
+          overrides: { blazed: 'implemented' },
+          scope: { extensions: ['.md'] },
+          to: 'implementation',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.apply).toMatchObject({
+        applied: 2,
+        filesChanged: 1,
+        review: 1,
+      });
+      expect(result.value?.run?.ledger.forms).toEqual({
+        blazing: 'deferred',
+      });
+      expect(
+        result.value?.run?.ledger.occurrences.map((occurrence) => ({
+          form: occurrence.form,
+          verdict: occurrence.verdict,
+        }))
+      ).toEqual([{ form: 'blazing', verdict: 'deferred' }]);
+      expect(readFileSync(join(dir, 'docs', 'blaze.md'), 'utf8')).toBe(
+        'implementation belongs here\nimplemented belongs here\nblazing needs review\n'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('matches override forms case-insensitively when removing derived defers', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'docs/blaze.md',
+        'blaze belongs here\nblazed belongs here\nblazing needs review\n'
+      );
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'blaze',
+          kind: 'vocabulary',
+          overrides: { Blazed: 'implemented' },
+          scope: { extensions: ['.md'] },
+          to: 'implementation',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.apply).toMatchObject({
+        applied: 2,
+        filesChanged: 1,
+        review: 1,
+      });
+      expect(result.value?.run?.ledger.forms).toEqual({
+        blazing: 'deferred',
+      });
+      expect(readFileSync(join(dir, 'docs', 'blaze.md'), 'utf8')).toBe(
+        'implementation belongs here\nimplemented belongs here\nblazing needs review\n'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('lets longer explicit overrides outrank overlapping derived defers', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'docs/blaze.md',
+        'the blazing trail is clear\nstandalone blazing needs review\n'
+      );
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          from: 'blaze',
+          kind: 'vocabulary',
+          overrides: { 'blazing trail': 'implementation trail' },
+          scope: { extensions: ['.md'] },
+          to: 'implementation',
+        },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.apply).toMatchObject({
+        applied: 1,
+        filesChanged: 1,
+        review: 1,
+      });
+      expect(result.value?.run?.ledger.forms).toEqual({
+        blazing: 'deferred',
+      });
+      expect(readFileSync(join(dir, 'docs', 'blaze.md'), 'utf8')).toBe(
+        'the implementation trail is clear\nstandalone blazing needs review\n'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('honors include globs when collecting vocabulary sources', () => {
     const dir = makeTempDir();
     try {

--- a/packages/regrade/src/downstream/vocabulary.ts
+++ b/packages/regrade/src/downstream/vocabulary.ts
@@ -383,10 +383,70 @@ const preserveCase = (sourceForm: string, replacement: string): string => {
   return replacement;
 };
 
-const pluralize = (value: string): string =>
-  value.endsWith('s') || value.endsWith('x') || value.endsWith('ch')
-    ? `${value}es`
-    : `${value}s`;
+const isSimpleVocabularyWord = (value: string): boolean =>
+  /^[A-Za-z]+$/.test(value);
+
+const endsWithConsonantY = (value: string): boolean => {
+  const penultimate = value.at(-2);
+  return (
+    value.endsWith('y') &&
+    penultimate !== undefined &&
+    !/[aeiou]/.test(penultimate)
+  );
+};
+
+const pluralize = (value: string): string => {
+  const lower = value.toLowerCase();
+  let lowerForm: string;
+  if (endsWithConsonantY(lower)) {
+    lowerForm = `${lower.slice(0, -1)}ies`;
+  } else if (
+    lower.endsWith('s') ||
+    lower.endsWith('x') ||
+    lower.endsWith('ch')
+  ) {
+    lowerForm = `${lower}es`;
+  } else {
+    lowerForm = `${lower}s`;
+  }
+  return preserveCase(value, lowerForm);
+};
+
+const pastTenseForm = (value: string): string => {
+  const lower = value.toLowerCase();
+  let lowerForm: string;
+  if (endsWithConsonantY(lower)) {
+    lowerForm = `${lower.slice(0, -1)}ied`;
+  } else if (lower.endsWith('e')) {
+    lowerForm = `${lower}d`;
+  } else {
+    lowerForm = `${lower}ed`;
+  }
+  return preserveCase(value, lowerForm);
+};
+
+const presentParticipleForm = (value: string): string => {
+  const lower = value.toLowerCase();
+  let lowerForm: string;
+  if (lower.endsWith('ie')) {
+    lowerForm = `${lower.slice(0, -2)}ying`;
+  } else if (lower.endsWith('e') && !lower.endsWith('ee')) {
+    lowerForm = `${lower.slice(0, -1)}ing`;
+  } else {
+    lowerForm = `${lower}ing`;
+  }
+  return preserveCase(value, lowerForm);
+};
+
+const defaultDeferredVocabularyForms = (from: string): readonly string[] => {
+  if (!isSimpleVocabularyWord(from)) {
+    return [];
+  }
+  return uniqueSorted([
+    pastTenseForm(from),
+    presentParticipleForm(from),
+  ]).filter((form) => form !== from && form !== pluralize(from));
+};
 
 const defaultVocabularyForms = (from: string, to: string) =>
   new Map<string, string>([
@@ -401,6 +461,11 @@ const normalizedOverrideEntries = (
     left.localeCompare(right)
   );
 
+const formIdentityForPlan = (
+  plan: VocabularyRegradePlan,
+  form: string
+): string => (plan.caseSensitive === true ? form : form.toLowerCase());
+
 const targetFormsForPlan = (
   plan: VocabularyRegradePlan
 ): Map<string, string> => {
@@ -411,8 +476,19 @@ const targetFormsForPlan = (
   return forms;
 };
 
-const deferFormsForPlan = (plan: VocabularyRegradePlan): readonly string[] =>
-  Array.isArray(plan.deferForms) ? uniqueSorted(plan.deferForms) : [];
+const deferFormsForPlan = (plan: VocabularyRegradePlan): readonly string[] => {
+  const overrideForms = new Set(
+    normalizedOverrideEntries(plan.overrides).map(([form]) =>
+      formIdentityForPlan(plan, form)
+    )
+  );
+  return uniqueSorted([
+    ...defaultDeferredVocabularyForms(plan.from).filter(
+      (form) => !overrideForms.has(formIdentityForPlan(plan, form))
+    ),
+    ...(plan.deferForms ?? []),
+  ]);
+};
 
 const validateVocabularyPlan = (
   plan: VocabularyRegradePlan
@@ -610,7 +686,10 @@ const preserveRuleForOccurrence = (
   });
 
 const occurrenceOverlaps = (
-  occurrences: readonly SourceOccurrence[],
+  occurrences: readonly {
+    readonly end: number;
+    readonly start: number;
+  }[],
   start: number,
   end: number
 ): boolean =>
@@ -678,17 +757,28 @@ const deferredOccurrenceFromDraft = (
 const exactDeferredFormOccurrencesForFile = (
   file: SourceFile,
   plan: VocabularyRegradePlan,
-  deferForms: readonly string[]
+  deferForms: readonly string[],
+  targetFormSpans: readonly {
+    readonly end: number;
+    readonly start: number;
+  }[]
 ): readonly SourceOccurrence[] => {
   const occurrences: SourceOccurrence[] = [];
+  const authoredDeferForms = new Set(
+    (plan.deferForms ?? []).map((form) => formIdentityForPlan(plan, form))
+  );
   for (const form of deferForms) {
     const pattern = new RegExp(escapeRegExp(form), vocabularyScanFlags(plan));
     for (const match of file.source.matchAll(pattern)) {
       const start = match.index ?? 0;
       const end = start + match[0].length;
+      const isAuthoredDefer = authoredDeferForms.has(
+        formIdentityForPlan(plan, form)
+      );
       if (
         !hasWordBoundary(file.source, start, end) ||
-        occurrenceOverlaps(occurrences, start, end)
+        occurrenceOverlaps(occurrences, start, end) ||
+        (!isAuthoredDefer && occurrenceOverlaps(targetFormSpans, start, end))
       ) {
         continue;
       }
@@ -703,6 +793,32 @@ const exactDeferredFormOccurrencesForFile = (
     }
   }
   return occurrences;
+};
+
+const targetFormSpansForFile = (
+  file: SourceFile,
+  plan: VocabularyRegradePlan,
+  targetForms: Map<string, string>
+): readonly {
+  readonly end: number;
+  readonly start: number;
+}[] => {
+  const spans: { end: number; start: number }[] = [];
+  for (const form of targetForms.keys()) {
+    const pattern = new RegExp(escapeRegExp(form), vocabularyScanFlags(plan));
+    for (const match of file.source.matchAll(pattern)) {
+      const start = match.index ?? 0;
+      const end = start + match[0].length;
+      if (
+        !hasWordBoundary(file.source, start, end) ||
+        occurrenceOverlaps(spans, start, end)
+      ) {
+        continue;
+      }
+      spans.push({ end, start });
+    }
+  }
+  return spans;
 };
 
 const occurrencesForFile = (
@@ -801,6 +917,7 @@ const deferredOccurrencesForFile = (
   targetForms: Map<string, string>
 ): readonly SourceOccurrence[] => {
   const deferForms = deferFormsForPlan(plan);
+  const targetFormSpans = targetFormSpansForFile(file, plan, targetForms);
   const knownForms = new Set(
     plan.caseSensitive === true
       ? [...targetForms.keys(), ...deferForms]
@@ -812,7 +929,12 @@ const deferredOccurrencesForFile = (
   const lowerFrom = plan.from.toLowerCase();
   const tokenPattern = /[A-Za-z_$][A-Za-z0-9_$-]*/g;
   const occurrences = [
-    ...exactDeferredFormOccurrencesForFile(file, plan, deferForms),
+    ...exactDeferredFormOccurrencesForFile(
+      file,
+      plan,
+      deferForms,
+      targetFormSpans
+    ),
   ];
 
   for (const form of targetForms.keys()) {


### PR DESCRIPTION
## Context

Closes [TRL-1064](https://linear.app/outfitter/issue/TRL-1064/build-deterministic-prose-discoveryapplyverify-executor-for-regrade). The Regrade vocabulary loop needed deterministic prose morphology so safe forms move and uncertain forms become review inventory instead of hidden manual search.

## Changes

- Derives simple default deferred morphology for vocabulary plans, such as past tense and present participle forms.
- Keeps authored `deferForms` as the strongest review signal.
- Lets explicit `overrides` resolve derived deferred forms once a deterministic target is known.
- Adds regression coverage for discovered morphology and override/defer precedence.

## Verification

- `bun test packages/regrade/src/downstream/__tests__/vocabulary.test.ts`
- Local review round 1 found an override precedence P2; fixed here. Round 2 was clean for P0-P2 and directly probed `overrides` plus `deferForms`.
- Full stack verification before submit: `bun run typecheck`, `bun run lint`, `bun run lint:ast-grep`, focused Regrade/MCP tests, `bun run test`, `bun run build`, `bun run check`, `bun run changeset:check`, `bun run wayfinder:dogfood`, `bun run publish:check`, `git diff --check`
- Graphite pre-push hook passed.

## Risk

The new morphology stays conservative: derived forms go to review unless explicitly overridden, and authored `deferForms` can still force review even when an override exists.