### PR TITLE
test(regrade): dogfood facet trailhead loop

### DIFF
--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -303,6 +303,169 @@ describe('Trails MCP surface shaping', () => {
     }
   });
 
+  test('executes facet to trailhead dogfood reports through MCP', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'docs/surface.md',
+        'The facet docs mention facets. facetId stays review.\n'
+      );
+      writeFile(
+        dir,
+        'src/surface.ts',
+        [
+          'export const facet = "facet";',
+          'export const facetId = facet;',
+          'export const facets = [facet];',
+          '',
+        ].join('\n')
+      );
+      writeFile(dir, '.agents/notes/history.md', 'facet\n');
+      writeFile(dir, '.agents/skills/trails/SKILL.md', 'facet\n');
+      writeFile(dir, '.scratch/history.md', 'facet\n');
+      writeFile(dir, 'plugin/skills/trails/SKILL.md', 'facet\n');
+
+      const tools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
+      const regrade = requireTool(tools, 'trails_regrade');
+
+      const result = await regrade.handler(
+        {
+          exclude: ['.agents/notes/**', '.scratch/**'],
+          from: 'facet',
+          includeEntries: 'all',
+          rootDir: dir,
+          to: 'trailhead',
+        },
+        {}
+      );
+
+      expect(result.isError).toBeUndefined();
+      const structured = result.structuredContent as {
+        readonly entries?: readonly {
+          readonly classId?: string;
+          readonly outcome?: string;
+          readonly path?: string;
+          readonly reason?: string;
+        }[];
+        readonly run?: {
+          readonly ledger?: {
+            readonly forms?: Record<string, string>;
+            readonly occurrences?: readonly {
+              readonly form?: string;
+              readonly path?: string;
+              readonly replacement?: string;
+              readonly verdict?: string;
+            }[];
+          };
+          readonly plan?: {
+            readonly from?: string;
+            readonly id?: string;
+            readonly scope?: { readonly exclude?: readonly string[] };
+            readonly to?: string;
+          };
+          readonly report?: {
+            readonly gate?: { readonly status?: string };
+            readonly modified?: number;
+            readonly open?: number;
+          };
+        };
+        readonly selectedClassIds?: readonly string[];
+      };
+
+      expect(structured.selectedClassIds).toEqual(
+        expect.arrayContaining([
+          'ast-symbol-rename:v1-facet-trailhead:facet->trailhead',
+          'ast-symbol-rename:v1-facet-trailhead:facetId->trailheadId',
+          'ast-symbol-rename:v1-facet-trailhead:facets->trailheads',
+          'v1-facet-trailhead',
+        ])
+      );
+      expect(structured.run?.plan).toMatchObject({
+        from: 'facet',
+        id: 'v1-facet-trailhead',
+        scope: { exclude: ['.agents/notes/**', '.scratch/**'] },
+        to: 'trailhead',
+      });
+      expect(structured.run?.ledger?.forms).toMatchObject({
+        facet: 'modified',
+        facetId: 'deferred',
+        facets: 'modified',
+      });
+      expect(structured.run?.ledger?.occurrences).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            form: 'facet',
+            path: '.agents/skills/trails/SKILL.md',
+            replacement: 'trailhead',
+            verdict: 'modified',
+          }),
+          expect.objectContaining({
+            form: 'facetId',
+            path: 'docs/surface.md',
+            verdict: 'deferred',
+          }),
+        ])
+      );
+      expect(
+        structured.run?.ledger?.occurrences?.map((entry) => entry.path)
+      ).not.toContain('.agents/notes/history.md');
+      expect(
+        structured.run?.ledger?.occurrences?.map((entry) => entry.path)
+      ).not.toContain('.scratch/history.md');
+      expect(structured.run?.report).toMatchObject({
+        gate: { status: 'open' },
+        modified: 4,
+        open: 5,
+      });
+      expect(structured.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            classId: 'ast-symbol-rename:v1-facet-trailhead:facet->trailhead',
+            outcome: 'rewrite',
+            path: 'src/surface.ts',
+          }),
+          expect.objectContaining({
+            outcome: 'needs-review',
+            path: 'docs/surface.md',
+            reason: 'vocabulary-judgment-deferred',
+          }),
+        ])
+      );
+      expect(readFileSync(join(dir, 'docs', 'surface.md'), 'utf8')).toBe(
+        'The facet docs mention facets. facetId stays review.\n'
+      );
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toBe(
+        [
+          'export const facet = "facet";',
+          'export const facetId = facet;',
+          'export const facets = [facet];',
+          '',
+        ].join('\n')
+      );
+      expect(
+        readFileSync(join(dir, '.agents', 'notes', 'history.md'), 'utf8')
+      ).toBe('facet\n');
+      expect(
+        readFileSync(
+          join(dir, '.agents', 'skills', 'trails', 'SKILL.md'),
+          'utf8'
+        )
+      ).toBe('facet\n');
+      expect(readFileSync(join(dir, '.scratch', 'history.md'), 'utf8')).toBe(
+        'facet\n'
+      );
+      expect(
+        readFileSync(
+          join(dir, 'plugin', 'skills', 'trails', 'SKILL.md'),
+          'utf8'
+        )
+      ).toBe('facet\n');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('executes registry-backed regrade review forms through MCP', async () => {
     const dir = makeTempDir();
     try {

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -369,6 +369,190 @@ describe('trails regrade', () => {
     }
   });
 
+  test('CLI dogfoods facet to trailhead through plan, ledger, and report', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'docs/surface.md',
+        'The facet docs mention facets. facetId stays review. Facet heading.\n'
+      );
+      writeFile(
+        dir,
+        'src/surface.ts',
+        [
+          'export const facet = "facet";',
+          'export const facetId = facet;',
+          'export const facets = [facet];',
+          '',
+        ].join('\n')
+      );
+      writeFile(dir, '.agents/notes/history.md', 'facet\n');
+      writeFile(dir, '.agents/skills/trails/SKILL.md', 'facet\n');
+      writeFile(dir, '.scratch/history.md', 'facet\n');
+      writeFile(dir, 'plugin/skills/trails/SKILL.md', 'facet\n');
+
+      const result = runRawCli([
+        'regrade',
+        'facet',
+        'trailhead',
+        '--root-dir',
+        dir,
+        '--exclude',
+        '.agents/notes/**',
+        '--exclude',
+        '.scratch/**',
+        '--include-entries',
+        'all',
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        readonly entries?: readonly {
+          readonly classId?: string;
+          readonly outcome?: string;
+          readonly path?: string;
+          readonly reason?: string;
+        }[];
+        readonly run?: {
+          readonly ledger?: {
+            readonly forms?: Record<string, string>;
+            readonly occurrences?: readonly {
+              readonly disposition?: string;
+              readonly form?: string;
+              readonly path?: string;
+              readonly replacement?: string;
+              readonly verdict?: string;
+            }[];
+          };
+          readonly plan?: {
+            readonly from?: string;
+            readonly id?: string;
+            readonly scope?: { readonly exclude?: readonly string[] };
+            readonly to?: string;
+          };
+          readonly report?: {
+            readonly gate?: {
+              readonly reasons?: readonly string[];
+              readonly status?: string;
+            };
+            readonly modified?: number;
+            readonly open?: number;
+          };
+        };
+        readonly selectedClassIds?: readonly string[];
+        readonly skipsByReason?: Record<string, number>;
+      };
+
+      expect(parsed.selectedClassIds).toEqual(
+        expect.arrayContaining([
+          'ast-symbol-rename:v1-facet-trailhead:facet->trailhead',
+          'ast-symbol-rename:v1-facet-trailhead:facetId->trailheadId',
+          'ast-symbol-rename:v1-facet-trailhead:facets->trailheads',
+          'v1-facet-trailhead',
+        ])
+      );
+      expect(parsed.run?.plan).toMatchObject({
+        from: 'facet',
+        id: 'v1-facet-trailhead',
+        scope: { exclude: ['.agents/notes/**', '.scratch/**'] },
+        to: 'trailhead',
+      });
+      expect(parsed.run?.ledger?.forms).toMatchObject({
+        Facet: 'deferred',
+        facet: 'modified',
+        facetId: 'deferred',
+        facets: 'modified',
+      });
+      expect(parsed.run?.ledger?.occurrences).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            form: 'facet',
+            path: '.agents/skills/trails/SKILL.md',
+            replacement: 'trailhead',
+            verdict: 'modified',
+          }),
+          expect.objectContaining({
+            form: 'facet',
+            path: 'plugin/skills/trails/SKILL.md',
+            replacement: 'trailhead',
+            verdict: 'modified',
+          }),
+          expect.objectContaining({
+            disposition: 'in-family-unresolved',
+            form: 'facetId',
+            path: 'docs/surface.md',
+            verdict: 'deferred',
+          }),
+        ])
+      );
+      expect(
+        parsed.run?.ledger?.occurrences?.map((entry) => entry.path)
+      ).not.toContain('.agents/notes/history.md');
+      expect(
+        parsed.run?.ledger?.occurrences?.map((entry) => entry.path)
+      ).not.toContain('.scratch/history.md');
+      expect(parsed.run?.report).toMatchObject({
+        gate: {
+          reasons: [
+            'safe-modifications-not-yet-applied',
+            'deferred-forms-or-occurrences',
+          ],
+          status: 'open',
+        },
+        modified: 4,
+        open: 6,
+      });
+      expect(parsed.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            classId: 'ast-symbol-rename:v1-facet-trailhead:facet->trailhead',
+            outcome: 'rewrite',
+            path: 'src/surface.ts',
+          }),
+          expect.objectContaining({
+            outcome: 'needs-review',
+            path: 'docs/surface.md',
+            reason: 'vocabulary-judgment-deferred',
+          }),
+        ])
+      );
+      expect(parsed.skipsByReason).toMatchObject({ 'ignored-glob': 2 });
+      expect(readFileSync(join(dir, 'docs', 'surface.md'), 'utf8')).toBe(
+        'The facet docs mention facets. facetId stays review. Facet heading.\n'
+      );
+      expect(readFileSync(join(dir, 'src', 'surface.ts'), 'utf8')).toBe(
+        [
+          'export const facet = "facet";',
+          'export const facetId = facet;',
+          'export const facets = [facet];',
+          '',
+        ].join('\n')
+      );
+      expect(
+        readFileSync(join(dir, '.agents', 'notes', 'history.md'), 'utf8')
+      ).toBe('facet\n');
+      expect(
+        readFileSync(
+          join(dir, '.agents', 'skills', 'trails', 'SKILL.md'),
+          'utf8'
+        )
+      ).toBe('facet\n');
+      expect(readFileSync(join(dir, '.scratch', 'history.md'), 'utf8')).toBe(
+        'facet\n'
+      );
+      expect(
+        readFileSync(
+          join(dir, 'plugin', 'skills', 'trails', 'SKILL.md'),
+          'utf8'
+        )
+      ).toBe('facet\n');
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('CLI applies governed symbol include scope before rewriting', () => {
     const dir = makeTempDir();
     try {


### PR DESCRIPTION
## Context

Closes [TRL-1069](https://linear.app/outfitter/issue/TRL-1069/dogfood-facet-to-trailhead-through-the-authored-regrade-loop). This proves the `facet -> trailhead` transition can run through Regrade as a plan/ledger/report loop across CLI and MCP, while keeping broad prose review inventory open.

## Changes

- Adds a CLI dogfood test for `trails regrade facet trailhead` using the registry plan and governed AST classes.
- Adds an MCP dogfood test through `trails_regrade` for the same transition.
- Proves scoped excludes for `.agents/notes/**` and `.scratch/**`, while keeping `.agents/skills/**` and `plugin/skills/**` in scope.
- Proves dry-run no-mutation with exact post-run file equality across docs, source, excluded paths, and included skill fixtures.

## Verification

- Live smoke before test capture: `bun apps/trails/bin/trails.ts regrade --root-dir . --from facet --to trailhead --exclude .agents/notes/** --exclude .agents/plans/** --exclude .agents/goals/** --exclude .scratch/** --json` produced selected governed classes, 67 entries, 25 rewrites, 42 review items, and an open report gate without mutating the repo.
- `bun test apps/trails/src/__tests__/mcp.test.ts apps/trails/src/__tests__/regrade.test.ts` passed, 39 tests / 389 assertions.
- Local review round 1 found a dry-run no-mutation proof P2; fixed here. Round 2 was clean for P0-P2.
- Full stack verification before submit: `bun run typecheck`, `bun run lint`, `bun run lint:ast-grep`, focused Regrade/MCP tests, `bun run test`, `bun run build`, `bun run check`, `bun run changeset:check`, `bun run wayfinder:dogfood`, `bun run publish:check`, `git diff --check`
- Graphite pre-push hook passed.

## Risk

Test-only branch. The live dogfood output intentionally leaves the gate open because prose review inventory remains, which is the desired Regrade loop behavior.