### PR TITLE
feat(examples): add packlist CRUD showcase

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -188,6 +188,21 @@
     "examples/packlist": {
       "name": "packlist",
       "version": "0.0.0",
+      "bin": {
+        "packlist": "./bin/packlist.ts",
+      },
+      "dependencies": {
+        "@ontrails/commander": "workspace:^",
+        "@ontrails/core": "workspace:^",
+        "@ontrails/drizzle": "workspace:^",
+        "@ontrails/hono": "workspace:^",
+        "@ontrails/mcp": "workspace:^",
+        "@ontrails/store": "workspace:^",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@ontrails/testing": "workspace:^",
+      },
     },
     "examples/stash": {
       "name": "stash",

--- a/examples/packlist/.gitignore
+++ b/examples/packlist/.gitignore
@@ -1,0 +1,4 @@
+packlist.sqlite
+packlist.sqlite-journal
+packlist.sqlite-wal
+packlist.sqlite-shm

--- a/examples/packlist/README.md
+++ b/examples/packlist/README.md
@@ -1,0 +1,180 @@
+# packlist
+
+Gear & trip checklists — the "show me a normal app" Trails showcase. Three entities, a schema-derived store, factory CRUD, derived signals, and an honest schema-versioning walkthrough.
+
+## What this showcases
+
+| Capability | Where it appears |
+| --- | --- |
+| Schema-derived store, three versioned tables | [`src/store.ts`](src/store.ts) — `gear`, `pack`, `trip` with fixtures and generated ids |
+| SQLite resource + zero-config mock | [`src/resources/db.ts`](src/resources/db.ts) — file-backed at runtime, in-memory for `testAll` |
+| CRUD factory | [`src/trails/pack.ts`](src/trails/pack.ts), [`src/trails/trip.ts`](src/trails/trip.ts) — five trails per table, derived from the table definition |
+| Hand-authored trails that tighten the contract | [`src/trails/gear.ts`](src/trails/gear.ts) — duplicate-name conflict, error-path examples |
+| **Trail versioning (the hero)** | [`src/trails/gear.ts`](src/trails/gear.ts) — `gear.create` v1 (`weightOz`) → v2 (`weightGrams`) with a preserved fork blaze |
+| Store-derived signals | `db:gear.updated` and friends — emitted by the store resource, no hand-rolled plumbing |
+| Authored signal + reactive consumer | [`src/signals.ts`](src/signals.ts), [`src/trails/weight.ts`](src/trails/weight.ts) — `gear.update` fires `pack.weight-stale`, `pack.recalculate` consumes it |
+| Compose | [`src/trails/weight.ts`](src/trails/weight.ts) (`pack.weight` → `gear.read`), [`src/trails/trip.ts`](src/trails/trip.ts) (`trip.checklist` → `pack.read` + `gear.list`) |
+| Reconcile per versioned table | [`src/trails/reconcile.ts`](src/trails/reconcile.ts) |
+| Examples-as-tests | every hand-authored trail carries success and error examples; [`__tests__/contract.test.ts`](__tests__/contract.test.ts) is one line of `testAll` |
+| Error taxonomy | NotFound / Validation / Conflict — one class, three surface mappings (table below) |
+| Surfaces | [`bin/packlist.ts`](bin/packlist.ts) (CLI), [`src/http.ts`](src/http.ts) (HTTP), [`src/mcp.ts`](src/mcp.ts) (MCP) |
+
+## Quickstart
+
+From a fresh checkout of the repo:
+
+```bash
+bun install
+cd examples/packlist
+
+bun bin/packlist.ts seed demo
+bun bin/packlist.ts gear ls
+bun bin/packlist.ts gear add --name "Rain Shell" --category wear --weight-grams 310
+bun bin/packlist.ts pack add-gear --pack-id pack-weekend --gear-id gear-bearcan --quantity 1
+bun bin/packlist.ts pack weight --pack-id pack-weekend
+bun bin/packlist.ts gear update --id gear-stove --weight-grams 250
+bun bin/packlist.ts trip checklist --id trip-lostcoast
+```
+
+Every command, flag, alias (`gear ls`, `gear get`, `gear add`), and exit code above is derived from the trail contracts — there is no hand-rolled argument parsing in this app.
+
+The `gear update` step is the reactive loop firing in plain sight. Because the stove rides in Weekend Loop, the weight change fires `pack.weight-stale`, and the `pack.recalculate` consumer recomputes the pack before the command returns:
+
+```text
+[packlist] info pack "Weekend Loop" recalculated: 2990 g (Canister Stove: 220 g → 250 g) {"packId":"pack-weekend"}
+```
+
+The final command prints the trip checklist — pack items joined with current gear weights:
+
+```json
+{
+  "packName": "Weekend Loop",
+  "rows": [
+    { "category": "shelter", "name": "Tent", "packed": false, "quantity": 1, "weightGrams": 1800 },
+    { "category": "cook", "name": "Canister Stove", "packed": false, "quantity": 1, "weightGrams": 250 },
+    { "category": "carry", "name": "Bear Canister", "packed": false, "quantity": 1, "weightGrams": 940 }
+  ],
+  "totalWeightGrams": 2990,
+  "tripId": "trip-lostcoast",
+  "tripName": "Lost Coast"
+}
+```
+
+### The same data over HTTP
+
+Routes, verbs, and error statuses derive from the same contracts. In a second terminal (the first one keeps the server):
+
+```bash
+bun run http
+```
+
+```bash
+curl -s 'http://localhost:3210/trip/checklist?id=trip-lostcoast'
+```
+
+The response is the same checklist the CLI printed, served from the same SQLite file.
+
+### The MCP surface cost zero lines
+
+That is the demo point: [`src/mcp.ts`](src/mcp.ts) is only the `surface(graph)` call — every tool name, JSON Schema, and annotation is derived. Register it with any MCP client, for example:
+
+```bash
+claude mcp add packlist -- bun /path/to/trails/examples/packlist/src/mcp.ts
+```
+
+Then call the `packlist_trip_checklist` tool with `{ "id": "trip-lostcoast" }` to get the same checklist a third way.
+
+## The versioning walkthrough
+
+Nobody demos schema versioning honestly, so here it is with real history. `gear.create` v1 shipped with `weightOz`. The v2 contract moved to `weightGrams`. Both live on the same trail in [`src/trails/gear.ts`](src/trails/gear.ts) — and the v1 world is real committed history on this branch, not a retrofit.
+
+**Here's v1** — preserved as a fork entry with its own blaze, so the old contract still runs exactly as it used to (ounces in, ounces out, converted to grams at the store boundary):
+
+```ts
+version: 2,
+versions: {
+  1: {
+    blaze: async (rawInput, ctx) => {
+      // accepts weightOz, stores grams, reports weightOz back
+    },
+    input: gearCreateV1Input,          // { name, category, weightOz, notes? }
+    output: gearEntityV1Schema,        // { ..., weightOz }
+    examples: [ /* v1 success + conflict examples — still tested */ ],
+    status: {
+      state: 'deprecated',
+      successor: 2,
+      migration: [
+        'Send weightGrams instead of weightOz (1 oz = 28.3495 g).',
+        'Read weights back in grams; v2 responses no longer include weightOz.',
+      ],
+      note: 'v1 stays callable through version negotiation while integrations move to grams.',
+    },
+  },
+},
+```
+
+**Here's the v2 migration in action.** The current contract takes grams; the deprecated version is still callable by number:
+
+```bash
+bun bin/packlist.ts gear create --trail-version 1 \
+  --input-json '{"name":"Ultralight Tarp","category":"shelter","weightOz":16}'
+```
+
+```json
+{
+  "category": "shelter",
+  "id": "…",
+  "name": "Ultralight Tarp",
+  "version": 1,
+  "weightOz": 16
+}
+```
+
+The row lands in the store in grams (`453.592`); the v1 caller keeps seeing ounces.
+
+**Here's what the warden says.** Four rules govern this history, and the app passes all of them:
+
+- `version-gap` (error) — coverage must be contiguous from v1 through the current version. Skip a number and the build fails.
+- `fork-without-preserved-blaze` (error) — a historical entry must either preserve its blaze (fork) or declare a `transpose` (revision). Deleting the v1 blaze without one fails.
+- `deprecation-without-guidance` (error) — drop the `successor`/`migration`/`note` guidance from the deprecated entry and warden reports: `Trail "gear.create@1" is deprecated without successor, migration, or note guidance.`
+- `version-without-examples` (warn) — live historical versions keep their examples, and `testAll` executes them (they run here as `gear.create@1` targets).
+
+Versioned contracts also stay inside the marker-safe schema subset (`marker-schema-unsupported`): plain objects, primitives, enums, optionals — which is why the gear schemas look deliberately boring.
+
+## Errors: one class, three mappings
+
+The blaze returns `Result.err(new NotFoundError(...))` once; every surface derives its own representation:
+
+| Error | CLI exit code | HTTP status | MCP |
+| --- | --- | --- | --- |
+| `NotFoundError` (missing id) | 2 | 404 | error result, `category: not_found` |
+| `ValidationError` (e.g. `--quantity 0`) | 1 | 400 | error result, `category: validation` |
+| `AlreadyExistsError` (duplicate gear name) | 3 | 409 | error result, `category: conflict` |
+
+Try it: `bun bin/packlist.ts gear get --id nope; echo $?` prints `2`.
+
+## Tests and governance
+
+```bash
+bun test          # testAll(graph) + the signals-loop test, against the mocked db
+bun run warden    # 0 errors; scoped to this app's topo and sources
+```
+
+The committed [`trails.lock`](trails.lock) is the compiled story of the app. Wayfinder answers questions from it without loading source:
+
+```bash
+bun ../../apps/trails/bin/trails.ts wayfind pattern "gear.*" --root-dir .
+```
+
+Regenerate the lock after contract changes:
+
+```bash
+bun ../../apps/trails/bin/trails.ts compile --root-dir . \
+  --permit '{"id":"packlist-build","scopes":["topo:write"]}'
+```
+
+## Notes
+
+- Write and destroy trails declare a `packlist:write` permit; each surface entry point injects a local operator permit, so there is no auth UX here (the `junction` showcase owns the real permits story).
+- The runtime database is a local `packlist.sqlite` file (override with `PACKLIST_DB`); tests and examples run against the in-memory mock and never touch it.
+- `totalWeightGrams` is never stored — `pack.weight` derives it from current gear weights on every call.

--- a/examples/packlist/__tests__/contract.test.ts
+++ b/examples/packlist/__tests__/contract.test.ts
@@ -1,0 +1,7 @@
+import { testAll } from '@ontrails/testing';
+
+import { graph } from '../src/app.js';
+import { operatorPermit } from '../src/permit.js';
+
+// oxlint-disable-next-line require-hook -- testAll registers describe/test blocks at module level by design
+testAll(graph, () => ({ permit: operatorPermit }));

--- a/examples/packlist/__tests__/signals.test.ts
+++ b/examples/packlist/__tests__/signals.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Proves the reactive loop end to end against the mocked store:
+ * gear.update fires pack.weight-stale, pack.recalculate consumes it,
+ * recomputes the affected pack, and logs the fresh total (which is what the
+ * CLI surfaces to the operator).
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { run } from '@ontrails/core';
+import type { Logger } from '@ontrails/core';
+
+import { graph } from '../src/app.js';
+import { db } from '../src/resources/db.js';
+import { operatorPermit } from '../src/permit.js';
+
+interface CapturedLine {
+  readonly data: Record<string, unknown> | undefined;
+  readonly level: string;
+  readonly message: string;
+}
+
+const createCapturingLogger = (
+  lines: CapturedLine[],
+  context: Record<string, unknown> = {}
+): Logger => {
+  const capture =
+    (level: string) =>
+    (message: string, data?: Record<string, unknown>): void => {
+      lines.push({ data, level, message });
+    };
+  return {
+    child: (childContext) =>
+      createCapturingLogger(lines, { ...context, ...childContext }),
+    debug: capture('debug'),
+    error: capture('error'),
+    fatal: capture('fatal'),
+    info: capture('info'),
+    trace: capture('trace'),
+    warn: capture('warn'),
+  };
+};
+
+const createMockConnection = async () => {
+  if (db.mock === undefined) {
+    throw new Error('packlist db resource must declare a mock factory');
+  }
+  return await db.mock();
+};
+
+describe('gear weight change → pack recalculation', () => {
+  test('gear.update fires pack.weight-stale and the consumer recomputes the pack', async () => {
+    const connection = await createMockConnection();
+    const lines: CapturedLine[] = [];
+    const result = await run(
+      graph,
+      'gear.update',
+      { id: 'gear-stove', weightGrams: 300 },
+      {
+        ctx: {
+          extensions: { db: connection },
+          logger: createCapturingLogger(lines),
+          permit: operatorPermit,
+        },
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+
+    // The consumer recomputed Weekend Loop with the new stove weight:
+    // tent 1800 g + stove 300 g = 2100 g.
+    const recalcLine = lines.find(
+      (line) =>
+        line.level === 'info' && line.message.includes('recalculated: 2100 g')
+    );
+    expect(recalcLine).toBeDefined();
+    expect(recalcLine?.message).toContain('Weekend Loop');
+    expect(recalcLine?.message).toContain('220 g → 300 g');
+    expect(recalcLine?.data).toEqual({ packId: 'pack-weekend' });
+  });
+
+  test('weight changes to gear no pack carries stay silent', async () => {
+    const connection = await createMockConnection();
+    const lines: CapturedLine[] = [];
+    const result = await run(
+      graph,
+      'gear.update',
+      { id: 'gear-bearcan', weightGrams: 900 },
+      {
+        ctx: {
+          extensions: { db: connection },
+          logger: createCapturingLogger(lines),
+          permit: operatorPermit,
+        },
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(
+      lines.filter((line) => line.message.includes('recalculated'))
+    ).toHaveLength(0);
+  });
+
+  test('non-weight updates do not fire the stale signal', async () => {
+    const connection = await createMockConnection();
+    const lines: CapturedLine[] = [];
+    const result = await run(
+      graph,
+      'gear.update',
+      { id: 'gear-stove', notes: 'New valve' },
+      {
+        ctx: {
+          extensions: { db: connection },
+          logger: createCapturingLogger(lines),
+          permit: operatorPermit,
+        },
+      }
+    );
+
+    expect(result.isOk()).toBe(true);
+    expect(
+      lines.filter((line) => line.message.includes('recalculated'))
+    ).toHaveLength(0);
+  });
+});

--- a/examples/packlist/bin/packlist.ts
+++ b/examples/packlist/bin/packlist.ts
@@ -1,0 +1,47 @@
+#!/usr/bin/env bun
+
+/**
+ * packlist CLI — commands, flags, aliases, help text, and exit codes all
+ * derive from the trail contracts in `src/app.ts`.
+ *
+ * The injected context carries the local operator permit (no auth UX in
+ * this showcase — `junction` owns the permits story) and a stderr logger so
+ * signal consumers like `pack.recalculate` are visible in normal output.
+ */
+
+import { createTrailContext } from '@ontrails/core';
+import { surface } from '@ontrails/commander';
+
+import { graph } from '../src/app.js';
+import { createStderrLogger } from '../src/logger.js';
+import { operatorPermit } from '../src/permit.js';
+
+/**
+ * Surface-owned CLI aliases, kept here (not exported from `src/app.ts`)
+ * because `trails compile` embeds app-module aliases into the lock graph
+ * while Warden's drift check derives the fresh graph without them, which
+ * would report the committed lock as permanently stale.
+ *
+ * TODO ::: trails-gap: warden drift ignores cliAliases that compile embeds,
+ * so alias-exporting app modules never pass the drift check. Open as
+ * TRL-1179; move the aliases back to `src/app.ts` once it lands.
+ */
+const cliAliases = {
+  'gear.create': [['gear', 'add']],
+  'gear.list': [['gear', 'ls']],
+  'gear.read': [['gear', 'get']],
+  'pack.list': [['pack', 'ls']],
+  'pack.read': [['pack', 'get']],
+  'trip.list': [['trip', 'ls']],
+  'trip.read': [['trip', 'get']],
+} as const;
+
+// oxlint-disable-next-line require-hook -- CLI entry point, not a test file
+await surface(graph, {
+  aliases: cliAliases,
+  createContext: () =>
+    createTrailContext({
+      logger: createStderrLogger(),
+      permit: operatorPermit,
+    }),
+});

--- a/examples/packlist/package.json
+++ b/examples/packlist/package.json
@@ -2,12 +2,29 @@
   "name": "packlist",
   "version": "0.0.0",
   "private": true,
+  "bin": {
+    "packlist": "./bin/packlist.ts"
+  },
   "type": "module",
   "scripts": {
     "build": "tsc -b",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint ./src",
-    "clean": "rm -rf dist *.tsbuildinfo"
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "http": "bun src/http.ts",
+    "warden": "bun ../../apps/trails/bin/trails.ts warden --root-dir . --apps src/app.ts"
+  },
+  "dependencies": {
+    "@ontrails/commander": "workspace:^",
+    "@ontrails/core": "workspace:^",
+    "@ontrails/drizzle": "workspace:^",
+    "@ontrails/hono": "workspace:^",
+    "@ontrails/mcp": "workspace:^",
+    "@ontrails/store": "workspace:^",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@ontrails/testing": "workspace:^"
   }
 }

--- a/examples/packlist/src/app.ts
+++ b/examples/packlist/src/app.ts
@@ -1,0 +1,34 @@
+/**
+ * packlist application — wires the store, resource, and trails into a topo.
+ *
+ * This module stays side-effect-free: surfaces open in the dedicated entry
+ * points (`bin/packlist.ts`, `src/http.ts`, `src/mcp.ts`).
+ */
+
+import { topo } from '@ontrails/core';
+
+import * as dbResource from './resources/db.js';
+import * as signals from './signals.js';
+import * as gear from './trails/gear.js';
+import * as pack from './trails/pack.js';
+import * as reconcileTrails from './trails/reconcile.js';
+import * as seed from './trails/seed.js';
+import * as trip from './trails/trip.js';
+import * as weight from './trails/weight.js';
+
+export const graph = topo(
+  {
+    description:
+      'Gear & trip checklist manager — the Trails "normal app" showcase',
+    name: 'packlist',
+    version: '0.1.0',
+  },
+  dbResource,
+  signals,
+  gear,
+  pack,
+  trip,
+  weight,
+  seed,
+  reconcileTrails
+);

--- a/examples/packlist/src/http.ts
+++ b/examples/packlist/src/http.ts
@@ -1,0 +1,21 @@
+/**
+ * packlist HTTP surface — routes, verbs, and error statuses derive from the
+ * same trail contracts the CLI uses. Serves the same SQLite file, so data
+ * written from the CLI is readable here immediately.
+ */
+
+import { createTrailContext } from '@ontrails/core';
+import { surface } from '@ontrails/hono';
+
+import { graph } from './app.js';
+import { createStderrLogger } from './logger.js';
+import { operatorPermit } from './permit.js';
+
+await surface(graph, {
+  createContext: () =>
+    createTrailContext({
+      logger: createStderrLogger(),
+      permit: operatorPermit,
+    }),
+  port: Number(Bun.env['PACKLIST_PORT'] ?? 3210),
+});

--- a/examples/packlist/src/logger.ts
+++ b/examples/packlist/src/logger.ts
@@ -1,0 +1,39 @@
+/**
+ * Minimal stderr logger for the packlist surfaces.
+ *
+ * Blazes never print — they log through `ctx.logger`, and each surface
+ * entry point decides where that goes. This one writes info and above to
+ * stderr so reactive work (like `pack.recalculate`) is visible in normal
+ * CLI output without polluting stdout's structured results.
+ */
+
+import type { Logger } from '@ontrails/core';
+
+const write = (
+  level: string,
+  message: string,
+  data?: Record<string, unknown>
+): void => {
+  const suffix =
+    data === undefined || Object.keys(data).length === 0
+      ? ''
+      : ` ${JSON.stringify(data)}`;
+  process.stderr.write(`[packlist] ${level} ${message}${suffix}\n`);
+};
+
+export const createStderrLogger = (
+  context: Record<string, unknown> = {}
+): Logger => ({
+  child: (childContext) => createStderrLogger({ ...context, ...childContext }),
+  debug: () => {
+    // silent unless surfaced later
+  },
+  error: (message, data) => write('error', message, data),
+  fatal: (message, data) => write('fatal', message, data),
+  info: (message, data) => write('info', message, data),
+  name: 'packlist',
+  trace: () => {
+    // silent unless surfaced later
+  },
+  warn: (message, data) => write('warn', message, data),
+});

--- a/examples/packlist/src/mcp.ts
+++ b/examples/packlist/src/mcp.ts
@@ -1,0 +1,20 @@
+/**
+ * packlist MCP surface — tool names, JSON Schemas, and annotations derive
+ * from the same trail contracts as the CLI and HTTP surfaces. This file is
+ * the entire cost of the surface.
+ */
+
+import { createTrailContext } from '@ontrails/core';
+import { surface } from '@ontrails/mcp';
+
+import { graph } from './app.js';
+import { createStderrLogger } from './logger.js';
+import { operatorPermit } from './permit.js';
+
+await surface(graph, {
+  createContext: () =>
+    createTrailContext({
+      logger: createStderrLogger(),
+      permit: operatorPermit,
+    }),
+});

--- a/examples/packlist/src/permit.ts
+++ b/examples/packlist/src/permit.ts
@@ -1,0 +1,13 @@
+/**
+ * The local operator permit.
+ *
+ * Write and destroy trails declare a `packlist:write` scope requirement;
+ * every surface entry point (and the test suite) injects this permit via
+ * `createContext`, so permit governance holds without any auth UX — the
+ * `junction` showcase owns the real permits story.
+ */
+
+export const operatorPermit = {
+  id: 'packlist-operator',
+  scopes: ['packlist:write'],
+} as const;

--- a/examples/packlist/src/resources/db.ts
+++ b/examples/packlist/src/resources/db.ts
@@ -1,0 +1,26 @@
+/**
+ * The packlist `db` resource — a Drizzle-backed SQLite store.
+ *
+ * Runtime opens (or creates) a SQLite file so state persists across CLI
+ * invocations and is shared with the HTTP and MCP surfaces. The mock factory
+ * opens an in-memory database seeded with the table fixtures, which is what
+ * `testAll(app)` and trail examples run against — zero configuration.
+ *
+ * Write methods on the connection are bound to `ctx.fire`, so every insert,
+ * update, and remove emits the matching store-derived signal
+ * (`db:gear.updated`, `db:pack.created`, ...) without any hand-rolled
+ * signal plumbing.
+ */
+
+import { connectDrizzle } from '@ontrails/drizzle';
+
+import { packlistStore } from '../store.js';
+
+const databaseUrl = Bun.env['PACKLIST_DB'] ?? 'packlist.sqlite';
+
+export const db = connectDrizzle(packlistStore, {
+  description:
+    'SQLite gear/pack/trip store. Set PACKLIST_DB to relocate the database file.',
+  id: 'db',
+  url: databaseUrl,
+});

--- a/examples/packlist/src/signals.ts
+++ b/examples/packlist/src/signals.ts
@@ -1,0 +1,27 @@
+/**
+ * Authored signals for the packlist app.
+ *
+ * The store already derives `db:gear.created` / `db:gear.updated` /
+ * `db:gear.removed` (and the same for pack and trip) from the table
+ * definitions. `pack.weight-stale` sits one level up: `gear.update` fires it
+ * only when a weight change touches gear that some pack actually carries,
+ * and `pack.recalculate` consumes it to recompute those packs.
+ */
+
+import { signal } from '@ontrails/core';
+import { z } from 'zod';
+
+export const packWeightStale = signal('pack.weight-stale', {
+  description:
+    'Fired when a gear weight change invalidates the derived weight of packs carrying that gear',
+  from: ['gear.update'],
+  payload: z.object({
+    gearId: z.string().describe('Gear whose weight changed'),
+    gearName: z.string().describe('Name of the changed gear'),
+    packIds: z
+      .array(z.string())
+      .describe('Packs whose derived weight is now stale'),
+    previousWeightGrams: z.number().describe('Weight before the update'),
+    weightGrams: z.number().describe('Weight after the update'),
+  }),
+});

--- a/examples/packlist/src/store.ts
+++ b/examples/packlist/src/store.ts
@@ -1,0 +1,148 @@
+/**
+ * Schema-derived store for the packlist app.
+ *
+ * Three versioned tables — `gear`, `pack`, `trip` — authored once and
+ * projected everywhere: CRUD factory trails, reconcile trails, store-derived
+ * change signals, and mock fixtures for `testAll(app)`.
+ *
+ * The tables are `versioned: true`, so the framework manages an optimistic
+ * concurrency `version` column on every row and each table gets a
+ * `reconcile` trail (see `src/trails/reconcile.ts`).
+ */
+
+import { store as defineStore } from '@ontrails/store';
+import { z } from 'zod';
+
+export const gearCategories = [
+  'shelter',
+  'cook',
+  'wear',
+  'carry',
+  'other',
+] as const;
+
+export const gearSchema = z.object({
+  category: z.enum(gearCategories),
+  id: z.string(),
+  name: z.string(),
+  notes: z.string().nullable().optional(),
+  weightGrams: z.number(),
+});
+
+const packItemSchema = z.object({
+  gearId: z.string(),
+  quantity: z.number(),
+});
+
+export const packSchema = z.object({
+  id: z.string(),
+  items: z.array(packItemSchema),
+  name: z.string(),
+});
+
+export const tripStatuses = ['planned', 'active', 'done'] as const;
+
+export const tripSchema = z.object({
+  endDate: z.string(),
+  id: z.string(),
+  name: z.string(),
+  notes: z.string().nullable().optional(),
+  packId: z.string(),
+  startDate: z.string(),
+  status: z.enum(tripStatuses),
+});
+
+/**
+ * Mock fixtures ship stable ids so trail examples can reference them.
+ * `gear-oldstove` exists only to be deleted by the `gear.delete` example, so
+ * the other examples never race it.
+ */
+const gearFixtures = [
+  {
+    category: 'shelter',
+    id: 'gear-tent',
+    name: 'Tent',
+    weightGrams: 1800,
+  },
+  {
+    category: 'cook',
+    id: 'gear-stove',
+    name: 'Canister Stove',
+    weightGrams: 220,
+  },
+  {
+    category: 'carry',
+    id: 'gear-bearcan',
+    name: 'Bear Canister',
+    notes: 'Required in the Sierra',
+    weightGrams: 940,
+  },
+  {
+    category: 'cook',
+    id: 'gear-oldstove',
+    name: 'Old Stove',
+    weightGrams: 480,
+  },
+] as const;
+
+const packFixtures = [
+  {
+    id: 'pack-weekend',
+    items: [
+      { gearId: 'gear-tent', quantity: 1 },
+      { gearId: 'gear-stove', quantity: 1 },
+    ],
+    name: 'Weekend Loop',
+  },
+  {
+    id: 'pack-retired',
+    items: [],
+    name: 'Retired Pack',
+  },
+] as const;
+
+const tripFixtures = [
+  {
+    endDate: '2026-08-16',
+    id: 'trip-lostcoast',
+    name: 'Lost Coast',
+    packId: 'pack-weekend',
+    startDate: '2026-08-14',
+    status: 'planned',
+  },
+  {
+    endDate: '2026-05-03',
+    id: 'trip-done',
+    name: 'Desolation Overnight',
+    packId: 'pack-weekend',
+    startDate: '2026-05-02',
+    status: 'done',
+  },
+] as const;
+
+export const packlistStore = defineStore({
+  gear: {
+    fixtures: gearFixtures,
+    generated: ['id'],
+    identity: 'id',
+    schema: gearSchema,
+    versioned: true,
+  },
+  pack: {
+    fixtures: packFixtures,
+    generated: ['id'],
+    identity: 'id',
+    schema: packSchema,
+    versioned: true,
+  },
+  trip: {
+    fixtures: tripFixtures,
+    generated: ['id'],
+    identity: 'id',
+    schema: tripSchema,
+    versioned: true,
+  },
+});
+
+export type Gear = z.output<typeof gearSchema>;
+export type Pack = z.output<typeof packSchema>;

--- a/examples/packlist/src/trails/gear.ts
+++ b/examples/packlist/src/trails/gear.ts
@@ -1,0 +1,326 @@
+/**
+ * Gear trails — hand-authored CRUD for the `gear` table.
+ *
+ * Unlike `pack` and `trip` (which take the derived CRUD factory as-is),
+ * gear trails are authored by hand because they tighten the contract beyond
+ * what the factory derives: a duplicate-name conflict on create, a real
+ * v1→v2 version history on `gear.create`, and a `pack.weight-stale` fire on
+ * `gear.update`. The schemas stay inside the version-marker subset (plain
+ * objects, primitives, enums, optionals) as versioned contracts require.
+ */
+
+import {
+  AlreadyExistsError,
+  NotFoundError,
+  Result,
+  forkVersion,
+  trail,
+} from '@ontrails/core';
+import { z } from 'zod';
+
+import { db } from '../resources/db.js';
+import { packWeightStale } from '../signals.js';
+import { gearCategories } from '../store.js';
+
+const GRAMS_PER_OUNCE = 28.3495;
+
+const categorySchema = z
+  .enum(gearCategories)
+  .describe('Gear category: shelter, cook, wear, carry, or other');
+
+/** Full gear entity as stored, including the framework-managed version. */
+export const gearEntitySchema = z.object({
+  category: categorySchema,
+  id: z.string().describe('Generated gear id'),
+  name: z.string().describe('Unique gear name'),
+  notes: z.string().nullable().optional().describe('Free-form notes'),
+  version: z.number().describe('Optimistic concurrency version'),
+  weightGrams: z.number().describe('Weight in grams'),
+});
+
+/**
+ * The v1 `gear.create` contract, preserved as a fork entry below. Version 1
+ * accepted (and reported) ounces; version 2 moved the contract to grams.
+ */
+const gearCreateV1Input = z.object({
+  category: categorySchema,
+  name: z.string().describe('Unique gear name'),
+  notes: z.string().nullable().optional().describe('Free-form notes'),
+  weightOz: z.number().describe('Weight in ounces'),
+});
+
+const gearEntityV1Schema = z.object({
+  category: categorySchema,
+  id: z.string().describe('Generated gear id'),
+  name: z.string().describe('Unique gear name'),
+  notes: z.string().nullable().optional().describe('Free-form notes'),
+  version: z.number().describe('Optimistic concurrency version'),
+  weightOz: z.number().describe('Weight in ounces'),
+});
+
+export const create = trail('gear.create', {
+  blaze: async (input, ctx) => {
+    const connection = db.from(ctx);
+    const duplicates = await connection.gear.list({ name: input.name });
+    if (duplicates.length > 0) {
+      return Result.err(
+        new AlreadyExistsError(`Gear named "${input.name}" already exists`)
+      );
+    }
+    const gear = await connection.gear.insert(input);
+    return Result.ok(gear);
+  },
+  description: 'Add a piece of gear to the locker',
+  examples: [
+    {
+      description: 'Create gear with a unique name',
+      expectedMatch: {
+        category: 'other',
+        name: 'Sleeping Bag',
+        weightGrams: 860,
+      },
+      input: { category: 'other', name: 'Sleeping Bag', weightGrams: 860 },
+      name: 'Add new gear',
+    },
+    {
+      description: 'Duplicate gear names are rejected with a conflict',
+      error: 'AlreadyExistsError',
+      input: { category: 'shelter', name: 'Tent', weightGrams: 1700 },
+      name: 'Duplicate gear name conflicts',
+    },
+  ],
+  input: z.object({
+    category: categorySchema,
+    name: z.string().describe('Unique gear name'),
+    notes: z.string().nullable().optional().describe('Free-form notes'),
+    weightGrams: z.number().describe('Weight in grams'),
+  }),
+  intent: 'write',
+  output: gearEntitySchema,
+  permit: { scopes: ['packlist:write'] },
+  resources: [db],
+  version: 2,
+  versions: {
+    1: forkVersion({
+      blaze: async (input, ctx) => {
+        const connection = db.from(ctx);
+        const duplicates = await connection.gear.list({ name: input.name });
+        if (duplicates.length > 0) {
+          return Result.err(
+            new AlreadyExistsError(`Gear named "${input.name}" already exists`)
+          );
+        }
+        const gear = await connection.gear.insert({
+          category: input.category,
+          name: input.name,
+          ...(input.notes === undefined ? {} : { notes: input.notes }),
+          weightGrams: input.weightOz * GRAMS_PER_OUNCE,
+        });
+        const { weightGrams, ...rest } = gear;
+        return Result.ok({
+          ...rest,
+          weightOz: weightGrams / GRAMS_PER_OUNCE,
+        });
+      },
+      examples: [
+        {
+          description: 'The v1 contract accepts ounces and reports ounces',
+          expectedMatch: { category: 'shelter', name: 'Ultralight Tarp' },
+          input: { category: 'shelter', name: 'Ultralight Tarp', weightOz: 16 },
+          name: 'Add gear in ounces (v1)',
+        },
+        {
+          description: 'The duplicate-name conflict predates v2',
+          error: 'AlreadyExistsError',
+          input: { category: 'shelter', name: 'Tent', weightOz: 60 },
+          name: 'Duplicate gear name conflicts (v1)',
+        },
+      ],
+      input: gearCreateV1Input,
+      output: gearEntityV1Schema,
+      resources: [db],
+      status: {
+        migration: [
+          'Send weightGrams instead of weightOz (1 oz = 28.3495 g).',
+          'Read weights back in grams; v2 responses no longer include weightOz.',
+        ],
+        note: 'v1 stays callable through version negotiation while integrations move to grams.',
+        state: 'deprecated',
+        successor: 2,
+      },
+    }),
+  },
+});
+
+export const read = trail('gear.read', {
+  blaze: async (input, ctx) => {
+    const connection = db.from(ctx);
+    const gear = await connection.gear.get(input.id);
+    if (!gear) {
+      return Result.err(new NotFoundError(`Gear "${input.id}" not found`));
+    }
+    return Result.ok(gear);
+  },
+  description: 'Show one piece of gear by id',
+  examples: [
+    {
+      description: 'Look up gear by its id',
+      expectedMatch: { id: 'gear-tent', name: 'Tent' },
+      input: { id: 'gear-tent' },
+      name: 'Read existing gear',
+    },
+    {
+      description: 'Missing ids report not found',
+      error: 'NotFoundError',
+      input: { id: 'gear-missing' },
+      name: 'Read missing gear',
+    },
+  ],
+  input: z.object({
+    id: z.string().describe('Gear id to look up'),
+  }),
+  intent: 'read',
+  output: gearEntitySchema,
+  resources: [db],
+});
+
+export const update = trail('gear.update', {
+  blaze: async (input, ctx) => {
+    const connection = db.from(ctx);
+    const existing = await connection.gear.get(input.id);
+    if (!existing) {
+      return Result.err(new NotFoundError(`Gear "${input.id}" not found`));
+    }
+    const gear = await connection.gear.update(input.id, {
+      ...(input.category === undefined ? {} : { category: input.category }),
+      ...(input.name === undefined ? {} : { name: input.name }),
+      ...(input.notes === undefined ? {} : { notes: input.notes }),
+      ...(input.weightGrams === undefined
+        ? {}
+        : { weightGrams: input.weightGrams }),
+    });
+    if (!gear) {
+      return Result.err(new NotFoundError(`Gear "${input.id}" not found`));
+    }
+    if (gear.weightGrams !== existing.weightGrams) {
+      const packs = await connection.pack.list();
+      const packIds = packs
+        .filter((pack) => pack.items.some((item) => item.gearId === gear.id))
+        .map((pack) => pack.id);
+      if (packIds.length > 0) {
+        await ctx.fire?.(packWeightStale, {
+          gearId: gear.id,
+          gearName: gear.name,
+          packIds,
+          previousWeightGrams: existing.weightGrams,
+          weightGrams: gear.weightGrams,
+        });
+      }
+    }
+    return Result.ok(gear);
+  },
+  description:
+    'Update fields on a piece of gear; weight changes mark carrying packs stale',
+  examples: [
+    {
+      description: 'Re-weighing gear carried by a pack fires pack.weight-stale',
+      expectedMatch: { id: 'gear-stove', weightGrams: 250 },
+      input: { id: 'gear-stove', weightGrams: 250 },
+      name: 'Update gear weight',
+      signals: [
+        {
+          payloadMatch: {
+            gearId: 'gear-stove',
+            packIds: ['pack-weekend'],
+            weightGrams: 250,
+          },
+          signal: packWeightStale,
+        },
+      ],
+    },
+    {
+      description: 'Missing ids report not found',
+      error: 'NotFoundError',
+      input: { id: 'gear-missing', weightGrams: 1 },
+      name: 'Update missing gear',
+    },
+  ],
+  fires: [packWeightStale],
+  input: z.object({
+    category: categorySchema.optional(),
+    id: z.string().describe('Gear id to update'),
+    name: z.string().optional().describe('New unique gear name'),
+    notes: z.string().nullable().optional().describe('Free-form notes'),
+    weightGrams: z.number().optional().describe('Weight in grams'),
+  }),
+  intent: 'write',
+  output: gearEntitySchema,
+  permit: { scopes: ['packlist:write'] },
+  resources: [db],
+});
+
+export const remove = trail('gear.delete', {
+  blaze: async (input, ctx) => {
+    const connection = db.from(ctx);
+    const existing = await connection.gear.get(input.id);
+    if (!existing) {
+      return Result.err(new NotFoundError(`Gear "${input.id}" not found`));
+    }
+    await connection.gear.remove(input.id);
+    return Result.ok({ deleted: true, id: input.id });
+  },
+  description: 'Remove a piece of gear from the locker',
+  examples: [
+    {
+      description: 'Delete gear that exists',
+      expected: { deleted: true, id: 'gear-oldstove' },
+      input: { id: 'gear-oldstove' },
+      name: 'Delete existing gear',
+    },
+    {
+      description: 'Missing ids report not found',
+      error: 'NotFoundError',
+      input: { id: 'gear-missing' },
+      name: 'Delete missing gear',
+    },
+  ],
+  input: z.object({
+    id: z.string().describe('Gear id to delete'),
+  }),
+  intent: 'destroy',
+  output: z.object({
+    deleted: z.boolean(),
+    id: z.string(),
+  }),
+  permit: { scopes: ['packlist:write'] },
+  resources: [db],
+});
+
+export const list = trail('gear.list', {
+  blaze: async (input, ctx) => {
+    const connection = db.from(ctx);
+    const filters =
+      input.category === undefined ? undefined : { category: input.category };
+    const gear = await connection.gear.list(filters);
+    return Result.ok(gear);
+  },
+  description: 'List gear, optionally filtered by category',
+  examples: [
+    {
+      description: 'List the whole gear locker',
+      input: {},
+      name: 'List all gear',
+    },
+    {
+      description: 'Filter the locker down to one category',
+      input: { category: 'cook' },
+      name: 'List cook gear',
+    },
+  ],
+  input: z.object({
+    category: categorySchema.optional(),
+  }),
+  intent: 'read',
+  output: z.array(gearEntitySchema),
+  resources: [db],
+});

--- a/examples/packlist/src/trails/pack.ts
+++ b/examples/packlist/src/trails/pack.ts
@@ -1,0 +1,145 @@
+/**
+ * Pack trails — derived CRUD plus hand-authored item management.
+ *
+ * The five CRUD trails (`pack.create`, `pack.read`, `pack.update`,
+ * `pack.delete`, `pack.list`) come straight from the CRUD factory: schemas,
+ * examples, blazes, permits, and resource wiring are all derived from the
+ * table definition and the factory options.
+ *
+ * `pack.add-gear` and `pack.remove-gear` are authored by hand: they carry
+ * cross-table checks (the gear must exist) that the factory cannot derive.
+ */
+
+import { NotFoundError, Result, trail } from '@ontrails/core';
+import { crud } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+import { db } from '../resources/db.js';
+import { packlistStore } from '../store.js';
+
+const writePermit = { scopes: ['packlist:write'] } as const;
+
+const packCrud = crud(packlistStore.tables.pack, db, {
+  permits: {
+    create: writePermit,
+    delete: writePermit,
+    update: writePermit,
+  },
+});
+
+export const [create, read, update, remove, list] = packCrud;
+
+/** Shared with `reconcile()` so the topo sees one `pack` contour instance. */
+export const packContour = packCrud.contour;
+
+/** Pack entity shape shared by the hand-authored pack trails. */
+export const packEntitySchema = z.object({
+  id: z.string().describe('Generated pack id'),
+  items: z.array(
+    z.object({
+      gearId: z.string().describe('Gear carried in this pack'),
+      quantity: z.number().describe('How many of that gear'),
+    })
+  ),
+  name: z.string().describe('Pack name'),
+  version: z.number().describe('Optimistic concurrency version'),
+});
+
+export const addGear = trail('pack.add-gear', {
+  blaze: async (input, ctx) => {
+    const connection = db.from(ctx);
+    const pack = await connection.pack.get(input.packId);
+    if (!pack) {
+      return Result.err(new NotFoundError(`Pack "${input.packId}" not found`));
+    }
+    const gear = await connection.gear.get(input.gearId);
+    if (!gear) {
+      return Result.err(new NotFoundError(`Gear "${input.gearId}" not found`));
+    }
+    const existing = pack.items.find((item) => item.gearId === input.gearId);
+    const items = existing
+      ? pack.items.map((item) =>
+          item.gearId === input.gearId
+            ? { gearId: item.gearId, quantity: item.quantity + input.quantity }
+            : item
+        )
+      : [...pack.items, { gearId: input.gearId, quantity: input.quantity }];
+    const updated = await connection.pack.update(input.packId, { items });
+    return Result.ok(updated);
+  },
+  description: 'Add gear to a pack (or increase its quantity)',
+  examples: [
+    {
+      description: 'Adding gear appends an item line to the pack',
+      expectedMatch: { id: 'pack-weekend' },
+      input: { gearId: 'gear-bearcan', packId: 'pack-weekend', quantity: 1 },
+      name: 'Add gear to a pack',
+    },
+    {
+      description: 'Quantities below one are rejected at the boundary',
+      error: 'ValidationError',
+      input: { gearId: 'gear-tent', packId: 'pack-weekend', quantity: 0 },
+      name: 'Reject zero quantity',
+    },
+    {
+      description: 'Unknown gear ids report not found',
+      error: 'NotFoundError',
+      input: { gearId: 'gear-missing', packId: 'pack-weekend', quantity: 1 },
+      name: 'Add missing gear',
+    },
+  ],
+  input: z.object({
+    gearId: z.string().describe('Gear id to add'),
+    packId: z.string().describe('Pack id to modify'),
+    quantity: z.number().min(1).describe('How many to add (at least 1)'),
+  }),
+  intent: 'write',
+  output: packEntitySchema,
+  permit: writePermit,
+  resources: [db],
+});
+
+export const removeGear = trail('pack.remove-gear', {
+  blaze: async (input, ctx) => {
+    const connection = db.from(ctx);
+    const pack = await connection.pack.get(input.packId);
+    if (!pack) {
+      return Result.err(new NotFoundError(`Pack "${input.packId}" not found`));
+    }
+    const items = pack.items.filter((item) => item.gearId !== input.gearId);
+    if (items.length === pack.items.length) {
+      return Result.ok(pack);
+    }
+    const updated = await connection.pack.update(input.packId, { items });
+    return Result.ok(updated);
+  },
+  description: 'Remove gear from a pack (idempotent)',
+  examples: [
+    {
+      description: 'Removing carried gear drops its item line',
+      expectedMatch: { id: 'pack-weekend' },
+      input: { gearId: 'gear-stove', packId: 'pack-weekend' },
+      name: 'Remove gear from a pack',
+    },
+    {
+      description: 'Removing gear that is not in the pack is a no-op',
+      expectedMatch: { id: 'pack-weekend' },
+      input: { gearId: 'gear-bearcan', packId: 'pack-weekend' },
+      name: 'Remove absent gear is idempotent',
+    },
+    {
+      description: 'Unknown pack ids report not found',
+      error: 'NotFoundError',
+      input: { gearId: 'gear-tent', packId: 'pack-missing' },
+      name: 'Remove from missing pack',
+    },
+  ],
+  input: z.object({
+    gearId: z.string().describe('Gear id to remove'),
+    packId: z.string().describe('Pack id to modify'),
+  }),
+  intent: 'write',
+  output: packEntitySchema,
+  permit: writePermit,
+  resources: [db],
+});

--- a/examples/packlist/src/trails/reconcile.ts
+++ b/examples/packlist/src/trails/reconcile.ts
@@ -1,0 +1,44 @@
+/**
+ * Reconcile trails — one per versioned table.
+ *
+ * `reconcile()` completes the versioned-store pattern: it upserts a full
+ * row carrying an expected `version` and retries once through a
+ * ConflictError detour using the declared strategy. `last-write-wins` keeps
+ * the demo simple; real apps can pass a merge function instead.
+ *
+ * The pack and trip reconcile trails reuse the contour their `crud()` call
+ * exposes, so the topo sees a single contour instance per table.
+ */
+
+import { reconcile } from '@ontrails/store/trails';
+
+import { db } from '../resources/db.js';
+import { packlistStore } from '../store.js';
+
+import { packContour } from './pack.js';
+import { tripContour } from './trip.js';
+
+const writePermit = { scopes: ['packlist:write'] } as const;
+
+export const gearReconcile = reconcile({
+  permit: writePermit,
+  resource: db,
+  strategy: 'last-write-wins',
+  table: packlistStore.tables.gear,
+});
+
+export const packReconcile = reconcile({
+  contour: packContour,
+  permit: writePermit,
+  resource: db,
+  strategy: 'last-write-wins',
+  table: packlistStore.tables.pack,
+});
+
+export const tripReconcile = reconcile({
+  contour: tripContour,
+  permit: writePermit,
+  resource: db,
+  strategy: 'last-write-wins',
+  table: packlistStore.tables.trip,
+});

--- a/examples/packlist/src/trails/seed.ts
+++ b/examples/packlist/src/trails/seed.ts
@@ -1,0 +1,92 @@
+/**
+ * Demo seed — one command that makes the quickstart real.
+ *
+ * Upserts a small, fixed data set (stable ids, so re-running is
+ * harmless) directly through the store accessors.
+ */
+
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { db } from '../resources/db.js';
+
+const demoGear = [
+  { category: 'shelter', id: 'gear-tent', name: 'Tent', weightGrams: 1800 },
+  {
+    category: 'cook',
+    id: 'gear-stove',
+    name: 'Canister Stove',
+    weightGrams: 220,
+  },
+  {
+    category: 'carry',
+    id: 'gear-bearcan',
+    name: 'Bear Canister',
+    notes: 'Required in the Sierra',
+    weightGrams: 940,
+  },
+  { category: 'wear', id: 'gear-puffy', name: 'Down Puffy', weightGrams: 380 },
+] as const;
+
+const demoPacks = [
+  {
+    id: 'pack-weekend',
+    items: [
+      { gearId: 'gear-tent', quantity: 1 },
+      { gearId: 'gear-stove', quantity: 1 },
+    ],
+    name: 'Weekend Loop',
+  },
+] as const;
+
+const demoTrips = [
+  {
+    endDate: '2026-08-16',
+    id: 'trip-lostcoast',
+    name: 'Lost Coast',
+    packId: 'pack-weekend',
+    startDate: '2026-08-14',
+    status: 'planned',
+  },
+] as const;
+
+export const seedDemo = trail('seed.demo', {
+  blaze: async (_input, ctx) => {
+    const connection = db.from(ctx);
+    for (const gear of demoGear) {
+      await connection.gear.upsert(gear);
+    }
+    for (const pack of demoPacks) {
+      await connection.pack.upsert({
+        ...pack,
+        items: [...pack.items],
+      });
+    }
+    for (const trip of demoTrips) {
+      await connection.trip.upsert(trip);
+    }
+    return Result.ok({
+      gear: demoGear.length,
+      packs: demoPacks.length,
+      trips: demoTrips.length,
+    });
+  },
+  description: 'Load the demo gear, pack, and trip (idempotent)',
+  examples: [
+    {
+      description: 'Seeding reports how many rows were written',
+      expected: { gear: 4, packs: 1, trips: 1 },
+      input: {},
+      name: 'Seed the demo data',
+    },
+  ],
+  input: z.object({}),
+  intent: 'write',
+  output: z.object({
+    gear: z.number(),
+    packs: z.number(),
+    trips: z.number(),
+  }),
+  permit: { scopes: ['packlist:write'] },
+  resources: [db],
+});

--- a/examples/packlist/src/trails/trip.ts
+++ b/examples/packlist/src/trails/trip.ts
@@ -1,0 +1,173 @@
+/**
+ * Trip trails — derived CRUD plus lifecycle and the checklist composition.
+ *
+ * The CRUD set comes from the factory (see `pack.ts` for the pattern).
+ * `trip.complete` is a lifecycle write with a validation error path, and
+ * `trip.checklist` is the composition showcase: it gathers `pack.read` and
+ * `gear.list` through `ctx.compose()` and joins them into checklist rows.
+ */
+
+import { NotFoundError, Result, ValidationError, trail } from '@ontrails/core';
+import { crud } from '@ontrails/store/trails';
+import { z } from 'zod';
+
+import { db } from '../resources/db.js';
+import { packlistStore, tripStatuses } from '../store.js';
+import type { Gear, Pack } from '../store.js';
+
+const writePermit = { scopes: ['packlist:write'] } as const;
+
+const tripCrud = crud(packlistStore.tables.trip, db, {
+  permits: {
+    create: writePermit,
+    delete: writePermit,
+    update: writePermit,
+  },
+});
+
+export const [create, read, update, remove, list] = tripCrud;
+
+/** Shared with `reconcile()` so the topo sees one `trip` contour instance. */
+export const tripContour = tripCrud.contour;
+
+const tripEntitySchema = z.object({
+  endDate: z.string().describe('Trip end date (ISO)'),
+  id: z.string().describe('Generated trip id'),
+  name: z.string().describe('Trip name'),
+  notes: z.string().nullable().optional().describe('Free-form notes'),
+  packId: z.string().describe('Pack carried on this trip'),
+  startDate: z.string().describe('Trip start date (ISO)'),
+  status: z.enum(tripStatuses).describe('planned, active, or done'),
+  version: z.number().describe('Optimistic concurrency version'),
+});
+
+export const complete = trail('trip.complete', {
+  blaze: async (input, ctx) => {
+    const connection = db.from(ctx);
+    const trip = await connection.trip.get(input.id);
+    if (!trip) {
+      return Result.err(new NotFoundError(`Trip "${input.id}" not found`));
+    }
+    if (trip.status === 'done') {
+      return Result.err(
+        new ValidationError(`Trip "${trip.name}" is already done`)
+      );
+    }
+    const updated = await connection.trip.update(input.id, { status: 'done' });
+    if (!updated) {
+      return Result.err(new NotFoundError(`Trip "${input.id}" not found`));
+    }
+    return Result.ok(updated);
+  },
+  description: 'Mark a trip as done',
+  examples: [
+    {
+      description: 'Completing a planned trip flips its status',
+      expectedMatch: { id: 'trip-lostcoast', status: 'done' },
+      input: { id: 'trip-lostcoast' },
+      name: 'Complete a planned trip',
+    },
+    {
+      description: 'Trips cannot be completed twice',
+      error: 'ValidationError',
+      input: { id: 'trip-done' },
+      name: 'Complete an already-done trip',
+    },
+  ],
+  input: z.object({
+    id: z.string().describe('Trip id to complete'),
+  }),
+  intent: 'write',
+  output: tripEntitySchema,
+  permit: writePermit,
+  resources: [db],
+});
+
+const checklistRowSchema = z.object({
+  category: z.string().describe('Gear category'),
+  name: z.string().describe('Gear name'),
+  packed: z.boolean().describe('Starting state for the checklist'),
+  quantity: z.number().describe('How many to pack'),
+  weightGrams: z.number().describe('Weight of one unit'),
+});
+
+export const checklist = trail('trip.checklist', {
+  blaze: async (input, ctx) => {
+    const connection = db.from(ctx);
+    const trip = await connection.trip.get(input.id);
+    if (!trip) {
+      return Result.err(new NotFoundError(`Trip "${input.id}" not found`));
+    }
+    const pack = await ctx.compose<Pack & { version: number }>('pack.read', {
+      id: trip.packId,
+    });
+    if (pack.isErr()) {
+      return pack;
+    }
+    const gear = await ctx.compose<(Gear & { version: number })[]>(
+      'gear.list',
+      {}
+    );
+    if (gear.isErr()) {
+      return gear;
+    }
+    const gearById = new Map(gear.value.map((item) => [item.id, item]));
+    const rows = [];
+    for (const item of pack.value.items) {
+      const carried = gearById.get(item.gearId);
+      if (!carried) {
+        continue;
+      }
+      rows.push({
+        category: carried.category,
+        name: carried.name,
+        packed: false,
+        quantity: item.quantity,
+        weightGrams: carried.weightGrams,
+      });
+    }
+    const totalWeightGrams = rows.reduce(
+      (total, row) => total + row.quantity * row.weightGrams,
+      0
+    );
+    return Result.ok({
+      packName: pack.value.name,
+      rows,
+      totalWeightGrams,
+      tripId: trip.id,
+      tripName: trip.name,
+    });
+  },
+  composes: ['pack.read', 'gear.list'],
+  description: 'Build the packing checklist for a trip from its pack',
+  examples: [
+    {
+      description: 'Checklist rows join pack items with current gear',
+      expectedMatch: {
+        packName: 'Weekend Loop',
+        totalWeightGrams: 2020,
+        tripName: 'Lost Coast',
+      },
+      input: { id: 'trip-lostcoast' },
+      name: 'Checklist for a planned trip',
+    },
+    {
+      description: 'Unknown trip ids report not found',
+      error: 'NotFoundError',
+      input: { id: 'trip-missing' },
+      name: 'Checklist for a missing trip',
+    },
+  ],
+  input: z.object({
+    id: z.string().describe('Trip id to build a checklist for'),
+  }),
+  intent: 'read',
+  output: z.object({
+    packName: z.string(),
+    rows: z.array(checklistRowSchema),
+    totalWeightGrams: z.number(),
+    tripId: z.string(),
+    tripName: z.string(),
+  }),
+  resources: [db],
+});

--- a/examples/packlist/src/trails/weight.ts
+++ b/examples/packlist/src/trails/weight.ts
@@ -1,0 +1,170 @@
+/**
+ * Derived pack weight — the reactive loop of the showcase.
+ *
+ * `pack.weight` recomputes a pack's total from current gear weights on
+ * every call (`totalWeightGrams` is never stored), composing `gear.read`
+ * through `ctx.compose()`. `pack.recalculate` consumes the authored
+ * `pack.weight-stale` signal that `gear.update` fires, recomputes each
+ * affected pack, and logs the fresh totals — which is what makes the loop
+ * visible in normal CLI output.
+ */
+
+import { NotFoundError, Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { db } from '../resources/db.js';
+import { packWeightStale } from '../signals.js';
+import type { Gear } from '../store.js';
+
+const weightItemSchema = z.object({
+  gearId: z.string().describe('Gear carried in the pack'),
+  name: z.string().describe('Gear name'),
+  quantity: z.number().describe('How many are carried'),
+  subtotalGrams: z.number().describe('quantity × weightGrams'),
+  weightGrams: z.number().describe('Current weight of one unit'),
+});
+
+export const weight = trail('pack.weight', {
+  blaze: async (input, ctx) => {
+    const connection = db.from(ctx);
+    const pack = await connection.pack.get(input.packId);
+    if (!pack) {
+      return Result.err(new NotFoundError(`Pack "${input.packId}" not found`));
+    }
+    const items = [];
+    for (const item of pack.items) {
+      const gear = await ctx.compose<Gear & { version: number }>('gear.read', {
+        id: item.gearId,
+      });
+      if (gear.isErr()) {
+        return gear;
+      }
+      items.push({
+        gearId: item.gearId,
+        name: gear.value.name,
+        quantity: item.quantity,
+        subtotalGrams: item.quantity * gear.value.weightGrams,
+        weightGrams: gear.value.weightGrams,
+      });
+    }
+    const totalWeightGrams = items.reduce(
+      (total, item) => total + item.subtotalGrams,
+      0
+    );
+    return Result.ok({
+      items,
+      name: pack.name,
+      packId: pack.id,
+      totalWeightGrams,
+    });
+  },
+  composes: ['gear.read'],
+  description:
+    'Derive a pack’s total weight from current gear weights (never stored)',
+  examples: [
+    {
+      description: 'Weekend Loop carries the tent and stove fixtures',
+      expectedMatch: {
+        name: 'Weekend Loop',
+        packId: 'pack-weekend',
+        totalWeightGrams: 2020,
+      },
+      input: { packId: 'pack-weekend' },
+      name: 'Weigh a pack',
+    },
+    {
+      description: 'Unknown pack ids report not found',
+      error: 'NotFoundError',
+      input: { packId: 'pack-missing' },
+      name: 'Weigh a missing pack',
+    },
+  ],
+  input: z.object({
+    packId: z.string().describe('Pack id to weigh'),
+  }),
+  intent: 'read',
+  output: z.object({
+    items: z.array(weightItemSchema),
+    name: z.string(),
+    packId: z.string(),
+    totalWeightGrams: z.number(),
+  }),
+  resources: [db],
+});
+
+export const recalculate = trail('pack.recalculate', {
+  blaze: async (input, ctx) => {
+    const recalculated = [];
+    for (const packId of input.packIds) {
+      const result = await ctx.compose<{
+        name: string;
+        packId: string;
+        totalWeightGrams: number;
+      }>('pack.weight', { packId });
+      if (result.isErr()) {
+        ctx.logger?.warn('pack.recalculate skipped a pack', {
+          error: result.error.message,
+          packId,
+        });
+        continue;
+      }
+      ctx.logger?.info(
+        `pack "${result.value.name}" recalculated: ${result.value.totalWeightGrams} g (${input.gearName}: ${input.previousWeightGrams} g → ${input.weightGrams} g)`,
+        { packId }
+      );
+      recalculated.push({
+        name: result.value.name,
+        packId: result.value.packId,
+        totalWeightGrams: result.value.totalWeightGrams,
+      });
+    }
+    return Result.ok({ recalculated });
+  },
+  composes: ['pack.weight'],
+  description:
+    'React to pack.weight-stale by recomputing and logging affected pack weights',
+  examples: [
+    {
+      description: 'Recompute the packs named in the stale signal payload',
+      input: {
+        gearId: 'gear-stove',
+        gearName: 'Canister Stove',
+        packIds: ['pack-weekend'],
+        previousWeightGrams: 220,
+        weightGrams: 250,
+      },
+      name: 'Recalculate stale packs',
+    },
+    {
+      description: 'An empty pack list is a no-op',
+      expected: { recalculated: [] },
+      input: {
+        gearId: 'gear-stove',
+        gearName: 'Canister Stove',
+        packIds: [],
+        previousWeightGrams: 220,
+        weightGrams: 250,
+      },
+      name: 'Recalculate nothing',
+    },
+  ],
+  input: z.object({
+    gearId: z.string().describe('Gear whose weight changed'),
+    gearName: z.string().describe('Name of the changed gear'),
+    packIds: z.array(z.string()).describe('Packs to recompute'),
+    previousWeightGrams: z.number().describe('Weight before the update'),
+    weightGrams: z.number().describe('Weight after the update'),
+  }),
+  intent: 'read',
+  on: [packWeightStale],
+  output: z.object({
+    recalculated: z.array(
+      z.object({
+        name: z.string(),
+        packId: z.string(),
+        totalWeightGrams: z.number(),
+      })
+    ),
+  }),
+  resources: [db],
+});

--- a/examples/packlist/trails.lock
+++ b/examples/packlist/trails.lock
@@ -1,0 +1,6221 @@
+{
+  "scope": {
+    "app": "packlist"
+  },
+  "summary": {
+    "contours": 3,
+    "resources": 1,
+    "signals": 10,
+    "trails": 25
+  },
+  "topoGraph": {
+    "activationGraph": {
+      "edgeCount": 1,
+      "edges": [
+        {
+          "hasWhere": false,
+          "sourceId": "pack.weight-stale",
+          "sourceKey": "signal:pack.weight-stale",
+          "sourceKind": "signal",
+          "trailId": "pack.recalculate"
+        }
+      ],
+      "sourceCount": 1,
+      "sourceKeys": [
+        "signal:pack.weight-stale"
+      ],
+      "trailIds": [
+        "pack.recalculate"
+      ]
+    },
+    "activationSources": {
+      "signal:pack.weight-stale": {
+        "id": "pack.weight-stale",
+        "key": "signal:pack.weight-stale",
+        "kind": "signal"
+      }
+    },
+    "entries": [
+      {
+        "exampleCount": 0,
+        "id": "db",
+        "kind": "resource",
+        "surfaces": [],
+        "description": "SQLite gear/pack/trip store. Set PACKLIST_DB to relocate the database file.",
+        "healthcheck": true
+      },
+      {
+        "exampleCount": 0,
+        "id": "db:gear.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"gear\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "category": {
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "version": {
+              "type": "number"
+            },
+            "weightGrams": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "id",
+            "name",
+            "weightGrams",
+            "version"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "category": {
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "version": {
+              "type": "number"
+            },
+            "weightGrams": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "id",
+            "name",
+            "weightGrams",
+            "version"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "db:gear.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"gear\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "category": {
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "version": {
+              "type": "number"
+            },
+            "weightGrams": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "id",
+            "name",
+            "weightGrams",
+            "version"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "category": {
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "version": {
+              "type": "number"
+            },
+            "weightGrams": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "id",
+            "name",
+            "weightGrams",
+            "version"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "db:gear.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"gear\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "category": {
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "version": {
+              "type": "number"
+            },
+            "weightGrams": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "id",
+            "name",
+            "weightGrams",
+            "version"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "category": {
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "version": {
+              "type": "number"
+            },
+            "weightGrams": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "id",
+            "name",
+            "weightGrams",
+            "version"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "db:pack.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"pack\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "db:pack.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"pack\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "db:pack.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"pack\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "db:trip.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"trip\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "id",
+            "name",
+            "packId",
+            "startDate",
+            "status",
+            "version"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "id",
+            "name",
+            "packId",
+            "startDate",
+            "status",
+            "version"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "db:trip.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"trip\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "id",
+            "name",
+            "packId",
+            "startDate",
+            "status",
+            "version"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "id",
+            "name",
+            "packId",
+            "startDate",
+            "status",
+            "version"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "db:trip.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"trip\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "id",
+            "name",
+            "packId",
+            "startDate",
+            "status",
+            "version"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "id",
+            "name",
+            "packId",
+            "startDate",
+            "status",
+            "version"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 4,
+        "id": "gear",
+        "kind": "contour",
+        "surfaces": [],
+        "identity": "id",
+        "schema": {
+          "properties": {
+            "category": {
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "version": {
+              "type": "number"
+            },
+            "weightGrams": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "id",
+            "name",
+            "weightGrams"
+          ],
+          "type": "object"
+        }
+      },
+      {
+        "exampleCount": 2,
+        "id": "gear.create",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "gear",
+            "create"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "gear",
+                "create"
+              ],
+              "source": "derived",
+              "target": "gear.create"
+            }
+          ]
+        },
+        "description": "Add a piece of gear to the locker",
+        "examples": [
+          {
+            "input": {
+              "category": "other",
+              "name": "Sleeping Bag",
+              "weightGrams": 860
+            },
+            "kind": "success",
+            "name": "Add new gear",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Create gear with a unique name",
+            "expectedMatch": {
+              "category": "other",
+              "name": "Sleeping Bag",
+              "weightGrams": 860
+            }
+          },
+          {
+            "input": {
+              "category": "shelter",
+              "name": "Tent",
+              "weightGrams": 1700
+            },
+            "kind": "error",
+            "name": "Duplicate gear name conflicts",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Duplicate gear names are rejected with a conflict",
+            "error": "AlreadyExistsError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "category": {
+              "description": "Gear category: shelter, cook, wear, carry, or other",
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Unique gear name",
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Free-form notes"
+            },
+            "weightGrams": {
+              "description": "Weight in grams",
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "name",
+            "weightGrams"
+          ],
+          "type": "object"
+        },
+        "marker": "bf6d820b7eb2c67b",
+        "output": {
+          "properties": {
+            "category": {
+              "description": "Gear category: shelter, cook, wear, carry, or other",
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "description": "Generated gear id",
+              "type": "string"
+            },
+            "name": {
+              "description": "Unique gear name",
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Free-form notes"
+            },
+            "version": {
+              "description": "Optimistic concurrency version",
+              "type": "number"
+            },
+            "weightGrams": {
+              "description": "Weight in grams",
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "id",
+            "name",
+            "version",
+            "weightGrams"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ],
+        "supports": [
+          1,
+          2
+        ],
+        "version": 2,
+        "versions": {
+          "1": {
+            "exampleCount": 2,
+            "examples": [
+              {
+                "input": {
+                  "category": "shelter",
+                  "name": "Ultralight Tarp",
+                  "weightOz": 16
+                },
+                "kind": "success",
+                "name": "Add gear in ounces (v1)",
+                "provenance": {
+                  "source": "trail.versions.examples"
+                },
+                "description": "The v1 contract accepts ounces and reports ounces",
+                "expectedMatch": {
+                  "category": "shelter",
+                  "name": "Ultralight Tarp"
+                }
+              },
+              {
+                "input": {
+                  "category": "shelter",
+                  "name": "Tent",
+                  "weightOz": 60
+                },
+                "kind": "error",
+                "name": "Duplicate gear name conflicts (v1)",
+                "provenance": {
+                  "source": "trail.versions.examples"
+                },
+                "description": "The duplicate-name conflict predates v2",
+                "error": "AlreadyExistsError"
+              }
+            ],
+            "input": {
+              "properties": {
+                "category": {
+                  "description": "Gear category: shelter, cook, wear, carry, or other",
+                  "enum": [
+                    "shelter",
+                    "cook",
+                    "wear",
+                    "carry",
+                    "other"
+                  ],
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Unique gear name",
+                  "type": "string"
+                },
+                "notes": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Free-form notes"
+                },
+                "weightOz": {
+                  "description": "Weight in ounces",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "category",
+                "name",
+                "weightOz"
+              ],
+              "type": "object"
+            },
+            "kind": "fork",
+            "marker": "2e86f88bc0098367",
+            "output": {
+              "properties": {
+                "category": {
+                  "description": "Gear category: shelter, cook, wear, carry, or other",
+                  "enum": [
+                    "shelter",
+                    "cook",
+                    "wear",
+                    "carry",
+                    "other"
+                  ],
+                  "type": "string"
+                },
+                "id": {
+                  "description": "Generated gear id",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Unique gear name",
+                  "type": "string"
+                },
+                "notes": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Free-form notes"
+                },
+                "version": {
+                  "description": "Optimistic concurrency version",
+                  "type": "number"
+                },
+                "weightOz": {
+                  "description": "Weight in ounces",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "category",
+                "id",
+                "name",
+                "version",
+                "weightOz"
+              ],
+              "type": "object"
+            },
+            "resources": [
+              "db"
+            ],
+            "status": {
+              "migration": [
+                "Send weightGrams instead of weightOz (1 oz = 28.3495 g).",
+                "Read weights back in grams; v2 responses no longer include weightOz."
+              ],
+              "note": "v1 stays callable through version negotiation while integrations move to grams.",
+              "state": "deprecated",
+              "successor": 2
+            }
+          }
+        }
+      },
+      {
+        "exampleCount": 2,
+        "id": "gear.delete",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "gear",
+            "delete"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "gear",
+                "delete"
+              ],
+              "source": "derived",
+              "target": "gear.delete"
+            }
+          ]
+        },
+        "description": "Remove a piece of gear from the locker",
+        "examples": [
+          {
+            "input": {
+              "id": "gear-oldstove"
+            },
+            "kind": "success",
+            "name": "Delete existing gear",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Delete gear that exists",
+            "expected": {
+              "deleted": true,
+              "id": "gear-oldstove"
+            }
+          },
+          {
+            "input": {
+              "id": "gear-missing"
+            },
+            "kind": "error",
+            "name": "Delete missing gear",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Missing ids report not found",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Gear id to delete",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "intent": "destroy",
+        "output": {
+          "properties": {
+            "deleted": {
+              "type": "boolean"
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "deleted",
+            "id"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "gear.list",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "gear",
+            "list"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "gear",
+                "list"
+              ],
+              "source": "derived",
+              "target": "gear.list"
+            }
+          ]
+        },
+        "description": "List gear, optionally filtered by category",
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "List all gear",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "List the whole gear locker"
+          },
+          {
+            "input": {
+              "category": "cook"
+            },
+            "kind": "success",
+            "name": "List cook gear",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Filter the locker down to one category"
+          }
+        ],
+        "input": {
+          "properties": {
+            "category": {
+              "description": "Gear category: shelter, cook, wear, carry, or other",
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "items": {
+            "properties": {
+              "category": {
+                "description": "Gear category: shelter, cook, wear, carry, or other",
+                "enum": [
+                  "shelter",
+                  "cook",
+                  "wear",
+                  "carry",
+                  "other"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "description": "Generated gear id",
+                "type": "string"
+              },
+              "name": {
+                "description": "Unique gear name",
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Free-form notes"
+              },
+              "version": {
+                "description": "Optimistic concurrency version",
+                "type": "number"
+              },
+              "weightGrams": {
+                "description": "Weight in grams",
+                "type": "number"
+              }
+            },
+            "required": [
+              "category",
+              "id",
+              "name",
+              "version",
+              "weightGrams"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "gear.read",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "gear",
+            "read"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "gear",
+                "read"
+              ],
+              "source": "derived",
+              "target": "gear.read"
+            }
+          ]
+        },
+        "description": "Show one piece of gear by id",
+        "examples": [
+          {
+            "input": {
+              "id": "gear-tent"
+            },
+            "kind": "success",
+            "name": "Read existing gear",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Look up gear by its id",
+            "expectedMatch": {
+              "id": "gear-tent",
+              "name": "Tent"
+            }
+          },
+          {
+            "input": {
+              "id": "gear-missing"
+            },
+            "kind": "error",
+            "name": "Read missing gear",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Missing ids report not found",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Gear id to look up",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "category": {
+              "description": "Gear category: shelter, cook, wear, carry, or other",
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "description": "Generated gear id",
+              "type": "string"
+            },
+            "name": {
+              "description": "Unique gear name",
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Free-form notes"
+            },
+            "version": {
+              "description": "Optimistic concurrency version",
+              "type": "number"
+            },
+            "weightGrams": {
+              "description": "Weight in grams",
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "id",
+            "name",
+            "version",
+            "weightGrams"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "gear.reconcile",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "gear",
+            "reconcile"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "gear",
+                "reconcile"
+              ],
+              "source": "derived",
+              "target": "gear.reconcile"
+            }
+          ]
+        },
+        "contours": [
+          "gear"
+        ],
+        "description": "Reconcile version conflicts for \"gear\" entities.",
+        "detours": [
+          {
+            "maxAttempts": 1,
+            "on": "ConflictError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "category": {
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "version": {
+              "type": "number"
+            },
+            "weightGrams": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "name",
+            "weightGrams",
+            "version"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "category": {
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "version": {
+              "type": "number"
+            },
+            "weightGrams": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "id",
+            "name",
+            "weightGrams",
+            "version"
+          ],
+          "type": "object"
+        },
+        "pattern": "reconcile",
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "gear.update",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "gear",
+            "update"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "gear",
+                "update"
+              ],
+              "source": "derived",
+              "target": "gear.update"
+            }
+          ]
+        },
+        "description": "Update fields on a piece of gear; weight changes mark carrying packs stale",
+        "examples": [
+          {
+            "input": {
+              "id": "gear-stove",
+              "weightGrams": 250
+            },
+            "kind": "success",
+            "name": "Update gear weight",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Re-weighing gear carried by a pack fires pack.weight-stale",
+            "expectedMatch": {
+              "id": "gear-stove",
+              "weightGrams": 250
+            },
+            "signals": [
+              {
+                "signalId": "pack.weight-stale",
+                "payloadMatch": {
+                  "gearId": "gear-stove",
+                  "packIds": [
+                    "pack-weekend"
+                  ],
+                  "weightGrams": 250
+                }
+              }
+            ]
+          },
+          {
+            "input": {
+              "id": "gear-missing",
+              "weightGrams": 1
+            },
+            "kind": "error",
+            "name": "Update missing gear",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Missing ids report not found",
+            "error": "NotFoundError"
+          }
+        ],
+        "fires": [
+          "pack.weight-stale"
+        ],
+        "input": {
+          "properties": {
+            "category": {
+              "description": "Gear category: shelter, cook, wear, carry, or other",
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "description": "Gear id to update",
+              "type": "string"
+            },
+            "name": {
+              "description": "New unique gear name",
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Free-form notes"
+            },
+            "weightGrams": {
+              "description": "Weight in grams",
+              "type": "number"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "category": {
+              "description": "Gear category: shelter, cook, wear, carry, or other",
+              "enum": [
+                "shelter",
+                "cook",
+                "wear",
+                "carry",
+                "other"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "description": "Generated gear id",
+              "type": "string"
+            },
+            "name": {
+              "description": "Unique gear name",
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Free-form notes"
+            },
+            "version": {
+              "description": "Optimistic concurrency version",
+              "type": "number"
+            },
+            "weightGrams": {
+              "description": "Weight in grams",
+              "type": "number"
+            }
+          },
+          "required": [
+            "category",
+            "id",
+            "name",
+            "version",
+            "weightGrams"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "pack",
+        "kind": "contour",
+        "surfaces": [],
+        "identity": "id",
+        "schema": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name"
+          ],
+          "type": "object"
+        }
+      },
+      {
+        "exampleCount": 3,
+        "id": "pack.add-gear",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "pack",
+            "add-gear"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "pack",
+                "add-gear"
+              ],
+              "source": "derived",
+              "target": "pack.add-gear"
+            }
+          ]
+        },
+        "description": "Add gear to a pack (or increase its quantity)",
+        "examples": [
+          {
+            "input": {
+              "gearId": "gear-bearcan",
+              "packId": "pack-weekend",
+              "quantity": 1
+            },
+            "kind": "success",
+            "name": "Add gear to a pack",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Adding gear appends an item line to the pack",
+            "expectedMatch": {
+              "id": "pack-weekend"
+            }
+          },
+          {
+            "input": {
+              "gearId": "gear-tent",
+              "packId": "pack-weekend",
+              "quantity": 0
+            },
+            "kind": "error",
+            "name": "Reject zero quantity",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Quantities below one are rejected at the boundary",
+            "error": "ValidationError"
+          },
+          {
+            "input": {
+              "gearId": "gear-missing",
+              "packId": "pack-weekend",
+              "quantity": 1
+            },
+            "kind": "error",
+            "name": "Add missing gear",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown gear ids report not found",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "gearId": {
+              "description": "Gear id to add",
+              "type": "string"
+            },
+            "packId": {
+              "description": "Pack id to modify",
+              "type": "string"
+            },
+            "quantity": {
+              "description": "How many to add (at least 1)",
+              "type": "number"
+            }
+          },
+          "required": [
+            "gearId",
+            "packId",
+            "quantity"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "id": {
+              "description": "Generated pack id",
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "description": "Gear carried in this pack",
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "description": "How many of that gear",
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "Pack name",
+              "type": "string"
+            },
+            "version": {
+              "description": "Optimistic concurrency version",
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "pack.create",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "pack",
+            "create"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "pack",
+                "create"
+              ],
+              "source": "derived",
+              "target": "pack.create"
+            }
+          ]
+        },
+        "contours": [
+          "pack"
+        ],
+        "input": {
+          "properties": {
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "items",
+            "name"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "pattern": "crud",
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "pack.delete",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "pack",
+            "delete"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "pack",
+                "delete"
+              ],
+              "source": "derived",
+              "target": "pack.delete"
+            }
+          ]
+        },
+        "contours": [
+          "pack"
+        ],
+        "examples": [
+          {
+            "input": {
+              "id": "pack-weekend"
+            },
+            "kind": "success",
+            "name": "Delete pack pack-weekend",
+            "provenance": {
+              "source": "trail.examples"
+            }
+          },
+          {
+            "input": {
+              "id": "pack-retired"
+            },
+            "kind": "success",
+            "name": "Delete pack pack-retired",
+            "provenance": {
+              "source": "trail.examples"
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "intent": "destroy",
+        "output": {},
+        "pattern": "crud",
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "pack.list",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "pack",
+            "list"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "pack",
+                "list"
+              ],
+              "source": "derived",
+              "target": "pack.list"
+            }
+          ]
+        },
+        "contours": [
+          "pack"
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "items": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "properties": {
+                    "gearId": {
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "gearId",
+                    "quantity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "items",
+              "name",
+              "version"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "pattern": "crud",
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "pack.read",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "pack",
+            "read"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "pack",
+                "read"
+              ],
+              "source": "derived",
+              "target": "pack.read"
+            }
+          ]
+        },
+        "contours": [
+          "pack"
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "pattern": "crud",
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "pack.recalculate",
+        "kind": "trail",
+        "surfaces": [],
+        "activationSources": [
+          {
+            "source": {
+              "id": "pack.weight-stale",
+              "key": "signal:pack.weight-stale",
+              "kind": "signal"
+            }
+          }
+        ],
+        "cli": {
+          "path": [
+            "pack",
+            "recalculate"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "pack",
+                "recalculate"
+              ],
+              "source": "derived",
+              "target": "pack.recalculate"
+            }
+          ]
+        },
+        "composes": [
+          "pack.weight"
+        ],
+        "description": "React to pack.weight-stale by recomputing and logging affected pack weights",
+        "examples": [
+          {
+            "input": {
+              "gearId": "gear-stove",
+              "gearName": "Canister Stove",
+              "packIds": [
+                "pack-weekend"
+              ],
+              "previousWeightGrams": 220,
+              "weightGrams": 250
+            },
+            "kind": "success",
+            "name": "Recalculate stale packs",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Recompute the packs named in the stale signal payload"
+          },
+          {
+            "input": {
+              "gearId": "gear-stove",
+              "gearName": "Canister Stove",
+              "packIds": [],
+              "previousWeightGrams": 220,
+              "weightGrams": 250
+            },
+            "kind": "success",
+            "name": "Recalculate nothing",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "An empty pack list is a no-op",
+            "expected": {
+              "recalculated": []
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "gearId": {
+              "description": "Gear whose weight changed",
+              "type": "string"
+            },
+            "gearName": {
+              "description": "Name of the changed gear",
+              "type": "string"
+            },
+            "packIds": {
+              "description": "Packs to recompute",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "previousWeightGrams": {
+              "description": "Weight before the update",
+              "type": "number"
+            },
+            "weightGrams": {
+              "description": "Weight after the update",
+              "type": "number"
+            }
+          },
+          "required": [
+            "gearId",
+            "gearName",
+            "packIds",
+            "previousWeightGrams",
+            "weightGrams"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "on": [
+          "pack.weight-stale"
+        ],
+        "output": {
+          "properties": {
+            "recalculated": {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "packId": {
+                    "type": "string"
+                  },
+                  "totalWeightGrams": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "name",
+                  "packId",
+                  "totalWeightGrams"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "recalculated"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "pack.reconcile",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "pack",
+            "reconcile"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "pack",
+                "reconcile"
+              ],
+              "source": "derived",
+              "target": "pack.reconcile"
+            }
+          ]
+        },
+        "contours": [
+          "pack"
+        ],
+        "description": "Reconcile version conflicts for \"pack\" entities.",
+        "detours": [
+          {
+            "maxAttempts": 1,
+            "on": "ConflictError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "pattern": "reconcile",
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 3,
+        "id": "pack.remove-gear",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "pack",
+            "remove-gear"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "pack",
+                "remove-gear"
+              ],
+              "source": "derived",
+              "target": "pack.remove-gear"
+            }
+          ]
+        },
+        "description": "Remove gear from a pack (idempotent)",
+        "examples": [
+          {
+            "input": {
+              "gearId": "gear-stove",
+              "packId": "pack-weekend"
+            },
+            "kind": "success",
+            "name": "Remove gear from a pack",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Removing carried gear drops its item line",
+            "expectedMatch": {
+              "id": "pack-weekend"
+            }
+          },
+          {
+            "input": {
+              "gearId": "gear-bearcan",
+              "packId": "pack-weekend"
+            },
+            "kind": "success",
+            "name": "Remove absent gear is idempotent",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Removing gear that is not in the pack is a no-op",
+            "expectedMatch": {
+              "id": "pack-weekend"
+            }
+          },
+          {
+            "input": {
+              "gearId": "gear-tent",
+              "packId": "pack-missing"
+            },
+            "kind": "error",
+            "name": "Remove from missing pack",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown pack ids report not found",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "gearId": {
+              "description": "Gear id to remove",
+              "type": "string"
+            },
+            "packId": {
+              "description": "Pack id to modify",
+              "type": "string"
+            }
+          },
+          "required": [
+            "gearId",
+            "packId"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "id": {
+              "description": "Generated pack id",
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "description": "Gear carried in this pack",
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "description": "How many of that gear",
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "description": "Pack name",
+              "type": "string"
+            },
+            "version": {
+              "description": "Optimistic concurrency version",
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "pack.update",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "pack",
+            "update"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "pack",
+                "update"
+              ],
+              "source": "derived",
+              "target": "pack.update"
+            }
+          ]
+        },
+        "contours": [
+          "pack"
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "quantity"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "id",
+            "items",
+            "name",
+            "version"
+          ],
+          "type": "object"
+        },
+        "pattern": "crud",
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "pack.weight",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "pack",
+            "weight"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "pack",
+                "weight"
+              ],
+              "source": "derived",
+              "target": "pack.weight"
+            }
+          ]
+        },
+        "composes": [
+          "gear.read"
+        ],
+        "description": "Derive a pack’s total weight from current gear weights (never stored)",
+        "examples": [
+          {
+            "input": {
+              "packId": "pack-weekend"
+            },
+            "kind": "success",
+            "name": "Weigh a pack",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Weekend Loop carries the tent and stove fixtures",
+            "expectedMatch": {
+              "name": "Weekend Loop",
+              "packId": "pack-weekend",
+              "totalWeightGrams": 2020
+            }
+          },
+          {
+            "input": {
+              "packId": "pack-missing"
+            },
+            "kind": "error",
+            "name": "Weigh a missing pack",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown pack ids report not found",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "packId": {
+              "description": "Pack id to weigh",
+              "type": "string"
+            }
+          },
+          "required": [
+            "packId"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "items": {
+              "items": {
+                "properties": {
+                  "gearId": {
+                    "description": "Gear carried in the pack",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Gear name",
+                    "type": "string"
+                  },
+                  "quantity": {
+                    "description": "How many are carried",
+                    "type": "number"
+                  },
+                  "subtotalGrams": {
+                    "description": "quantity × weightGrams",
+                    "type": "number"
+                  },
+                  "weightGrams": {
+                    "description": "Current weight of one unit",
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "gearId",
+                  "name",
+                  "quantity",
+                  "subtotalGrams",
+                  "weightGrams"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "name": {
+              "type": "string"
+            },
+            "packId": {
+              "type": "string"
+            },
+            "totalWeightGrams": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "items",
+            "name",
+            "packId",
+            "totalWeightGrams"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "pack.weight-stale",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [
+          "pack.recalculate"
+        ],
+        "description": "Fired when a gear weight change invalidates the derived weight of packs carrying that gear",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "from": [
+          "gear.update"
+        ],
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "gearId": {
+              "description": "Gear whose weight changed",
+              "type": "string"
+            },
+            "gearName": {
+              "description": "Name of the changed gear",
+              "type": "string"
+            },
+            "packIds": {
+              "description": "Packs whose derived weight is now stale",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "previousWeightGrams": {
+              "description": "Weight before the update",
+              "type": "number"
+            },
+            "weightGrams": {
+              "description": "Weight after the update",
+              "type": "number"
+            }
+          },
+          "required": [
+            "gearId",
+            "gearName",
+            "packIds",
+            "previousWeightGrams",
+            "weightGrams"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "gearId": {
+              "description": "Gear whose weight changed",
+              "type": "string"
+            },
+            "gearName": {
+              "description": "Name of the changed gear",
+              "type": "string"
+            },
+            "packIds": {
+              "description": "Packs whose derived weight is now stale",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "previousWeightGrams": {
+              "description": "Weight before the update",
+              "type": "number"
+            },
+            "weightGrams": {
+              "description": "Weight after the update",
+              "type": "number"
+            }
+          },
+          "required": [
+            "gearId",
+            "gearName",
+            "packIds",
+            "previousWeightGrams",
+            "weightGrams"
+          ],
+          "type": "object"
+        },
+        "producers": [
+          "gear.update"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "seed.demo",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "seed",
+            "demo"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "seed",
+                "demo"
+              ],
+              "source": "derived",
+              "target": "seed.demo"
+            }
+          ]
+        },
+        "description": "Load the demo gear, pack, and trip (idempotent)",
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "Seed the demo data",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Seeding reports how many rows were written",
+            "expected": {
+              "gear": 4,
+              "packs": 1,
+              "trips": 1
+            }
+          }
+        ],
+        "input": {
+          "properties": {},
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "gear": {
+              "type": "number"
+            },
+            "packs": {
+              "type": "number"
+            },
+            "trips": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "gear",
+            "packs",
+            "trips"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "trip",
+        "kind": "contour",
+        "surfaces": [],
+        "identity": "id",
+        "schema": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "id",
+            "name",
+            "packId",
+            "startDate",
+            "status"
+          ],
+          "type": "object"
+        }
+      },
+      {
+        "exampleCount": 2,
+        "id": "trip.checklist",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "trip",
+            "checklist"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "trip",
+                "checklist"
+              ],
+              "source": "derived",
+              "target": "trip.checklist"
+            }
+          ]
+        },
+        "composes": [
+          "gear.list",
+          "pack.read"
+        ],
+        "description": "Build the packing checklist for a trip from its pack",
+        "examples": [
+          {
+            "input": {
+              "id": "trip-lostcoast"
+            },
+            "kind": "success",
+            "name": "Checklist for a planned trip",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Checklist rows join pack items with current gear",
+            "expectedMatch": {
+              "packName": "Weekend Loop",
+              "totalWeightGrams": 2020,
+              "tripName": "Lost Coast"
+            }
+          },
+          {
+            "input": {
+              "id": "trip-missing"
+            },
+            "kind": "error",
+            "name": "Checklist for a missing trip",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown trip ids report not found",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Trip id to build a checklist for",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "packName": {
+              "type": "string"
+            },
+            "rows": {
+              "items": {
+                "properties": {
+                  "category": {
+                    "description": "Gear category",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Gear name",
+                    "type": "string"
+                  },
+                  "packed": {
+                    "description": "Starting state for the checklist",
+                    "type": "boolean"
+                  },
+                  "quantity": {
+                    "description": "How many to pack",
+                    "type": "number"
+                  },
+                  "weightGrams": {
+                    "description": "Weight of one unit",
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "category",
+                  "name",
+                  "packed",
+                  "quantity",
+                  "weightGrams"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "totalWeightGrams": {
+              "type": "number"
+            },
+            "tripId": {
+              "type": "string"
+            },
+            "tripName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "packName",
+            "rows",
+            "totalWeightGrams",
+            "tripId",
+            "tripName"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "trip.complete",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "trip",
+            "complete"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "trip",
+                "complete"
+              ],
+              "source": "derived",
+              "target": "trip.complete"
+            }
+          ]
+        },
+        "description": "Mark a trip as done",
+        "examples": [
+          {
+            "input": {
+              "id": "trip-lostcoast"
+            },
+            "kind": "success",
+            "name": "Complete a planned trip",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Completing a planned trip flips its status",
+            "expectedMatch": {
+              "id": "trip-lostcoast",
+              "status": "done"
+            }
+          },
+          {
+            "input": {
+              "id": "trip-done"
+            },
+            "kind": "error",
+            "name": "Complete an already-done trip",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Trips cannot be completed twice",
+            "error": "ValidationError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Trip id to complete",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "endDate": {
+              "description": "Trip end date (ISO)",
+              "type": "string"
+            },
+            "id": {
+              "description": "Generated trip id",
+              "type": "string"
+            },
+            "name": {
+              "description": "Trip name",
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Free-form notes"
+            },
+            "packId": {
+              "description": "Pack carried on this trip",
+              "type": "string"
+            },
+            "startDate": {
+              "description": "Trip start date (ISO)",
+              "type": "string"
+            },
+            "status": {
+              "description": "planned, active, or done",
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "description": "Optimistic concurrency version",
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "id",
+            "name",
+            "packId",
+            "startDate",
+            "status",
+            "version"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "trip.create",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "trip",
+            "create"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "trip",
+                "create"
+              ],
+              "source": "derived",
+              "target": "trip.create"
+            }
+          ]
+        },
+        "contours": [
+          "trip"
+        ],
+        "input": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "endDate",
+            "name",
+            "packId",
+            "startDate",
+            "status"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "id",
+            "name",
+            "packId",
+            "startDate",
+            "status",
+            "version"
+          ],
+          "type": "object"
+        },
+        "pattern": "crud",
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "trip.delete",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "trip",
+            "delete"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "trip",
+                "delete"
+              ],
+              "source": "derived",
+              "target": "trip.delete"
+            }
+          ]
+        },
+        "contours": [
+          "trip"
+        ],
+        "examples": [
+          {
+            "input": {
+              "id": "trip-lostcoast"
+            },
+            "kind": "success",
+            "name": "Delete trip trip-lostcoast",
+            "provenance": {
+              "source": "trail.examples"
+            }
+          },
+          {
+            "input": {
+              "id": "trip-done"
+            },
+            "kind": "success",
+            "name": "Delete trip trip-done",
+            "provenance": {
+              "source": "trail.examples"
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "intent": "destroy",
+        "output": {},
+        "pattern": "crud",
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "trip.list",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "trip",
+            "list"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "trip",
+                "list"
+              ],
+              "source": "derived",
+              "target": "trip.list"
+            }
+          ]
+        },
+        "contours": [
+          "trip"
+        ],
+        "input": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "items": {
+            "properties": {
+              "endDate": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "packId": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "planned",
+                  "active",
+                  "done"
+                ],
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "endDate",
+              "id",
+              "name",
+              "packId",
+              "startDate",
+              "status",
+              "version"
+            ],
+            "type": "object"
+          },
+          "type": "array"
+        },
+        "pattern": "crud",
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "trip.read",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "trip",
+            "read"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "trip",
+                "read"
+              ],
+              "source": "derived",
+              "target": "trip.read"
+            }
+          ]
+        },
+        "contours": [
+          "trip"
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "id",
+            "name",
+            "packId",
+            "startDate",
+            "status",
+            "version"
+          ],
+          "type": "object"
+        },
+        "pattern": "crud",
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "trip.reconcile",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "trip",
+            "reconcile"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "trip",
+                "reconcile"
+              ],
+              "source": "derived",
+              "target": "trip.reconcile"
+            }
+          ]
+        },
+        "contours": [
+          "trip"
+        ],
+        "description": "Reconcile version conflicts for \"trip\" entities.",
+        "detours": [
+          {
+            "maxAttempts": 1,
+            "on": "ConflictError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "name",
+            "packId",
+            "startDate",
+            "status",
+            "version"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "id",
+            "name",
+            "packId",
+            "startDate",
+            "status",
+            "version"
+          ],
+          "type": "object"
+        },
+        "pattern": "reconcile",
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "trip.update",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "trip",
+            "update"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "trip",
+                "update"
+              ],
+              "source": "derived",
+              "target": "trip.update"
+            }
+          ]
+        },
+        "contours": [
+          "trip"
+        ],
+        "input": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "endDate": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "notes": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "packId": {
+              "type": "string"
+            },
+            "startDate": {
+              "type": "string"
+            },
+            "status": {
+              "enum": [
+                "planned",
+                "active",
+                "done"
+              ],
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "endDate",
+            "id",
+            "name",
+            "packId",
+            "startDate",
+            "status",
+            "version"
+          ],
+          "type": "object"
+        },
+        "pattern": "crud",
+        "permit": {
+          "scopes": [
+            "packlist:write"
+          ]
+        },
+        "resources": [
+          "db"
+        ]
+      }
+    ],
+    "library": {
+      "app": "packlist",
+      "collisions": [],
+      "excluded": [
+        {
+          "reason": "activation",
+          "trailId": "pack.recalculate"
+        }
+      ],
+      "exports": [
+        {
+          "description": "Add a piece of gear to the locker",
+          "exportName": "gearCreate",
+          "input": {
+            "properties": {
+              "category": {
+                "description": "Gear category: shelter, cook, wear, carry, or other",
+                "enum": [
+                  "shelter",
+                  "cook",
+                  "wear",
+                  "carry",
+                  "other"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Unique gear name",
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Free-form notes"
+              },
+              "weightGrams": {
+                "description": "Weight in grams",
+                "type": "number"
+              }
+            },
+            "required": [
+              "category",
+              "name",
+              "weightGrams"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "category": {
+                "description": "Gear category: shelter, cook, wear, carry, or other",
+                "enum": [
+                  "shelter",
+                  "cook",
+                  "wear",
+                  "carry",
+                  "other"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "description": "Generated gear id",
+                "type": "string"
+              },
+              "name": {
+                "description": "Unique gear name",
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Free-form notes"
+              },
+              "version": {
+                "description": "Optimistic concurrency version",
+                "type": "number"
+              },
+              "weightGrams": {
+                "description": "Weight in grams",
+                "type": "number"
+              }
+            },
+            "required": [
+              "category",
+              "id",
+              "name",
+              "version",
+              "weightGrams"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "gear.create",
+          "version": 2
+        },
+        {
+          "description": "Remove a piece of gear from the locker",
+          "exportName": "gearDelete",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Gear id to delete",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "destroy",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "deleted": {
+                "type": "boolean"
+              },
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "deleted",
+              "id"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "gear.delete"
+        },
+        {
+          "description": "List gear, optionally filtered by category",
+          "exportName": "gearList",
+          "input": {
+            "properties": {
+              "category": {
+                "description": "Gear category: shelter, cook, wear, carry, or other",
+                "enum": [
+                  "shelter",
+                  "cook",
+                  "wear",
+                  "carry",
+                  "other"
+                ],
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "items": {
+              "properties": {
+                "category": {
+                  "description": "Gear category: shelter, cook, wear, carry, or other",
+                  "enum": [
+                    "shelter",
+                    "cook",
+                    "wear",
+                    "carry",
+                    "other"
+                  ],
+                  "type": "string"
+                },
+                "id": {
+                  "description": "Generated gear id",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Unique gear name",
+                  "type": "string"
+                },
+                "notes": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ],
+                  "description": "Free-form notes"
+                },
+                "version": {
+                  "description": "Optimistic concurrency version",
+                  "type": "number"
+                },
+                "weightGrams": {
+                  "description": "Weight in grams",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "category",
+                "id",
+                "name",
+                "version",
+                "weightGrams"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "gear.list"
+        },
+        {
+          "description": "Show one piece of gear by id",
+          "exportName": "gearRead",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Gear id to look up",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "category": {
+                "description": "Gear category: shelter, cook, wear, carry, or other",
+                "enum": [
+                  "shelter",
+                  "cook",
+                  "wear",
+                  "carry",
+                  "other"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "description": "Generated gear id",
+                "type": "string"
+              },
+              "name": {
+                "description": "Unique gear name",
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Free-form notes"
+              },
+              "version": {
+                "description": "Optimistic concurrency version",
+                "type": "number"
+              },
+              "weightGrams": {
+                "description": "Weight in grams",
+                "type": "number"
+              }
+            },
+            "required": [
+              "category",
+              "id",
+              "name",
+              "version",
+              "weightGrams"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "gear.read"
+        },
+        {
+          "description": "Reconcile version conflicts for \"gear\" entities.",
+          "exportName": "gearReconcile",
+          "input": {
+            "properties": {
+              "category": {
+                "enum": [
+                  "shelter",
+                  "cook",
+                  "wear",
+                  "carry",
+                  "other"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "version": {
+                "type": "number"
+              },
+              "weightGrams": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "category",
+              "name",
+              "weightGrams",
+              "version"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "category": {
+                "enum": [
+                  "shelter",
+                  "cook",
+                  "wear",
+                  "carry",
+                  "other"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "version": {
+                "type": "number"
+              },
+              "weightGrams": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "category",
+              "id",
+              "name",
+              "weightGrams",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "gear.reconcile"
+        },
+        {
+          "description": "Update fields on a piece of gear; weight changes mark carrying packs stale",
+          "exportName": "gearUpdate",
+          "input": {
+            "properties": {
+              "category": {
+                "description": "Gear category: shelter, cook, wear, carry, or other",
+                "enum": [
+                  "shelter",
+                  "cook",
+                  "wear",
+                  "carry",
+                  "other"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "description": "Gear id to update",
+                "type": "string"
+              },
+              "name": {
+                "description": "New unique gear name",
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Free-form notes"
+              },
+              "weightGrams": {
+                "description": "Weight in grams",
+                "type": "number"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "category": {
+                "description": "Gear category: shelter, cook, wear, carry, or other",
+                "enum": [
+                  "shelter",
+                  "cook",
+                  "wear",
+                  "carry",
+                  "other"
+                ],
+                "type": "string"
+              },
+              "id": {
+                "description": "Generated gear id",
+                "type": "string"
+              },
+              "name": {
+                "description": "Unique gear name",
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Free-form notes"
+              },
+              "version": {
+                "description": "Optimistic concurrency version",
+                "type": "number"
+              },
+              "weightGrams": {
+                "description": "Weight in grams",
+                "type": "number"
+              }
+            },
+            "required": [
+              "category",
+              "id",
+              "name",
+              "version",
+              "weightGrams"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "gear.update"
+        },
+        {
+          "description": "Add gear to a pack (or increase its quantity)",
+          "exportName": "packAddGear",
+          "input": {
+            "properties": {
+              "gearId": {
+                "description": "Gear id to add",
+                "type": "string"
+              },
+              "packId": {
+                "description": "Pack id to modify",
+                "type": "string"
+              },
+              "quantity": {
+                "description": "How many to add (at least 1)",
+                "type": "number"
+              }
+            },
+            "required": [
+              "gearId",
+              "packId",
+              "quantity"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "id": {
+                "description": "Generated pack id",
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "properties": {
+                    "gearId": {
+                      "description": "Gear carried in this pack",
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "description": "How many of that gear",
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "gearId",
+                    "quantity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "description": "Pack name",
+                "type": "string"
+              },
+              "version": {
+                "description": "Optimistic concurrency version",
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "items",
+              "name",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "pack.add-gear"
+        },
+        {
+          "exportName": "packCreate",
+          "input": {
+            "properties": {
+              "items": {
+                "items": {
+                  "properties": {
+                    "gearId": {
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "gearId",
+                    "quantity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "items",
+              "name"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "properties": {
+                    "gearId": {
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "gearId",
+                    "quantity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "items",
+              "name",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "pack.create"
+        },
+        {
+          "exportName": "packDelete",
+          "input": {
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "destroy",
+          "nameSource": "derived",
+          "output": {},
+          "resources": [
+            "db"
+          ],
+          "trailId": "pack.delete"
+        },
+        {
+          "exportName": "packList",
+          "input": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "properties": {
+                    "gearId": {
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "gearId",
+                    "quantity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "items": {
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "items": {
+                  "items": {
+                    "properties": {
+                      "gearId": {
+                        "type": "string"
+                      },
+                      "quantity": {
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "gearId",
+                      "quantity"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "id",
+                "items",
+                "name",
+                "version"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "pack.list"
+        },
+        {
+          "exportName": "packRead",
+          "input": {
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "properties": {
+                    "gearId": {
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "gearId",
+                    "quantity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "items",
+              "name",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "pack.read"
+        },
+        {
+          "description": "Reconcile version conflicts for \"pack\" entities.",
+          "exportName": "packReconcile",
+          "input": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "properties": {
+                    "gearId": {
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "gearId",
+                    "quantity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "items",
+              "name",
+              "version"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "properties": {
+                    "gearId": {
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "gearId",
+                    "quantity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "items",
+              "name",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "pack.reconcile"
+        },
+        {
+          "description": "Remove gear from a pack (idempotent)",
+          "exportName": "packRemoveGear",
+          "input": {
+            "properties": {
+              "gearId": {
+                "description": "Gear id to remove",
+                "type": "string"
+              },
+              "packId": {
+                "description": "Pack id to modify",
+                "type": "string"
+              }
+            },
+            "required": [
+              "gearId",
+              "packId"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "id": {
+                "description": "Generated pack id",
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "properties": {
+                    "gearId": {
+                      "description": "Gear carried in this pack",
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "description": "How many of that gear",
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "gearId",
+                    "quantity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "description": "Pack name",
+                "type": "string"
+              },
+              "version": {
+                "description": "Optimistic concurrency version",
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "items",
+              "name",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "pack.remove-gear"
+        },
+        {
+          "exportName": "packUpdate",
+          "input": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "properties": {
+                    "gearId": {
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "gearId",
+                    "quantity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "items": {
+                "items": {
+                  "properties": {
+                    "gearId": {
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "gearId",
+                    "quantity"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "id",
+              "items",
+              "name",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "pack.update"
+        },
+        {
+          "description": "Derive a pack’s total weight from current gear weights (never stored)",
+          "exportName": "packWeight",
+          "input": {
+            "properties": {
+              "packId": {
+                "description": "Pack id to weigh",
+                "type": "string"
+              }
+            },
+            "required": [
+              "packId"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "items": {
+                "items": {
+                  "properties": {
+                    "gearId": {
+                      "description": "Gear carried in the pack",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Gear name",
+                      "type": "string"
+                    },
+                    "quantity": {
+                      "description": "How many are carried",
+                      "type": "number"
+                    },
+                    "subtotalGrams": {
+                      "description": "quantity × weightGrams",
+                      "type": "number"
+                    },
+                    "weightGrams": {
+                      "description": "Current weight of one unit",
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "gearId",
+                    "name",
+                    "quantity",
+                    "subtotalGrams",
+                    "weightGrams"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "name": {
+                "type": "string"
+              },
+              "packId": {
+                "type": "string"
+              },
+              "totalWeightGrams": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "items",
+              "name",
+              "packId",
+              "totalWeightGrams"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "pack.weight"
+        },
+        {
+          "description": "Load the demo gear, pack, and trip (idempotent)",
+          "exportName": "seedDemo",
+          "input": {
+            "properties": {},
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "gear": {
+                "type": "number"
+              },
+              "packs": {
+                "type": "number"
+              },
+              "trips": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "gear",
+              "packs",
+              "trips"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "seed.demo"
+        },
+        {
+          "description": "Build the packing checklist for a trip from its pack",
+          "exportName": "tripChecklist",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Trip id to build a checklist for",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "packName": {
+                "type": "string"
+              },
+              "rows": {
+                "items": {
+                  "properties": {
+                    "category": {
+                      "description": "Gear category",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Gear name",
+                      "type": "string"
+                    },
+                    "packed": {
+                      "description": "Starting state for the checklist",
+                      "type": "boolean"
+                    },
+                    "quantity": {
+                      "description": "How many to pack",
+                      "type": "number"
+                    },
+                    "weightGrams": {
+                      "description": "Weight of one unit",
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "category",
+                    "name",
+                    "packed",
+                    "quantity",
+                    "weightGrams"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "totalWeightGrams": {
+                "type": "number"
+              },
+              "tripId": {
+                "type": "string"
+              },
+              "tripName": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "packName",
+              "rows",
+              "totalWeightGrams",
+              "tripId",
+              "tripName"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "trip.checklist"
+        },
+        {
+          "description": "Mark a trip as done",
+          "exportName": "tripComplete",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Trip id to complete",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "endDate": {
+                "description": "Trip end date (ISO)",
+                "type": "string"
+              },
+              "id": {
+                "description": "Generated trip id",
+                "type": "string"
+              },
+              "name": {
+                "description": "Trip name",
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Free-form notes"
+              },
+              "packId": {
+                "description": "Pack carried on this trip",
+                "type": "string"
+              },
+              "startDate": {
+                "description": "Trip start date (ISO)",
+                "type": "string"
+              },
+              "status": {
+                "description": "planned, active, or done",
+                "enum": [
+                  "planned",
+                  "active",
+                  "done"
+                ],
+                "type": "string"
+              },
+              "version": {
+                "description": "Optimistic concurrency version",
+                "type": "number"
+              }
+            },
+            "required": [
+              "endDate",
+              "id",
+              "name",
+              "packId",
+              "startDate",
+              "status",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "trip.complete"
+        },
+        {
+          "exportName": "tripCreate",
+          "input": {
+            "properties": {
+              "endDate": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "packId": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "planned",
+                  "active",
+                  "done"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "endDate",
+              "name",
+              "packId",
+              "startDate",
+              "status"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "endDate": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "packId": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "planned",
+                  "active",
+                  "done"
+                ],
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "endDate",
+              "id",
+              "name",
+              "packId",
+              "startDate",
+              "status",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "trip.create"
+        },
+        {
+          "exportName": "tripDelete",
+          "input": {
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "destroy",
+          "nameSource": "derived",
+          "output": {},
+          "resources": [
+            "db"
+          ],
+          "trailId": "trip.delete"
+        },
+        {
+          "exportName": "tripList",
+          "input": {
+            "properties": {
+              "endDate": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "packId": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "planned",
+                  "active",
+                  "done"
+                ],
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "items": {
+              "properties": {
+                "endDate": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "notes": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "packId": {
+                  "type": "string"
+                },
+                "startDate": {
+                  "type": "string"
+                },
+                "status": {
+                  "enum": [
+                    "planned",
+                    "active",
+                    "done"
+                  ],
+                  "type": "string"
+                },
+                "version": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "endDate",
+                "id",
+                "name",
+                "packId",
+                "startDate",
+                "status",
+                "version"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "trip.list"
+        },
+        {
+          "exportName": "tripRead",
+          "input": {
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "endDate": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "packId": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "planned",
+                  "active",
+                  "done"
+                ],
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "endDate",
+              "id",
+              "name",
+              "packId",
+              "startDate",
+              "status",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "trip.read"
+        },
+        {
+          "description": "Reconcile version conflicts for \"trip\" entities.",
+          "exportName": "tripReconcile",
+          "input": {
+            "properties": {
+              "endDate": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "packId": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "planned",
+                  "active",
+                  "done"
+                ],
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "endDate",
+              "name",
+              "packId",
+              "startDate",
+              "status",
+              "version"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "endDate": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "packId": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "planned",
+                  "active",
+                  "done"
+                ],
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "endDate",
+              "id",
+              "name",
+              "packId",
+              "startDate",
+              "status",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "trip.reconcile"
+        },
+        {
+          "exportName": "tripUpdate",
+          "input": {
+            "properties": {
+              "endDate": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "packId": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "planned",
+                  "active",
+                  "done"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "endDate": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "notes": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "packId": {
+                "type": "string"
+              },
+              "startDate": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "planned",
+                  "active",
+                  "done"
+                ],
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "endDate",
+              "id",
+              "name",
+              "packId",
+              "startDate",
+              "status",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "db"
+          ],
+          "trailId": "trip.update"
+        }
+      ]
+    },
+    "topoGraphSchemaVersion": 3
+  },
+  "topoGraphHash": "38e6c1180c853844867e8070381c75bc14f57aa0333e4e0824bc14c12626d0ca",
+  "version": 4
+}

--- a/examples/packlist/tsconfig.json
+++ b/examples/packlist/tsconfig.json
@@ -4,6 +4,6 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["src"],
+  "include": ["src", "bin"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
 }


### PR DESCRIPTION
Implements [TRL-1149](https://linear.app/outfitter/issue/TRL-1149/build-packlist-per-prd-fable-goal-run) per the [packlist PRD](https://linear.app/outfitter/document/prd-packlist-gear-and-trip-checklists-crud-showcase-ad1c46ccc381): the "show me a normal app" showcase — entities, store, CRUD factory, reconcile, store-derived signals, and an honest schema-versioning walkthrough. Replaces the `examples/packlist` placeholder.

## What's here

Three commits, each green on its own:

1. **Entities + store + CRUD + reconcile** — three versioned tables (`gear`, `pack`, `trip`) on a Drizzle SQLite `db` resource with an in-memory mock; hand-authored gear trails (duplicate-name → `AlreadyExistsError`, error-path examples); factory CRUD for pack and trip; reconcile per table. Gear is authored at **v1 (`weightOz`)** so the migration is real history.
2. **Versioning fork + signals loop + compose** — `gear.create` becomes `version: 2` (`weightGrams`) with a v1 **fork entry preserving the ounces blaze** and deprecation guidance (`successor: 2`, migration steps, note). `gear.update` fires `pack.weight-stale` when a weight change touches carried gear; `pack.recalculate` consumes it and logs recomputed totals. `pack.weight` and `trip.checklist` compose through `ctx.compose()`; plus `pack.add-gear`/`remove-gear`, `trip.complete`, `seed.demo`.
3. **Surfaces + tests + lock + README** — CLI/HTTP/MCP entry points (one `surface()` call each), the signals-loop test, committed `trails.lock`, and the README (showcase matrix, verbatim quickstart, versioning walkthrough).

## Verification evidence

- `testAll(app)` green with the mocked db: **100 tests pass** (`bun test` in `examples/packlist`), including the v1 fork examples (run as `gear.create@1` targets) and a signal assertion on the `gear.update` example.
- Warden: `bun run warden` (workspace script, scoped to this app) → **PASS, 0 errors**, 10 warnings (9 × `signal-graph-coaching` on unconsumed store-derived signals, 1 × `duplicate-public-contract` false positive on factory deletes — both filed, see below). Repo-wide `bun run check` exits 0.
- Committed `trails.lock` (25 trails, 10 signals, 1 resource); `trails wayfind pattern "gear.*" --root-dir .` answers from it with drift `aligned`.
- Version history clean under `version-gap`, `version-without-examples`, `fork-without-preserved-blaze`, `deprecation-without-guidance`, and `marker-schema-unsupported`.
- Signals loop proven by test (`__tests__/signals.test.ts`) **and** visible in normal CLI output:
  `[packlist] info pack "Weekend Loop" recalculated: 2990 g (Canister Stove: 220 g → 250 g)`
- README quickstart executed verbatim from a clean checkout: seed → gear ls/add → pack add-gear → pack weight → gear update (recalc line above) → printed trip checklist (`totalWeightGrams: 2990`), then the same checklist over HTTP (`curl http://localhost:3210/trip/checklist?id=trip-lostcoast`) and taxonomy-mapped errors (NotFound → exit 2 / HTTP 404, conflict → exit 3 / 409).
- v1 callable end-to-end: `packlist gear create --trail-version 1 --input-json '{"name":"Ultralight Tarp","category":"shelter","weightOz":16}'` returns ounces; the row lands in grams.

## Framework gaps found (dogfood payoff — filed, worked around, kept building)

- [TRL-1177](https://linear.app/outfitter/issue/TRL-1177): `crud()` + `reconcile()` on one table collide on duplicate contour registration (workaround: `withoutTableContour`).
- [TRL-1178](https://linear.app/outfitter/issue/TRL-1178): store factories can't declare permits; factory destroy trails fail permit governance (workaround: `withOperatorPermit` + operator permit injected per surface).
- [TRL-1179](https://linear.app/outfitter/issue/TRL-1179): warden drift ignores `cliAliases` that compile embeds — alias-exporting app modules are permanently "stale" (workaround: aliases live in `bin/packlist.ts` only).
- [TRL-1180](https://linear.app/outfitter/issue/TRL-1180): fork-entry blazes get `unknown` input (workaround: re-parse with the v1 schema to narrow).
- [TRL-1181](https://linear.app/outfitter/issue/TRL-1181): `duplicate-public-contract` false positive on factory deletes across tables (accepted warning).
- [TRL-1182](https://linear.app/outfitter/issue/TRL-1182): `examples/*` apps need first-class warden coverage; root `trails.config.ts` is off-limits to app PRs, so the app-scoped run lives in the workspace `warden` script.
- [TRL-1183](https://linear.app/outfitter/issue/TRL-1183): `signal-graph-coaching` noise for store-derived signals (accepted warnings).

## PRD deviations (explicit waivers, not silent drops)

- **Trail ids follow factory derivation**: `gear.read`/`gear.delete` instead of the PRD inventory's `gear.get`/`gear.archive`; `get`/`ls`/`add` exist as CLI aliases, and archive semantics would fork the CRUD contract (derive-by-default won).
- **Gear CRUD is hand-authored** rather than factory-produced, because the factory cannot carry `versions`, `fires`, or the conflict check (that is TRL-1178/TRL-1180 territory); pack and trip take the factory as-is, so both stories are shown.
- **`entity()` phrasing**: the framework's entity primitive is the store table + derived contour; there is no `entity()` function or `gear.id()` helper, so the showcase matrix names what actually exists (branded-id helpers live in `@ontrails/core`, and pack items reference gear ids as plain strings validated at the trail boundary).
- **Factory-trail examples** come from fixture derivation and don't include error examples (only hand-authored trails meet the "≥2 examples incl. one error" bar) — same TRL-1178-family factory limitation.
- **Cloudflare stretch: not attempted** — no `adapters/cloudflare/d1` exists in the repo.
- `wayfinder-dogfood` smoke: not applicable — example-only PR, no framework surface changes (per `examples/README.md`).

Do not merge — staying in draft until CI is green, then marked ready for review.