### PR TITLE
feat(examples): add switchback feature-flags showcase

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -157,6 +157,21 @@
     "examples/switchback": {
       "name": "switchback",
       "version": "0.0.0",
+      "bin": {
+        "switchback": "./bin/switchback.ts",
+      },
+      "dependencies": {
+        "@ontrails/commander": "workspace:^",
+        "@ontrails/core": "workspace:^",
+        "@ontrails/library": "workspace:^",
+        "@ontrails/mcp": "workspace:^",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@ontrails/testing": "workspace:^",
+        "@ontrails/topographer": "workspace:^",
+        "@ontrails/warden": "workspace:^",
+      },
     },
     "packages/adapter-kit": {
       "name": "@ontrails/adapter-kit",

--- a/examples/switchback/README.md
+++ b/examples/switchback/README.md
@@ -1,0 +1,129 @@
+# switchback
+
+Feature flags with deterministic, explainable evaluation — the Trails library-first showcase. A switchback is a turn in the trail: the same flag can send different subjects down different paths, and this app always tells you exactly why.
+
+This is the app for "I don't want a server, I want a package." One authored trail contract is consumed three ways with zero divergence: as a typed in-process library, as CLI commands, and as MCP tools.
+
+## What this showcases
+
+| Capability | Where it appears |
+| --- | --- |
+| Library surface + projection artifacts | [quickstart.ts](quickstart.ts) consumes the topo through `@ontrails/library`; the committed [trails.lock](trails.lock) embeds the collision-free projection, and [governance.test.ts](src/__tests__/governance.test.ts) keeps `library-projection-coherence` clean |
+| Pure, deterministic blazes | [engine.ts](src/engine.ts) is a pure function of (flag definition, evaluation context) — no clock, no randomness; [engine.test.ts](src/__tests__/engine.test.ts) pins fixed hash vectors forever |
+| Explainability | every `flag.evaluate` result carries a rule-by-rule `EvalTrace`; the CLI renders it with `--explain` ([evaluate.ts](src/trails/evaluate.ts)) |
+| Percentage rollouts | seeded FNV-1a hashing buckets each flag+subject stably ([engine.ts](src/engine.ts)) |
+| Non-DB resource | the `flags` resource is a JSON file reloaded on every read, deliberately not a database ([resources/flags.ts](src/resources/flags.ts)) |
+| Surface parity | every trail example runs identically on CLI, MCP, and HTTP harnesses ([surface-parity.test.ts](src/__tests__/surface-parity.test.ts)) |
+| Publishability | the example passes `bun pm pack --dry-run` cleanly, as scaffolding for real library packages |
+
+## Quickstart
+
+Every command below runs verbatim from a fresh checkout.
+
+```bash
+bun install        # from the repo root
+cd examples/switchback
+```
+
+The library surface first — five lines to your first evaluation. This is the committed [quickstart.ts](quickstart.ts):
+
+```ts
+import { surface } from '@ontrails/library';
+import { app } from 'switchback';
+
+const lib = await surface(app);
+console.log(await lib.call.flagEvaluate({ context: { subjectId: 'user-1' }, key: 'checkout-v2' }));
+```
+
+```bash
+bun quickstart.ts
+bun test           # examples, fixed vectors, parity, governance
+```
+
+## One contract, three surfaces
+
+`flag.evaluate` is authored once in [src/trails/evaluate.ts](src/trails/evaluate.ts). The same trail, invoked three ways:
+
+**Library import** (the hero):
+
+```ts
+const lib = await surface(app);
+await lib.call.flagEvaluate({ context: { subjectId: 'user-1' }, key: 'checkout-v2' });
+```
+
+**CLI command:**
+
+```bash
+bun bin/switchback.ts flag evaluate checkout-v2 '{"context":{"subjectId":"user-1"}}' --explain
+```
+
+**MCP tool** — start the server with `bun src/mcp.ts` and the same trail is the `switchback_flag_evaluate` tool, trace included, so an agent can ask "is checkout-v2 on for this user, and why?":
+
+```json
+{ "name": "switchback_flag_evaluate", "arguments": { "key": "checkout-v2", "context": { "subjectId": "user-1" } } }
+```
+
+No divergence is possible: the CLI flags, the tool schema, and the library method are all projected from the one authored input schema.
+
+## Every answer explains itself
+
+Evaluation never just returns a value — it returns the `EvalTrace` of how the value was chosen. Rules are checked in order; the trace records each one as `matched`, `skipped` (with the failing condition), or `percentage` (with the bucket):
+
+```json
+{
+  "key": "checkout-v2",
+  "value": "treatment",
+  "variant": "treatment",
+  "reason": {
+    "reason": "percentage-rollout",
+    "steps": [
+      { "ruleId": "beta-users", "outcome": "skipped", "detail": "attribute \"plan\" is missing" },
+      { "ruleId": "gradual-rollout", "outcome": "percentage", "bucket": 7, "served": "treatment" }
+    ]
+  }
+}
+```
+
+Pass `explain: true` (the CLI `--explain` flag) and the result adds a human-readable rendering of the same trace.
+
+## Deterministic rollouts: the hash contract
+
+Percentage rollouts must be stable forever: a subject that sees the treatment today must see it tomorrow. `bucketFor` in [src/engine.ts](src/engine.ts) is standard FNV-1a 32-bit over the UTF-8 bytes of `"<flagKey>:<subjectId>"`:
+
+```text
+hash = 0x811c9dc5
+for each byte b: hash = (hash XOR b) * 0x01000193  (mod 2^32)
+bucket = hash mod 100
+```
+
+The bucket is stable per flag+subject and independent across flags. Fixed vectors are asserted in [engine.test.ts](src/__tests__/engine.test.ts) and must never change: `checkout-v2:user-1 → 7`, `checkout-v2:user-42 → 10`, `dark-mode:user-1 → 58`. `flag.evaluate` is a pure function of the flag definition and the evaluation context — no clock, no randomness, no I/O beyond reading the `flags` resource — which is why its examples can pin exact expected results and serve as the spec.
+
+## The flags resource is a file on purpose
+
+Flag definitions live in [switchback.flags.json](switchback.flags.json), reloaded on every read and rewritten by the mutation trails. Not every resource is a database; this one shows the resource contract carrying a plain file, with a mock factory that serves the same fixture definitions so `testAll(app)` runs with zero configuration. Point `SWITCHBACK_FLAGS_PATH` at another file to relocate it. The definitions file and [src/fixtures.ts](src/fixtures.ts) are kept in sync by a test; regenerate with `bun run scripts/generate-flags-file.ts`.
+
+`flag.evaluate-all` produces the bootstrap payload (every live flag for one subject) and records it in the in-memory `audit` resource — the demo eval log behind `audit.list`, deliberately ephemeral and clock-free. Single-flag `flag.evaluate` stays hermetically pure.
+
+## The trails
+
+| Trail | Intent | Notes |
+| --- | --- | --- |
+| `flag.evaluate` | read | the hero: value + variant + `EvalTrace`, optional `explain` rendering |
+| `flag.evaluate-all` | read | bootstrap payload for one subject; recorded in the demo audit log |
+| `flag.create` / `flag.list` / `flag.get` / `flag.update` / `flag.archive` | write/read | definitions CRUD; duplicate keys conflict, archived flags retire from evaluation |
+| `flag.enable` / `flag.disable` | write | idempotent lifecycle toggles |
+| `rule.add` / `rule.remove` / `rule.reorder` | write | ordered rules; first full match wins, so position matters |
+| `audit.list` | read | the in-memory demo eval log |
+
+## Fork this as your package scaffold
+
+If you are building a library-first Trails package, this example is the template:
+
+- **Author trails, export the topo.** [src/index.ts](src/index.ts) is the package entry: the `app` topo plus the domain schemas and the pure engine.
+- **The library projection is governed.** `deriveLibraryApi(app)` derives one camelCase export per trail (`flag.evaluate` → `flagEvaluate`); the Warden rule `library-projection-coherence` fails the build if two trails ever collide on an export name, and the resolved projection is committed inside [trails.lock](trails.lock). When you want fully typed per-trail exports instead of the in-memory client, `compile(app, …)` from `@ontrails/library` emits a TypeScript package from the same projection.
+- **Packing is checked.** `bun pm pack --dry-run` packs source, bin, and demo data with no test files — the same shape a real published package needs. This example stays `private: true`; delete that field, name your package, and publish checks apply as-is.
+- **Surfaces come free.** [bin/switchback.ts](bin/switchback.ts) and [src/mcp.ts](src/mcp.ts) are three lines each; CLI commands and MCP tools are projections of the contract you already wrote.
+
+## Governance
+
+The committed [trails.lock](trails.lock) is the resolved story of the app: 13 trails, 2 resources, 28 examples, and the library projection, all inspectable with Wayfinder (`bun ../../apps/trails/bin/trails.ts wayfind --overview --root-dir . --json`). [governance.test.ts](src/__tests__/governance.test.ts) runs Warden in CI: zero errors and no lock drift, or the suite fails.

--- a/examples/switchback/bin/switchback.ts
+++ b/examples/switchback/bin/switchback.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env bun
+
+/**
+ * CLI entry point for switchback.
+ *
+ * Usage:
+ *   bun run bin/switchback.ts flag list
+ *   bun run bin/switchback.ts flag evaluate --key checkout-v2 \
+ *     --context '{"subjectId":"user-1","attributes":{"plan":"beta"}}' --explain
+ */
+
+import { surface } from '@ontrails/commander';
+
+import { app } from '../src/app.js';
+
+// oxlint-disable-next-line require-hook -- CLI entry point, not a test file
+await surface(app);

--- a/examples/switchback/package.json
+++ b/examples/switchback/package.json
@@ -2,12 +2,41 @@
   "name": "switchback",
   "version": "0.0.0",
   "private": true,
+  "description": "Feature flags with deterministic, explainable evaluation — the Trails library-first showcase",
+  "bin": {
+    "switchback": "./bin/switchback.ts"
+  },
+  "files": [
+    "bin/**/*.ts",
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "switchback.flags.json",
+    "README.md"
+  ],
   "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./app": "./src/app.ts",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "tsc -b",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint ./src",
     "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "dependencies": {
+    "@ontrails/commander": "workspace:^",
+    "@ontrails/core": "workspace:^",
+    "@ontrails/library": "workspace:^",
+    "@ontrails/mcp": "workspace:^",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@ontrails/testing": "workspace:^",
+    "@ontrails/topographer": "workspace:^",
+    "@ontrails/warden": "workspace:^"
   }
 }

--- a/examples/switchback/quickstart.ts
+++ b/examples/switchback/quickstart.ts
@@ -1,0 +1,10 @@
+import { surface } from '@ontrails/library';
+import { app } from 'switchback';
+
+const lib = await surface(app);
+console.log(
+  await lib.call.flagEvaluate({
+    context: { subjectId: 'user-1' },
+    key: 'checkout-v2',
+  })
+);

--- a/examples/switchback/scripts/generate-flags-file.ts
+++ b/examples/switchback/scripts/generate-flags-file.ts
@@ -1,0 +1,15 @@
+/**
+ * Regenerate the committed demo flag definitions from src/fixtures.ts so the
+ * file-backed store and the mock resource always serve the same data.
+ *
+ * Usage: bun run scripts/generate-flags-file.ts (from examples/switchback)
+ */
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { fixtureFlags } from '../src/fixtures.js';
+
+const sorted = fixtureFlags().toSorted((a, b) => a.key.localeCompare(b.key));
+const target = join(import.meta.dir, '..', 'switchback.flags.json');
+writeFileSync(target, `${JSON.stringify(sorted, null, 2)}\n`);
+console.log(`wrote ${target}`);

--- a/examples/switchback/src/__tests__/app.test.ts
+++ b/examples/switchback/src/__tests__/app.test.ts
@@ -1,0 +1,15 @@
+/* oxlint-disable eslint-plugin-jest/require-hook -- testAll registers describe/test blocks at module scope */
+import { testAll } from '@ontrails/testing';
+
+import { app } from '../app.js';
+import { createAuditLog } from '../resources/audit.js';
+import { createMemoryFlagStore } from '../resources/flags.js';
+
+// Fresh in-memory stores per test so mutation examples stay isolated and
+// every example runs against exactly the committed fixture definitions.
+testAll(app, () => ({
+  resources: {
+    audit: createAuditLog(),
+    flags: createMemoryFlagStore(),
+  },
+}));

--- a/examples/switchback/src/__tests__/engine.test.ts
+++ b/examples/switchback/src/__tests__/engine.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from 'bun:test';
+import { bucketFor, evaluateFlag } from '../engine.js';
+import type { Flag } from '../model.js';
+
+/**
+ * Fixed hash vectors: these assert the documented FNV-1a bucketing contract.
+ * They must never change — a subject's bucket is stable forever. If one of
+ * these fails, the hash implementation drifted; fix the implementation, not
+ * the vector.
+ */
+describe('bucketFor fixed vectors', () => {
+  const vectors: [flagKey: string, subjectId: string, bucket: number][] = [
+    ['checkout-v2', 'user-1', 7],
+    ['checkout-v2', 'user-2', 26],
+    ['checkout-v2', 'user-3', 45],
+    ['checkout-v2', 'user-42', 10],
+    ['new-onboarding', 'user-1', 64],
+    ['new-onboarding', 'subject-abc', 10],
+    ['dark-mode', 'user-1', 58],
+  ];
+
+  test.each(vectors)('%s : %s -> bucket %i', (flagKey, subjectId, bucket) => {
+    expect(bucketFor(flagKey, subjectId)).toBe(bucket);
+  });
+
+  test('is a pure function of flagKey + subjectId', () => {
+    const repeated = Array.from({ length: 5 }, () =>
+      bucketFor('checkout-v2', 'user-1')
+    );
+    expect(repeated).toEqual([7, 7, 7, 7, 7]);
+  });
+
+  test('buckets the same subject independently per flag', () => {
+    expect(bucketFor('checkout-v2', 'user-1')).not.toBe(
+      bucketFor('dark-mode', 'user-1')
+    );
+  });
+});
+
+const rolloutFlag: Flag = {
+  archived: false,
+  defaultValue: 'control',
+  description: 'New checkout flow',
+  enabled: true,
+  key: 'checkout-v2',
+  kind: 'variant',
+  rules: [
+    {
+      id: 'beta-users',
+      serve: { value: 'treatment' },
+      when: [{ attribute: 'plan', op: 'eq', value: 'beta' }],
+    },
+    {
+      id: 'gradual-rollout',
+      serve: {
+        split: [
+          { value: 'treatment', weight: 20 },
+          { value: 'control', weight: 80 },
+        ],
+      },
+      when: [],
+    },
+  ],
+  variants: ['control', 'treatment'],
+};
+
+describe('evaluateFlag', () => {
+  test('first matching rule wins and the trace records the skip', () => {
+    const evaluation = evaluateFlag(rolloutFlag, {
+      attributes: { plan: 'beta' },
+      subjectId: 'user-1',
+    });
+    expect(evaluation.value).toBe('treatment');
+    expect(evaluation.variant).toBe('treatment');
+    expect(evaluation.reason).toEqual({
+      reason: 'rule-match',
+      steps: [{ outcome: 'matched', ruleId: 'beta-users' }],
+    });
+  });
+
+  test('percentage rollout resolves deterministically through the bucket', () => {
+    // user-1 buckets to 7 (< 20) -> treatment; user-3 buckets to 45 -> control.
+    const treated = evaluateFlag(rolloutFlag, {
+      attributes: {},
+      subjectId: 'user-1',
+    });
+    expect(treated.value).toBe('treatment');
+    expect(treated.reason).toEqual({
+      reason: 'percentage-rollout',
+      steps: [
+        {
+          detail: 'attribute "plan" is missing',
+          outcome: 'skipped',
+          ruleId: 'beta-users',
+        },
+        {
+          bucket: 7,
+          outcome: 'percentage',
+          ruleId: 'gradual-rollout',
+          served: 'treatment',
+        },
+      ],
+    });
+
+    const control = evaluateFlag(rolloutFlag, {
+      attributes: {},
+      subjectId: 'user-3',
+    });
+    expect(control.value).toBe('control');
+    expect(control.reason.steps.at(-1)).toEqual({
+      bucket: 45,
+      outcome: 'percentage',
+      ruleId: 'gradual-rollout',
+      served: 'control',
+    });
+  });
+
+  test('disabled flag serves the default with reason disabled and no rule steps', () => {
+    const evaluation = evaluateFlag(
+      { ...rolloutFlag, enabled: false },
+      {
+        attributes: { plan: 'beta' },
+        subjectId: 'user-1',
+      }
+    );
+    expect(evaluation.value).toBe('control');
+    expect(evaluation.reason).toEqual({ reason: 'disabled', steps: [] });
+  });
+
+  test('no matching rule serves the default with the full skip trace', () => {
+    const gated: Flag = {
+      ...rolloutFlag,
+      rules: [rolloutFlag.rules[0] as Flag['rules'][number]],
+    };
+    const evaluation = evaluateFlag(gated, {
+      attributes: { plan: 'free' },
+      subjectId: 'user-9',
+    });
+    expect(evaluation.value).toBe('control');
+    expect(evaluation.reason.reason).toBe('no-rule-match');
+    expect(evaluation.reason.steps).toHaveLength(1);
+    expect(evaluation.reason.steps[0]?.outcome).toBe('skipped');
+  });
+
+  test('empty rules serve the default', () => {
+    const bare: Flag = { ...rolloutFlag, rules: [] };
+    const evaluation = evaluateFlag(bare, {
+      attributes: {},
+      subjectId: 'user-1',
+    });
+    expect(evaluation.value).toBe('control');
+    expect(evaluation.reason).toEqual({ reason: 'no-rule-match', steps: [] });
+  });
+
+  test('condition operators: neq, in, gte, lte', () => {
+    const flag: Flag = {
+      archived: false,
+      defaultValue: false,
+      description: 'operator coverage',
+      enabled: true,
+      key: 'ops-check',
+      kind: 'boolean',
+      rules: [
+        {
+          id: 'ops',
+          serve: { value: true },
+          when: [
+            { attribute: 'region', op: 'neq', value: 'eu' },
+            { attribute: 'plan', op: 'in', value: ['pro', 'team'] },
+            { attribute: 'seats', op: 'gte', value: 5 },
+            { attribute: 'seats', op: 'lte', value: 500 },
+          ],
+        },
+      ],
+    };
+    const match = evaluateFlag(flag, {
+      attributes: { plan: 'pro', region: 'us', seats: 12 },
+      subjectId: 'org-1',
+    });
+    expect(match.value).toBe(true);
+
+    const miss = evaluateFlag(flag, {
+      attributes: { plan: 'pro', region: 'us', seats: 3 },
+      subjectId: 'org-2',
+    });
+    expect(miss.value).toBe(false);
+    expect(miss.reason.steps[0]).toEqual({
+      detail: 'attribute "seats" = 3 is not gte 5',
+      outcome: 'skipped',
+      ruleId: 'ops',
+    });
+  });
+
+  test('boolean-kind flags never report a variant', () => {
+    const flag: Flag = {
+      archived: false,
+      defaultValue: false,
+      description: 'dark mode',
+      enabled: true,
+      key: 'dark-mode',
+      kind: 'boolean',
+      rules: [{ id: 'all-on', serve: { value: true }, when: [] }],
+    };
+    const evaluation = evaluateFlag(flag, {
+      attributes: {},
+      subjectId: 'user-1',
+    });
+    expect(evaluation.value).toBe(true);
+    expect(evaluation.variant).toBeUndefined();
+  });
+});

