### PR TITLE
chore(examples): add showcase suite workspace substrate

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -123,6 +123,26 @@
         "@ontrails/warden": "workspace:^",
       },
     },
+    "examples/junction": {
+      "name": "junction",
+      "version": "0.0.0",
+    },
+    "examples/lookout": {
+      "name": "lookout",
+      "version": "0.0.0",
+    },
+    "examples/packlist": {
+      "name": "packlist",
+      "version": "0.0.0",
+    },
+    "examples/stash": {
+      "name": "stash",
+      "version": "0.0.0",
+    },
+    "examples/switchback": {
+      "name": "switchback",
+      "version": "0.0.0",
+    },
     "packages/adapter-kit": {
       "name": "@ontrails/adapter-kit",
       "version": "1.0.0-beta.36",
@@ -883,6 +903,8 @@
 
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
 
+    "junction": ["junction@workspace:examples/junction"],
+
     "katex": ["katex@0.16.43", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-K7NL5JtGrFEglipOAjY4UYA69CnTuNmjArxeXF6+bw7h2OGySUPv6QWRjfb1gmutJ4Mw/qLeBqiROOEDULp4nA=="],
 
     "knip": ["knip@6.12.2", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "minimist": "^1.2.8", "oxc-parser": "^0.128.0", "oxc-resolver": "^11.19.1", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.16", "unbash": "^3.0.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-RcZpT1sVziKZgDk1F0hAcp+bq71VJAF8vg1Y9ZLXc1+UXQaMm1rjiUqpJQTIj+lqwmiBQT19/u7ikgazs23cvA=="],
@@ -914,6 +936,8 @@
     "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "lodash.startcase": ["lodash.startcase@4.4.0", "", {}, "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg=="],
+
+    "lookout": ["lookout@workspace:examples/lookout"],
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
@@ -1041,6 +1065,8 @@
 
     "package-manager-detector": ["package-manager-detector@0.2.11", "", { "dependencies": { "quansync": "^0.2.7" } }, "sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ=="],
 
+    "packlist": ["packlist@workspace:examples/packlist"],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
@@ -1131,6 +1157,8 @@
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
+    "stash": ["stash@workspace:examples/stash"],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-width": ["string-width@8.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "strip-ansi": "^7.1.0" } }, "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg=="],
@@ -1140,6 +1168,8 @@
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
+
+    "switchback": ["switchback@workspace:examples/switchback"],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,39 @@
+# Trails Showcase Suite
+
+Five showcase apps, each with one hero capability, at least two surfaces, and a one-sentence explanation a stranger understands. Together they cover the entire primitive set and serve as public showcases, forkable scaffolding for adopters, and a standing dogfood corpus.
+
+Each app lives in `examples/<name>/` and is built in its own run, confined to its own directory. The workspaces here start as placeholders so `bun.lock` takes the workspace-membership churn once, before the parallel builds begin.
+
+## The lineup
+
+| App | One-liner | Hero |
+| --- | --------- | ---- |
+| `packlist` | Gear & trip checklists | entities, store, CRUD factory, versioning, store signals |
+| `junction` | Self-hosted webhook relay | HTTP at full strength: webhooks, permits/JWT, error taxonomy, OpenAPI |
+| `switchback` | Feature flags | the library surface — one contract as import, command, and tool |
+| `stash` | Self-hosted Gists (the mega app) | breadth: revisions/forks, permits, search, trailheads, MCP-first |
+| `lookout` | Uptime monitor & status page | activation (cron), signals, detours, compose, observe/tracing |
+
+## Shared conventions (every app)
+
+- Lives in-repo under `examples/<name>` as a `private: true` workspace — never published, excluded from publish discovery, lockstep versioning, and changeset requirements.
+- `testAll(app)` green with every resource mocked.
+- Committed `trails.lock`.
+- Warden-clean (0 errors) and Wayfinder-navigable.
+- README opens with a "what this showcases" matrix plus a quickstart that actually runs — usable end-to-end is the exit criterion, not "compiles".
+- Current-live vocabulary only.
+- Each app is roughly 15–25 trails, except `stash` (the deliberate kitchen sink and standing mega-dogfood).
+
+### The showcase-matrix README pattern
+
+Every app README opens with a table mapping framework capabilities to where the app exercises them, so a reader can jump from "I want to see signals" straight to the file that shows them. The quickstart that follows must run as written.
+
+## Hard rule for app builds
+
+An app build run may **not** modify `packages/*`, `adapters/*`, or root config. Framework bugs or gaps found while building are the dogfood payoff — file them as issues (plus fieldwork notes) and work around, or hand the fix to a separate small branch. This keeps app PRs reviewable and framework changes changeset'd.
+
+Because app builds cannot touch framework surfaces, the wayfinder-dogfood smoke (`bun run wayfinder:dogfood`) is normally not applicable to example-only PRs — say so in the PR. A framework fix spun out to its own branch follows the usual rules, including wayfinder-dogfood when it changes framework surfaces.
+
+## CI
+
+Example workspaces run in the normal gates: turbo picks up `build`, `test`, `typecheck`, and `lint` from each example's package scripts, and `bun run check` covers the repo-wide checks. An example app never needs a changeset; the release check only tracks publishable `@ontrails/*` workspaces.

--- a/examples/junction/package.json
+++ b/examples/junction/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "junction",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  }
+}

--- a/examples/junction/src/__tests__/placeholder.test.ts
+++ b/examples/junction/src/__tests__/placeholder.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test';
+
+import { workspaceName } from '../index.js';
+
+describe('junction workspace placeholder', () => {
+  test('reserves the workspace name', () => {
+    expect(workspaceName).toBe('junction');
+  });
+});

--- a/examples/junction/src/index.ts
+++ b/examples/junction/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Placeholder module for the `junction` showcase app.
+ *
+ * The real app lands in its own build run confined to `examples/junction/`.
+ * This placeholder only reserves the workspace so `bun.lock` takes the
+ * membership churn once, before the parallel builds start.
+ */
+export const workspaceName = 'junction';

--- a/examples/junction/tsconfig.json
+++ b/examples/junction/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/examples/lookout/package.json
+++ b/examples/lookout/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "lookout",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  }
+}

--- a/examples/lookout/src/__tests__/placeholder.test.ts
+++ b/examples/lookout/src/__tests__/placeholder.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test';
+
+import { workspaceName } from '../index.js';
+
+describe('lookout workspace placeholder', () => {
+  test('reserves the workspace name', () => {
+    expect(workspaceName).toBe('lookout');
+  });
+});

--- a/examples/lookout/src/index.ts
+++ b/examples/lookout/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Placeholder module for the `lookout` showcase app.
+ *
+ * The real app lands in its own build run confined to `examples/lookout/`.
+ * This placeholder only reserves the workspace so `bun.lock` takes the
+ * membership churn once, before the parallel builds start.
+ */
+export const workspaceName = 'lookout';

--- a/examples/lookout/tsconfig.json
+++ b/examples/lookout/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/examples/packlist/package.json
+++ b/examples/packlist/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "packlist",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  }
+}

--- a/examples/packlist/src/__tests__/placeholder.test.ts
+++ b/examples/packlist/src/__tests__/placeholder.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test';
+
+import { workspaceName } from '../index.js';
+
+describe('packlist workspace placeholder', () => {
+  test('reserves the workspace name', () => {
+    expect(workspaceName).toBe('packlist');
+  });
+});

--- a/examples/packlist/src/index.ts
+++ b/examples/packlist/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Placeholder module for the `packlist` showcase app.
+ *
+ * The real app lands in its own build run confined to `examples/packlist/`.
+ * This placeholder only reserves the workspace so `bun.lock` takes the
+ * membership churn once, before the parallel builds start.
+ */
+export const workspaceName = 'packlist';

--- a/examples/packlist/tsconfig.json
+++ b/examples/packlist/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/examples/stash/package.json
+++ b/examples/stash/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "stash",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  }
+}

--- a/examples/stash/src/__tests__/placeholder.test.ts
+++ b/examples/stash/src/__tests__/placeholder.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test';
+
+import { workspaceName } from '../index.js';
+
+describe('stash workspace placeholder', () => {
+  test('reserves the workspace name', () => {
+    expect(workspaceName).toBe('stash');
+  });
+});