--- a/examples/switchback/src/__tests__/flags-store.test.ts
+++ b/examples/switchback/src/__tests__/flags-store.test.ts
@@ -1,0 +1,87 @@
+/**
+ * File-backed store behavior plus the fixture/JSON sync guarantee: the
+ * committed switchback.flags.json must stay identical to src/fixtures.ts
+ * (regenerate with `bun run scripts/generate-flags-file.ts`).
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { fixtureFlags } from '../fixtures.js';
+import { flagSchema } from '../model.js';
+import { createFileFlagStore } from '../resources/flags.js';
+
+const tempDirs: string[] = [];
+const tempStorePath = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'switchback-flags-'));
+  tempDirs.push(dir);
+  return join(dir, 'switchback.flags.json');
+};
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe('committed flag definitions', () => {
+  test('switchback.flags.json matches src/fixtures.ts exactly', () => {
+    const committed = JSON.parse(
+      readFileSync(
+        join(import.meta.dir, '..', '..', 'switchback.flags.json'),
+        'utf8'
+      )
+    );
+    const expected = fixtureFlags().toSorted((a, b) =>
+      a.key.localeCompare(b.key)
+    );
+    expect(committed).toEqual(expected);
+  });
+
+  test('every committed definition parses against the flag schema', () => {
+    for (const flag of fixtureFlags()) {
+      expect(flagSchema.parse(flag)).toEqual(flag);
+    }
+  });
+});
+
+describe('createFileFlagStore', () => {
+  test('missing file reads as an empty definition set', async () => {
+    const store = createFileFlagStore(tempStorePath());
+    expect(await store.list()).toEqual([]);
+    expect(await store.get('anything')).toBeUndefined();
+  });
+
+  test('put persists and reloads on the next read', async () => {
+    const path = tempStorePath();
+    const store = createFileFlagStore(path);
+    const [flag] = fixtureFlags();
+    await store.put(flag as NonNullable<typeof flag>);
+    expect(await store.get('checkout-v2')).toEqual(flag);
+
+    // A second store over the same file sees the write: reload-on-read.
+    const reopened = createFileFlagStore(path);
+    const reloaded = await reopened.list();
+    expect(reloaded.map((entry) => entry.key)).toEqual(['checkout-v2']);
+  });
+
+  test('put replaces an existing definition by key', async () => {
+    const store = createFileFlagStore(tempStorePath());
+    const [flag] = fixtureFlags();
+    const base = flag as NonNullable<typeof flag>;
+    await store.put(base);
+    await store.put({ ...base, description: 'Updated' });
+    const flags = await store.list();
+    expect(flags).toHaveLength(1);
+    expect(flags[0]?.description).toBe('Updated');
+  });
+
+  test('invalid stored content fails loudly at the schema boundary', async () => {
+    const path = tempStorePath();
+    await Bun.write(path, JSON.stringify([{ key: 'not-a-flag' }]));
+    const store = createFileFlagStore(path);
+    expect(store.list()).rejects.toThrow();
+  });
+});

--- a/examples/switchback/src/__tests__/governance.test.ts
+++ b/examples/switchback/src/__tests__/governance.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Governance gates for the showcase, enforced in CI:
+ * - Warden reports zero errors for the switchback topo, including the
+ *   topo-aware library-projection-coherence rule.
+ * - The committed trails.lock matches the current graph (no drift).
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+
+import { deriveTopoGraph } from '@ontrails/topographer';
+import { runWarden } from '@ontrails/warden';
+
+import { app } from '../app.js';
+
+const appRoot = join(import.meta.dir, '..', '..');
+
+describe('warden', () => {
+  test('zero errors and no lock drift for the switchback topo', async () => {
+    const report = await runWarden({
+      rootDir: appRoot,
+      topos: [{ graph: deriveTopoGraph(app), name: 'switchback', topo: app }],
+    });
+    const errors = report.diagnostics.filter(
+      (diagnostic) => diagnostic.severity === 'error'
+    );
+    expect(errors).toEqual([]);
+    expect(report.errorCount).toBe(0);
+    expect(report.drift?.stale ?? false).toBe(false);
+  });
+});
+
+describe('trails.lock', () => {
+  test('committed lock embeds the collision-free library projection', async () => {
+    const lock = (await Bun.file(join(appRoot, 'trails.lock')).json()) as {
+      topoGraph: {
+        library?: {
+          collisions: unknown[];
+          exports: { exportName: string }[];
+        };
+      };
+    };
+    expect(lock.topoGraph.library?.collisions).toEqual([]);
+    expect(
+      lock.topoGraph.library?.exports.map((entry) => entry.exportName)
+    ).toContain('flagEvaluate');
+  });
+});

--- a/examples/switchback/src/__tests__/library.test.ts
+++ b/examples/switchback/src/__tests__/library.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The hero surface: the switchback topo consumed as a typed in-process
+ * library. Also proves the projection is collision-free and that the same
+ * trail produces identical results through the library client and headless
+ * execution.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { run } from '@ontrails/core';
+import { deriveLibraryApi, surface } from '@ontrails/library';
+
+import { app } from '../app.js';
+import { createAuditLog } from '../resources/audit.js';
+import { createMemoryFlagStore } from '../resources/flags.js';
+
+const freshResources = () => ({
+  audit: createAuditLog(),
+  flags: createMemoryFlagStore(),
+});
+
+const evaluateInput = {
+  context: { attributes: { plan: 'beta' }, subjectId: 'user-1' },
+  key: 'checkout-v2',
+};
+
+describe('library projection', () => {
+  const projection = deriveLibraryApi(app);
+
+  test('is collision-free with no exclusions', () => {
+    expect(projection.collisions).toEqual([]);
+    expect(projection.excluded).toEqual([]);
+  });
+
+  test('exports every trail under a consumer-native name', () => {
+    const names = projection.exports.map((entry) => entry.exportName);
+    expect(names).toEqual([
+      'auditList',
+      'flagArchive',
+      'flagCreate',
+      'flagDisable',
+      'flagEnable',
+      'flagEvaluate',
+      'flagEvaluateAll',
+      'flagGet',
+      'flagList',
+      'flagUpdate',
+      'ruleAdd',
+      'ruleRemove',
+      'ruleReorder',
+    ]);
+  });
+});
+
+describe('library client', () => {
+  test('flagEvaluate returns the evaluation with its trace', async () => {
+    const lib = await surface(app, { resources: freshResources() });
+    const evaluation = await lib.call['flagEvaluate']?.(evaluateInput);
+    expect(evaluation).toEqual({
+      key: 'checkout-v2',
+      reason: {
+        reason: 'rule-match',
+        steps: [{ outcome: 'matched', ruleId: 'beta-users' }],
+      },
+      value: 'treatment',
+      variant: 'treatment',
+    });
+  });
+
+  test('the result lane keeps the Result boundary', async () => {
+    const lib = await surface(app, { resources: freshResources() });
+    const missing = await lib.result['flagGet']?.({ key: 'does-not-exist' });
+    expect(missing?.isErr()).toBe(true);
+  });
+
+  test('the same trail gives the same answer through headless run', async () => {
+    const lib = await surface(app, { resources: freshResources() });
+    const viaLibrary = await lib.call['flagEvaluate']?.(evaluateInput);
+    const viaRun = await run(app, 'flag.evaluate', evaluateInput, {
+      resources: freshResources(),
+    });
+    expect(viaRun.isOk()).toBe(true);
+    if (viaRun.isOk()) {
+      expect(viaLibrary).toEqual(viaRun.value);
+    }
+  });
+});

--- a/examples/switchback/src/__tests__/placeholder.test.ts
+++ b/examples/switchback/src/__tests__/placeholder.test.ts
@@ -1,9 +1,0 @@
-import { describe, expect, test } from 'bun:test';
-
-import { workspaceName } from '../index.js';
-
-describe('switchback workspace placeholder', () => {
-  test('reserves the workspace name', () => {
-    expect(workspaceName).toBe('switchback');
-  });
-});

--- a/examples/switchback/src/__tests__/quickstart.test.ts
+++ b/examples/switchback/src/__tests__/quickstart.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The README quickstart must execute verbatim on a fresh checkout. This runs
+ * the committed quickstart.ts (the library hero snippet) and the CLI
+ * invocation exactly as the README shows them.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+
+const appRoot = join(import.meta.dir, '..', '..');
+
+const runInAppRoot = async (
+  cmd: string[]
+): Promise<{ exitCode: number; stdout: string }> => {
+  const proc = Bun.spawn(cmd, { cwd: appRoot, stderr: 'pipe', stdout: 'pipe' });
+  const stdout = await new Response(proc.stdout).text();
+  const exitCode = await proc.exited;
+  return { exitCode, stdout };
+};
+
+describe('README quickstart', () => {
+  test('quickstart.ts evaluates checkout-v2 through the library surface', async () => {
+    const { exitCode, stdout } = await runInAppRoot(['bun', 'quickstart.ts']);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('checkout-v2');
+    expect(stdout).toContain('treatment');
+  });
+
+  test('the CLI invocation from the README works verbatim', async () => {
+    const { exitCode, stdout } = await runInAppRoot([
+      'bun',
+      'bin/switchback.ts',
+      'flag',
+      'evaluate',
+      'checkout-v2',
+      '{"context":{"subjectId":"user-1"}}',
+      '--explain',
+    ]);
+    expect(exitCode).toBe(0);
+    const evaluation = JSON.parse(stdout) as {
+      explanation: string[];
+      reason: { reason: string };
+      value: string;
+    };
+    expect(evaluation.value).toBe('treatment');
+    expect(evaluation.reason.reason).toBe('percentage-rollout');
+    expect(evaluation.explanation.at(-1)).toBe(
+      'result: "treatment" (percentage-rollout)'
+    );
+  });
+});

--- a/examples/switchback/src/__tests__/surface-parity.test.ts
+++ b/examples/switchback/src/__tests__/surface-parity.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Example-driven parity across shipped surfaces: every trail example must
+ * produce the same result no matter which surface invokes the trail.
+ */
+
+/* oxlint-disable eslint-plugin-jest/require-hook -- testSurfaceParity registers tests at module scope */
+import { testSurfaceParity } from '@ontrails/testing/surface-parity';
+
+import { app } from '../app.js';
+import { createAuditLog } from '../resources/audit.js';
+import { createMemoryFlagStore } from '../resources/flags.js';
+
+testSurfaceParity(app, {
+  createResources: () => ({
+    audit: createAuditLog(),
+    flags: createMemoryFlagStore(),
+  }),
+});

--- a/examples/switchback/src/app.ts
+++ b/examples/switchback/src/app.ts
@@ -1,0 +1,28 @@
+import { topo } from '@ontrails/core';
+
+import * as auditLog from './resources/audit.js';
+import * as flags from './resources/flags.js';
+import * as audit from './trails/audit.js';
+import * as evaluate from './trails/evaluate.js';
+import * as flagCrud from './trails/flag-crud.js';
+import * as flagLifecycle from './trails/flag-lifecycle.js';
+import * as rule from './trails/rule.js';
+
+/**
+ * The switchback topo: one authored contract consumed as a typed library
+ * import, a CLI command, and an MCP tool with zero divergence.
+ */
+export const app = topo(
+  {
+    description: 'Feature flags with deterministic, explainable evaluation',
+    name: 'switchback',
+    version: '0.1.0',
+  },
+  flags,
+  auditLog,
+  flagCrud,
+  flagLifecycle,
+  evaluate,
+  rule,
+  audit
+);

--- a/examples/switchback/src/engine.ts
+++ b/examples/switchback/src/engine.ts
@@ -1,0 +1,173 @@
+import type {
+  Condition,
+  EvalContext,
+  Evaluation,
+  Flag,
+  FlagValue,
+  TraceStep,
+} from './model.js';
+
+/**
+ * Pure evaluation engine. No clock, no randomness, no I/O — a function of
+ * (flag definition, evaluation context) only, so identical inputs produce
+ * identical outputs forever.
+ *
+ * ## Bucketing hash (stable contract — do not change)
+ *
+ * Percentage rollouts bucket subjects with standard FNV-1a 32-bit over the
+ * UTF-8 bytes of `"<flagKey>:<subjectId>"`:
+ *
+ *   hash = 0x811c9dc5
+ *   for each byte b: hash = (hash XOR b) * 0x01000193  (mod 2^32)
+ *   bucket = hash mod 100
+ *
+ * The bucket is stable per flag+subject, so a subject keeps its variant as
+ * long as the split stays the same, and different flags bucket the same
+ * subject independently. Fixed vectors (asserted in tests, valid forever):
+ *
+ *   checkout-v2 : user-1  -> bucket 7
+ *   checkout-v2 : user-42 -> bucket 10
+ *   dark-mode   : user-1  -> bucket 58
+ */
+export const bucketFor = (flagKey: string, subjectId: string): number => {
+  const bytes = new TextEncoder().encode(`${flagKey}:${subjectId}`);
+  // FNV offset basis (0x811c9dc5)
+  let hash = 2_166_136_261;
+  for (const byte of bytes) {
+    // oxlint-disable-next-line no-bitwise -- FNV-1a is defined over 32-bit XOR
+    hash ^= byte;
+    // oxlint-disable-next-line no-bitwise, unicorn/prefer-math-trunc -- `>>> 0` normalizes Math.imul to unsigned 32-bit; Math.trunc is not equivalent
+    hash = Math.imul(hash, 0x01_00_01_93) >>> 0;
+  }
+  return hash % 100;
+};
+
+const conditionMatches = (
+  condition: Condition,
+  context: EvalContext
+): { matched: boolean; detail?: string } => {
+  const actual = context.attributes[condition.attribute];
+  if (actual === undefined) {
+    return {
+      detail: `attribute "${condition.attribute}" is missing`,
+      matched: false,
+    };
+  }
+  const describe = (verdict: boolean, relation: string) =>
+    verdict
+      ? { matched: true as const }
+      : {
+          detail: `attribute "${condition.attribute}" = ${JSON.stringify(actual)} is not ${relation} ${JSON.stringify(condition.value)}`,
+          matched: false as const,
+        };
+  if (condition.op === 'eq') {
+    return describe(actual === condition.value, 'eq');
+  }
+  if (condition.op === 'neq') {
+    return describe(actual !== condition.value, 'neq');
+  }
+  if (condition.op === 'in') {
+    const allowed = Array.isArray(condition.value)
+      ? condition.value
+      : [condition.value];
+    return describe(
+      allowed.some((entry) => entry === actual),
+      'in'
+    );
+  }
+  if (condition.op === 'gte') {
+    return describe(
+      typeof actual === 'number' &&
+        typeof condition.value === 'number' &&
+        actual >= condition.value,
+      'gte'
+    );
+  }
+  return describe(
+    typeof actual === 'number' &&
+      typeof condition.value === 'number' &&
+      actual <= condition.value,
+    'lte'
+  );
+};
+
+/**
+ * Assemble an Evaluation, including `variant` only for variant-kind flags so
+ * example `expected` blocks can deep-equal results without undefined noise.
+ */
+const toEvaluation = (
+  flag: Flag,
+  value: FlagValue,
+  reason: Evaluation['reason']
+): Evaluation => {
+  const variant =
+    flag.kind === 'variant' && typeof value === 'string' ? value : undefined;
+  return variant === undefined
+    ? { key: flag.key, reason, value }
+    : { key: flag.key, reason, value, variant };
+};
+
+const resolveSplit = (
+  arms: readonly { value: FlagValue; weight: number }[],
+  bucket: number
+): FlagValue => {
+  let upperBound = 0;
+  for (const arm of arms) {
+    upperBound += arm.weight;
+    if (bucket < upperBound) {
+      return arm.value;
+    }
+  }
+  // Weights are validated to total 100, so bucket (0-99) always lands above;
+  // serve the last arm if a stored definition slipped past validation.
+  return arms.at(-1)?.value as FlagValue;
+};
+
+/**
+ * Evaluate a flag against a context, producing the served value and a
+ * rule-by-rule trace explaining why.
+ *
+ * Semantics: disabled flags serve the default with reason `disabled` and no
+ * rules are inspected. Otherwise rules run in order; the first rule whose
+ * conditions all match serves either its fixed value (`rule-match`) or a
+ * split arm chosen by `bucketFor` (`percentage-rollout`). If no rule
+ * matches, the default is served (`no-rule-match`). Archived flags are the
+ * caller's concern — the trails treat them as not found.
+ */
+export const evaluateFlag = (flag: Flag, context: EvalContext): Evaluation => {
+  const steps: TraceStep[] = [];
+
+  if (!flag.enabled) {
+    return toEvaluation(flag, flag.defaultValue, { reason: 'disabled', steps });
+  }
+
+  for (const rule of flag.rules) {
+    const failure = rule.when
+      .map((condition) => conditionMatches(condition, context))
+      .find((verdict) => !verdict.matched);
+    if (failure) {
+      steps.push({
+        detail: failure.detail ?? 'condition failed',
+        outcome: 'skipped',
+        ruleId: rule.id,
+      });
+      continue;
+    }
+    if ('value' in rule.serve) {
+      steps.push({ outcome: 'matched', ruleId: rule.id });
+      return toEvaluation(flag, rule.serve.value, {
+        reason: 'rule-match',
+        steps,
+      });
+    }
+    const bucket = bucketFor(flag.key, context.subjectId);
+    const served = resolveSplit(rule.serve.split, bucket);
+    steps.push({ bucket, outcome: 'percentage', ruleId: rule.id, served });
+    return toEvaluation(flag, served, { reason: 'percentage-rollout', steps });
+  }
+
+  return toEvaluation(flag, flag.defaultValue, {
+    reason: 'no-rule-match',
+    steps,
+  });
+};

--- a/examples/switchback/src/fixtures.ts
+++ b/examples/switchback/src/fixtures.ts
@@ -1,0 +1,79 @@
+import type { Flag } from './model.js';
+
+/**
+ * Demo flag definitions. The committed `switchback.flags.json` carries the
+ * same data for the file-backed store; a test asserts the two stay in sync.
+ * The mock flags resource serves a fresh copy of these, so trail examples
+ * evaluate against exactly the data a fresh checkout ships with.
+ */
+export const fixtureFlags = (): Flag[] => [
+  {
+    archived: false,
+    defaultValue: 'control',
+    description: 'New checkout flow rollout',
+    enabled: true,
+    key: 'checkout-v2',
+    kind: 'variant',
+    rules: [
+      {
+        id: 'beta-users',
+        serve: { value: 'treatment' },
+        when: [{ attribute: 'plan', op: 'eq', value: 'beta' }],
+      },
+      {
+        id: 'gradual-rollout',
+        serve: {
+          split: [
+            { value: 'treatment', weight: 20 },
+            { value: 'control', weight: 80 },
+          ],
+        },
+        when: [],
+      },
+    ],
+    variants: ['control', 'treatment'],
+  },
+  {
+    archived: false,
+    defaultValue: false,
+    description: 'Dark mode for paid plans, half rollout for everyone else',
+    enabled: true,
+    key: 'dark-mode',
+    kind: 'boolean',
+    rules: [
+      {
+        id: 'paid-plans',
+        serve: { value: true },
+        when: [{ attribute: 'plan', op: 'in', value: ['pro', 'team'] }],
+      },
+      {
+        id: 'half-rollout',
+        serve: {
+          split: [
+            { value: true, weight: 50 },
+            { value: false, weight: 50 },
+          ],
+        },
+        when: [],
+      },
+    ],
+  },
+  {
+    archived: false,
+    defaultValue: false,
+    description: 'Guided onboarding checklist (not yet enabled)',
+    enabled: false,
+    key: 'new-onboarding',
+    kind: 'boolean',
+    rules: [{ id: 'everyone', serve: { value: true }, when: [] }],
+  },
+  {
+    archived: true,
+    defaultValue: true,
+    description: 'Retired promo banner',
+    enabled: true,
+    key: 'legacy-banner',
+    kind: 'boolean',
+    rules: [],
+  },
+];

--- a/examples/switchback/src/index.ts
+++ b/examples/switchback/src/index.ts
@@ -1,8 +1,85 @@
 /**
- * Placeholder module for the `switchback` showcase app.
+ * switchback — feature flags, library-first.
  *
- * The real app lands in its own build run confined to `examples/switchback/`.
- * This placeholder only reserves the workspace so `bun.lock` takes the
- * membership churn once, before the parallel builds start.
+ * The same authored trail contract is consumable three ways with zero
+ * divergence: as a typed in-process library, as CLI commands, and as MCP
+ * tools. This barrel is the library entry.
  */
-export const workspaceName = 'switchback';
+
+/**
+ * The switchback topo. Open it on any surface, or hand it to the library
+ * surface for typed in-process calls.
+ *
+ * @example
+ * ```ts
+ * import { surface } from '@ontrails/library';
+ * import { app } from 'switchback';
+ *
+ * const lib = await surface(app);
+ * const evaluation = await lib.call.flagEvaluate({
+ *   context: { attributes: { plan: 'beta' }, subjectId: 'user-1' },
+ *   key: 'checkout-v2',
+ * });
+ * ```
+ */
+export { app } from './app.js';
+
+/**
+ * Deterministic bucketing and the pure evaluation engine.
+ *
+ * @example
+ * ```ts
+ * import { bucketFor } from 'switchback';
+ *
+ * bucketFor('checkout-v2', 'user-1'); // 7, forever
+ * ```
+ */
+export { bucketFor, evaluateFlag } from './engine.js';
+
+/**
+ * Domain schemas and types for flag definitions and evaluation results.
+ *
+ * @example
+ * ```ts
+ * import { flagSchema } from 'switchback';
+ *
+ * const flag = flagSchema.parse(JSON.parse(raw));
+ * ```
+ */
+export {
+  conditionSchema,
+  evalContextSchema,
+  evalTraceSchema,
+  evaluationSchema,
+  flagSchema,
+  flagValueSchema,
+  ruleSchema,
+} from './model.js';
+export type {
+  Condition,
+  EvalContext,
+  EvalTrace,
+  Evaluation,
+  Flag,
+  FlagValue,
+  Rule,
+  TraceStep,
+} from './model.js';
+
+/**
+ * The file-backed flags resource and its store contract, for forkers who
+ * want to swap the definition source while keeping the trail contract.
+ *
+ * @example
+ * ```ts
+ * import { createMemoryFlagStore, flagsResource } from 'switchback';
+ *
+ * const store = createMemoryFlagStore();
+ * ```
+ */
+export {
+  createFileFlagStore,
+  createMemoryFlagStore,
+  flagsResource,
+} from './resources/flags.js';
+export type { FlagStore } from './resources/flags.js';

--- a/examples/switchback/src/mcp.ts
+++ b/examples/switchback/src/mcp.ts
@@ -1,0 +1,12 @@
+/**
+ * MCP entry point for switchback.
+ *
+ * Usage:
+ *   bun run src/mcp.ts
+ */
+
+import { surface } from '@ontrails/mcp';
+
+import { app } from './app.js';
+
+await surface(app);

--- a/examples/switchback/src/model.ts
+++ b/examples/switchback/src/model.ts
@@ -1,0 +1,171 @@
+import { z } from 'zod';
+
+/**
+ * Domain model for switchback feature flags.
+ *
+ * A flag is either boolean-kind (serves `true`/`false`) or variant-kind
+ * (serves one of its named variants). Ordered rules decide what a flag serves
+ * for a given evaluation context; the first rule whose conditions all match
+ * wins. A rule serves either a fixed value or a percentage split resolved by
+ * a deterministic seeded hash (see `engine.ts`).
+ */
+
+export const conditionOps = ['eq', 'neq', 'in', 'gte', 'lte'] as const;
+
+/** A single attribute check inside a rule's `when` clause. */
+export const conditionSchema = z.object({
+  attribute: z
+    .string()
+    .min(1)
+    .describe('Attribute name to inspect on the evaluation context'),
+  op: z.enum(conditionOps).describe('Comparison operator'),
+  value: z
+    .union([
+      z.string(),
+      z.number(),
+      z.boolean(),
+      z.array(z.union([z.string(), z.number()])),
+    ])
+    .describe(
+      'Value to compare against; an array is required for the "in" operator'
+    ),
+});
+
+/** A flag value a rule or default can serve. */
+export const flagValueSchema = z
+  .union([z.string(), z.number(), z.boolean()])
+  .describe(
+    'Value a flag serves; boolean flags serve booleans, variant flags serve variant names'
+  );
+
+/** One weighted arm of a percentage split. Weights must total 100. */
+export const splitArmSchema = z.object({
+  value: flagValueSchema.describe(
+    'Value served when the subject buckets into this arm'
+  ),
+  weight: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .describe('Share of the 0-99 bucket range, out of 100'),
+});
+
+/** What a matched rule serves: a fixed value or a percentage split. */
+export const serveSchema = z.union([
+  z.object({ value: flagValueSchema.describe('Fixed value to serve') }),
+  z.object({
+    split: z
+      .array(splitArmSchema)
+      .min(1)
+      .describe('Weighted arms; weights must total 100'),
+  }),
+]);
+
+/** An ordered rule: all `when` conditions must match for the rule to serve. */
+export const ruleSchema = z.object({
+  id: z
+    .string()
+    .min(1)
+    .describe('Stable rule identifier, unique within the flag'),
+  serve: serveSchema.describe('What to serve when the rule matches'),
+  when: z
+    .array(conditionSchema)
+    .describe('Conditions that must all match for this rule to apply'),
+});
+
+/** A feature flag definition. */
+export const flagSchema = z.object({
+  archived: z
+    .boolean()
+    .describe('Archived flags are hidden and cannot be evaluated'),
+  defaultValue: flagValueSchema.describe(
+    'Value served when disabled or when no rule matches'
+  ),
+  description: z.string().describe('What the flag controls'),
+  enabled: z
+    .boolean()
+    .describe('Disabled flags always serve the default value'),
+  key: z
+    .string()
+    .regex(/^[a-z0-9]+(-[a-z0-9]+)*$/, 'kebab-case key')
+    .describe('Unique kebab-case flag key'),
+  kind: z
+    .enum(['boolean', 'variant'])
+    .describe('boolean serves true/false; variant serves a named variant'),
+  rules: z.array(ruleSchema).describe('Ordered rules; first full match wins'),
+  variants: z
+    .array(z.string().min(1))
+    .optional()
+    .describe('Allowed variant names (variant-kind flags only)'),
+});
+
+/** The context a flag is evaluated against. */
+export const evalContextSchema = z.object({
+  attributes: z
+    .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+    .default({})
+    .describe('Attributes rules can match on (e.g. plan, region)'),
+  subjectId: z
+    .string()
+    .min(1)
+    .describe('Stable subject identifier used for percentage bucketing'),
+});
+
+/** One entry in the rule-by-rule evaluation trace. */
+export const traceStepSchema = z.discriminatedUnion('outcome', [
+  z.object({
+    outcome: z
+      .literal('matched')
+      .describe('All conditions matched; the rule served a fixed value'),
+    ruleId: z.string().describe('Rule that was inspected'),
+  }),
+  z.object({
+    detail: z.string().describe('Which condition failed and why'),
+    outcome: z
+      .literal('skipped')
+      .describe('A condition failed; the rule did not apply'),
+    ruleId: z.string().describe('Rule that was inspected'),
+  }),
+  z.object({
+    bucket: z
+      .number()
+      .int()
+      .min(0)
+      .max(99)
+      .describe('Deterministic bucket for flagKey + subjectId'),
+    outcome: z
+      .literal('percentage')
+      .describe('The rule matched and resolved through a split'),
+    ruleId: z.string().describe('Rule that was inspected'),
+    served: flagValueSchema.describe('Value the bucket landed on'),
+  }),
+]);
+
+/** Why an evaluation produced its value: terminal reason plus the rule trace. */
+export const evalTraceSchema = z.object({
+  reason: z
+    .enum(['rule-match', 'percentage-rollout', 'no-rule-match', 'disabled'])
+    .describe('Terminal reason the served value was chosen'),
+  steps: z.array(traceStepSchema).describe('Ordered rule-by-rule outcomes'),
+});
+
+/** Result of evaluating one flag. */
+export const evaluationSchema = z.object({
+  key: flagSchema.shape.key,
+  reason: evalTraceSchema.describe('Rule-by-rule explanation of the outcome'),
+  value: flagValueSchema.describe('The served value'),
+  variant: z
+    .string()
+    .optional()
+    .describe('Variant name when the flag is variant-kind'),
+});
+
+export type Condition = z.infer<typeof conditionSchema>;
+export type FlagValue = z.infer<typeof flagValueSchema>;
+export type Rule = z.infer<typeof ruleSchema>;
+export type Flag = z.infer<typeof flagSchema>;
+export type EvalContext = z.infer<typeof evalContextSchema>;
+export type TraceStep = z.infer<typeof traceStepSchema>;
+export type EvalTrace = z.infer<typeof evalTraceSchema>;
+export type Evaluation = z.infer<typeof evaluationSchema>;

--- a/examples/switchback/src/resources/audit.ts
+++ b/examples/switchback/src/resources/audit.ts
@@ -1,0 +1,38 @@
+import { Result, resource } from '@ontrails/core';
+
+import type { FlagValue } from '../model.js';
+
+/**
+ * One bootstrap payload served by `flag.evaluate-all`. Entries carry no
+ * timestamp on purpose — the demo log stays clock-free so recorded content
+ * is as deterministic as the evaluations themselves.
+ */
+export interface AuditEntry {
+  readonly subjectId: string;
+  readonly values: Readonly<Record<string, FlagValue>>;
+}
+
+/** Tiny in-memory eval log for the demo; nothing persists across processes. */
+export interface AuditLog {
+  record(entry: AuditEntry): void;
+  list(): readonly AuditEntry[];
+}
+
+export const createAuditLog = (): AuditLog => {
+  const entries: AuditEntry[] = [];
+  return {
+    list() {
+      return [...entries];
+    },
+    record(entry) {
+      entries.push(entry);
+    },
+  };
+};
+
+export const auditResource = resource('audit', {
+  create: () => Result.ok(createAuditLog()),
+  description:
+    'In-memory demo log of bootstrap payloads served by flag.evaluate-all. Deliberately ephemeral.',
+  mock: () => createAuditLog(),
+});

--- a/examples/switchback/src/resources/flags.ts
+++ b/examples/switchback/src/resources/flags.ts
@@ -1,0 +1,106 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, join } from 'node:path';
+
+import { Result, resource } from '@ontrails/core';
+import { z } from 'zod';
+
+import { fixtureFlags } from '../fixtures.js';
+import { flagSchema } from '../model.js';
+import type { Flag } from '../model.js';
+
+/**
+ * Flag definition source. Deliberately not a database: the real store is a
+ * JSON file (`switchback.flags.json`) reloaded on every read, so external
+ * edits to the file are picked up by the next evaluation.
+ */
+export interface FlagStore {
+  /** All flag definitions, including archived ones. */
+  list(): Promise<readonly Flag[]>;
+  /** One flag by key, or undefined when no definition exists. */
+  get(key: string): Promise<Flag | undefined>;
+  /** Insert or replace a flag definition by key. */
+  put(flag: Flag): Promise<void>;
+}
+
+const flagFileSchema = z.array(flagSchema);
+
+const sortByKey = (flags: readonly Flag[]): Flag[] =>
+  [...flags].toSorted((a, b) => a.key.localeCompare(b.key));
+
+/** File-backed store: reads the JSON file on every access, writes on `put`. */
+export const createFileFlagStore = (filePath: string): FlagStore => {
+  const load = async (): Promise<Flag[]> => {
+    let raw: string;
+    try {
+      raw = await readFile(filePath, 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return [];
+      }
+      throw error;
+    }
+    return flagFileSchema.parse(JSON.parse(raw));
+  };
+  const save = async (flags: readonly Flag[]): Promise<void> => {
+    await mkdir(dirname(filePath), { recursive: true });
+    await writeFile(
+      filePath,
+      `${JSON.stringify(sortByKey(flags), null, 2)}\n`,
+      'utf8'
+    );
+  };
+  return {
+    get: async (key) => {
+      const flags = await load();
+      return flags.find((flag) => flag.key === key);
+    },
+    list: () => load(),
+    put: async (flag) => {
+      const existing = await load();
+      const flags = existing.filter((entry) => entry.key !== flag.key);
+      flags.push(flag);
+      await save(flags);
+    },
+  };
+};
+
+/** In-memory store used by the mock factory and isolated tests. */
+export const createMemoryFlagStore = (
+  seed: readonly Flag[] = fixtureFlags()
+): FlagStore => {
+  const flags = new Map(
+    structuredClone([...seed]).map((flag) => [flag.key, flag])
+  );
+  return {
+    get: (key) => Promise.resolve(flags.get(key)),
+    list: () => Promise.resolve(sortByKey([...flags.values()])),
+    put: (flag) => {
+      flags.set(flag.key, structuredClone(flag));
+      return Promise.resolve();
+    },
+  };
+};
+
+/** Default flag definition file, relative to the process working directory. */
+export const FLAGS_FILE = 'switchback.flags.json';
+
+const resolveFlagsPath = (
+  cwd: string,
+  configured: string | undefined
+): string => {
+  if (configured === undefined) {
+    return join(cwd, FLAGS_FILE);
+  }
+  return isAbsolute(configured) ? configured : join(cwd, configured);
+};
+
+export const flagsResource = resource('flags', {
+  create: (resourceCtx) => {
+    const cwd = resourceCtx.cwd ?? process.cwd();
+    const configured = resourceCtx.env?.['SWITCHBACK_FLAGS_PATH'];
+    return Result.ok(createFileFlagStore(resolveFlagsPath(cwd, configured)));
+  },
+  description:
+    'File-backed flag definition source (switchback.flags.json), reloaded on every read. Deliberately not a database.',
+  mock: () => createMemoryFlagStore(),
+});

--- a/examples/switchback/src/trails/audit.ts
+++ b/examples/switchback/src/trails/audit.ts
@@ -1,0 +1,37 @@
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { flagValueSchema } from '../model.js';
+import { auditResource } from '../resources/audit.js';
+
+export const list = trail('audit.list', {
+  blaze: (_input, ctx) => {
+    const audit = auditResource.from(ctx);
+    return Result.ok({ entries: audit.list() });
+  },
+  description:
+    'List the in-memory demo log of bootstrap payloads served by flag.evaluate-all',
+  examples: [
+    {
+      description: 'A fresh process starts with an empty log',
+      expected: { entries: [] },
+      input: {},
+      name: 'Empty audit log',
+    },
+  ],
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({
+    entries: z
+      .array(
+        z.object({
+          subjectId: z.string().describe('Subject the payload was served to'),
+          values: z
+            .record(z.string(), flagValueSchema)
+            .describe('Flag key to served value'),
+        })
+      )
+      .describe('Recorded bootstrap payloads, oldest first'),
+  }),
+  resources: [auditResource],
+});

--- a/examples/switchback/src/trails/evaluate.ts
+++ b/examples/switchback/src/trails/evaluate.ts
@@ -1,0 +1,273 @@
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { evaluateFlag } from '../engine.js';
+import {
+  evalContextSchema,
+  evaluationSchema,
+  flagValueSchema,
+} from '../model.js';
+import type { Evaluation, FlagValue } from '../model.js';
+import { auditResource } from '../resources/audit.js';
+import { flagsResource } from '../resources/flags.js';
+import { requireLiveFlag } from './shared.js';
+
+/** Render an EvalTrace as human-readable lines for the `--explain` flag. */
+const renderTrace = (evaluation: Evaluation): string[] => {
+  const lines = evaluation.reason.steps.map((step) => {
+    if (step.outcome === 'matched') {
+      return `rule ${step.ruleId}: matched`;
+    }
+    if (step.outcome === 'skipped') {
+      return `rule ${step.ruleId}: skipped (${step.detail})`;
+    }
+    return `rule ${step.ruleId}: bucket ${step.bucket} served ${JSON.stringify(step.served)}`;
+  });
+  lines.push(
+    `result: ${JSON.stringify(evaluation.value)} (${evaluation.reason.reason})`
+  );
+  return lines;
+};
+
+/**
+ * The hero trail: a pure, deterministic function of (flag definition,
+ * evaluation context). No clock, no randomness, no I/O beyond reading the
+ * flags resource — identical inputs produce identical results forever, and
+ * every result carries the rule-by-rule EvalTrace explaining why.
+ */
+export const evaluate = trail('flag.evaluate', {
+  blaze: async (input, ctx) => {
+    const store = flagsResource.from(ctx);
+    const flag = await requireLiveFlag(store, input.key);
+    if (flag.isErr()) {
+      return flag;
+    }
+    const evaluation = evaluateFlag(flag.value, input.context);
+    if (!input.explain) {
+      return Result.ok(evaluation);
+    }
+    return Result.ok({ ...evaluation, explanation: renderTrace(evaluation) });
+  },
+  description:
+    'Evaluate one flag for a subject, returning the served value and a rule-by-rule trace of why',
+  examples: [
+    {
+      description: 'A targeting rule matches on the plan attribute',
+      expected: {
+        key: 'checkout-v2',
+        reason: {
+          reason: 'rule-match',
+          steps: [{ outcome: 'matched', ruleId: 'beta-users' }],
+        },
+        value: 'treatment',
+        variant: 'treatment',
+      },
+      input: {
+        context: { attributes: { plan: 'beta' }, subjectId: 'user-9' },
+        key: 'checkout-v2',
+      },
+      name: 'Beta plan gets the treatment',
+    },
+    {
+      description:
+        'Percentage rollout is seeded-hash deterministic: user-1 buckets to 7 (< 20) forever',
+      expected: {
+        key: 'checkout-v2',
+        reason: {
+          reason: 'percentage-rollout',
+          steps: [
+            {
+              detail: 'attribute "plan" is missing',
+              outcome: 'skipped',
+              ruleId: 'beta-users',
+            },
+            {
+              bucket: 7,
+              outcome: 'percentage',
+              ruleId: 'gradual-rollout',
+              served: 'treatment',
+            },
+          ],
+        },
+        value: 'treatment',
+        variant: 'treatment',
+      },
+      input: {
+        context: { attributes: {}, subjectId: 'user-1' },
+        key: 'checkout-v2',
+      },
+      name: 'Fixed vector: user-1 buckets to 7 and gets the treatment',
+    },
+    {
+      description:
+        'The same rollout keeps user-3 on control: bucket 45 falls in the 80% arm',
+      expected: {
+        key: 'checkout-v2',
+        reason: {
+          reason: 'percentage-rollout',
+          steps: [
+            {
+              detail: 'attribute "plan" is missing',
+              outcome: 'skipped',
+              ruleId: 'beta-users',
+            },
+            {
+              bucket: 45,
+              outcome: 'percentage',
+              ruleId: 'gradual-rollout',
+              served: 'control',
+            },
+          ],
+        },
+        value: 'control',
+        variant: 'control',
+      },
+      input: {
+        context: { attributes: {}, subjectId: 'user-3' },
+        key: 'checkout-v2',
+      },
+      name: 'Fixed vector: user-3 buckets to 45 and stays on control',
+    },
+    {
+      description:
+        'Disabled flags serve their default without inspecting rules',
+      expected: {
+        key: 'new-onboarding',
+        reason: { reason: 'disabled', steps: [] },
+        value: false,
+      },
+      input: {
+        context: { attributes: {}, subjectId: 'user-1' },
+        key: 'new-onboarding',
+      },
+      name: 'Disabled flag serves its default',
+    },
+    {
+      description: 'Archived flags are retired and cannot be evaluated',
+      error: 'NotFoundError',
+      input: {
+        context: { attributes: {}, subjectId: 'user-1' },
+        key: 'legacy-banner',
+      },
+      name: 'Archived flag is not found',
+    },
+    {
+      description:
+        'explain: true adds a human-readable rendering of the trace (the CLI --explain flag)',
+      expected: {
+        explanation: [
+          'rule beta-users: skipped (attribute "plan" is missing)',
+          'rule gradual-rollout: bucket 7 served "treatment"',
+          'result: "treatment" (percentage-rollout)',
+        ],
+        key: 'checkout-v2',
+        reason: {
+          reason: 'percentage-rollout',
+          steps: [
+            {
+              detail: 'attribute "plan" is missing',
+              outcome: 'skipped',
+              ruleId: 'beta-users',
+            },
+            {
+              bucket: 7,
+              outcome: 'percentage',
+              ruleId: 'gradual-rollout',
+              served: 'treatment',
+            },
+          ],
+        },
+        value: 'treatment',
+        variant: 'treatment',
+      },
+      input: {
+        context: { attributes: {}, subjectId: 'user-1' },
+        explain: true,
+        key: 'checkout-v2',
+      },
+      name: 'Explain the evaluation',
+    },
+  ],
+  input: z.object({
+    context: evalContextSchema.describe('Who the flag is evaluated for'),
+    explain: z
+      .boolean()
+      .default(false)
+      .describe('Include a human-readable rendering of the trace'),
+    key: z.string().describe('Flag key to evaluate'),
+  }),
+  intent: 'read',
+  output: evaluationSchema.extend({
+    explanation: z
+      .array(z.string())
+      .optional()
+      .describe('Human-readable trace lines, present when explain is true'),
+  }),
+  resources: [flagsResource],
+});
+
+/**
+ * Bulk bootstrap: evaluate every live flag for one context. Each served
+ * payload is recorded in the in-memory demo audit log.
+ */
+export const evaluateAll = trail('flag.evaluate-all', {
+  blaze: async (input, ctx) => {
+    const store = flagsResource.from(ctx);
+    const audit = auditResource.from(ctx);
+    const flags = await store.list();
+    const live = flags.filter((flag) => !flag.archived);
+    const values: Record<string, FlagValue> = {};
+    for (const flag of live) {
+      values[flag.key] = evaluateFlag(flag, input.context).value;
+    }
+    audit.record({ subjectId: input.context.subjectId, values });
+    return Result.ok({ evaluated: live.length, values });
+  },
+  description:
+    'Evaluate every live flag for one subject — the bootstrap payload pattern',
+  examples: [
+    {
+      description:
+        'A beta-plan subject gets the treatment via targeting; dark-mode misses its 50% rollout (bucket 58)',
+      expected: {
+        evaluated: 3,
+        values: {
+          'checkout-v2': 'treatment',
+          'dark-mode': false,
+          'new-onboarding': false,
+        },
+      },
+      input: {
+        context: { attributes: { plan: 'beta' }, subjectId: 'user-1' },
+      },
+      name: 'Bootstrap payload for a beta subject',
+    },
+    {
+      description:
+        'Fixed vector: user-42 buckets to 10 (< 20) on checkout-v2; the pro plan turns dark-mode on',
+      expected: {
+        evaluated: 3,
+        values: {
+          'checkout-v2': 'treatment',
+          'dark-mode': true,
+          'new-onboarding': false,
+        },
+      },
+      input: {
+        context: { attributes: { plan: 'pro' }, subjectId: 'user-42' },
+      },
+      name: 'Bootstrap payload for a pro subject',
+    },
+  ],
+  input: z.object({
+    context: evalContextSchema.describe('Who the flags are evaluated for'),
+  }),
+  intent: 'read',
+  output: z.object({
+    evaluated: z.number().int().describe('Number of live flags evaluated'),
+    values: z
+      .record(z.string(), flagValueSchema)
+      .describe('Flag key to served value — the bootstrap payload'),
+  }),
+  resources: [flagsResource, auditResource],
+});