--- a/examples/stash/src/index.ts
+++ b/examples/stash/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Placeholder module for the `stash` showcase app.
+ *
+ * The real app lands in its own build run confined to `examples/stash/`.
+ * This placeholder only reserves the workspace so `bun.lock` takes the
+ * membership churn once, before the parallel builds start.
+ */
+export const workspaceName = 'stash';

--- a/examples/stash/tsconfig.json
+++ b/examples/stash/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/examples/switchback/package.json
+++ b/examples/switchback/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "switchback",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  }
+}

--- a/examples/switchback/src/__tests__/placeholder.test.ts
+++ b/examples/switchback/src/__tests__/placeholder.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test';
+
+import { workspaceName } from '../index.js';
+
+describe('switchback workspace placeholder', () => {
+  test('reserves the workspace name', () => {
+    expect(workspaceName).toBe('switchback');
+  });
+});

--- a/examples/switchback/src/index.ts
+++ b/examples/switchback/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Placeholder module for the `switchback` showcase app.
+ *
+ * The real app lands in its own build run confined to `examples/switchback/`.
+ * This placeholder only reserves the workspace so `bun.lock` takes the
+ * membership churn once, before the parallel builds start.
+ */
+export const workspaceName = 'switchback';

--- a/examples/switchback/tsconfig.json
+++ b/examples/switchback/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "."
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -70,6 +70,9 @@ const workspaceEntries = [
   ...packageWorkspaceDirs('apps').map(
     (workspace) => [workspace, createAppWorkspace(workspace)] as const
   ),
+  ...packageWorkspaceDirs('examples').map(
+    (workspace) => [workspace, createAppWorkspace(workspace)] as const
+  ),
 ];
 
 const workspaceMap = Object.fromEntries(workspaceEntries);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "workspaces": [
     "packages/*",
     "adapters/*",
-    "apps/*"
+    "apps/*",
+    "examples/*"
   ],
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Context

Implements [TRL-1173](https://linear.app/outfitter/issue/TRL-1173/suite-substrate-examples-workspace-wiring-lands-first-blocks-all-five): the shared seam for the Trails Showcase Suite. Five parallel build runs land next, each confined to `examples/<name>/` — this PR takes the workspace-membership churn (root `package.json`, `bun.lock`, knip config) once so those runs are file-disjoint.

## What's here

- `examples/*` added to the root workspace globs; turbo pipeline coverage (build/test/typecheck/lint) comes from each example's package scripts — no `turbo.json` changes needed since the tasks are generic.
- Five placeholder workspaces (`packlist`, `junction`, `switchback`, `stash`, `lookout`), each `private: true` with a minimal `src/index.ts`, tsconfig, and one placeholder test so every CI gate exercises the workspaces non-vacuously.
- `examples/README.md` with the suite table, shared conventions from the Trails Showcase Suite initiative, the showcase-matrix README pattern, and the hard rule: app build runs may not modify `packages/*`, `adapters/*`, or root config.
- `knip.config.ts` enumerates `examples/*` with the app workspace shape so dead-code checks cover them.

## Release intent

No changeset: this PR ships no publishable package content. The placeholders are `private: true`, so they are invisible to `publish:check` discovery (verified: it reports `Skipping <name> (private)` for all five), lockstep versioning, and the release check (`trails release check` passes with "no publishable package content files changed" — no `release:none` label needed).

## Verification

- `bun run build` — 30/30 tasks successful; all five examples in turbo scope and building
- `bun run test` — 48/48 tasks successful, placeholder tests pass
- `bun run check` — exit 0 (lint, format, typecheck, docs checks, warden, knip)
- `bun run publish:check` — all pack checks pass; all five placeholders skipped as private
- `bun run changeset:check` — "Release check passed: no publishable package content files changed."

**Wayfinder dogfood:** not applicable — this PR changes no framework surfaces, operator topo exposure, Topographer artifact export, Wayfinder queries, or fresh app loading; it is root workspace wiring plus empty placeholder workspaces.