--- a/examples/switchback/src/trails/flag-crud.ts
+++ b/examples/switchback/src/trails/flag-crud.ts
@@ -1,0 +1,271 @@
+import {
+  AlreadyExistsError,
+  NotFoundError,
+  Result,
+  trail,
+} from '@ontrails/core';
+import { z } from 'zod';
+
+import { flagSchema, flagValueSchema, ruleSchema } from '../model.js';
+import type { Flag } from '../model.js';
+import { flagsResource } from '../resources/flags.js';
+import { requireLiveFlag, validateFlagInvariants } from './shared.js';
+
+export const create = trail('flag.create', {
+  blaze: async (input, ctx) => {
+    const store = flagsResource.from(ctx);
+    if (await store.get(input.key)) {
+      return Result.err(
+        new AlreadyExistsError(`Flag "${input.key}" already exists`)
+      );
+    }
+    const flag: Flag = {
+      archived: false,
+      defaultValue: input.defaultValue,
+      description: input.description,
+      enabled: input.enabled,
+      key: input.key,
+      kind: input.kind,
+      rules: input.rules,
+      ...(input.variants === undefined ? {} : { variants: input.variants }),
+    };
+    const valid = validateFlagInvariants(flag);
+    if (valid.isErr()) {
+      return valid;
+    }
+    await store.put(flag);
+    return Result.ok(flag);
+  },
+  description: 'Create a new feature flag',
+  examples: [
+    {
+      description: 'Boolean flags default to enabled with no rules',
+      expected: {
+        archived: false,
+        defaultValue: false,
+        description: 'Seasonal banner',
+        enabled: true,
+        key: 'holiday-banner',
+        kind: 'boolean',
+        rules: [],
+      },
+      input: {
+        defaultValue: false,
+        description: 'Seasonal banner',
+        key: 'holiday-banner',
+        kind: 'boolean',
+      },
+      name: 'Create a boolean flag',
+    },
+    {
+      description: 'Flag keys are unique, including archived flags',
+      error: 'AlreadyExistsError',
+      input: {
+        defaultValue: false,
+        description: 'Duplicate of an existing flag',
+        key: 'checkout-v2',
+        kind: 'boolean',
+      },
+      name: 'Duplicate key conflicts',
+    },
+  ],
+  input: z.object({
+    defaultValue: flagValueSchema.describe(
+      'Value served when disabled or when no rule matches'
+    ),
+    description: z.string().describe('What the flag controls'),
+    enabled: z.boolean().default(true).describe('Start the flag enabled'),
+    key: flagSchema.shape.key,
+    kind: flagSchema.shape.kind,
+    rules: z.array(ruleSchema).default([]).describe('Initial ordered rules'),
+    variants: flagSchema.shape.variants,
+  }),
+  intent: 'write',
+  output: flagSchema,
+  resources: [flagsResource],
+});
+
+export const list = trail('flag.list', {
+  blaze: async (input, ctx) => {
+    const store = flagsResource.from(ctx);
+    const flags = await store.list();
+    return Result.ok({
+      flags: flags.filter((flag) => input.includeArchived || !flag.archived),
+    });
+  },
+  description: 'List flag definitions, sorted by key',
+  examples: [
+    {
+      description: 'Archived flags are hidden by default',
+      input: {},
+      name: 'List live flags',
+    },
+    {
+      description: 'Pass includeArchived to see retired flags too',
+      input: { includeArchived: true },
+      name: 'List all flags including archived',
+    },
+  ],
+  input: z.object({
+    includeArchived: z
+      .boolean()
+      .default(false)
+      .describe('Include archived flags in the listing'),
+  }),
+  intent: 'read',
+  output: z.object({
+    flags: z.array(flagSchema).describe('Flag definitions sorted by key'),
+  }),
+  resources: [flagsResource],
+});
+
+export const get = trail('flag.get', {
+  blaze: async (input, ctx) => {
+    const store = flagsResource.from(ctx);
+    const flag = await store.get(input.key);
+    if (!flag) {
+      return Result.err(new NotFoundError(`Flag "${input.key}" not found`));
+    }
+    return Result.ok(flag);
+  },
+  description: 'Show one flag definition by key, including archived flags',
+  examples: [
+    {
+      description: 'The full definition includes the ordered rules',
+      expected: {
+        archived: false,
+        defaultValue: false,
+        description: 'Dark mode for paid plans, half rollout for everyone else',
+        enabled: true,
+        key: 'dark-mode',
+        kind: 'boolean',
+        rules: [
+          {
+            id: 'paid-plans',
+            serve: { value: true },
+            when: [{ attribute: 'plan', op: 'in', value: ['pro', 'team'] }],
+          },
+          {
+            id: 'half-rollout',
+            serve: {
+              split: [
+                { value: true, weight: 50 },
+                { value: false, weight: 50 },
+              ],
+            },
+            when: [],
+          },
+        ],
+      },
+      input: { key: 'dark-mode' },
+      name: 'Show a flag definition',
+    },
+    {
+      description: 'Unknown keys are not found',
+      error: 'NotFoundError',
+      input: { key: 'does-not-exist' },
+      name: 'Unknown flag is not found',
+    },
+  ],
+  input: z.object({
+    key: z.string().describe('Flag key to look up'),
+  }),
+  intent: 'read',
+  output: flagSchema,
+  resources: [flagsResource],
+});
+
+export const update = trail('flag.update', {
+  blaze: async (input, ctx) => {
+    const store = flagsResource.from(ctx);
+    const existing = await requireLiveFlag(store, input.key);
+    if (existing.isErr()) {
+      return existing;
+    }
+    const updated: Flag = {
+      ...existing.value,
+      ...(input.defaultValue === undefined
+        ? {}
+        : { defaultValue: input.defaultValue }),
+      ...(input.description === undefined
+        ? {}
+        : { description: input.description }),
+      ...(input.variants === undefined ? {} : { variants: input.variants }),
+    };
+    const valid = validateFlagInvariants(updated);
+    if (valid.isErr()) {
+      return valid;
+    }
+    await store.put(updated);
+    return Result.ok(updated);
+  },
+  description: 'Update the description, default value, or variants of a flag',
+  examples: [
+    {
+      description: 'Only the provided fields change',
+      input: {
+        description: 'Dark mode for every plan',
+        key: 'dark-mode',
+      },
+      name: 'Update a description',
+    },
+    {
+      description: 'Archived and unknown flags cannot be updated',
+      error: 'NotFoundError',
+      input: { description: 'Bring it back', key: 'legacy-banner' },
+      name: 'Archived flag cannot be updated',
+    },
+  ],
+  input: z.object({
+    defaultValue: flagValueSchema
+      .optional()
+      .describe('New default value, servable for the flag kind'),
+    description: z.string().optional().describe('New description'),
+    key: z.string().describe('Flag key to update'),
+    variants: flagSchema.shape.variants,
+  }),
+  intent: 'write',
+  output: flagSchema,
+  resources: [flagsResource],
+});
+
+export const archive = trail('flag.archive', {
+  blaze: async (input, ctx) => {
+    const store = flagsResource.from(ctx);
+    const flag = await store.get(input.key);
+    if (!flag) {
+      return Result.err(new NotFoundError(`Flag "${input.key}" not found`));
+    }
+    if (flag.archived) {
+      return Result.ok(flag);
+    }
+    const archived: Flag = { ...flag, archived: true };
+    await store.put(archived);
+    return Result.ok(archived);
+  },
+  description:
+    'Archive a flag: it disappears from evaluation and listings but its definition is kept',
+  examples: [
+    {
+      description: 'Archiving retires the flag without deleting its definition',
+      expected: {
+        archived: true,
+        defaultValue: false,
+        description: 'Guided onboarding checklist (not yet enabled)',
+        enabled: false,
+        key: 'new-onboarding',
+        kind: 'boolean',
+        rules: [{ id: 'everyone', serve: { value: true }, when: [] }],
+      },
+      input: { key: 'new-onboarding' },
+      name: 'Archive a flag',
+    },
+  ],
+  idempotent: true,
+  input: z.object({
+    key: z.string().describe('Flag key to archive'),
+  }),
+  intent: 'write',
+  output: flagSchema,
+  resources: [flagsResource],
+});

--- a/examples/switchback/src/trails/flag-lifecycle.ts
+++ b/examples/switchback/src/trails/flag-lifecycle.ts
@@ -1,0 +1,82 @@
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { flagSchema } from '../model.js';
+import type { Flag } from '../model.js';
+import type { FlagStore } from '../resources/flags.js';
+import { flagsResource } from '../resources/flags.js';
+import { requireLiveFlag } from './shared.js';
+
+const setEnabled = async (
+  store: FlagStore,
+  key: string,
+  enabled: boolean
+): Promise<Result<Flag, Error>> => {
+  const existing = await requireLiveFlag(store, key);
+  if (existing.isErr()) {
+    return existing;
+  }
+  if (existing.value.enabled === enabled) {
+    return existing;
+  }
+  const updated: Flag = { ...existing.value, enabled };
+  await store.put(updated);
+  return Result.ok(updated);
+};
+
+export const enable = trail('flag.enable', {
+  blaze: async (input, ctx) =>
+    setEnabled(flagsResource.from(ctx), input.key, true),
+  description: 'Enable a flag so its rules apply; idempotent',
+  examples: [
+    {
+      description: 'Enabling a disabled flag lets its rules serve values',
+      expected: {
+        archived: false,
+        defaultValue: false,
+        description: 'Guided onboarding checklist (not yet enabled)',
+        enabled: true,
+        key: 'new-onboarding',
+        kind: 'boolean',
+        rules: [{ id: 'everyone', serve: { value: true }, when: [] }],
+      },
+      input: { key: 'new-onboarding' },
+      name: 'Enable a flag',
+    },
+  ],
+  idempotent: true,
+  input: z.object({
+    key: z.string().describe('Flag key to enable'),
+  }),
+  intent: 'write',
+  output: flagSchema,
+  resources: [flagsResource],
+});
+
+export const disable = trail('flag.disable', {
+  blaze: async (input, ctx) =>
+    setEnabled(flagsResource.from(ctx), input.key, false),
+  description:
+    'Disable a flag so it always serves its default value; idempotent',
+  examples: [
+    {
+      description:
+        'Disabled flags serve their default with reason "disabled" until re-enabled',
+      input: { key: 'checkout-v2' },
+      name: 'Disable a flag',
+    },
+    {
+      description: 'Archived flags cannot be toggled',
+      error: 'NotFoundError',
+      input: { key: 'legacy-banner' },
+      name: 'Archived flag cannot be disabled',
+    },
+  ],
+  idempotent: true,
+  input: z.object({
+    key: z.string().describe('Flag key to disable'),
+  }),
+  intent: 'write',
+  output: flagSchema,
+  resources: [flagsResource],
+});

--- a/examples/switchback/src/trails/rule.ts
+++ b/examples/switchback/src/trails/rule.ts
@@ -1,0 +1,252 @@
+import {
+  AlreadyExistsError,
+  NotFoundError,
+  Result,
+  ValidationError,
+  trail,
+} from '@ontrails/core';
+import { z } from 'zod';
+
+import { flagSchema, ruleSchema } from '../model.js';
+import type { Flag, Rule } from '../model.js';
+import { flagsResource } from '../resources/flags.js';
+import { requireLiveFlag, validateFlagInvariants } from './shared.js';
+
+const withRules = (flag: Flag, rules: readonly Rule[]): Flag => ({
+  ...flag,
+  rules: [...rules],
+});
+
+export const add = trail('rule.add', {
+  blaze: async (input, ctx) => {
+    const store = flagsResource.from(ctx);
+    const existing = await requireLiveFlag(store, input.key);
+    if (existing.isErr()) {
+      return existing;
+    }
+    const flag = existing.value;
+    if (flag.rules.some((rule) => rule.id === input.rule.id)) {
+      return Result.err(
+        new AlreadyExistsError(
+          `Rule "${input.rule.id}" already exists on flag "${flag.key}"`
+        )
+      );
+    }
+    const position = Math.min(
+      input.position ?? flag.rules.length,
+      flag.rules.length
+    );
+    const rules = [...flag.rules];
+    rules.splice(position, 0, input.rule);
+    const valid = validateFlagInvariants(withRules(flag, rules));
+    if (valid.isErr()) {
+      return valid;
+    }
+    await store.put(valid.value);
+    return Result.ok(valid.value);
+  },
+  description:
+    'Add an ordered rule to a flag; earlier rules win, so position matters',
+  examples: [
+    {
+      description: 'Insert at position 0 so the new rule is checked first',
+      expected: {
+        archived: false,
+        defaultValue: false,
+        description: 'Guided onboarding checklist (not yet enabled)',
+        enabled: false,
+        key: 'new-onboarding',
+        kind: 'boolean',
+        rules: [
+          {
+            id: 'pro-users',
+            serve: { value: true },
+            when: [{ attribute: 'plan', op: 'eq', value: 'pro' }],
+          },
+          { id: 'everyone', serve: { value: true }, when: [] },
+        ],
+      },
+      input: {
+        key: 'new-onboarding',
+        position: 0,
+        rule: {
+          id: 'pro-users',
+          serve: { value: true },
+          when: [{ attribute: 'plan', op: 'eq', value: 'pro' }],
+        },
+      },
+      name: 'Add a targeting rule first',
+    },
+    {
+      description: 'Rule ids are unique within a flag',
+      error: 'AlreadyExistsError',
+      input: {
+        key: 'new-onboarding',
+        rule: { id: 'everyone', serve: { value: false }, when: [] },
+      },
+      name: 'Duplicate rule id conflicts',
+    },
+    {
+      description: 'Served values must fit the flag kind and variants',
+      error: 'ValidationError',
+      input: {
+        key: 'dark-mode',
+        rule: { id: 'bad-serve', serve: { value: 'blue' }, when: [] },
+      },
+      name: 'Unservable value is rejected',
+    },
+  ],
+  input: z.object({
+    key: z.string().describe('Flag key to add the rule to'),
+    position: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe('Insertion index; appended when omitted'),
+    rule: ruleSchema.describe('The rule to add'),
+  }),
+  intent: 'write',
+  output: flagSchema,
+  resources: [flagsResource],
+});
+
+export const remove = trail('rule.remove', {
+  blaze: async (input, ctx) => {
+    const store = flagsResource.from(ctx);
+    const existing = await requireLiveFlag(store, input.key);
+    if (existing.isErr()) {
+      return existing;
+    }
+    const flag = existing.value;
+    if (!flag.rules.some((rule) => rule.id === input.ruleId)) {
+      return Result.err(
+        new NotFoundError(
+          `Rule "${input.ruleId}" not found on flag "${flag.key}"`
+        )
+      );
+    }
+    const updated = withRules(
+      flag,
+      flag.rules.filter((rule) => rule.id !== input.ruleId)
+    );
+    await store.put(updated);
+    return Result.ok(updated);
+  },
+  description: 'Remove a rule from a flag by rule id',
+  examples: [
+    {
+      description: 'Removing the only rule leaves the default serving everyone',
+      expected: {
+        archived: false,
+        defaultValue: false,
+        description: 'Guided onboarding checklist (not yet enabled)',
+        enabled: false,
+        key: 'new-onboarding',
+        kind: 'boolean',
+        rules: [],
+      },
+      input: { key: 'new-onboarding', ruleId: 'everyone' },
+      name: 'Remove a rule',
+    },
+    {
+      description: 'Unknown rule ids are not found',
+      error: 'NotFoundError',
+      input: { key: 'new-onboarding', ruleId: 'missing-rule' },
+      name: 'Unknown rule is not found',
+    },
+  ],
+  input: z.object({
+    key: z.string().describe('Flag key to remove the rule from'),
+    ruleId: z.string().describe('Rule id to remove'),
+  }),
+  intent: 'write',
+  output: flagSchema,
+  resources: [flagsResource],
+});
+
+export const reorder = trail('rule.reorder', {
+  blaze: async (input, ctx) => {
+    const store = flagsResource.from(ctx);
+    const existing = await requireLiveFlag(store, input.key);
+    if (existing.isErr()) {
+      return existing;
+    }
+    const flag = existing.value;
+    const current = flag.rules.map((rule) => rule.id);
+    const requested = [...input.ruleIds];
+    if (
+      requested.length !== current.length ||
+      [...requested].toSorted().join('\n') !==
+        [...current].toSorted().join('\n')
+    ) {
+      return Result.err(
+        new ValidationError(
+          `Rule order for flag "${flag.key}" must be a permutation of [${current.join(', ')}]`
+        )
+      );
+    }
+    const byId = new Map(flag.rules.map((rule) => [rule.id, rule]));
+    const updated = withRules(
+      flag,
+      requested.map((id) => byId.get(id) as Rule)
+    );
+    await store.put(updated);
+    return Result.ok(updated);
+  },
+  description:
+    'Reorder the rules of a flag; the list must be a permutation of the current rule ids',
+  examples: [
+    {
+      description:
+        'Moving the rollout ahead of targeting changes which rule wins',
+      expected: {
+        archived: false,
+        defaultValue: 'control',
+        description: 'New checkout flow rollout',
+        enabled: true,
+        key: 'checkout-v2',
+        kind: 'variant',
+        rules: [
+          {
+            id: 'gradual-rollout',
+            serve: {
+              split: [
+                { value: 'treatment', weight: 20 },
+                { value: 'control', weight: 80 },
+              ],
+            },
+            when: [],
+          },
+          {
+            id: 'beta-users',
+            serve: { value: 'treatment' },
+            when: [{ attribute: 'plan', op: 'eq', value: 'beta' }],
+          },
+        ],
+        variants: ['control', 'treatment'],
+      },
+      input: {
+        key: 'checkout-v2',
+        ruleIds: ['gradual-rollout', 'beta-users'],
+      },
+      name: 'Reorder rules',
+    },
+    {
+      description: 'The new order must mention every current rule exactly once',
+      error: 'ValidationError',
+      input: { key: 'checkout-v2', ruleIds: ['beta-users'] },
+      name: 'Partial order is rejected',
+    },
+  ],
+  input: z.object({
+    key: z.string().describe('Flag key to reorder rules on'),
+    ruleIds: z
+      .array(z.string())
+      .min(1)
+      .describe('Complete rule id list in the new order'),
+  }),
+  intent: 'write',
+  output: flagSchema,
+  resources: [flagsResource],
+});

--- a/examples/switchback/src/trails/shared.ts
+++ b/examples/switchback/src/trails/shared.ts
@@ -1,0 +1,77 @@
+import { NotFoundError, Result, ValidationError } from '@ontrails/core';
+
+import type { FlagStore } from '../resources/flags.js';
+import type { Flag, FlagValue } from '../model.js';
+
+/**
+ * Load a flag that trails may act on. Archived flags are retired: they are
+ * invisible to evaluation and mutation, so they resolve as not found.
+ */
+export const requireLiveFlag = async (
+  store: FlagStore,
+  key: string
+): Promise<Result<Flag, NotFoundError>> => {
+  const flag = await store.get(key);
+  if (!flag || flag.archived) {
+    return Result.err(new NotFoundError(`Flag "${key}" not found`));
+  }
+  return Result.ok(flag);
+};
+
+const servable = (flag: Flag, value: FlagValue): boolean =>
+  flag.kind === 'boolean'
+    ? typeof value === 'boolean'
+    : typeof value === 'string' && (flag.variants ?? []).includes(value);
+
+/**
+ * Cross-field invariants the schema alone cannot express: variant coverage,
+ * servable values, unique rule ids, and split weights totaling 100.
+ */
+export const validateFlagInvariants = (
+  flag: Flag
+): Result<Flag, ValidationError> => {
+  const fail = (message: string) =>
+    Result.err(new ValidationError(`Flag "${flag.key}": ${message}`));
+
+  if (flag.kind === 'variant' && (flag.variants?.length ?? 0) === 0) {
+    return fail('variant flags must declare at least one variant');
+  }
+  if (flag.kind === 'boolean' && flag.variants !== undefined) {
+    return fail('boolean flags must not declare variants');
+  }
+  if (!servable(flag, flag.defaultValue)) {
+    return fail(
+      `default value ${JSON.stringify(flag.defaultValue)} is not servable for this flag`
+    );
+  }
+
+  const seen = new Set<string>();
+  for (const rule of flag.rules) {
+    if (seen.has(rule.id)) {
+      return fail(`duplicate rule id "${rule.id}"`);
+    }
+    seen.add(rule.id);
+    if ('value' in rule.serve) {
+      if (!servable(flag, rule.serve.value)) {
+        return fail(
+          `rule "${rule.id}" serves ${JSON.stringify(rule.serve.value)}, which is not servable for this flag`
+        );
+      }
+      continue;
+    }
+    const total = rule.serve.split.reduce((sum, arm) => sum + arm.weight, 0);
+    if (total !== 100) {
+      return fail(
+        `rule "${rule.id}" split weights total ${total}, expected 100`
+      );
+    }
+    for (const arm of rule.serve.split) {
+      if (!servable(flag, arm.value)) {
+        return fail(
+          `rule "${rule.id}" split serves ${JSON.stringify(arm.value)}, which is not servable for this flag`
+        );
+      }
+    }
+  }
+  return Result.ok(flag);
+};

--- a/examples/switchback/switchback.flags.json
+++ b/examples/switchback/switchback.flags.json
@@ -1,0 +1,107 @@
+[
+  {
+    "archived": false,
+    "defaultValue": "control",
+    "description": "New checkout flow rollout",
+    "enabled": true,
+    "key": "checkout-v2",
+    "kind": "variant",
+    "rules": [
+      {
+        "id": "beta-users",
+        "serve": {
+          "value": "treatment"
+        },
+        "when": [
+          {
+            "attribute": "plan",
+            "op": "eq",
+            "value": "beta"
+          }
+        ]
+      },
+      {
+        "id": "gradual-rollout",
+        "serve": {
+          "split": [
+            {
+              "value": "treatment",
+              "weight": 20
+            },
+            {
+              "value": "control",
+              "weight": 80
+            }
+          ]
+        },
+        "when": []
+      }
+    ],
+    "variants": ["control", "treatment"]
+  },
+  {
+    "archived": false,
+    "defaultValue": false,
+    "description": "Dark mode for paid plans, half rollout for everyone else",
+    "enabled": true,
+    "key": "dark-mode",
+    "kind": "boolean",
+    "rules": [
+      {
+        "id": "paid-plans",
+        "serve": {
+          "value": true
+        },
+        "when": [
+          {
+            "attribute": "plan",
+            "op": "in",
+            "value": ["pro", "team"]
+          }
+        ]
+      },
+      {
+        "id": "half-rollout",
+        "serve": {
+          "split": [
+            {
+              "value": true,
+              "weight": 50
+            },
+            {
+              "value": false,
+              "weight": 50
+            }
+          ]
+        },
+        "when": []
+      }
+    ]
+  },
+  {
+    "archived": true,
+    "defaultValue": true,
+    "description": "Retired promo banner",
+    "enabled": true,
+    "key": "legacy-banner",
+    "kind": "boolean",
+    "rules": []
+  },
+  {
+    "archived": false,
+    "defaultValue": false,
+    "description": "Guided onboarding checklist (not yet enabled)",
+    "enabled": false,
+    "key": "new-onboarding",
+    "kind": "boolean",
+    "rules": [
+      {
+        "id": "everyone",
+        "serve": {
+          "value": true
+        },
+        "when": []
+      }
+    ]
+  }
+]

--- a/examples/switchback/trails.lock
+++ b/examples/switchback/trails.lock
@@ -1,0 +1,6701 @@
+{
+  "scope": {
+    "app": "switchback"
+  },
+  "summary": {
+    "contours": 0,
+    "resources": 2,
+    "signals": 0,
+    "trails": 13
+  },
+  "topoGraph": {
+    "activationGraph": {
+      "edgeCount": 0,
+      "edges": [],
+      "sourceCount": 0,
+      "sourceKeys": [],
+      "trailIds": []
+    },
+    "activationSources": {},
+    "entries": [
+      {
+        "exampleCount": 0,
+        "id": "audit",
+        "kind": "resource",
+        "surfaces": [],
+        "description": "In-memory demo log of bootstrap payloads served by flag.evaluate-all. Deliberately ephemeral."
+      },
+      {
+        "exampleCount": 1,
+        "id": "audit.list",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "audit",
+            "list"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "audit",
+                "list"
+              ],
+              "source": "derived",
+              "target": "audit.list"
+            }
+          ]
+        },
+        "description": "List the in-memory demo log of bootstrap payloads served by flag.evaluate-all",
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "Empty audit log",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "A fresh process starts with an empty log",
+            "expected": {
+              "entries": []
+            }
+          }
+        ],
+        "input": {
+          "properties": {},
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "entries": {
+              "description": "Recorded bootstrap payloads, oldest first",
+              "items": {
+                "properties": {
+                  "subjectId": {
+                    "description": "Subject the payload was served to",
+                    "type": "string"
+                  },
+                  "values": {
+                    "description": "Flag key to served value"
+                  }
+                },
+                "required": [
+                  "subjectId",
+                  "values"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "entries"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "audit"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "flag.archive",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "flag",
+            "archive"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "flag",
+                "archive"
+              ],
+              "source": "derived",
+              "target": "flag.archive"
+            }
+          ]
+        },
+        "description": "Archive a flag: it disappears from evaluation and listings but its definition is kept",
+        "examples": [
+          {
+            "input": {
+              "key": "new-onboarding"
+            },
+            "kind": "success",
+            "name": "Archive a flag",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Archiving retires the flag without deleting its definition",
+            "expected": {
+              "archived": true,
+              "defaultValue": false,
+              "description": "Guided onboarding checklist (not yet enabled)",
+              "enabled": false,
+              "key": "new-onboarding",
+              "kind": "boolean",
+              "rules": [
+                {
+                  "id": "everyone",
+                  "serve": {
+                    "value": true
+                  },
+                  "when": []
+                }
+              ]
+            }
+          }
+        ],
+        "idempotent": true,
+        "input": {
+          "properties": {
+            "key": {
+              "description": "Flag key to archive",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "archived": {
+              "description": "Archived flags are hidden and cannot be evaluated",
+              "type": "boolean"
+            },
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "Value served when disabled or when no rule matches"
+            },
+            "description": {
+              "description": "What the flag controls",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Disabled flags always serve the default value",
+              "type": "boolean"
+            },
+            "key": {
+              "description": "Unique kebab-case flag key",
+              "type": "string"
+            },
+            "kind": {
+              "description": "boolean serves true/false; variant serves a named variant",
+              "enum": [
+                "boolean",
+                "variant"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "description": "Ordered rules; first full match wins",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "Stable rule identifier, unique within the flag",
+                    "type": "string"
+                  },
+                  "serve": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ],
+                            "description": "Fixed value to serve"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "split": {
+                            "description": "Weighted arms; weights must total 100",
+                            "items": {
+                              "properties": {
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Value served when the subject buckets into this arm"
+                                },
+                                "weight": {
+                                  "description": "Share of the 0-99 bucket range, out of 100",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "weight"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "split"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "description": "What to serve when the rule matches"
+                  },
+                  "when": {
+                    "description": "Conditions that must all match for this rule to apply",
+                    "items": {
+                      "properties": {
+                        "attribute": {
+                          "description": "Attribute name to inspect on the evaluation context",
+                          "type": "string"
+                        },
+                        "op": {
+                          "description": "Comparison operator",
+                          "enum": [
+                            "eq",
+                            "neq",
+                            "in",
+                            "gte",
+                            "lte"
+                          ],
+                          "type": "string"
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "Value to compare against; an array is required for the \"in\" operator"
+                        }
+                      },
+                      "required": [
+                        "attribute",
+                        "op",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id",
+                  "serve",
+                  "when"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "variants": {
+              "description": "Allowed variant names (variant-kind flags only)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "archived",
+            "defaultValue",
+            "description",
+            "enabled",
+            "key",
+            "kind",
+            "rules"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "flags"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "flag.create",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "flag",
+            "create"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "flag",
+                "create"
+              ],
+              "source": "derived",
+              "target": "flag.create"
+            }
+          ]
+        },
+        "description": "Create a new feature flag",
+        "examples": [
+          {
+            "input": {
+              "defaultValue": false,
+              "description": "Seasonal banner",
+              "key": "holiday-banner",
+              "kind": "boolean"
+            },
+            "kind": "success",
+            "name": "Create a boolean flag",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Boolean flags default to enabled with no rules",
+            "expected": {
+              "archived": false,
+              "defaultValue": false,
+              "description": "Seasonal banner",
+              "enabled": true,
+              "key": "holiday-banner",
+              "kind": "boolean",
+              "rules": []
+            }
+          },
+          {
+            "input": {
+              "defaultValue": false,
+              "description": "Duplicate of an existing flag",
+              "key": "checkout-v2",
+              "kind": "boolean"
+            },
+            "kind": "error",
+            "name": "Duplicate key conflicts",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Flag keys are unique, including archived flags",
+            "error": "AlreadyExistsError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "Value served when disabled or when no rule matches"
+            },
+            "description": {
+              "description": "What the flag controls",
+              "type": "string"
+            },
+            "enabled": {
+              "default": true,
+              "description": "Start the flag enabled",
+              "type": "boolean"
+            },
+            "key": {
+              "description": "Unique kebab-case flag key",
+              "type": "string"
+            },
+            "kind": {
+              "description": "boolean serves true/false; variant serves a named variant",
+              "enum": [
+                "boolean",
+                "variant"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "default": [],
+              "description": "Initial ordered rules",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "Stable rule identifier, unique within the flag",
+                    "type": "string"
+                  },
+                  "serve": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ],
+                            "description": "Fixed value to serve"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "split": {
+                            "description": "Weighted arms; weights must total 100",
+                            "items": {
+                              "properties": {
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Value served when the subject buckets into this arm"
+                                },
+                                "weight": {
+                                  "description": "Share of the 0-99 bucket range, out of 100",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "weight"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "split"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "description": "What to serve when the rule matches"
+                  },
+                  "when": {
+                    "description": "Conditions that must all match for this rule to apply",
+                    "items": {
+                      "properties": {
+                        "attribute": {
+                          "description": "Attribute name to inspect on the evaluation context",
+                          "type": "string"
+                        },
+                        "op": {
+                          "description": "Comparison operator",
+                          "enum": [
+                            "eq",
+                            "neq",
+                            "in",
+                            "gte",
+                            "lte"
+                          ],
+                          "type": "string"
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "Value to compare against; an array is required for the \"in\" operator"
+                        }
+                      },
+                      "required": [
+                        "attribute",
+                        "op",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id",
+                  "serve",
+                  "when"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "variants": {
+              "description": "Allowed variant names (variant-kind flags only)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "defaultValue",
+            "description",
+            "key",
+            "kind"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "archived": {
+              "description": "Archived flags are hidden and cannot be evaluated",
+              "type": "boolean"
+            },
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "Value served when disabled or when no rule matches"
+            },
+            "description": {
+              "description": "What the flag controls",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Disabled flags always serve the default value",
+              "type": "boolean"
+            },
+            "key": {
+              "description": "Unique kebab-case flag key",
+              "type": "string"
+            },
+            "kind": {
+              "description": "boolean serves true/false; variant serves a named variant",
+              "enum": [
+                "boolean",
+                "variant"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "description": "Ordered rules; first full match wins",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "Stable rule identifier, unique within the flag",
+                    "type": "string"
+                  },
+                  "serve": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ],
+                            "description": "Fixed value to serve"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "split": {
+                            "description": "Weighted arms; weights must total 100",
+                            "items": {
+                              "properties": {
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Value served when the subject buckets into this arm"
+                                },
+                                "weight": {
+                                  "description": "Share of the 0-99 bucket range, out of 100",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "weight"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "split"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "description": "What to serve when the rule matches"
+                  },
+                  "when": {
+                    "description": "Conditions that must all match for this rule to apply",
+                    "items": {
+                      "properties": {
+                        "attribute": {
+                          "description": "Attribute name to inspect on the evaluation context",
+                          "type": "string"
+                        },
+                        "op": {
+                          "description": "Comparison operator",
+                          "enum": [
+                            "eq",
+                            "neq",
+                            "in",
+                            "gte",
+                            "lte"
+                          ],
+                          "type": "string"
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "Value to compare against; an array is required for the \"in\" operator"
+                        }
+                      },
+                      "required": [
+                        "attribute",
+                        "op",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id",
+                  "serve",
+                  "when"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "variants": {
+              "description": "Allowed variant names (variant-kind flags only)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "archived",
+            "defaultValue",
+            "description",
+            "enabled",
+            "key",
+            "kind",
+            "rules"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "flags"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "flag.disable",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "flag",
+            "disable"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "flag",
+                "disable"
+              ],
+              "source": "derived",
+              "target": "flag.disable"
+            }
+          ]
+        },
+        "description": "Disable a flag so it always serves its default value; idempotent",
+        "examples": [
+          {
+            "input": {
+              "key": "checkout-v2"
+            },
+            "kind": "success",
+            "name": "Disable a flag",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Disabled flags serve their default with reason \"disabled\" until re-enabled"
+          },
+          {
+            "input": {
+              "key": "legacy-banner"
+            },
+            "kind": "error",
+            "name": "Archived flag cannot be disabled",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Archived flags cannot be toggled",
+            "error": "NotFoundError"
+          }
+        ],
+        "idempotent": true,
+        "input": {
+          "properties": {
+            "key": {
+              "description": "Flag key to disable",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "archived": {
+              "description": "Archived flags are hidden and cannot be evaluated",
+              "type": "boolean"
+            },
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "Value served when disabled or when no rule matches"
+            },
+            "description": {
+              "description": "What the flag controls",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Disabled flags always serve the default value",
+              "type": "boolean"
+            },
+            "key": {
+              "description": "Unique kebab-case flag key",
+              "type": "string"
+            },
+            "kind": {
+              "description": "boolean serves true/false; variant serves a named variant",
+              "enum": [
+                "boolean",
+                "variant"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "description": "Ordered rules; first full match wins",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "Stable rule identifier, unique within the flag",
+                    "type": "string"
+                  },
+                  "serve": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ],
+                            "description": "Fixed value to serve"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "split": {
+                            "description": "Weighted arms; weights must total 100",
+                            "items": {
+                              "properties": {
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Value served when the subject buckets into this arm"
+                                },
+                                "weight": {
+                                  "description": "Share of the 0-99 bucket range, out of 100",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "weight"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "split"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "description": "What to serve when the rule matches"
+                  },
+                  "when": {
+                    "description": "Conditions that must all match for this rule to apply",
+                    "items": {
+                      "properties": {
+                        "attribute": {
+                          "description": "Attribute name to inspect on the evaluation context",
+                          "type": "string"
+                        },
+                        "op": {
+                          "description": "Comparison operator",
+                          "enum": [
+                            "eq",
+                            "neq",
+                            "in",
+                            "gte",
+                            "lte"
+                          ],
+                          "type": "string"
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "Value to compare against; an array is required for the \"in\" operator"
+                        }
+                      },
+                      "required": [
+                        "attribute",
+                        "op",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id",
+                  "serve",
+                  "when"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "variants": {
+              "description": "Allowed variant names (variant-kind flags only)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "archived",
+            "defaultValue",
+            "description",
+            "enabled",
+            "key",
+            "kind",
+            "rules"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "flags"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "flag.enable",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "flag",
+            "enable"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "flag",
+                "enable"
+              ],
+              "source": "derived",
+              "target": "flag.enable"
+            }
+          ]
+        },
+        "description": "Enable a flag so its rules apply; idempotent",
+        "examples": [
+          {
+            "input": {
+              "key": "new-onboarding"
+            },
+            "kind": "success",
+            "name": "Enable a flag",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Enabling a disabled flag lets its rules serve values",
+            "expected": {
+              "archived": false,
+              "defaultValue": false,
+              "description": "Guided onboarding checklist (not yet enabled)",
+              "enabled": true,
+              "key": "new-onboarding",
+              "kind": "boolean",
+              "rules": [
+                {
+                  "id": "everyone",
+                  "serve": {
+                    "value": true
+                  },
+                  "when": []
+                }
+              ]
+            }
+          }
+        ],
+        "idempotent": true,
+        "input": {
+          "properties": {
+            "key": {
+              "description": "Flag key to enable",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "archived": {
+              "description": "Archived flags are hidden and cannot be evaluated",
+              "type": "boolean"
+            },
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "Value served when disabled or when no rule matches"
+            },
+            "description": {
+              "description": "What the flag controls",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Disabled flags always serve the default value",
+              "type": "boolean"
+            },
+            "key": {
+              "description": "Unique kebab-case flag key",
+              "type": "string"
+            },
+            "kind": {
+              "description": "boolean serves true/false; variant serves a named variant",
+              "enum": [
+                "boolean",
+                "variant"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "description": "Ordered rules; first full match wins",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "Stable rule identifier, unique within the flag",
+                    "type": "string"
+                  },
+                  "serve": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ],
+                            "description": "Fixed value to serve"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "split": {
+                            "description": "Weighted arms; weights must total 100",
+                            "items": {
+                              "properties": {
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Value served when the subject buckets into this arm"
+                                },
+                                "weight": {
+                                  "description": "Share of the 0-99 bucket range, out of 100",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "weight"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "split"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "description": "What to serve when the rule matches"
+                  },
+                  "when": {
+                    "description": "Conditions that must all match for this rule to apply",
+                    "items": {
+                      "properties": {
+                        "attribute": {
+                          "description": "Attribute name to inspect on the evaluation context",
+                          "type": "string"
+                        },
+                        "op": {
+                          "description": "Comparison operator",
+                          "enum": [
+                            "eq",
+                            "neq",
+                            "in",
+                            "gte",
+                            "lte"
+                          ],
+                          "type": "string"
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "Value to compare against; an array is required for the \"in\" operator"
+                        }
+                      },
+                      "required": [
+                        "attribute",
+                        "op",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id",
+                  "serve",
+                  "when"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "variants": {
+              "description": "Allowed variant names (variant-kind flags only)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "archived",
+            "defaultValue",
+            "description",
+            "enabled",
+            "key",
+            "kind",
+            "rules"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "flags"
+        ]
+      },
+      {
+        "exampleCount": 6,
+        "id": "flag.evaluate",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "flag",
+            "evaluate"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "flag",
+                "evaluate"
+              ],
+              "source": "derived",
+              "target": "flag.evaluate"
+            }
+          ]
+        },
+        "description": "Evaluate one flag for a subject, returning the served value and a rule-by-rule trace of why",
+        "examples": [
+          {
+            "input": {
+              "context": {
+                "attributes": {
+                  "plan": "beta"
+                },
+                "subjectId": "user-9"
+              },
+              "key": "checkout-v2"
+            },
+            "kind": "success",
+            "name": "Beta plan gets the treatment",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "A targeting rule matches on the plan attribute",
+            "expected": {
+              "key": "checkout-v2",
+              "reason": {
+                "reason": "rule-match",
+                "steps": [
+                  {
+                    "outcome": "matched",
+                    "ruleId": "beta-users"
+                  }
+                ]
+              },
+              "value": "treatment",
+              "variant": "treatment"
+            }
+          },
+          {
+            "input": {
+              "context": {
+                "attributes": {},
+                "subjectId": "user-1"
+              },
+              "key": "checkout-v2"
+            },
+            "kind": "success",
+            "name": "Fixed vector: user-1 buckets to 7 and gets the treatment",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Percentage rollout is seeded-hash deterministic: user-1 buckets to 7 (< 20) forever",
+            "expected": {
+              "key": "checkout-v2",
+              "reason": {
+                "reason": "percentage-rollout",
+                "steps": [
+                  {
+                    "detail": "attribute \"plan\" is missing",
+                    "outcome": "skipped",
+                    "ruleId": "beta-users"
+                  },
+                  {
+                    "bucket": 7,
+                    "outcome": "percentage",
+                    "ruleId": "gradual-rollout",
+                    "served": "treatment"
+                  }
+                ]
+              },
+              "value": "treatment",
+              "variant": "treatment"
+            }
+          },
+          {
+            "input": {
+              "context": {
+                "attributes": {},
+                "subjectId": "user-3"
+              },
+              "key": "checkout-v2"
+            },
+            "kind": "success",
+            "name": "Fixed vector: user-3 buckets to 45 and stays on control",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "The same rollout keeps user-3 on control: bucket 45 falls in the 80% arm",
+            "expected": {
+              "key": "checkout-v2",
+              "reason": {
+                "reason": "percentage-rollout",
+                "steps": [
+                  {
+                    "detail": "attribute \"plan\" is missing",
+                    "outcome": "skipped",
+                    "ruleId": "beta-users"
+                  },
+                  {
+                    "bucket": 45,
+                    "outcome": "percentage",
+                    "ruleId": "gradual-rollout",
+                    "served": "control"
+                  }
+                ]
+              },
+              "value": "control",
+              "variant": "control"
+            }
+          },
+          {
+            "input": {
+              "context": {
+                "attributes": {},
+                "subjectId": "user-1"
+              },
+              "key": "new-onboarding"
+            },
+            "kind": "success",
+            "name": "Disabled flag serves its default",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Disabled flags serve their default without inspecting rules",
+            "expected": {
+              "key": "new-onboarding",
+              "reason": {
+                "reason": "disabled",
+                "steps": []
+              },
+              "value": false
+            }
+          },
+          {
+            "input": {
+              "context": {
+                "attributes": {},
+                "subjectId": "user-1"
+              },
+              "key": "legacy-banner"
+            },
+            "kind": "error",
+            "name": "Archived flag is not found",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Archived flags are retired and cannot be evaluated",
+            "error": "NotFoundError"
+          },
+          {
+            "input": {
+              "context": {
+                "attributes": {},
+                "subjectId": "user-1"
+              },
+              "explain": true,
+              "key": "checkout-v2"
+            },
+            "kind": "success",
+            "name": "Explain the evaluation",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "explain: true adds a human-readable rendering of the trace (the CLI --explain flag)",
+            "expected": {
+              "explanation": [
+                "rule beta-users: skipped (attribute \"plan\" is missing)",
+                "rule gradual-rollout: bucket 7 served \"treatment\"",
+                "result: \"treatment\" (percentage-rollout)"
+              ],
+              "key": "checkout-v2",
+              "reason": {
+                "reason": "percentage-rollout",
+                "steps": [
+                  {
+                    "detail": "attribute \"plan\" is missing",
+                    "outcome": "skipped",
+                    "ruleId": "beta-users"
+                  },
+                  {
+                    "bucket": 7,
+                    "outcome": "percentage",
+                    "ruleId": "gradual-rollout",
+                    "served": "treatment"
+                  }
+                ]
+              },
+              "value": "treatment",
+              "variant": "treatment"
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "context": {
+              "description": "Who the flag is evaluated for",
+              "properties": {
+                "attributes": {
+                  "default": {},
+                  "description": "Attributes rules can match on (e.g. plan, region)"
+                },
+                "subjectId": {
+                  "description": "Stable subject identifier used for percentage bucketing",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "subjectId"
+              ],
+              "type": "object"
+            },
+            "explain": {
+              "default": false,
+              "description": "Include a human-readable rendering of the trace",
+              "type": "boolean"
+            },
+            "key": {
+              "description": "Flag key to evaluate",
+              "type": "string"
+            }
+          },
+          "required": [
+            "context",
+            "key"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "explanation": {
+              "description": "Human-readable trace lines, present when explain is true",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "key": {
+              "description": "Unique kebab-case flag key",
+              "type": "string"
+            },
+            "reason": {
+              "description": "Rule-by-rule explanation of the outcome",
+              "properties": {
+                "reason": {
+                  "description": "Terminal reason the served value was chosen",
+                  "enum": [
+                    "rule-match",
+                    "percentage-rollout",
+                    "no-rule-match",
+                    "disabled"
+                  ],
+                  "type": "string"
+                },
+                "steps": {
+                  "description": "Ordered rule-by-rule outcomes",
+                  "items": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "outcome": {
+                            "const": "matched",
+                            "description": "All conditions matched; the rule served a fixed value"
+                          },
+                          "ruleId": {
+                            "description": "Rule that was inspected",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "outcome",
+                          "ruleId"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "detail": {
+                            "description": "Which condition failed and why",
+                            "type": "string"
+                          },
+                          "outcome": {
+                            "const": "skipped",
+                            "description": "A condition failed; the rule did not apply"
+                          },
+                          "ruleId": {
+                            "description": "Rule that was inspected",
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "detail",
+                          "outcome",
+                          "ruleId"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "bucket": {
+                            "description": "Deterministic bucket for flagKey + subjectId",
+                            "type": "number"
+                          },
+                          "outcome": {
+                            "const": "percentage",
+                            "description": "The rule matched and resolved through a split"
+                          },
+                          "ruleId": {
+                            "description": "Rule that was inspected",
+                            "type": "string"
+                          },
+                          "served": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ],
+                            "description": "Value the bucket landed on"
+                          }
+                        },
+                        "required": [
+                          "bucket",
+                          "outcome",
+                          "ruleId",
+                          "served"
+                        ],
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "reason",
+                "steps"
+              ],
+              "type": "object"
+            },
+            "value": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "The served value"
+            },
+            "variant": {
+              "description": "Variant name when the flag is variant-kind",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "reason",
+            "value"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "flags"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "flag.evaluate-all",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "flag",
+            "evaluate-all"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "flag",
+                "evaluate-all"
+              ],
+              "source": "derived",
+              "target": "flag.evaluate-all"
+            }
+          ]
+        },
+        "description": "Evaluate every live flag for one subject — the bootstrap payload pattern",
+        "examples": [
+          {
+            "input": {
+              "context": {
+                "attributes": {
+                  "plan": "beta"
+                },
+                "subjectId": "user-1"
+              }
+            },
+            "kind": "success",
+            "name": "Bootstrap payload for a beta subject",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "A beta-plan subject gets the treatment via targeting; dark-mode misses its 50% rollout (bucket 58)",
+            "expected": {
+              "evaluated": 3,
+              "values": {
+                "checkout-v2": "treatment",
+                "dark-mode": false,
+                "new-onboarding": false
+              }
+            }
+          },
+          {
+            "input": {
+              "context": {
+                "attributes": {
+                  "plan": "pro"
+                },
+                "subjectId": "user-42"
+              }
+            },
+            "kind": "success",
+            "name": "Bootstrap payload for a pro subject",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Fixed vector: user-42 buckets to 10 (< 20) on checkout-v2; the pro plan turns dark-mode on",
+            "expected": {
+              "evaluated": 3,
+              "values": {
+                "checkout-v2": "treatment",
+                "dark-mode": true,
+                "new-onboarding": false
+              }
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "context": {
+              "description": "Who the flags are evaluated for",
+              "properties": {
+                "attributes": {
+                  "default": {},
+                  "description": "Attributes rules can match on (e.g. plan, region)"
+                },
+                "subjectId": {
+                  "description": "Stable subject identifier used for percentage bucketing",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "subjectId"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "context"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "evaluated": {
+              "description": "Number of live flags evaluated",
+              "type": "number"
+            },
+            "values": {
+              "description": "Flag key to served value — the bootstrap payload"
+            }
+          },
+          "required": [
+            "evaluated",
+            "values"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "audit",
+          "flags"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "flag.get",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "flag",
+            "get"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "flag",
+                "get"
+              ],
+              "source": "derived",
+              "target": "flag.get"
+            }
+          ]
+        },
+        "description": "Show one flag definition by key, including archived flags",
+        "examples": [
+          {
+            "input": {
+              "key": "dark-mode"
+            },
+            "kind": "success",
+            "name": "Show a flag definition",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "The full definition includes the ordered rules",
+            "expected": {
+              "archived": false,
+              "defaultValue": false,
+              "description": "Dark mode for paid plans, half rollout for everyone else",
+              "enabled": true,
+              "key": "dark-mode",
+              "kind": "boolean",
+              "rules": [
+                {
+                  "id": "paid-plans",
+                  "serve": {
+                    "value": true
+                  },
+                  "when": [
+                    {
+                      "attribute": "plan",
+                      "op": "in",
+                      "value": [
+                        "pro",
+                        "team"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "id": "half-rollout",
+                  "serve": {
+                    "split": [
+                      {
+                        "value": true,
+                        "weight": 50
+                      },
+                      {
+                        "value": false,
+                        "weight": 50
+                      }
+                    ]
+                  },
+                  "when": []
+                }
+              ]
+            }
+          },
+          {
+            "input": {
+              "key": "does-not-exist"
+            },
+            "kind": "error",
+            "name": "Unknown flag is not found",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown keys are not found",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "key": {
+              "description": "Flag key to look up",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "archived": {
+              "description": "Archived flags are hidden and cannot be evaluated",
+              "type": "boolean"
+            },
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "Value served when disabled or when no rule matches"
+            },
+            "description": {
+              "description": "What the flag controls",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Disabled flags always serve the default value",
+              "type": "boolean"
+            },
+            "key": {
+              "description": "Unique kebab-case flag key",
+              "type": "string"
+            },
+            "kind": {
+              "description": "boolean serves true/false; variant serves a named variant",
+              "enum": [
+                "boolean",
+                "variant"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "description": "Ordered rules; first full match wins",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "Stable rule identifier, unique within the flag",
+                    "type": "string"
+                  },
+                  "serve": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ],
+                            "description": "Fixed value to serve"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "split": {
+                            "description": "Weighted arms; weights must total 100",
+                            "items": {
+                              "properties": {
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Value served when the subject buckets into this arm"
+                                },
+                                "weight": {
+                                  "description": "Share of the 0-99 bucket range, out of 100",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "weight"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "split"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "description": "What to serve when the rule matches"
+                  },
+                  "when": {
+                    "description": "Conditions that must all match for this rule to apply",
+                    "items": {
+                      "properties": {
+                        "attribute": {
+                          "description": "Attribute name to inspect on the evaluation context",
+                          "type": "string"
+                        },
+                        "op": {
+                          "description": "Comparison operator",
+                          "enum": [
+                            "eq",
+                            "neq",
+                            "in",
+                            "gte",
+                            "lte"
+                          ],
+                          "type": "string"
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "Value to compare against; an array is required for the \"in\" operator"
+                        }
+                      },
+                      "required": [
+                        "attribute",
+                        "op",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id",
+                  "serve",
+                  "when"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "variants": {
+              "description": "Allowed variant names (variant-kind flags only)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "archived",
+            "defaultValue",
+            "description",
+            "enabled",
+            "key",
+            "kind",
+            "rules"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "flags"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "flag.list",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "flag",
+            "list"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "flag",
+                "list"
+              ],
+              "source": "derived",
+              "target": "flag.list"
+            }
+          ]
+        },
+        "description": "List flag definitions, sorted by key",
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "List live flags",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Archived flags are hidden by default"
+          },
+          {
+            "input": {
+              "includeArchived": true
+            },
+            "kind": "success",
+            "name": "List all flags including archived",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Pass includeArchived to see retired flags too"
+          }
+        ],
+        "input": {
+          "properties": {
+            "includeArchived": {
+              "default": false,
+              "description": "Include archived flags in the listing",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "flags": {
+              "description": "Flag definitions sorted by key",
+              "items": {
+                "properties": {
+                  "archived": {
+                    "description": "Archived flags are hidden and cannot be evaluated",
+                    "type": "boolean"
+                  },
+                  "defaultValue": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "boolean"
+                      }
+                    ],
+                    "description": "Value served when disabled or when no rule matches"
+                  },
+                  "description": {
+                    "description": "What the flag controls",
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "description": "Disabled flags always serve the default value",
+                    "type": "boolean"
+                  },
+                  "key": {
+                    "description": "Unique kebab-case flag key",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "boolean serves true/false; variant serves a named variant",
+                    "enum": [
+                      "boolean",
+                      "variant"
+                    ],
+                    "type": "string"
+                  },
+                  "rules": {
+                    "description": "Ordered rules; first full match wins",
+                    "items": {
+                      "properties": {
+                        "id": {
+                          "description": "Stable rule identifier, unique within the flag",
+                          "type": "string"
+                        },
+                        "serve": {
+                          "anyOf": [
+                            {
+                              "properties": {
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Fixed value to serve"
+                                }
+                              },
+                              "required": [
+                                "value"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "properties": {
+                                "split": {
+                                  "description": "Weighted arms; weights must total 100",
+                                  "items": {
+                                    "properties": {
+                                      "value": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          },
+                                          {
+                                            "type": "boolean"
+                                          }
+                                        ],
+                                        "description": "Value served when the subject buckets into this arm"
+                                      },
+                                      "weight": {
+                                        "description": "Share of the 0-99 bucket range, out of 100",
+                                        "type": "number"
+                                      }
+                                    },
+                                    "required": [
+                                      "value",
+                                      "weight"
+                                    ],
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                }
+                              },
+                              "required": [
+                                "split"
+                              ],
+                              "type": "object"
+                            }
+                          ],
+                          "description": "What to serve when the rule matches"
+                        },
+                        "when": {
+                          "description": "Conditions that must all match for this rule to apply",
+                          "items": {
+                            "properties": {
+                              "attribute": {
+                                "description": "Attribute name to inspect on the evaluation context",
+                                "type": "string"
+                              },
+                              "op": {
+                                "description": "Comparison operator",
+                                "enum": [
+                                  "eq",
+                                  "neq",
+                                  "in",
+                                  "gte",
+                                  "lte"
+                                ],
+                                "type": "string"
+                              },
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "items": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
+                                    },
+                                    "type": "array"
+                                  }
+                                ],
+                                "description": "Value to compare against; an array is required for the \"in\" operator"
+                              }
+                            },
+                            "required": [
+                              "attribute",
+                              "op",
+                              "value"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "serve",
+                        "when"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  },
+                  "variants": {
+                    "description": "Allowed variant names (variant-kind flags only)",
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "archived",
+                  "defaultValue",
+                  "description",
+                  "enabled",
+                  "key",
+                  "kind",
+                  "rules"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "flags"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "flags"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "flag.update",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "flag",
+            "update"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "flag",
+                "update"
+              ],
+              "source": "derived",
+              "target": "flag.update"
+            }
+          ]
+        },
+        "description": "Update the description, default value, or variants of a flag",
+        "examples": [
+          {
+            "input": {
+              "description": "Dark mode for every plan",
+              "key": "dark-mode"
+            },
+            "kind": "success",
+            "name": "Update a description",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Only the provided fields change"
+          },
+          {
+            "input": {
+              "description": "Bring it back",
+              "key": "legacy-banner"
+            },
+            "kind": "error",
+            "name": "Archived flag cannot be updated",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Archived and unknown flags cannot be updated",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "New default value, servable for the flag kind"
+            },
+            "description": {
+              "description": "New description",
+              "type": "string"
+            },
+            "key": {
+              "description": "Flag key to update",
+              "type": "string"
+            },
+            "variants": {
+              "description": "Allowed variant names (variant-kind flags only)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "key"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "archived": {
+              "description": "Archived flags are hidden and cannot be evaluated",
+              "type": "boolean"
+            },
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "Value served when disabled or when no rule matches"
+            },
+            "description": {
+              "description": "What the flag controls",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Disabled flags always serve the default value",
+              "type": "boolean"
+            },
+            "key": {
+              "description": "Unique kebab-case flag key",
+              "type": "string"
+            },
+            "kind": {
+              "description": "boolean serves true/false; variant serves a named variant",
+              "enum": [
+                "boolean",
+                "variant"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "description": "Ordered rules; first full match wins",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "Stable rule identifier, unique within the flag",
+                    "type": "string"
+                  },
+                  "serve": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ],
+                            "description": "Fixed value to serve"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "split": {
+                            "description": "Weighted arms; weights must total 100",
+                            "items": {
+                              "properties": {
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Value served when the subject buckets into this arm"
+                                },
+                                "weight": {
+                                  "description": "Share of the 0-99 bucket range, out of 100",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "weight"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "split"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "description": "What to serve when the rule matches"
+                  },
+                  "when": {
+                    "description": "Conditions that must all match for this rule to apply",
+                    "items": {
+                      "properties": {
+                        "attribute": {
+                          "description": "Attribute name to inspect on the evaluation context",
+                          "type": "string"
+                        },
+                        "op": {
+                          "description": "Comparison operator",
+                          "enum": [
+                            "eq",
+                            "neq",
+                            "in",
+                            "gte",
+                            "lte"
+                          ],
+                          "type": "string"
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "Value to compare against; an array is required for the \"in\" operator"
+                        }
+                      },
+                      "required": [
+                        "attribute",
+                        "op",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id",
+                  "serve",
+                  "when"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "variants": {
+              "description": "Allowed variant names (variant-kind flags only)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "archived",
+            "defaultValue",
+            "description",
+            "enabled",
+            "key",
+            "kind",
+            "rules"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "flags"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "flags",
+        "kind": "resource",
+        "surfaces": [],
+        "description": "File-backed flag definition source (switchback.flags.json), reloaded on every read. Deliberately not a database."
+      },
+      {
+        "exampleCount": 3,
+        "id": "rule.add",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "rule",
+            "add"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "rule",
+                "add"
+              ],
+              "source": "derived",
+              "target": "rule.add"
+            }
+          ]
+        },
+        "description": "Add an ordered rule to a flag; earlier rules win, so position matters",
+        "examples": [
+          {
+            "input": {
+              "key": "new-onboarding",
+              "position": 0,
+              "rule": {
+                "id": "pro-users",
+                "serve": {
+                  "value": true
+                },
+                "when": [
+                  {
+                    "attribute": "plan",
+                    "op": "eq",
+                    "value": "pro"
+                  }
+                ]
+              }
+            },
+            "kind": "success",
+            "name": "Add a targeting rule first",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Insert at position 0 so the new rule is checked first",
+            "expected": {
+              "archived": false,
+              "defaultValue": false,
+              "description": "Guided onboarding checklist (not yet enabled)",
+              "enabled": false,
+              "key": "new-onboarding",
+              "kind": "boolean",
+              "rules": [
+                {
+                  "id": "pro-users",
+                  "serve": {
+                    "value": true
+                  },
+                  "when": [
+                    {
+                      "attribute": "plan",
+                      "op": "eq",
+                      "value": "pro"
+                    }
+                  ]
+                },
+                {
+                  "id": "everyone",
+                  "serve": {
+                    "value": true
+                  },
+                  "when": []
+                }
+              ]
+            }
+          },
+          {
+            "input": {
+              "key": "new-onboarding",
+              "rule": {
+                "id": "everyone",
+                "serve": {
+                  "value": false
+                },
+                "when": []
+              }
+            },
+            "kind": "error",
+            "name": "Duplicate rule id conflicts",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Rule ids are unique within a flag",
+            "error": "AlreadyExistsError"
+          },
+          {
+            "input": {
+              "key": "dark-mode",
+              "rule": {
+                "id": "bad-serve",
+                "serve": {
+                  "value": "blue"
+                },
+                "when": []
+              }
+            },
+            "kind": "error",
+            "name": "Unservable value is rejected",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Served values must fit the flag kind and variants",
+            "error": "ValidationError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "key": {
+              "description": "Flag key to add the rule to",
+              "type": "string"
+            },
+            "position": {
+              "description": "Insertion index; appended when omitted",
+              "type": "number"
+            },
+            "rule": {
+              "description": "The rule to add",
+              "properties": {
+                "id": {
+                  "description": "Stable rule identifier, unique within the flag",
+                  "type": "string"
+                },
+                "serve": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            }
+                          ],
+                          "description": "Fixed value to serve"
+                        }
+                      },
+                      "required": [
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    {
+                      "properties": {
+                        "split": {
+                          "description": "Weighted arms; weights must total 100",
+                          "items": {
+                            "properties": {
+                              "value": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  },
+                                  {
+                                    "type": "boolean"
+                                  }
+                                ],
+                                "description": "Value served when the subject buckets into this arm"
+                              },
+                              "weight": {
+                                "description": "Share of the 0-99 bucket range, out of 100",
+                                "type": "number"
+                              }
+                            },
+                            "required": [
+                              "value",
+                              "weight"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "required": [
+                        "split"
+                      ],
+                      "type": "object"
+                    }
+                  ],
+                  "description": "What to serve when the rule matches"
+                },
+                "when": {
+                  "description": "Conditions that must all match for this rule to apply",
+                  "items": {
+                    "properties": {
+                      "attribute": {
+                        "description": "Attribute name to inspect on the evaluation context",
+                        "type": "string"
+                      },
+                      "op": {
+                        "description": "Comparison operator",
+                        "enum": [
+                          "eq",
+                          "neq",
+                          "in",
+                          "gte",
+                          "lte"
+                        ],
+                        "type": "string"
+                      },
+                      "value": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "number"
+                          },
+                          {
+                            "type": "boolean"
+                          },
+                          {
+                            "items": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                }
+                              ]
+                            },
+                            "type": "array"
+                          }
+                        ],
+                        "description": "Value to compare against; an array is required for the \"in\" operator"
+                      }
+                    },
+                    "required": [
+                      "attribute",
+                      "op",
+                      "value"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "required": [
+                "id",
+                "serve",
+                "when"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "key",
+            "rule"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "archived": {
+              "description": "Archived flags are hidden and cannot be evaluated",
+              "type": "boolean"
+            },
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "Value served when disabled or when no rule matches"
+            },
+            "description": {
+              "description": "What the flag controls",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Disabled flags always serve the default value",
+              "type": "boolean"
+            },
+            "key": {
+              "description": "Unique kebab-case flag key",
+              "type": "string"
+            },
+            "kind": {
+              "description": "boolean serves true/false; variant serves a named variant",
+              "enum": [
+                "boolean",
+                "variant"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "description": "Ordered rules; first full match wins",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "Stable rule identifier, unique within the flag",
+                    "type": "string"
+                  },
+                  "serve": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ],
+                            "description": "Fixed value to serve"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "split": {
+                            "description": "Weighted arms; weights must total 100",
+                            "items": {
+                              "properties": {
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Value served when the subject buckets into this arm"
+                                },
+                                "weight": {
+                                  "description": "Share of the 0-99 bucket range, out of 100",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "weight"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "split"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "description": "What to serve when the rule matches"
+                  },
+                  "when": {
+                    "description": "Conditions that must all match for this rule to apply",
+                    "items": {
+                      "properties": {
+                        "attribute": {
+                          "description": "Attribute name to inspect on the evaluation context",
+                          "type": "string"
+                        },
+                        "op": {
+                          "description": "Comparison operator",
+                          "enum": [
+                            "eq",
+                            "neq",
+                            "in",
+                            "gte",
+                            "lte"
+                          ],
+                          "type": "string"
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "Value to compare against; an array is required for the \"in\" operator"
+                        }
+                      },
+                      "required": [
+                        "attribute",
+                        "op",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id",
+                  "serve",
+                  "when"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "variants": {
+              "description": "Allowed variant names (variant-kind flags only)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "archived",
+            "defaultValue",
+            "description",
+            "enabled",
+            "key",
+            "kind",
+            "rules"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "flags"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "rule.remove",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "rule",
+            "remove"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "rule",
+                "remove"
+              ],
+              "source": "derived",
+              "target": "rule.remove"
+            }
+          ]
+        },
+        "description": "Remove a rule from a flag by rule id",
+        "examples": [
+          {
+            "input": {
+              "key": "new-onboarding",
+              "ruleId": "everyone"
+            },
+            "kind": "success",
+            "name": "Remove a rule",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Removing the only rule leaves the default serving everyone",
+            "expected": {
+              "archived": false,
+              "defaultValue": false,
+              "description": "Guided onboarding checklist (not yet enabled)",
+              "enabled": false,
+              "key": "new-onboarding",
+              "kind": "boolean",
+              "rules": []
+            }
+          },
+          {
+            "input": {
+              "key": "new-onboarding",
+              "ruleId": "missing-rule"
+            },
+            "kind": "error",
+            "name": "Unknown rule is not found",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown rule ids are not found",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "key": {
+              "description": "Flag key to remove the rule from",
+              "type": "string"
+            },
+            "ruleId": {
+              "description": "Rule id to remove",
+              "type": "string"
+            }
+          },
+          "required": [
+            "key",
+            "ruleId"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "archived": {
+              "description": "Archived flags are hidden and cannot be evaluated",
+              "type": "boolean"
+            },
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "Value served when disabled or when no rule matches"
+            },
+            "description": {
+              "description": "What the flag controls",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Disabled flags always serve the default value",
+              "type": "boolean"
+            },
+            "key": {
+              "description": "Unique kebab-case flag key",
+              "type": "string"
+            },
+            "kind": {
+              "description": "boolean serves true/false; variant serves a named variant",
+              "enum": [
+                "boolean",
+                "variant"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "description": "Ordered rules; first full match wins",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "Stable rule identifier, unique within the flag",
+                    "type": "string"
+                  },
+                  "serve": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ],
+                            "description": "Fixed value to serve"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "split": {
+                            "description": "Weighted arms; weights must total 100",
+                            "items": {
+                              "properties": {
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Value served when the subject buckets into this arm"
+                                },
+                                "weight": {
+                                  "description": "Share of the 0-99 bucket range, out of 100",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "weight"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "split"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "description": "What to serve when the rule matches"
+                  },
+                  "when": {
+                    "description": "Conditions that must all match for this rule to apply",
+                    "items": {
+                      "properties": {
+                        "attribute": {
+                          "description": "Attribute name to inspect on the evaluation context",
+                          "type": "string"
+                        },
+                        "op": {
+                          "description": "Comparison operator",
+                          "enum": [
+                            "eq",
+                            "neq",
+                            "in",
+                            "gte",
+                            "lte"
+                          ],
+                          "type": "string"
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "Value to compare against; an array is required for the \"in\" operator"
+                        }
+                      },
+                      "required": [
+                        "attribute",
+                        "op",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id",
+                  "serve",
+                  "when"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "variants": {
+              "description": "Allowed variant names (variant-kind flags only)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "archived",
+            "defaultValue",
+            "description",
+            "enabled",
+            "key",
+            "kind",
+            "rules"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "flags"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "rule.reorder",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "rule",
+            "reorder"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "rule",
+                "reorder"
+              ],
+              "source": "derived",
+              "target": "rule.reorder"
+            }
+          ]
+        },
+        "description": "Reorder the rules of a flag; the list must be a permutation of the current rule ids",
+        "examples": [
+          {
+            "input": {
+              "key": "checkout-v2",
+              "ruleIds": [
+                "gradual-rollout",
+                "beta-users"
+              ]
+            },
+            "kind": "success",
+            "name": "Reorder rules",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Moving the rollout ahead of targeting changes which rule wins",
+            "expected": {
+              "archived": false,
+              "defaultValue": "control",
+              "description": "New checkout flow rollout",
+              "enabled": true,
+              "key": "checkout-v2",
+              "kind": "variant",
+              "rules": [
+                {
+                  "id": "gradual-rollout",
+                  "serve": {
+                    "split": [
+                      {
+                        "value": "treatment",
+                        "weight": 20
+                      },
+                      {
+                        "value": "control",
+                        "weight": 80
+                      }
+                    ]
+                  },
+                  "when": []
+                },
+                {
+                  "id": "beta-users",
+                  "serve": {
+                    "value": "treatment"
+                  },
+                  "when": [
+                    {
+                      "attribute": "plan",
+                      "op": "eq",
+                      "value": "beta"
+                    }
+                  ]
+                }
+              ],
+              "variants": [
+                "control",
+                "treatment"
+              ]
+            }
+          },
+          {
+            "input": {
+              "key": "checkout-v2",
+              "ruleIds": [
+                "beta-users"
+              ]
+            },
+            "kind": "error",
+            "name": "Partial order is rejected",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "The new order must mention every current rule exactly once",
+            "error": "ValidationError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "key": {
+              "description": "Flag key to reorder rules on",
+              "type": "string"
+            },
+            "ruleIds": {
+              "description": "Complete rule id list in the new order",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "key",
+            "ruleIds"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "archived": {
+              "description": "Archived flags are hidden and cannot be evaluated",
+              "type": "boolean"
+            },
+            "defaultValue": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                }
+              ],
+              "description": "Value served when disabled or when no rule matches"
+            },
+            "description": {
+              "description": "What the flag controls",
+              "type": "string"
+            },
+            "enabled": {
+              "description": "Disabled flags always serve the default value",
+              "type": "boolean"
+            },
+            "key": {
+              "description": "Unique kebab-case flag key",
+              "type": "string"
+            },
+            "kind": {
+              "description": "boolean serves true/false; variant serves a named variant",
+              "enum": [
+                "boolean",
+                "variant"
+              ],
+              "type": "string"
+            },
+            "rules": {
+              "description": "Ordered rules; first full match wins",
+              "items": {
+                "properties": {
+                  "id": {
+                    "description": "Stable rule identifier, unique within the flag",
+                    "type": "string"
+                  },
+                  "serve": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ],
+                            "description": "Fixed value to serve"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "split": {
+                            "description": "Weighted arms; weights must total 100",
+                            "items": {
+                              "properties": {
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Value served when the subject buckets into this arm"
+                                },
+                                "weight": {
+                                  "description": "Share of the 0-99 bucket range, out of 100",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "weight"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "split"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "description": "What to serve when the rule matches"
+                  },
+                  "when": {
+                    "description": "Conditions that must all match for this rule to apply",
+                    "items": {
+                      "properties": {
+                        "attribute": {
+                          "description": "Attribute name to inspect on the evaluation context",
+                          "type": "string"
+                        },
+                        "op": {
+                          "description": "Comparison operator",
+                          "enum": [
+                            "eq",
+                            "neq",
+                            "in",
+                            "gte",
+                            "lte"
+                          ],
+                          "type": "string"
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "Value to compare against; an array is required for the \"in\" operator"
+                        }
+                      },
+                      "required": [
+                        "attribute",
+                        "op",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id",
+                  "serve",
+                  "when"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "variants": {
+              "description": "Allowed variant names (variant-kind flags only)",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "archived",
+            "defaultValue",
+            "description",
+            "enabled",
+            "key",
+            "kind",
+            "rules"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "flags"
+        ]
+      }
+    ],
+    "library": {
+      "app": "switchback",
+      "collisions": [],
+      "excluded": [],
+      "exports": [
+        {
+          "description": "List the in-memory demo log of bootstrap payloads served by flag.evaluate-all",
+          "exportName": "auditList",
+          "input": {
+            "properties": {},
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "entries": {
+                "description": "Recorded bootstrap payloads, oldest first",
+                "items": {
+                  "properties": {
+                    "subjectId": {
+                      "description": "Subject the payload was served to",
+                      "type": "string"
+                    },
+                    "values": {
+                      "description": "Flag key to served value"
+                    }
+                  },
+                  "required": [
+                    "subjectId",
+                    "values"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "entries"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "audit"
+          ],
+          "trailId": "audit.list"
+        },
+        {
+          "description": "Archive a flag: it disappears from evaluation and listings but its definition is kept",
+          "exportName": "flagArchive",
+          "input": {
+            "properties": {
+              "key": {
+                "description": "Flag key to archive",
+                "type": "string"
+              }
+            },
+            "required": [
+              "key"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "archived": {
+                "description": "Archived flags are hidden and cannot be evaluated",
+                "type": "boolean"
+              },
+              "defaultValue": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "Value served when disabled or when no rule matches"
+              },
+              "description": {
+                "description": "What the flag controls",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Disabled flags always serve the default value",
+                "type": "boolean"
+              },
+              "key": {
+                "description": "Unique kebab-case flag key",
+                "type": "string"
+              },
+              "kind": {
+                "description": "boolean serves true/false; variant serves a named variant",
+                "enum": [
+                  "boolean",
+                  "variant"
+                ],
+                "type": "string"
+              },
+              "rules": {
+                "description": "Ordered rules; first full match wins",
+                "items": {
+                  "properties": {
+                    "id": {
+                      "description": "Stable rule identifier, unique within the flag",
+                      "type": "string"
+                    },
+                    "serve": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ],
+                              "description": "Fixed value to serve"
+                            }
+                          },
+                          "required": [
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "properties": {
+                            "split": {
+                              "description": "Weighted arms; weights must total 100",
+                              "items": {
+                                "properties": {
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "Value served when the subject buckets into this arm"
+                                  },
+                                  "weight": {
+                                    "description": "Share of the 0-99 bucket range, out of 100",
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "value",
+                                  "weight"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "split"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "description": "What to serve when the rule matches"
+                    },
+                    "when": {
+                      "description": "Conditions that must all match for this rule to apply",
+                      "items": {
+                        "properties": {
+                          "attribute": {
+                            "description": "Attribute name to inspect on the evaluation context",
+                            "type": "string"
+                          },
+                          "op": {
+                            "description": "Comparison operator",
+                            "enum": [
+                              "eq",
+                              "neq",
+                              "in",
+                              "gte",
+                              "lte"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "Value to compare against; an array is required for the \"in\" operator"
+                          }
+                        },
+                        "required": [
+                          "attribute",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "serve",
+                    "when"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "variants": {
+                "description": "Allowed variant names (variant-kind flags only)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "archived",
+              "defaultValue",
+              "description",
+              "enabled",
+              "key",
+              "kind",
+              "rules"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "flags"
+          ],
+          "trailId": "flag.archive"
+        },
+        {
+          "description": "Create a new feature flag",
+          "exportName": "flagCreate",
+          "input": {
+            "properties": {
+              "defaultValue": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "Value served when disabled or when no rule matches"
+              },
+              "description": {
+                "description": "What the flag controls",
+                "type": "string"
+              },
+              "enabled": {
+                "default": true,
+                "description": "Start the flag enabled",
+                "type": "boolean"
+              },
+              "key": {
+                "description": "Unique kebab-case flag key",
+                "type": "string"
+              },
+              "kind": {
+                "description": "boolean serves true/false; variant serves a named variant",
+                "enum": [
+                  "boolean",
+                  "variant"
+                ],
+                "type": "string"
+              },
+              "rules": {
+                "default": [],
+                "description": "Initial ordered rules",
+                "items": {
+                  "properties": {
+                    "id": {
+                      "description": "Stable rule identifier, unique within the flag",
+                      "type": "string"
+                    },
+                    "serve": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ],
+                              "description": "Fixed value to serve"
+                            }
+                          },
+                          "required": [
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "properties": {
+                            "split": {
+                              "description": "Weighted arms; weights must total 100",
+                              "items": {
+                                "properties": {
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "Value served when the subject buckets into this arm"
+                                  },
+                                  "weight": {
+                                    "description": "Share of the 0-99 bucket range, out of 100",
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "value",
+                                  "weight"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "split"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "description": "What to serve when the rule matches"
+                    },
+                    "when": {
+                      "description": "Conditions that must all match for this rule to apply",
+                      "items": {
+                        "properties": {
+                          "attribute": {
+                            "description": "Attribute name to inspect on the evaluation context",
+                            "type": "string"
+                          },
+                          "op": {
+                            "description": "Comparison operator",
+                            "enum": [
+                              "eq",
+                              "neq",
+                              "in",
+                              "gte",
+                              "lte"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "Value to compare against; an array is required for the \"in\" operator"
+                          }
+                        },
+                        "required": [
+                          "attribute",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "serve",
+                    "when"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "variants": {
+                "description": "Allowed variant names (variant-kind flags only)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "defaultValue",
+              "description",
+              "key",
+              "kind"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "archived": {
+                "description": "Archived flags are hidden and cannot be evaluated",
+                "type": "boolean"
+              },
+              "defaultValue": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "Value served when disabled or when no rule matches"
+              },
+              "description": {
+                "description": "What the flag controls",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Disabled flags always serve the default value",
+                "type": "boolean"
+              },
+              "key": {
+                "description": "Unique kebab-case flag key",
+                "type": "string"
+              },
+              "kind": {
+                "description": "boolean serves true/false; variant serves a named variant",
+                "enum": [
+                  "boolean",
+                  "variant"
+                ],
+                "type": "string"
+              },
+              "rules": {
+                "description": "Ordered rules; first full match wins",
+                "items": {
+                  "properties": {
+                    "id": {
+                      "description": "Stable rule identifier, unique within the flag",
+                      "type": "string"
+                    },
+                    "serve": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ],
+                              "description": "Fixed value to serve"
+                            }
+                          },
+                          "required": [
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "properties": {
+                            "split": {
+                              "description": "Weighted arms; weights must total 100",
+                              "items": {
+                                "properties": {
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "Value served when the subject buckets into this arm"
+                                  },
+                                  "weight": {
+                                    "description": "Share of the 0-99 bucket range, out of 100",
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "value",
+                                  "weight"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "split"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "description": "What to serve when the rule matches"
+                    },
+                    "when": {
+                      "description": "Conditions that must all match for this rule to apply",
+                      "items": {
+                        "properties": {
+                          "attribute": {
+                            "description": "Attribute name to inspect on the evaluation context",
+                            "type": "string"
+                          },
+                          "op": {
+                            "description": "Comparison operator",
+                            "enum": [
+                              "eq",
+                              "neq",
+                              "in",
+                              "gte",
+                              "lte"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "Value to compare against; an array is required for the \"in\" operator"
+                          }
+                        },
+                        "required": [
+                          "attribute",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "serve",
+                    "when"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "variants": {
+                "description": "Allowed variant names (variant-kind flags only)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "archived",
+              "defaultValue",
+              "description",
+              "enabled",
+              "key",
+              "kind",
+              "rules"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "flags"
+          ],
+          "trailId": "flag.create"
+        },
+        {
+          "description": "Disable a flag so it always serves its default value; idempotent",
+          "exportName": "flagDisable",
+          "input": {
+            "properties": {
+              "key": {
+                "description": "Flag key to disable",
+                "type": "string"
+              }
+            },
+            "required": [
+              "key"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "archived": {
+                "description": "Archived flags are hidden and cannot be evaluated",
+                "type": "boolean"
+              },
+              "defaultValue": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "Value served when disabled or when no rule matches"
+              },
+              "description": {
+                "description": "What the flag controls",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Disabled flags always serve the default value",
+                "type": "boolean"
+              },
+              "key": {
+                "description": "Unique kebab-case flag key",
+                "type": "string"
+              },
+              "kind": {
+                "description": "boolean serves true/false; variant serves a named variant",
+                "enum": [
+                  "boolean",
+                  "variant"
+                ],
+                "type": "string"
+              },
+              "rules": {
+                "description": "Ordered rules; first full match wins",
+                "items": {
+                  "properties": {
+                    "id": {
+                      "description": "Stable rule identifier, unique within the flag",
+                      "type": "string"
+                    },
+                    "serve": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ],
+                              "description": "Fixed value to serve"
+                            }
+                          },
+                          "required": [
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "properties": {
+                            "split": {
+                              "description": "Weighted arms; weights must total 100",
+                              "items": {
+                                "properties": {
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "Value served when the subject buckets into this arm"
+                                  },
+                                  "weight": {
+                                    "description": "Share of the 0-99 bucket range, out of 100",
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "value",
+                                  "weight"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "split"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "description": "What to serve when the rule matches"
+                    },
+                    "when": {
+                      "description": "Conditions that must all match for this rule to apply",
+                      "items": {
+                        "properties": {
+                          "attribute": {
+                            "description": "Attribute name to inspect on the evaluation context",
+                            "type": "string"
+                          },
+                          "op": {
+                            "description": "Comparison operator",
+                            "enum": [
+                              "eq",
+                              "neq",
+                              "in",
+                              "gte",
+                              "lte"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "Value to compare against; an array is required for the \"in\" operator"
+                          }
+                        },
+                        "required": [
+                          "attribute",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "serve",
+                    "when"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "variants": {
+                "description": "Allowed variant names (variant-kind flags only)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "archived",
+              "defaultValue",
+              "description",
+              "enabled",
+              "key",
+              "kind",
+              "rules"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "flags"
+          ],
+          "trailId": "flag.disable"
+        },
+        {
+          "description": "Enable a flag so its rules apply; idempotent",
+          "exportName": "flagEnable",
+          "input": {
+            "properties": {
+              "key": {
+                "description": "Flag key to enable",
+                "type": "string"
+              }
+            },
+            "required": [
+              "key"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "archived": {
+                "description": "Archived flags are hidden and cannot be evaluated",
+                "type": "boolean"
+              },
+              "defaultValue": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "Value served when disabled or when no rule matches"
+              },
+              "description": {
+                "description": "What the flag controls",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Disabled flags always serve the default value",
+                "type": "boolean"
+              },
+              "key": {
+                "description": "Unique kebab-case flag key",
+                "type": "string"
+              },
+              "kind": {
+                "description": "boolean serves true/false; variant serves a named variant",
+                "enum": [
+                  "boolean",
+                  "variant"
+                ],
+                "type": "string"
+              },
+              "rules": {
+                "description": "Ordered rules; first full match wins",
+                "items": {
+                  "properties": {
+                    "id": {
+                      "description": "Stable rule identifier, unique within the flag",
+                      "type": "string"
+                    },
+                    "serve": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ],
+                              "description": "Fixed value to serve"
+                            }
+                          },
+                          "required": [
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "properties": {
+                            "split": {
+                              "description": "Weighted arms; weights must total 100",
+                              "items": {
+                                "properties": {
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "Value served when the subject buckets into this arm"
+                                  },
+                                  "weight": {
+                                    "description": "Share of the 0-99 bucket range, out of 100",
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "value",
+                                  "weight"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "split"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "description": "What to serve when the rule matches"
+                    },
+                    "when": {
+                      "description": "Conditions that must all match for this rule to apply",
+                      "items": {
+                        "properties": {
+                          "attribute": {
+                            "description": "Attribute name to inspect on the evaluation context",
+                            "type": "string"
+                          },
+                          "op": {
+                            "description": "Comparison operator",
+                            "enum": [
+                              "eq",
+                              "neq",
+                              "in",
+                              "gte",
+                              "lte"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "Value to compare against; an array is required for the \"in\" operator"
+                          }
+                        },
+                        "required": [
+                          "attribute",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "serve",
+                    "when"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "variants": {
+                "description": "Allowed variant names (variant-kind flags only)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "archived",
+              "defaultValue",
+              "description",
+              "enabled",
+              "key",
+              "kind",
+              "rules"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "flags"
+          ],
+          "trailId": "flag.enable"
+        },
+        {
+          "description": "Evaluate one flag for a subject, returning the served value and a rule-by-rule trace of why",
+          "exportName": "flagEvaluate",
+          "input": {
+            "properties": {
+              "context": {
+                "description": "Who the flag is evaluated for",
+                "properties": {
+                  "attributes": {
+                    "default": {},
+                    "description": "Attributes rules can match on (e.g. plan, region)"
+                  },
+                  "subjectId": {
+                    "description": "Stable subject identifier used for percentage bucketing",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "subjectId"
+                ],
+                "type": "object"
+              },
+              "explain": {
+                "default": false,
+                "description": "Include a human-readable rendering of the trace",
+                "type": "boolean"
+              },
+              "key": {
+                "description": "Flag key to evaluate",
+                "type": "string"
+              }
+            },
+            "required": [
+              "context",
+              "key"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "explanation": {
+                "description": "Human-readable trace lines, present when explain is true",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "key": {
+                "description": "Unique kebab-case flag key",
+                "type": "string"
+              },
+              "reason": {
+                "description": "Rule-by-rule explanation of the outcome",
+                "properties": {
+                  "reason": {
+                    "description": "Terminal reason the served value was chosen",
+                    "enum": [
+                      "rule-match",
+                      "percentage-rollout",
+                      "no-rule-match",
+                      "disabled"
+                    ],
+                    "type": "string"
+                  },
+                  "steps": {
+                    "description": "Ordered rule-by-rule outcomes",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "outcome": {
+                              "const": "matched",
+                              "description": "All conditions matched; the rule served a fixed value"
+                            },
+                            "ruleId": {
+                              "description": "Rule that was inspected",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "outcome",
+                            "ruleId"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "properties": {
+                            "detail": {
+                              "description": "Which condition failed and why",
+                              "type": "string"
+                            },
+                            "outcome": {
+                              "const": "skipped",
+                              "description": "A condition failed; the rule did not apply"
+                            },
+                            "ruleId": {
+                              "description": "Rule that was inspected",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "detail",
+                            "outcome",
+                            "ruleId"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "properties": {
+                            "bucket": {
+                              "description": "Deterministic bucket for flagKey + subjectId",
+                              "type": "number"
+                            },
+                            "outcome": {
+                              "const": "percentage",
+                              "description": "The rule matched and resolved through a split"
+                            },
+                            "ruleId": {
+                              "description": "Rule that was inspected",
+                              "type": "string"
+                            },
+                            "served": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ],
+                              "description": "Value the bucket landed on"
+                            }
+                          },
+                          "required": [
+                            "bucket",
+                            "outcome",
+                            "ruleId",
+                            "served"
+                          ],
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "reason",
+                  "steps"
+                ],
+                "type": "object"
+              },
+              "value": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "The served value"
+              },
+              "variant": {
+                "description": "Variant name when the flag is variant-kind",
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "reason",
+              "value"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "flags"
+          ],
+          "trailId": "flag.evaluate"
+        },
+        {
+          "description": "Evaluate every live flag for one subject — the bootstrap payload pattern",
+          "exportName": "flagEvaluateAll",
+          "input": {
+            "properties": {
+              "context": {
+                "description": "Who the flags are evaluated for",
+                "properties": {
+                  "attributes": {
+                    "default": {},
+                    "description": "Attributes rules can match on (e.g. plan, region)"
+                  },
+                  "subjectId": {
+                    "description": "Stable subject identifier used for percentage bucketing",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "subjectId"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "context"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "evaluated": {
+                "description": "Number of live flags evaluated",
+                "type": "number"
+              },
+              "values": {
+                "description": "Flag key to served value — the bootstrap payload"
+              }
+            },
+            "required": [
+              "evaluated",
+              "values"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "audit",
+            "flags"
+          ],
+          "trailId": "flag.evaluate-all"
+        },
+        {
+          "description": "Show one flag definition by key, including archived flags",
+          "exportName": "flagGet",
+          "input": {
+            "properties": {
+              "key": {
+                "description": "Flag key to look up",
+                "type": "string"
+              }
+            },
+            "required": [
+              "key"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "archived": {
+                "description": "Archived flags are hidden and cannot be evaluated",
+                "type": "boolean"
+              },
+              "defaultValue": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "Value served when disabled or when no rule matches"
+              },
+              "description": {
+                "description": "What the flag controls",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Disabled flags always serve the default value",
+                "type": "boolean"
+              },
+              "key": {
+                "description": "Unique kebab-case flag key",
+                "type": "string"
+              },
+              "kind": {
+                "description": "boolean serves true/false; variant serves a named variant",
+                "enum": [
+                  "boolean",
+                  "variant"
+                ],
+                "type": "string"
+              },
+              "rules": {
+                "description": "Ordered rules; first full match wins",
+                "items": {
+                  "properties": {
+                    "id": {
+                      "description": "Stable rule identifier, unique within the flag",
+                      "type": "string"
+                    },
+                    "serve": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ],
+                              "description": "Fixed value to serve"
+                            }
+                          },
+                          "required": [
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "properties": {
+                            "split": {
+                              "description": "Weighted arms; weights must total 100",
+                              "items": {
+                                "properties": {
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "Value served when the subject buckets into this arm"
+                                  },
+                                  "weight": {
+                                    "description": "Share of the 0-99 bucket range, out of 100",
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "value",
+                                  "weight"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "split"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "description": "What to serve when the rule matches"
+                    },
+                    "when": {
+                      "description": "Conditions that must all match for this rule to apply",
+                      "items": {
+                        "properties": {
+                          "attribute": {
+                            "description": "Attribute name to inspect on the evaluation context",
+                            "type": "string"
+                          },
+                          "op": {
+                            "description": "Comparison operator",
+                            "enum": [
+                              "eq",
+                              "neq",
+                              "in",
+                              "gte",
+                              "lte"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "Value to compare against; an array is required for the \"in\" operator"
+                          }
+                        },
+                        "required": [
+                          "attribute",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "serve",
+                    "when"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "variants": {
+                "description": "Allowed variant names (variant-kind flags only)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "archived",
+              "defaultValue",
+              "description",
+              "enabled",
+              "key",
+              "kind",
+              "rules"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "flags"
+          ],
+          "trailId": "flag.get"
+        },
+        {
+          "description": "List flag definitions, sorted by key",
+          "exportName": "flagList",
+          "input": {
+            "properties": {
+              "includeArchived": {
+                "default": false,
+                "description": "Include archived flags in the listing",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "flags": {
+                "description": "Flag definitions sorted by key",
+                "items": {
+                  "properties": {
+                    "archived": {
+                      "description": "Archived flags are hidden and cannot be evaluated",
+                      "type": "boolean"
+                    },
+                    "defaultValue": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "boolean"
+                        }
+                      ],
+                      "description": "Value served when disabled or when no rule matches"
+                    },
+                    "description": {
+                      "description": "What the flag controls",
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "Disabled flags always serve the default value",
+                      "type": "boolean"
+                    },
+                    "key": {
+                      "description": "Unique kebab-case flag key",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "boolean serves true/false; variant serves a named variant",
+                      "enum": [
+                        "boolean",
+                        "variant"
+                      ],
+                      "type": "string"
+                    },
+                    "rules": {
+                      "description": "Ordered rules; first full match wins",
+                      "items": {
+                        "properties": {
+                          "id": {
+                            "description": "Stable rule identifier, unique within the flag",
+                            "type": "string"
+                          },
+                          "serve": {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "Fixed value to serve"
+                                  }
+                                },
+                                "required": [
+                                  "value"
+                                ],
+                                "type": "object"
+                              },
+                              {
+                                "properties": {
+                                  "split": {
+                                    "description": "Weighted arms; weights must total 100",
+                                    "items": {
+                                      "properties": {
+                                        "value": {
+                                          "anyOf": [
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            }
+                                          ],
+                                          "description": "Value served when the subject buckets into this arm"
+                                        },
+                                        "weight": {
+                                          "description": "Share of the 0-99 bucket range, out of 100",
+                                          "type": "number"
+                                        }
+                                      },
+                                      "required": [
+                                        "value",
+                                        "weight"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    "type": "array"
+                                  }
+                                },
+                                "required": [
+                                  "split"
+                                ],
+                                "type": "object"
+                              }
+                            ],
+                            "description": "What to serve when the rule matches"
+                          },
+                          "when": {
+                            "description": "Conditions that must all match for this rule to apply",
+                            "items": {
+                              "properties": {
+                                "attribute": {
+                                  "description": "Attribute name to inspect on the evaluation context",
+                                  "type": "string"
+                                },
+                                "op": {
+                                  "description": "Comparison operator",
+                                  "enum": [
+                                    "eq",
+                                    "neq",
+                                    "in",
+                                    "gte",
+                                    "lte"
+                                  ],
+                                  "type": "string"
+                                },
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "number"
+                                          }
+                                        ]
+                                      },
+                                      "type": "array"
+                                    }
+                                  ],
+                                  "description": "Value to compare against; an array is required for the \"in\" operator"
+                                }
+                              },
+                              "required": [
+                                "attribute",
+                                "op",
+                                "value"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "serve",
+                          "when"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    },
+                    "variants": {
+                      "description": "Allowed variant names (variant-kind flags only)",
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "archived",
+                    "defaultValue",
+                    "description",
+                    "enabled",
+                    "key",
+                    "kind",
+                    "rules"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "flags"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "flags"
+          ],
+          "trailId": "flag.list"
+        },
+        {
+          "description": "Update the description, default value, or variants of a flag",
+          "exportName": "flagUpdate",
+          "input": {
+            "properties": {
+              "defaultValue": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "New default value, servable for the flag kind"
+              },
+              "description": {
+                "description": "New description",
+                "type": "string"
+              },
+              "key": {
+                "description": "Flag key to update",
+                "type": "string"
+              },
+              "variants": {
+                "description": "Allowed variant names (variant-kind flags only)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "key"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "archived": {
+                "description": "Archived flags are hidden and cannot be evaluated",
+                "type": "boolean"
+              },
+              "defaultValue": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "Value served when disabled or when no rule matches"
+              },
+              "description": {
+                "description": "What the flag controls",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Disabled flags always serve the default value",
+                "type": "boolean"
+              },
+              "key": {
+                "description": "Unique kebab-case flag key",
+                "type": "string"
+              },
+              "kind": {
+                "description": "boolean serves true/false; variant serves a named variant",
+                "enum": [
+                  "boolean",
+                  "variant"
+                ],
+                "type": "string"
+              },
+              "rules": {
+                "description": "Ordered rules; first full match wins",
+                "items": {
+                  "properties": {
+                    "id": {
+                      "description": "Stable rule identifier, unique within the flag",
+                      "type": "string"
+                    },
+                    "serve": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ],
+                              "description": "Fixed value to serve"
+                            }
+                          },
+                          "required": [
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "properties": {
+                            "split": {
+                              "description": "Weighted arms; weights must total 100",
+                              "items": {
+                                "properties": {
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "Value served when the subject buckets into this arm"
+                                  },
+                                  "weight": {
+                                    "description": "Share of the 0-99 bucket range, out of 100",
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "value",
+                                  "weight"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "split"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "description": "What to serve when the rule matches"
+                    },
+                    "when": {
+                      "description": "Conditions that must all match for this rule to apply",
+                      "items": {
+                        "properties": {
+                          "attribute": {
+                            "description": "Attribute name to inspect on the evaluation context",
+                            "type": "string"
+                          },
+                          "op": {
+                            "description": "Comparison operator",
+                            "enum": [
+                              "eq",
+                              "neq",
+                              "in",
+                              "gte",
+                              "lte"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "Value to compare against; an array is required for the \"in\" operator"
+                          }
+                        },
+                        "required": [
+                          "attribute",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "serve",
+                    "when"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "variants": {
+                "description": "Allowed variant names (variant-kind flags only)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "archived",
+              "defaultValue",
+              "description",
+              "enabled",
+              "key",
+              "kind",
+              "rules"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "flags"
+          ],
+          "trailId": "flag.update"
+        },
+        {
+          "description": "Add an ordered rule to a flag; earlier rules win, so position matters",
+          "exportName": "ruleAdd",
+          "input": {
+            "properties": {
+              "key": {
+                "description": "Flag key to add the rule to",
+                "type": "string"
+              },
+              "position": {
+                "description": "Insertion index; appended when omitted",
+                "type": "number"
+              },
+              "rule": {
+                "description": "The rule to add",
+                "properties": {
+                  "id": {
+                    "description": "Stable rule identifier, unique within the flag",
+                    "type": "string"
+                  },
+                  "serve": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              }
+                            ],
+                            "description": "Fixed value to serve"
+                          }
+                        },
+                        "required": [
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      {
+                        "properties": {
+                          "split": {
+                            "description": "Weighted arms; weights must total 100",
+                            "items": {
+                              "properties": {
+                                "value": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    },
+                                    {
+                                      "type": "boolean"
+                                    }
+                                  ],
+                                  "description": "Value served when the subject buckets into this arm"
+                                },
+                                "weight": {
+                                  "description": "Share of the 0-99 bucket range, out of 100",
+                                  "type": "number"
+                                }
+                              },
+                              "required": [
+                                "value",
+                                "weight"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
+                          }
+                        },
+                        "required": [
+                          "split"
+                        ],
+                        "type": "object"
+                      }
+                    ],
+                    "description": "What to serve when the rule matches"
+                  },
+                  "when": {
+                    "description": "Conditions that must all match for this rule to apply",
+                    "items": {
+                      "properties": {
+                        "attribute": {
+                          "description": "Attribute name to inspect on the evaluation context",
+                          "type": "string"
+                        },
+                        "op": {
+                          "description": "Comparison operator",
+                          "enum": [
+                            "eq",
+                            "neq",
+                            "in",
+                            "gte",
+                            "lte"
+                          ],
+                          "type": "string"
+                        },
+                        "value": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "items": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "number"
+                                  }
+                                ]
+                              },
+                              "type": "array"
+                            }
+                          ],
+                          "description": "Value to compare against; an array is required for the \"in\" operator"
+                        }
+                      },
+                      "required": [
+                        "attribute",
+                        "op",
+                        "value"
+                      ],
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "id",
+                  "serve",
+                  "when"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "key",
+              "rule"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "archived": {
+                "description": "Archived flags are hidden and cannot be evaluated",
+                "type": "boolean"
+              },
+              "defaultValue": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "Value served when disabled or when no rule matches"
+              },
+              "description": {
+                "description": "What the flag controls",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Disabled flags always serve the default value",
+                "type": "boolean"
+              },
+              "key": {
+                "description": "Unique kebab-case flag key",
+                "type": "string"
+              },
+              "kind": {
+                "description": "boolean serves true/false; variant serves a named variant",
+                "enum": [
+                  "boolean",
+                  "variant"
+                ],
+                "type": "string"
+              },
+              "rules": {
+                "description": "Ordered rules; first full match wins",
+                "items": {
+                  "properties": {
+                    "id": {
+                      "description": "Stable rule identifier, unique within the flag",
+                      "type": "string"
+                    },
+                    "serve": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ],
+                              "description": "Fixed value to serve"
+                            }
+                          },
+                          "required": [
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "properties": {
+                            "split": {
+                              "description": "Weighted arms; weights must total 100",
+                              "items": {
+                                "properties": {
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "Value served when the subject buckets into this arm"
+                                  },
+                                  "weight": {
+                                    "description": "Share of the 0-99 bucket range, out of 100",
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "value",
+                                  "weight"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "split"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "description": "What to serve when the rule matches"
+                    },
+                    "when": {
+                      "description": "Conditions that must all match for this rule to apply",
+                      "items": {
+                        "properties": {
+                          "attribute": {
+                            "description": "Attribute name to inspect on the evaluation context",
+                            "type": "string"
+                          },
+                          "op": {
+                            "description": "Comparison operator",
+                            "enum": [
+                              "eq",
+                              "neq",
+                              "in",
+                              "gte",
+                              "lte"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "Value to compare against; an array is required for the \"in\" operator"
+                          }
+                        },
+                        "required": [
+                          "attribute",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "serve",
+                    "when"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "variants": {
+                "description": "Allowed variant names (variant-kind flags only)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "archived",
+              "defaultValue",
+              "description",
+              "enabled",
+              "key",
+              "kind",
+              "rules"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "flags"
+          ],
+          "trailId": "rule.add"
+        },
+        {
+          "description": "Remove a rule from a flag by rule id",
+          "exportName": "ruleRemove",
+          "input": {
+            "properties": {
+              "key": {
+                "description": "Flag key to remove the rule from",
+                "type": "string"
+              },
+              "ruleId": {
+                "description": "Rule id to remove",
+                "type": "string"
+              }
+            },
+            "required": [
+              "key",
+              "ruleId"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "archived": {
+                "description": "Archived flags are hidden and cannot be evaluated",
+                "type": "boolean"
+              },
+              "defaultValue": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "Value served when disabled or when no rule matches"
+              },
+              "description": {
+                "description": "What the flag controls",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Disabled flags always serve the default value",
+                "type": "boolean"
+              },
+              "key": {
+                "description": "Unique kebab-case flag key",
+                "type": "string"
+              },
+              "kind": {
+                "description": "boolean serves true/false; variant serves a named variant",
+                "enum": [
+                  "boolean",
+                  "variant"
+                ],
+                "type": "string"
+              },
+              "rules": {
+                "description": "Ordered rules; first full match wins",
+                "items": {
+                  "properties": {
+                    "id": {
+                      "description": "Stable rule identifier, unique within the flag",
+                      "type": "string"
+                    },
+                    "serve": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ],
+                              "description": "Fixed value to serve"
+                            }
+                          },
+                          "required": [
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "properties": {
+                            "split": {
+                              "description": "Weighted arms; weights must total 100",
+                              "items": {
+                                "properties": {
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "Value served when the subject buckets into this arm"
+                                  },
+                                  "weight": {
+                                    "description": "Share of the 0-99 bucket range, out of 100",
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "value",
+                                  "weight"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "split"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "description": "What to serve when the rule matches"
+                    },
+                    "when": {
+                      "description": "Conditions that must all match for this rule to apply",
+                      "items": {
+                        "properties": {
+                          "attribute": {
+                            "description": "Attribute name to inspect on the evaluation context",
+                            "type": "string"
+                          },
+                          "op": {
+                            "description": "Comparison operator",
+                            "enum": [
+                              "eq",
+                              "neq",
+                              "in",
+                              "gte",
+                              "lte"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "Value to compare against; an array is required for the \"in\" operator"
+                          }
+                        },
+                        "required": [
+                          "attribute",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "serve",
+                    "when"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "variants": {
+                "description": "Allowed variant names (variant-kind flags only)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "archived",
+              "defaultValue",
+              "description",
+              "enabled",
+              "key",
+              "kind",
+              "rules"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "flags"
+          ],
+          "trailId": "rule.remove"
+        },
+        {
+          "description": "Reorder the rules of a flag; the list must be a permutation of the current rule ids",
+          "exportName": "ruleReorder",
+          "input": {
+            "properties": {
+              "key": {
+                "description": "Flag key to reorder rules on",
+                "type": "string"
+              },
+              "ruleIds": {
+                "description": "Complete rule id list in the new order",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "key",
+              "ruleIds"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "archived": {
+                "description": "Archived flags are hidden and cannot be evaluated",
+                "type": "boolean"
+              },
+              "defaultValue": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  }
+                ],
+                "description": "Value served when disabled or when no rule matches"
+              },
+              "description": {
+                "description": "What the flag controls",
+                "type": "string"
+              },
+              "enabled": {
+                "description": "Disabled flags always serve the default value",
+                "type": "boolean"
+              },
+              "key": {
+                "description": "Unique kebab-case flag key",
+                "type": "string"
+              },
+              "kind": {
+                "description": "boolean serves true/false; variant serves a named variant",
+                "enum": [
+                  "boolean",
+                  "variant"
+                ],
+                "type": "string"
+              },
+              "rules": {
+                "description": "Ordered rules; first full match wins",
+                "items": {
+                  "properties": {
+                    "id": {
+                      "description": "Stable rule identifier, unique within the flag",
+                      "type": "string"
+                    },
+                    "serve": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "value": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "number"
+                                },
+                                {
+                                  "type": "boolean"
+                                }
+                              ],
+                              "description": "Fixed value to serve"
+                            }
+                          },
+                          "required": [
+                            "value"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "properties": {
+                            "split": {
+                              "description": "Weighted arms; weights must total 100",
+                              "items": {
+                                "properties": {
+                                  "value": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      },
+                                      {
+                                        "type": "boolean"
+                                      }
+                                    ],
+                                    "description": "Value served when the subject buckets into this arm"
+                                  },
+                                  "weight": {
+                                    "description": "Share of the 0-99 bucket range, out of 100",
+                                    "type": "number"
+                                  }
+                                },
+                                "required": [
+                                  "value",
+                                  "weight"
+                                ],
+                                "type": "object"
+                              },
+                              "type": "array"
+                            }
+                          },
+                          "required": [
+                            "split"
+                          ],
+                          "type": "object"
+                        }
+                      ],
+                      "description": "What to serve when the rule matches"
+                    },
+                    "when": {
+                      "description": "Conditions that must all match for this rule to apply",
+                      "items": {
+                        "properties": {
+                          "attribute": {
+                            "description": "Attribute name to inspect on the evaluation context",
+                            "type": "string"
+                          },
+                          "op": {
+                            "description": "Comparison operator",
+                            "enum": [
+                              "eq",
+                              "neq",
+                              "in",
+                              "gte",
+                              "lte"
+                            ],
+                            "type": "string"
+                          },
+                          "value": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "items": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "number"
+                                    }
+                                  ]
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "Value to compare against; an array is required for the \"in\" operator"
+                          }
+                        },
+                        "required": [
+                          "attribute",
+                          "op",
+                          "value"
+                        ],
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "serve",
+                    "when"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "variants": {
+                "description": "Allowed variant names (variant-kind flags only)",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "archived",
+              "defaultValue",
+              "description",
+              "enabled",
+              "key",
+              "kind",
+              "rules"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "flags"
+          ],
+          "trailId": "rule.reorder"
+        }
+      ]
+    },
+    "topoGraphSchemaVersion": 3
+  },
+  "topoGraphHash": "57b5de27c4874c50d545c5f1b8a0be231ed18812c6e4ae5f7fc9967d1345d219",
+  "version": 4
+}

--- a/examples/switchback/tsconfig.json
+++ b/examples/switchback/tsconfig.json
@@ -4,6 +4,6 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["src"],
+  "include": ["src", "bin", "scripts"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
 }

--- a/examples/switchback/tsconfig.tests.json
+++ b/examples/switchback/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
Builds the `switchback` showcase app end to end per [TRL-1151](https://linear.app/outfitter/issue/TRL-1151/build-switchback-per-prd-fable-goal-run) and the binding [PRD: switchback — feature flags (library-first showcase)](https://linear.app/outfitter/document/prd-switchback-feature-flags-library-first-showcase-4af67844d18e), replacing the placeholder workspace at `examples/switchback/`.

## What this is

The library-first showcase: one authored trail contract consumed as an in-process library import, a CLI command, and an MCP tool with zero divergence. 13 trails, 2 resources (file-backed `flags` — deliberately not a database — and the in-memory `audit` demo log), 28 examples.

The hero, `flag.evaluate`, is a pure deterministic function of (flag definition, evaluation context): seeded FNV-1a 32-bit bucketing over the UTF-8 bytes of `"<flagKey>:<subjectId>"` (documented in `src/engine.ts`), rule-by-rule `EvalTrace` in every result, no clock, no randomness, no I/O beyond the flags resource. Fixed vectors (`checkout-v2:user-1 → 7`, `checkout-v2:user-42 → 10`, `dark-mode:user-1 → 58`) are pinned in tests forever.

## Verification evidence (all local, this branch)

- `bun test examples/switchback/` — 107 pass / 0 fail across 7 files: `testAll(app)` with mock resources (28 examples, exact expected traces), CLI/MCP/HTTP `testSurfaceParity` for all 13 trails, library projection + client tests, file-store behavior + fixture/JSON sync, governance, and quickstart-verbatim tests.
- `trails warden --root-dir examples/switchback` — **0 errors** (8 advisory `permit.writeWithoutPermit` warnings; permits are junction's showcase), `drift.stale: false`, `passed: true`. `library-projection-coherence` is topo-aware and runs in this pass; `governance.test.ts` re-asserts 0 errors + no lock drift in CI.
- Committed `examples/switchback/trails.lock` embeds the graph (hash `57b5de27…`) and the collision-free library projection (13 exports, `flagEvaluate` included).
- `bun pm pack --dry-run` — packs cleanly (18 files: src, bin, demo data, README; no tests).
- `bun run check` from repo root — green (exit 0).
- Wayfinder navigable: `trails wayfind --overview --root-dir examples/switchback --json` reports source `trails.lock`, drift `aligned`, 13 trails / 2 resources / 28 examples; per-trail views work.
- MCP stdio smoke: `tools/list` returns all 13 `switchback_*` tools including `switchback_flag_evaluate`.
- README quickstart executes verbatim (`quickstart.ts` + the CLI invocation are run by `src/__tests__/quickstart.test.ts` in CI).

## Framework gaps found while building (dogfood payoff)

Filed per the examples hard rule (no `packages/*`, `adapters/*`, or root-config changes in this PR; fieldwork notes captured):

- [TRL-1184](https://linear.app/outfitter/issue/TRL-1184/fresh-app-load-fails-with-opaque-internal-server-error-when-app) — fresh app load fails with an opaque "Internal server error" when app sources use extensionless relative imports (worked around with explicit `.js` suffixes).
- [TRL-1185](https://linear.app/outfitter/issue/TRL-1185/stale-per-user-topo-store-makes-trails-compile-force-write-an-outdated) — stale per-user topo store makes `trails compile --force` write an outdated graph into `trails.lock` (worked around by clearing `~/.local/state/trails/projects/<key>`).

## Notes for reviewers

- One PRD interpretation: the goal pins `flag.evaluate` to "no I/O beyond the flags resource", while the PRD's optional demo eval log implies recording evaluations. Resolution: single-flag `flag.evaluate` stays hermetically pure (`resources: [flags]` only); the bulk `flag.evaluate-all` bootstrap records its payloads in the in-memory `audit` resource behind `audit.list`. Both PRD lines hold.
- `wayfinder-dogfood` smoke: not applicable — example-only PR, no framework surfaces change (per `examples/README.md`).
- No changeset: example workspaces are private and outside release discovery.
