### PR TITLE
feat(cloudflare): add workers materializer and kv resource

### DIFF
--- a/.changeset/cloudflare-workers-kv.md
+++ b/.changeset/cloudflare-workers-kv.md
@@ -1,0 +1,11 @@
+---
+'@ontrails/cloudflare': minor
+'@ontrails/core': patch
+'@ontrails/warden': patch
+---
+
+Add the `@ontrails/cloudflare` adapter collection with its first two service subpaths. `@ontrails/cloudflare/workers` exports `createWorkersHandler`, a materializer producing the `{ fetch(request, env, ctx) }` Worker export on the shared HTTP fetch kernel, with an env bridge that re-resolves env-bound resources whenever a new Worker `env` arrives so no resource instance serves a request with a stale env. `@ontrails/cloudflare/kv` exports `cloudflareKv`, a resource definition wrapping a KV namespace binding (`get`/`put`/`delete`/`list` with TTL options) plus an in-memory `createMemoryKv` mock so `testAll` runs configuration-free.
+
+`@ontrails/core` now guards the default trail context fields: `requestId` falls back to `crypto.randomUUID()` when the `Bun` global is absent, and `cwd`/`env` fall back to `'/'`/`{}` when `process` is absent, so trail execution works on runtimes like Cloudflare Workers.
+
+`@ontrails/warden` registers the `@ontrails/cloudflare` public barrel in the repo-local `public-export-example-coverage` policy, requiring `@example` TSDoc coverage on `createWorkersHandler` and `cloudflareKv`.

--- a/adapters/cloudflare/README.md
+++ b/adapters/cloudflare/README.md
@@ -37,7 +37,7 @@ export default createWorkersHandler(graph, {
 Worker bindings (KV, D1, R2, queues) live on `env`, which arrives per request — they cannot be captured at module init. The bridge closes that gap once, for every subpath in this collection:
 
 1. A subpath authors an ordinary `resource()` definition and registers an `EnvBindingSpec` for it (`registerEnvBinding(definition, { binding, fromEnv })`).
-2. `createWorkersHandler` walks the topo's declared resources, and for each env-bound definition resolves `env[binding]` through `fromEnv` into a resource override.
+2. `createWorkersHandler` walks the declared resources of the trails the surface actually exposes (honoring `include`/`exclude`/`intent`, and including fork-version resources), and for each env-bound definition resolves `env[binding]` through `fromEnv` into a resource override. Explicitly overridden resource IDs skip env resolution entirely, so an override never requires its binding.
 3. The kernel handler is materialized per env identity. The Workers runtime keeps `env` stable within an isolate, so steady-state requests reuse one materialization — but any request carrying a different env object re-resolves every env-bound resource before it executes.
 
 Because resource overrides are checked before core's singleton resource cache, no resource instance can serve a request with a stale env. This guarantee has a dedicated regression test (`src/workers/__tests__/env-bridge.test.ts`).

--- a/adapters/cloudflare/README.md
+++ b/adapters/cloudflare/README.md
@@ -1,0 +1,103 @@
+# @ontrails/cloudflare
+
+The Cloudflare adapter collection for Trails. One package, one subpath per Cloudflare service, each connecting a service to the Trails primitive it naturally serves:
+
+| Subpath | Serves | Status |
+| --- | --- | --- |
+| `@ontrails/cloudflare/workers` | HTTP surface materializer (fetch handler) | ✅ |
+| `@ontrails/cloudflare/kv` | Key-value resource | ✅ |
+| `/d1` | Store driver | Planned |
+| `/queues` | Activation source + outbound delivery | Planned |
+| `/r2` | Blob/object resource | Planned |
+
+Adapter composition doctrine applies throughout: subpaths take primitive-authored declarations (a resource definition, a surface config) and never shadow authoring verbs. Bindings arrive ambiently on the Worker `env`, so runtime dependencies are near-zero.
+
+## `/workers` — the fetch-handler materializer
+
+`createWorkersHandler(graph, options)` produces the `{ fetch(request, env, ctx) }` Worker export by delegating to the shared HTTP fetch kernel from `@ontrails/http` — the same kernel behind the Bun and Hono surfaces, so routes, validation, error projection, and webhook handling behave identically.
+
+```ts
+// src/worker.ts
+import { createWorkersHandler } from '@ontrails/cloudflare/workers';
+import { graph } from './app.js';
+
+export default createWorkersHandler(graph, { basePath: '/api' });
+```
+
+Options mirror the other HTTP surfaces: `basePath`, `createContext`, `layers`, `maxJsonBodyBytes`, `resolvePermit`, plus include/exclude/intent filtering. `resources` accepts either a static override map or a function of the Worker env:
+
+```ts
+export default createWorkersHandler(graph, {
+  resources: (env) => ({ audit: createAuditClient(env['AUDIT_URL']) }),
+});
+```
+
+### The env bridge
+
+Worker bindings (KV, D1, R2, queues) live on `env`, which arrives per request — they cannot be captured at module init. The bridge closes that gap once, for every subpath in this collection:
+
+1. A subpath authors an ordinary `resource()` definition and registers an `EnvBindingSpec` for it (`registerEnvBinding(definition, { binding, fromEnv })`).
+2. `createWorkersHandler` walks the topo's declared resources, and for each env-bound definition resolves `env[binding]` through `fromEnv` into a resource override.
+3. The kernel handler is materialized per env identity. The Workers runtime keeps `env` stable within an isolate, so steady-state requests reuse one materialization — but any request carrying a different env object re-resolves every env-bound resource before it executes.
+
+Because resource overrides are checked before core's singleton resource cache, no resource instance can serve a request with a stale env. This guarantee has a dedicated regression test (`src/workers/__tests__/env-bridge.test.ts`).
+
+Missing or mistyped bindings fail the request with a redacted 500 and log full diagnostics to the Worker log, naming the binding and the resource that needed it.
+
+### Runtime notes
+
+These come straight from the runtime-constraint audit that shipped with this subpath (each is also filed as a Trails issue):
+
+- Enable the `nodejs_compat` compatibility flag and use a recent `compatibility_date`: modules on the `@ontrails/core` barrel import `node:fs`, `node:path`, and `node:crypto`, and workerd's `node:fs` support is compatibility-date gated (the integration lane pins `2026-06-01`).
+- Stub `bun:sqlite` in your Worker bundle: the core barrel re-exports `trails-db.js`, whose top-level `import { Database } from 'bun:sqlite'` survives bundling even though the Worker never calls it, and workerd refuses module graphs importing `bun:sqlite`. With wrangler, alias it to a stub module (see the `bunSqliteStub` plugin in `src/__tests__/miniflare.test.ts` for the shape).
+- Explicit `resources` overrides win over env-bound resolution, which is how tests substitute fakes.
+
+## `/kv` — the key-value resource
+
+`cloudflareKv(id, { binding })` authors a resource wrapping a KV namespace binding. Trails declare it with `resources: [...]` and read it with `flags.from(ctx)` — the standard accessor pattern.
+
+```ts
+import { cloudflareKv } from '@ontrails/cloudflare/kv';
+import { trail, Result } from '@ontrails/core';
+import { z } from 'zod';
+
+const flags = cloudflareKv('flags', { binding: 'FLAGS' });
+
+const showFlag = trail('flag.show', {
+  blaze: async (input, ctx) => {
+    const value = await flags.from(ctx).get(input.key);
+    return Result.ok({ value });
+  },
+  input: z.object({ key: z.string() }),
+  intent: 'read',
+  output: z.object({ value: z.string().nullable() }),
+  resources: [flags],
+});
+```
+
+The client surface is `get`/`put`/`delete`/`list`, with TTL options on `put` (`expirationTtl` in seconds, or an absolute `expiration` Unix timestamp) and prefix/limit/cursor pagination on `list`. A real `KVNamespace` binding satisfies the shape structurally, so the env bridge passes it through unchanged.
+
+Declare the binding in wrangler config:
+
+```toml
+kv_namespaces = [
+  { binding = "FLAGS", id = "<namespace-id>" }
+]
+```
+
+### Testing with the mock
+
+Every `cloudflareKv` resource carries an in-memory mock factory, so `testAll(app)` runs configuration-free — no Cloudflare account, no wrangler:
+
+```ts
+import { testAll } from '@ontrails/testing';
+import { graph } from '../src/app.js';
+
+testAll(graph);
+```
+
+`createMemoryKv()` is also exported directly for hand-rolled tests, with an injectable clock for TTL assertions. Two documented divergences from the real binding: the mock does not enforce KV's 60-second minimum TTL, and when both `expiration` and `expirationTtl` are passed the mock prefers `expirationTtl` where the real binding rejects the combination.
+
+## Local integration testing
+
+Integration runs are local-first via [miniflare](https://miniflare.dev) (workerd in-process): the test lane bundles a demo Worker with `Bun.build`, boots it with a real KV namespace, and exercises HTTP, webhook, and KV routes. See `src/__tests__/miniflare.test.ts`. Real-account deploys are manual and never CI-required.

--- a/adapters/cloudflare/package.json
+++ b/adapters/cloudflare/package.json
@@ -13,6 +13,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./workers": "./src/workers/index.ts",
+    "./kv": "./src/kv/index.ts",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/adapters/cloudflare/package.json
+++ b/adapters/cloudflare/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@ontrails/cloudflare",
+  "version": "1.0.0-beta.37",
+  "files": [
+    "src/**/*.ts",
+    "!src/**/__tests__/**",
+    "!src/**/*.test.ts",
+    "!src/**/*.test-d.ts",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./workers": "./src/workers/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint ./src",
+    "clean": "rm -rf dist *.tsbuildinfo"
+  },
+  "dependencies": {
+    "@ontrails/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@ontrails/testing": "workspace:^",
+    "miniflare": "^4.20250617.4"
+  },
+  "peerDependencies": {
+    "@ontrails/http": "workspace:^",
+    "zod": "catalog:"
+  },
+  "trails": {
+    "adapter": {
+      "target": "http"
+    }
+  }
+}

--- a/adapters/cloudflare/src/__tests__/fixtures/demo-worker.ts
+++ b/adapters/cloudflare/src/__tests__/fixtures/demo-worker.ts
@@ -1,0 +1,82 @@
+/**
+ * Demo Worker for the miniflare integration lane.
+ *
+ * A small Trails app serving HTTP routes (read + write), a webhook route,
+ * and a KV-backed trail — the wired combination the README teaches. Bundled
+ * by `../miniflare.test.ts` and executed under workerd via miniflare.
+ */
+
+import {
+  getWebhookHeader,
+  PermissionError,
+  Result,
+  topo,
+  trail,
+  webhook,
+} from '@ontrails/core';
+import { z } from 'zod';
+
+import { cloudflareKv } from '../../kv/index.js';
+import { createWorkersHandler } from '../../workers/index.js';
+
+const flags = cloudflareKv('flags', { binding: 'FLAGS' });
+
+const ping = trail('ping', {
+  blaze: (input) => Result.ok({ reply: `pong:${input.message}` }),
+  input: z.object({ message: z.string() }),
+  intent: 'read',
+  output: z.object({ reply: z.string() }),
+});
+
+const saveFlag = trail('flag.save', {
+  blaze: async (input, ctx) => {
+    await flags.from(ctx).put(input.key, input.value);
+    return Result.ok({ saved: true });
+  },
+  input: z.object({ key: z.string(), value: z.string() }),
+  intent: 'write',
+  output: z.object({ saved: z.boolean() }),
+  resources: [flags],
+});
+
+const showFlag = trail('flag.show', {
+  blaze: async (input, ctx) => {
+    const value = await flags.from(ctx).get(input.key);
+    return Result.ok({ value });
+  },
+  input: z.object({ key: z.string() }),
+  intent: 'read',
+  output: z.object({ value: z.string().nullable() }),
+  resources: [flags],
+});
+
+const deploySecret = 'demo-secret';
+const deployWebhook = webhook('webhook.deploy.finished', {
+  parse: z.object({ deployId: z.string() }),
+  path: '/webhooks/deploy',
+  verify: (request) =>
+    getWebhookHeader(request, 'x-webhook-secret') === deploySecret
+      ? Result.ok()
+      : Result.err(new PermissionError('Invalid webhook secret')),
+});
+
+const recordDeploy = trail('deploy.record', {
+  blaze: async (input, ctx) => {
+    await flags.from(ctx).put(`deploy/${input.deployId}`, 'finished');
+    return Result.ok({ deployId: input.deployId });
+  },
+  input: z.object({ deployId: z.string() }),
+  on: [deployWebhook],
+  output: z.object({ deployId: z.string() }),
+  resources: [flags],
+});
+
+const graph = topo('cf-demo', {
+  flags,
+  ping,
+  recordDeploy,
+  saveFlag,
+  showFlag,
+});
+
+export default createWorkersHandler(graph);

--- a/adapters/cloudflare/src/__tests__/miniflare.test.ts
+++ b/adapters/cloudflare/src/__tests__/miniflare.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Miniflare integration lane: bundles the demo Worker fixture and executes it
+ * under workerd. This is the local-first integration proof — no Cloudflare
+ * account is required — covering HTTP routes, a webhook route, and the KV
+ * resource served through the env bridge.
+ */
+
+import type { BunPlugin } from 'bun';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { Miniflare } from 'miniflare';
+
+const fixtureEntrypoint = new URL('fixtures/demo-worker.ts', import.meta.url)
+  .pathname;
+
+/**
+ * Runtime-constraint audit workaround (TRL: bun:sqlite in the core barrel):
+ * `@ontrails/core` re-exports `trails-db.js`, whose top-level
+ * `import { Database } from 'bun:sqlite'` survives bundling even though the
+ * Worker never touches it. workerd refuses module graphs that import
+ * `bun:sqlite`, so Worker bundles must stub it — the same aliasing a wrangler
+ * consumer would configure. Filed as a fix-or-document issue; remove this
+ * stub once core stops importing bun:sqlite eagerly on the barrel path.
+ */
+const bunSqliteStub: BunPlugin = {
+  name: 'stub-bun-sqlite',
+  setup(build) {
+    build.onResolve({ filter: /^bun:sqlite$/ }, () => ({
+      namespace: 'bun-sqlite-stub',
+      path: 'bun:sqlite',
+    }));
+    build.onLoad({ filter: /.*/, namespace: 'bun-sqlite-stub' }, () => ({
+      contents:
+        'export class Database { constructor() { throw new Error("bun:sqlite is unavailable on Cloudflare Workers"); } }',
+      loader: 'js',
+    }));
+  },
+};
+
+const bundleWorkerScript = async (): Promise<string> => {
+  const build = await Bun.build({
+    entrypoints: [fixtureEntrypoint],
+    external: ['node:*'],
+    format: 'esm',
+    minify: false,
+    plugins: [bunSqliteStub],
+    target: 'browser',
+  });
+  if (!build.success) {
+    throw new Error(
+      `Worker bundle failed: ${build.logs.map((log) => log.message).join('\n')}`
+    );
+  }
+  const [output] = build.outputs;
+  if (output === undefined) {
+    throw new Error('Worker bundle produced no output');
+  }
+  return await output.text();
+};
+
+describe('demo worker under miniflare', () => {
+  let mf: Miniflare;
+
+  beforeAll(async () => {
+    const script = await bundleWorkerScript();
+    mf = new Miniflare({
+      compatibilityDate: '2026-06-01',
+      compatibilityFlags: ['nodejs_compat'],
+      kvNamespaces: ['FLAGS'],
+      modules: true,
+      script,
+    });
+    await mf.ready;
+  }, 120_000);
+
+  afterAll(async () => {
+    await mf.dispose();
+  });
+
+  test('serves a read trail over HTTP', async () => {
+    const response = await mf.dispatchFetch('http://localhost/ping?message=hi');
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: { reply: 'pong:hi' } });
+  });
+
+  test('serves KV-backed write and read trails through the env bridge', async () => {
+    const saved = await mf.dispatchFetch('http://localhost/flag/save', {
+      body: JSON.stringify({ key: 'color', value: 'red' }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+    expect(saved.status).toBe(200);
+    expect(await saved.json()).toEqual({ data: { saved: true } });
+
+    const shown = await mf.dispatchFetch(
+      'http://localhost/flag/show?key=color'
+    );
+    expect(shown.status).toBe(200);
+    expect(await shown.json()).toEqual({ data: { value: 'red' } });
+  });
+
+  test('serves a webhook route with verification', async () => {
+    const accepted = await mf.dispatchFetch(
+      'http://localhost/webhooks/deploy',
+      {
+        body: JSON.stringify({ deployId: 'dep_1' }),
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Secret': 'demo-secret',
+        },
+        method: 'POST',
+      }
+    );
+    expect(accepted.status).toBe(200);
+    expect(await accepted.json()).toEqual({ data: { deployId: 'dep_1' } });
+
+    const recorded = await mf.dispatchFetch(
+      'http://localhost/flag/show?key=deploy/dep_1'
+    );
+    expect(await recorded.json()).toEqual({ data: { value: 'finished' } });
+
+    const denied = await mf.dispatchFetch('http://localhost/webhooks/deploy', {
+      body: JSON.stringify({ deployId: 'dep_2' }),
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Webhook-Secret': 'wrong',
+      },
+      method: 'POST',
+    });
+    expect(denied.status).toBe(403);
+  });
+
+  test('returns the projected 404 for unknown routes', async () => {
+    const response = await mf.dispatchFetch('http://localhost/nope');
+    expect(response.status).toBe(404);
+  });
+});

--- a/adapters/cloudflare/src/env.ts
+++ b/adapters/cloudflare/src/env.ts
@@ -14,8 +14,19 @@
  * `/d1`, `/queues`, `/r2` later) consumes this one seam.
  */
 
-import { InternalError, Result } from '@ontrails/core';
-import type { AnyResource, ResourceOverrideMap, Topo } from '@ontrails/core';
+import {
+  InternalError,
+  matchesTrailPattern,
+  Result,
+  filterSurfaceTrails,
+} from '@ontrails/core';
+import type {
+  AnyResource,
+  BaseSurfaceOptions,
+  ResourceOverrideMap,
+  Topo,
+  Trail,
+} from '@ontrails/core';
 
 /**
  * The ambient Worker environment: bindings keyed by their wrangler-configured
@@ -85,11 +96,129 @@ export const getEnvBinding = (
   resourceDefinition: AnyResource
 ): EnvBindingSpec | undefined => envBindings.get(resourceDefinition);
 
-const collectEnvBoundResources = (graph: Topo): readonly AnyResource[] => {
+/**
+ * Options for {@link buildEnvResourceOverrides}.
+ *
+ * `exclude`/`include`/`intent` mirror the fetch kernel's surface selection so
+ * env resolution only considers trails the surface actually exposes — a
+ * filtered-out trail's bindings are never required. `except` names resource
+ * IDs already provided explicitly, which skip env resolution entirely.
+ */
+export interface BuildEnvResourceOverridesOptions extends Pick<
+  BaseSurfaceOptions,
+  'exclude' | 'include' | 'intent'
+> {
+  /** Resource IDs already provided explicitly; env resolution skips them. */
+  readonly except?: readonly string[] | undefined;
+}
+
+const isInternalTrail = (
+  graphTrail: Trail<unknown, unknown, unknown>
+): boolean =>
+  graphTrail.visibility === 'internal' ||
+  graphTrail.meta?.['internal'] === true;
+
+const matchesAnyPattern = (
+  trailId: string,
+  patterns: readonly string[] | undefined
+): boolean =>
+  patterns !== undefined &&
+  patterns.some((pattern) => matchesTrailPattern(trailId, pattern));
+
+const passesIncludeFilter = (
+  trailId: string,
+  include: readonly string[] | undefined
+): boolean =>
+  include === undefined ||
+  include.length === 0 ||
+  matchesAnyPattern(trailId, include);
+
+/**
+ * Mirror of the fetch kernel's webhook trail eligibility: webhook consumers
+ * become HTTP routes even though `filterSurfaceTrails` skips
+ * activation-driven trails, so the bridge applies the same rules here.
+ */
+const isEligibleWebhookTrail = (
+  graphTrail: Trail<unknown, unknown, unknown>,
+  options: BuildEnvResourceOverridesOptions
+): boolean => {
+  const hasWebhookSource = graphTrail.activationSources.some(
+    (activation) => activation.source.kind === 'webhook'
+  );
+  if (!hasWebhookSource) {
+    return false;
+  }
+  if (
+    isInternalTrail(graphTrail) &&
+    !options.include?.includes(graphTrail.id)
+  ) {
+    return false;
+  }
+  if (matchesAnyPattern(graphTrail.id, options.exclude)) {
+    return false;
+  }
+  if (!passesIncludeFilter(graphTrail.id, options.include)) {
+    return false;
+  }
+  return (
+    options.intent === undefined ||
+    options.intent.length === 0 ||
+    options.intent.includes(graphTrail.intent)
+  );
+};
+
+const collectSurfaceEligibleTrails = (
+  graph: Topo,
+  options: BuildEnvResourceOverridesOptions
+): readonly Trail<unknown, unknown, unknown>[] => {
+  const trails = graph.list();
+  const eligible = new Map<string, Trail<unknown, unknown, unknown>>();
+  const filtered = filterSurfaceTrails(trails, {
+    exclude: options.exclude,
+    include: options.include,
+    intent: options.intent,
+  });
+  for (const graphTrail of filtered) {
+    eligible.set(graphTrail.id, graphTrail);
+  }
+  for (const graphTrail of trails) {
+    if (
+      !eligible.has(graphTrail.id) &&
+      isEligibleWebhookTrail(graphTrail, options)
+    ) {
+      eligible.set(graphTrail.id, graphTrail);
+    }
+  }
+  return [...eligible.values()];
+};
+
+/**
+ * All resources a trail can execute with: the current contract's declarations
+ * plus any fork version entry's own `resources`, since core runs historical
+ * forks with the entry's resource set.
+ */
+const declaredTrailResources = (
+  graphTrail: Trail<unknown, unknown, unknown>
+): readonly AnyResource[] => [
+  ...graphTrail.resources,
+  ...Object.values(graphTrail.versions ?? {}).flatMap(
+    (entry) => entry.resources ?? []
+  ),
+];
+
+const collectEnvBoundResources = (
+  graph: Topo,
+  options: BuildEnvResourceOverridesOptions
+): readonly AnyResource[] => {
+  const except = new Set(options.except);
   const collected = new Map<string, AnyResource>();
-  for (const graphTrail of graph.list()) {
-    for (const declared of graphTrail.resources) {
-      if (!collected.has(declared.id) && envBindings.has(declared)) {
+  for (const graphTrail of collectSurfaceEligibleTrails(graph, options)) {
+    for (const declared of declaredTrailResources(graphTrail)) {
+      if (
+        !collected.has(declared.id) &&
+        !except.has(declared.id) &&
+        envBindings.has(declared)
+      ) {
         collected.set(declared.id, declared);
       }
     }
@@ -98,11 +227,15 @@ const collectEnvBoundResources = (graph: Topo): readonly AnyResource[] => {
 };
 
 /**
- * Resolve every env-bound resource declared by the topo's trails into a
- * resource override map for one Worker env.
+ * Resolve every env-bound resource declared by the topo's surface-eligible
+ * trails (including fork-version resources) into a resource override map for
+ * one Worker env.
  *
  * Returns `Result.err` when a required binding is missing from the env or a
- * binding value fails the resource's narrowing check.
+ * binding value fails the resource's narrowing check. Trails filtered off the
+ * surface by `exclude`/`include`/`intent` never require their bindings, and
+ * resource IDs listed in `except` are skipped because the caller already
+ * provides them.
  *
  * @example
  * ```ts
@@ -114,10 +247,11 @@ const collectEnvBoundResources = (graph: Topo): readonly AnyResource[] => {
  */
 export const buildEnvResourceOverrides = (
   graph: Topo,
-  env: WorkersEnv
+  env: WorkersEnv,
+  options: BuildEnvResourceOverridesOptions = {}
 ): Result<ResourceOverrideMap, Error> => {
   const overrides: Record<string, unknown> = {};
-  for (const declared of collectEnvBoundResources(graph)) {
+  for (const declared of collectEnvBoundResources(graph, options)) {
     const spec = envBindings.get(declared);
     if (spec === undefined) {
       continue;

--- a/adapters/cloudflare/src/env.ts
+++ b/adapters/cloudflare/src/env.ts
@@ -1,0 +1,141 @@
+/**
+ * The Cloudflare env bridge.
+ *
+ * Worker bindings (KV, D1, R2, queues) arrive per-request on the `env`
+ * argument of the Worker `fetch` handler. Trails resources are authored as
+ * ordinary `resource()` definitions, so this module provides the seam that
+ * connects the two: a subpath registers an {@link EnvBindingSpec} for each
+ * resource definition it authors, and the Workers materializer resolves those
+ * specs against the live `env` into per-materialization resource overrides.
+ *
+ * Overrides are re-resolved whenever a new `env` object arrives, and core
+ * resolves overrides before its singleton resource cache, so no resource
+ * instance can capture a stale env. Every Cloudflare subpath (`/kv` today,
+ * `/d1`, `/queues`, `/r2` later) consumes this one seam.
+ */
+
+import { InternalError, Result } from '@ontrails/core';
+import type { AnyResource, ResourceOverrideMap, Topo } from '@ontrails/core';
+
+/**
+ * The ambient Worker environment: bindings keyed by their wrangler-configured
+ * names. Values are runtime binding objects (KV namespaces, D1 databases,
+ * queues), so they are typed as `unknown` and narrowed by each subpath.
+ */
+export type WorkersEnv = Readonly<Record<string, unknown>>;
+
+/**
+ * How a resource definition materializes from the Worker env.
+ *
+ * `fromEnv` receives the raw binding value found at `env[binding]` and either
+ * narrows it into the resource instance or explains why the binding does not
+ * match the resource's expectations.
+ */
+export interface EnvBindingSpec {
+  /** The wrangler binding name to read from the Worker env. */
+  readonly binding: string;
+  /** Narrow the raw binding value into the resource instance. */
+  readonly fromEnv: (value: unknown) => Result<unknown, Error>;
+}
+
+const envBindings = new WeakMap<AnyResource, EnvBindingSpec>();
+
+/**
+ * Register an env binding for a resource definition.
+ *
+ * Called by Cloudflare subpaths (and available to apps authoring their own
+ * env-bound resources) so the Workers materializer knows how to build the
+ * resource instance from the per-request env.
+ *
+ * @example
+ * ```ts
+ * import { resource, Result } from '@ontrails/core';
+ * import { registerEnvBinding } from '@ontrails/cloudflare/workers';
+ *
+ * const queue = resource<{ send(body: string): Promise<void> }>('outbox', {
+ *   create: () => Result.err(new Error('outbox is only available on Workers')),
+ *   mock: () => ({ send: () => Promise.resolve() }),
+ * });
+ * registerEnvBinding(queue, {
+ *   binding: 'OUTBOX',
+ *   fromEnv: (value) => Result.ok(value),
+ * });
+ * ```
+ */
+export const registerEnvBinding = (
+  resourceDefinition: AnyResource,
+  spec: EnvBindingSpec
+): void => {
+  envBindings.set(resourceDefinition, spec);
+};
+
+/**
+ * Read the env binding registered for a resource definition, if any.
+ *
+ * @example
+ * ```ts
+ * import { getEnvBinding } from '@ontrails/cloudflare/workers';
+ * import { cloudflareKv } from '@ontrails/cloudflare/kv';
+ *
+ * const flags = cloudflareKv('flags', { binding: 'FLAGS' });
+ * getEnvBinding(flags)?.binding; // 'FLAGS'
+ * ```
+ */
+export const getEnvBinding = (
+  resourceDefinition: AnyResource
+): EnvBindingSpec | undefined => envBindings.get(resourceDefinition);
+
+const collectEnvBoundResources = (graph: Topo): readonly AnyResource[] => {
+  const collected = new Map<string, AnyResource>();
+  for (const graphTrail of graph.list()) {
+    for (const declared of graphTrail.resources) {
+      if (!collected.has(declared.id) && envBindings.has(declared)) {
+        collected.set(declared.id, declared);
+      }
+    }
+  }
+  return [...collected.values()];
+};
+
+/**
+ * Resolve every env-bound resource declared by the topo's trails into a
+ * resource override map for one Worker env.
+ *
+ * Returns `Result.err` when a required binding is missing from the env or a
+ * binding value fails the resource's narrowing check.
+ *
+ * @example
+ * ```ts
+ * import { buildEnvResourceOverrides } from '@ontrails/cloudflare/workers';
+ *
+ * const overrides = buildEnvResourceOverrides(graph, env);
+ * if (overrides.isErr()) throw overrides.error;
+ * ```
+ */
+export const buildEnvResourceOverrides = (
+  graph: Topo,
+  env: WorkersEnv
+): Result<ResourceOverrideMap, Error> => {
+  const overrides: Record<string, unknown> = {};
+  for (const declared of collectEnvBoundResources(graph)) {
+    const spec = envBindings.get(declared);
+    if (spec === undefined) {
+      continue;
+    }
+    const value = env[spec.binding];
+    if (value === undefined) {
+      return Result.err(
+        new InternalError(
+          `Worker env is missing binding "${spec.binding}" required by resource "${declared.id}". Declare the binding in your wrangler configuration (for example a kv_namespaces entry) or provide an explicit resource override.`,
+          { context: { binding: spec.binding, resourceId: declared.id } }
+        )
+      );
+    }
+    const instance = spec.fromEnv(value);
+    if (instance.isErr()) {
+      return instance;
+    }
+    overrides[declared.id] = instance.value;
+  }
+  return Result.ok(overrides);
+};

--- a/adapters/cloudflare/src/index.ts
+++ b/adapters/cloudflare/src/index.ts
@@ -1,0 +1,22 @@
+/**
+ * `@ontrails/cloudflare` — the Cloudflare adapter collection.
+ *
+ * Service subpaths are the primary entry points:
+ * - `@ontrails/cloudflare/workers` — HTTP surface materializer (fetch handler)
+ *
+ * The root export re-exports the subpaths for convenience and adapter tooling.
+ */
+
+export {
+  buildEnvResourceOverrides,
+  getEnvBinding,
+  registerEnvBinding,
+} from './env.js';
+export type { EnvBindingSpec, WorkersEnv } from './env.js';
+export { createWorkersHandler } from './workers/index.js';
+export type {
+  CloudflareWorker,
+  CreateWorkersHandlerOptions,
+  WorkersExecutionContext,
+  WorkersResourceOverrides,
+} from './workers/index.js';

--- a/adapters/cloudflare/src/index.ts
+++ b/adapters/cloudflare/src/index.ts
@@ -13,7 +13,11 @@ export {
   getEnvBinding,
   registerEnvBinding,
 } from './env.js';
-export type { EnvBindingSpec, WorkersEnv } from './env.js';
+export type {
+  BuildEnvResourceOverridesOptions,
+  EnvBindingSpec,
+  WorkersEnv,
+} from './env.js';
 export { cloudflareKv, createMemoryKv } from './kv/index.js';
 export type {
   CloudflareKv,

--- a/adapters/cloudflare/src/index.ts
+++ b/adapters/cloudflare/src/index.ts
@@ -3,6 +3,7 @@
  *
  * Service subpaths are the primary entry points:
  * - `@ontrails/cloudflare/workers` — HTTP surface materializer (fetch handler)
+ * - `@ontrails/cloudflare/kv` — key-value resource
  *
  * The root export re-exports the subpaths for convenience and adapter tooling.
  */
@@ -13,6 +14,16 @@ export {
   registerEnvBinding,
 } from './env.js';
 export type { EnvBindingSpec, WorkersEnv } from './env.js';
+export { cloudflareKv, createMemoryKv } from './kv/index.js';
+export type {
+  CloudflareKv,
+  CloudflareKvListKey,
+  CloudflareKvListOptions,
+  CloudflareKvListResult,
+  CloudflareKvOptions,
+  CloudflareKvPutOptions,
+  CreateMemoryKvOptions,
+} from './kv/index.js';
 export { createWorkersHandler } from './workers/index.js';
 export type {
   CloudflareWorker,

--- a/adapters/cloudflare/src/kv/__tests__/kv.test.ts
+++ b/adapters/cloudflare/src/kv/__tests__/kv.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from 'bun:test';
+import { Result, topo, trail } from '@ontrails/core';
+import { testAll } from '@ontrails/testing';
+import { z } from 'zod';
+
+import { cloudflareKv, createMemoryKv } from '../index.js';
+
+describe('createMemoryKv', () => {
+  test('round-trips put/get/delete', async () => {
+    const kv = createMemoryKv();
+
+    expect(await kv.get('color')).toBeNull();
+    await kv.put('color', 'red');
+    expect(await kv.get('color')).toBe('red');
+    await kv.delete('color');
+    expect(await kv.get('color')).toBeNull();
+  });
+
+  test('expires entries by expirationTtl', async () => {
+    let nowMs = 1_000_000;
+    const kv = createMemoryKv({ now: () => nowMs });
+
+    await kv.put('session', 'abc', { expirationTtl: 60 });
+    expect(await kv.get('session')).toBe('abc');
+
+    nowMs += 59_999;
+    expect(await kv.get('session')).toBe('abc');
+
+    nowMs += 1;
+    expect(await kv.get('session')).toBeNull();
+  });
+
+  test('expires entries by absolute expiration and prefers expirationTtl', async () => {
+    let nowMs = 5_000_000;
+    const kv = createMemoryKv({ now: () => nowMs });
+
+    await kv.put('absolute', 'x', { expiration: 5100 });
+    await kv.put('both', 'y', { expiration: 5100, expirationTtl: 300 });
+
+    nowMs = 5_100_000;
+    expect(await kv.get('absolute')).toBeNull();
+    expect(await kv.get('both')).toBe('y');
+
+    nowMs = 5_000_000 + 300_000;
+    expect(await kv.get('both')).toBeNull();
+  });
+
+  test('lists keys sorted with prefix filtering and expirations', async () => {
+    let nowMs = 1_000_000;
+    const kv = createMemoryKv({ now: () => nowMs });
+
+    await kv.put('flag/beta', 'on');
+    await kv.put('flag/alpha', 'off', { expirationTtl: 120 });
+    await kv.put('session/1', 'x');
+
+    const listed = await kv.list({ prefix: 'flag/' });
+    expect(listed.list_complete).toBe(true);
+    expect(listed.cursor).toBeUndefined();
+    expect(listed.keys).toEqual([
+      { expiration: 1120, name: 'flag/alpha' },
+      { name: 'flag/beta' },
+    ]);
+
+    nowMs += 121_000;
+    const afterExpiry = await kv.list({ prefix: 'flag/' });
+    expect(afterExpiry.keys).toEqual([{ name: 'flag/beta' }]);
+  });
+
+  test('paginates with limit and cursor', async () => {
+    const kv = createMemoryKv();
+    await kv.put('a', '1');
+    await kv.put('b', '2');
+    await kv.put('c', '3');
+
+    const first = await kv.list({ limit: 2 });
+    expect(first.keys.map((key) => key.name)).toEqual(['a', 'b']);
+    expect(first.list_complete).toBe(false);
+    expect(first.cursor).toBe('b');
+
+    const second = await kv.list({ cursor: first.cursor, limit: 2 });
+    expect(second.keys.map((key) => key.name)).toEqual(['c']);
+    expect(second.list_complete).toBe(true);
+    expect(second.cursor).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resource definition + configuration-free testAll
+// ---------------------------------------------------------------------------
+
+const flags = cloudflareKv('flags', { binding: 'FLAGS' });
+
+const saveFlag = trail('flag.save', {
+  blaze: async (input, ctx) => {
+    await flags.from(ctx).put(input.key, input.value);
+    return Result.ok({ saved: true });
+  },
+  examples: [
+    {
+      expected: { saved: true },
+      input: { key: 'color', value: 'red' },
+      name: 'saves a flag',
+    },
+  ],
+  input: z.object({ key: z.string(), value: z.string() }),
+  intent: 'write',
+  output: z.object({ saved: z.boolean() }),
+  resources: [flags],
+});
+
+const showFlag = trail('flag.show', {
+  blaze: async (input, ctx) => {
+    const value = await flags.from(ctx).get(input.key);
+    return Result.ok({ value });
+  },
+  examples: [
+    {
+      expected: { value: null },
+      input: { key: 'missing' },
+      name: 'reads a missing flag as null',
+    },
+  ],
+  input: z.object({ key: z.string() }),
+  intent: 'read',
+  output: z.object({ value: z.string().nullable() }),
+  resources: [flags],
+});
+
+const graph = topo('cf-kv', { flags, saveFlag, showFlag });
+
+describe('cloudflareKv resource', () => {
+  test('declares the binding on meta and a mock factory', () => {
+    expect(flags.id).toBe('flags');
+    expect(flags.meta?.['cloudflare.binding']).toBe('FLAGS');
+    expect(typeof flags.mock).toBe('function');
+  });
+
+  test('create refuses to run outside a Workers env with guidance', async () => {
+    const created = await flags.create({
+      config: undefined,
+      cwd: '/',
+      env: {},
+      workspaceRoot: undefined,
+    });
+    expect(created.isErr()).toBe(true);
+    if (created.isErr()) {
+      expect(created.error.message).toContain('FLAGS');
+      expect(created.error.message).toContain('createWorkersHandler');
+    }
+  });
+});
+
+// Configuration-free contract suite: examples run against the in-memory mock.
+testAll(graph);

--- a/adapters/cloudflare/src/kv/index.ts
+++ b/adapters/cloudflare/src/kv/index.ts
@@ -1,0 +1,275 @@
+/**
+ * Cloudflare KV resource for Trails.
+ *
+ * `cloudflareKv` authors an ordinary `resource()` definition wrapping a KV
+ * namespace binding. On Workers, the env bridge (see `../env.ts`) resolves
+ * the binding per env so trails read live KV through `flags.from(ctx)`. In
+ * tests, the in-memory mock keeps `testAll(app)` configuration-free.
+ */
+
+import { InternalError, Result, resource } from '@ontrails/core';
+import type { Resource } from '@ontrails/core';
+
+import { registerEnvBinding } from '../env.js';
+
+// ---------------------------------------------------------------------------
+// Client shape
+// ---------------------------------------------------------------------------
+
+/** Options accepted by {@link CloudflareKv.put}. */
+export interface CloudflareKvPutOptions {
+  /** Absolute expiration as a Unix timestamp in seconds. */
+  readonly expiration?: number | undefined;
+  /** Relative expiration in seconds from now. Wins over `expiration`. */
+  readonly expirationTtl?: number | undefined;
+}
+
+/** Options accepted by {@link CloudflareKv.list}. */
+export interface CloudflareKvListOptions {
+  /** Opaque cursor from a previous page's result. */
+  readonly cursor?: string | undefined;
+  /** Maximum keys per page. Defaults to 1000, matching the KV binding. */
+  readonly limit?: number | undefined;
+  /** Restrict results to keys starting with this prefix. */
+  readonly prefix?: string | undefined;
+}
+
+/** One key entry in a {@link CloudflareKvListResult}. */
+export interface CloudflareKvListKey {
+  /** Absolute expiration as a Unix timestamp in seconds, when set. */
+  readonly expiration?: number | undefined;
+  readonly name: string;
+}
+
+/** Result shape of {@link CloudflareKv.list}, matching the KV binding. */
+export interface CloudflareKvListResult {
+  readonly cursor?: string | undefined;
+  readonly keys: readonly CloudflareKvListKey[];
+  readonly list_complete: boolean;
+}
+
+/**
+ * The KV surface trails consume. A real `KVNamespace` binding satisfies this
+ * shape structurally, so the env bridge passes bindings through unchanged.
+ */
+export interface CloudflareKv {
+  delete(key: string): Promise<void>;
+  get(key: string): Promise<string | null>;
+  list(options?: CloudflareKvListOptions): Promise<CloudflareKvListResult>;
+  put(
+    key: string,
+    value: string,
+    options?: CloudflareKvPutOptions
+  ): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory mock
+// ---------------------------------------------------------------------------
+
+/** Options for {@link createMemoryKv}. */
+export interface CreateMemoryKvOptions {
+  /** Clock override for TTL tests. Defaults to `Date.now`. */
+  readonly now?: (() => number) | undefined;
+}
+
+interface MemoryKvEntry {
+  readonly expiresAtMs: number | undefined;
+  readonly value: string;
+}
+
+const DEFAULT_LIST_LIMIT = 1000;
+const MS_PER_SECOND = 1000;
+
+const isExpired = (entry: MemoryKvEntry, nowMs: number): boolean =>
+  entry.expiresAtMs !== undefined && entry.expiresAtMs <= nowMs;
+
+const resolveExpiresAtMs = (
+  nowMs: number,
+  options: CloudflareKvPutOptions | undefined
+): number | undefined => {
+  if (options?.expirationTtl !== undefined) {
+    return nowMs + options.expirationTtl * MS_PER_SECOND;
+  }
+  if (options?.expiration !== undefined) {
+    return options.expiration * MS_PER_SECOND;
+  }
+  return undefined;
+};
+
+/**
+ * Create an in-memory {@link CloudflareKv} backed by a `Map`.
+ *
+ * This is the mock factory behind every `cloudflareKv` resource, exported for
+ * direct use in tests. TTL semantics mirror the KV binding (lazy expiry,
+ * seconds granularity) but the 60-second minimum TTL is intentionally not
+ * enforced so tests can use short expirations.
+ *
+ * @example
+ * ```ts
+ * import { createMemoryKv } from '@ontrails/cloudflare/kv';
+ *
+ * const kv = createMemoryKv();
+ * await kv.put('color', 'red', { expirationTtl: 60 });
+ * await kv.get('color'); // 'red'
+ * ```
+ */
+export const createMemoryKv = (
+  options: CreateMemoryKvOptions = {}
+): CloudflareKv => {
+  const now = options.now ?? Date.now;
+  const entries = new Map<string, MemoryKvEntry>();
+
+  const liveEntry = (key: string): MemoryKvEntry | undefined => {
+    const entry = entries.get(key);
+    if (entry === undefined) {
+      return undefined;
+    }
+    if (isExpired(entry, now())) {
+      entries.delete(key);
+      return undefined;
+    }
+    return entry;
+  };
+
+  return {
+    delete: (key) => {
+      entries.delete(key);
+      return Promise.resolve();
+    },
+    get: (key) => Promise.resolve(liveEntry(key)?.value ?? null),
+    list: (listOptions) => {
+      const limit = listOptions?.limit ?? DEFAULT_LIST_LIMIT;
+      const prefix = listOptions?.prefix ?? '';
+      const nowMs = now();
+      const names = [...entries.keys()]
+        .filter((name) => {
+          const entry = entries.get(name);
+          return (
+            entry !== undefined &&
+            !isExpired(entry, nowMs) &&
+            name.startsWith(prefix)
+          );
+        })
+        .toSorted();
+      const startIndex =
+        listOptions?.cursor === undefined
+          ? 0
+          : names.findIndex((name) => name > (listOptions.cursor ?? ''));
+      const pageStart = startIndex === -1 ? names.length : startIndex;
+      const page = names.slice(pageStart, pageStart + limit);
+      const listComplete = pageStart + page.length >= names.length;
+      const lastName = page.at(-1);
+      return Promise.resolve({
+        ...(listComplete || lastName === undefined ? {} : { cursor: lastName }),
+        keys: page.map((name) => {
+          const entry = entries.get(name);
+          const expiresAtMs = entry?.expiresAtMs;
+          return {
+            ...(expiresAtMs === undefined
+              ? {}
+              : { expiration: Math.floor(expiresAtMs / MS_PER_SECOND) }),
+            name,
+          };
+        }),
+        list_complete: listComplete,
+      });
+    },
+    put: (key, value, putOptions) => {
+      entries.set(key, {
+        expiresAtMs: resolveExpiresAtMs(now(), putOptions),
+        value,
+      });
+      return Promise.resolve();
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Resource factory
+// ---------------------------------------------------------------------------
+
+/** Options for {@link cloudflareKv}. */
+export interface CloudflareKvOptions {
+  /** The wrangler binding name (a `kv_namespaces` entry's `binding`). */
+  readonly binding: string;
+  readonly description?: string | undefined;
+  readonly meta?: Readonly<Record<string, unknown>> | undefined;
+}
+
+const isKvBinding = (value: unknown): value is CloudflareKv => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<Record<keyof CloudflareKv, unknown>>;
+  return (
+    typeof candidate.get === 'function' &&
+    typeof candidate.put === 'function' &&
+    typeof candidate.delete === 'function' &&
+    typeof candidate.list === 'function'
+  );
+};
+
+/**
+ * Author a Trails resource wrapping a Cloudflare KV namespace binding.
+ *
+ * The instance arrives through the Workers env bridge — `create` refuses to
+ * run outside a Worker because KV bindings only exist there. The in-memory
+ * mock keeps `testAll(app)` configuration-free.
+ *
+ * @example
+ * ```ts
+ * import { cloudflareKv } from '@ontrails/cloudflare/kv';
+ * import { trail, Result } from '@ontrails/core';
+ * import { z } from 'zod';
+ *
+ * const flags = cloudflareKv('flags', { binding: 'FLAGS' });
+ *
+ * const showFlag = trail('flag.show', {
+ *   blaze: async (input, ctx) => {
+ *     const value = await flags.from(ctx).get(input.key);
+ *     return Result.ok({ value });
+ *   },
+ *   input: z.object({ key: z.string() }),
+ *   intent: 'read',
+ *   output: z.object({ value: z.string().nullable() }),
+ *   resources: [flags],
+ * });
+ * ```
+ */
+export const cloudflareKv = (
+  id: string,
+  options: CloudflareKvOptions
+): Resource<CloudflareKv> => {
+  const definition = resource<CloudflareKv>(id, {
+    create: () =>
+      Result.err(
+        new InternalError(
+          `Resource "${id}" wraps Cloudflare KV binding "${options.binding}", which only exists on a Workers env. Serve the topo with createWorkersHandler from @ontrails/cloudflare/workers, or rely on the in-memory mock in tests.`,
+          { context: { binding: options.binding, resourceId: id } }
+        )
+      ),
+    description:
+      options.description ??
+      `Cloudflare KV namespace bound to "${options.binding}"`,
+    meta: {
+      ...options.meta,
+      'cloudflare.binding': options.binding,
+      'cloudflare.service': 'kv',
+    },
+    mock: () => createMemoryKv(),
+  });
+  registerEnvBinding(definition, {
+    binding: options.binding,
+    fromEnv: (value) =>
+      isKvBinding(value)
+        ? Result.ok(value)
+        : Result.err(
+            new InternalError(
+              `Worker env binding "${options.binding}" for resource "${id}" is not a KV namespace. Check the kv_namespaces entry in your wrangler configuration.`,
+              { context: { binding: options.binding, resourceId: id } }
+            )
+          ),
+  });
+  return definition;
+};

--- a/adapters/cloudflare/src/workers/__tests__/conformance.test.ts
+++ b/adapters/cloudflare/src/workers/__tests__/conformance.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, beforeEach, mock } from 'bun:test';
+import {
+  createHttpAdapterConformanceCases,
+  runConformance,
+} from '@ontrails/http/testing';
+import type { HttpAdapterConformanceAdapter } from '@ontrails/http/testing';
+
+import { createWorkersHandler } from '../index.js';
+
+const workersAdapter = {
+  createApp: (graph, options) => {
+    const worker = createWorkersHandler(graph, options);
+    return {
+      fetch: async (request: Request) => await worker.fetch(request, {}),
+    };
+  },
+  name: '@ontrails/cloudflare/workers',
+} satisfies HttpAdapterConformanceAdapter;
+
+let originalConsoleError = console.error;
+
+beforeEach(() => {
+  originalConsoleError = console.error;
+  console.error = mock(() => {});
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+runConformance(workersAdapter, createHttpAdapterConformanceCases());

--- a/adapters/cloudflare/src/workers/__tests__/env-bridge.test.ts
+++ b/adapters/cloudflare/src/workers/__tests__/env-bridge.test.ts
@@ -135,4 +135,81 @@ describe('workers env bridge', () => {
     );
     expect(value).toBe('override');
   });
+
+  test('an explicit override satisfies the resource when the env binding is absent', async () => {
+    const overrideKv = createMemoryKv();
+    await overrideKv.put('color', 'override');
+    const worker = createWorkersHandler(buildGraph(), {
+      resources: { flags: overrideKv },
+    });
+
+    // The documented escape hatch: no FLAGS binding on env, but the resource
+    // is provided explicitly, so no missing-binding error may surface.
+    const value = await readValue(await worker.fetch(flagRequest(), {}));
+    expect(value).toBe('override');
+  });
+
+  test('trails filtered off the surface never require their env bindings', async () => {
+    const ping = trail('ping', {
+      blaze: (input) => Result.ok({ reply: input.message }),
+      input: z.object({ message: z.string() }),
+      intent: 'read',
+      output: z.object({ reply: z.string() }),
+    });
+    const graph = topo('cf-env-bridge-filtered', { flags, ping, showFlag });
+    const worker = createWorkersHandler(graph, { include: ['ping'] });
+
+    // Only /ping is exposed; the KV-backed trail is filtered out, so the
+    // missing FLAGS binding must not fail materialization.
+    const response = await worker.fetch(
+      new Request('http://localhost/ping?message=hi'),
+      {}
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: { reply: 'hi' } });
+
+    const filteredOut = await worker.fetch(flagRequest(), {});
+    expect(filteredOut.status).toBe(404);
+  });
+
+  test('resolves env bindings declared only by fork version entries', async () => {
+    const versionedFlag = trail('flag.versioned', {
+      blaze: (input) => Result.ok({ value: `static:${input.key}` }),
+      input: z.object({ key: z.string() }),
+      intent: 'read',
+      output: z.object({ value: z.string().nullable() }),
+      version: 2,
+      versions: {
+        1: {
+          blaze: async (_input, ctx) => {
+            const value = await flags.from(ctx).get('color');
+            return Result.ok({ value });
+          },
+          input: z.object({ key: z.string() }),
+          output: z.object({ value: z.string().nullable() }),
+          resources: [flags],
+        },
+      },
+    });
+    const graph = topo('cf-env-bridge-versions', { flags, versionedFlag });
+    const worker = createWorkersHandler(graph);
+    const kv = createMemoryKv();
+    await kv.put('color', 'from-kv');
+
+    // The current contract declares no resources; only the fork entry does.
+    // Selecting the historical version must still receive the env binding.
+    const forkResponse = await worker.fetch(
+      new Request('http://localhost/flag/versioned?key=color', {
+        headers: { 'X-Trails-Version': '1' },
+      }),
+      { FLAGS: kv }
+    );
+    expect(await readValue(forkResponse)).toBe('from-kv');
+
+    const currentResponse = await worker.fetch(
+      new Request('http://localhost/flag/versioned?key=color'),
+      { FLAGS: kv }
+    );
+    expect(await readValue(currentResponse)).toBe('static:color');
+  });
 });

--- a/adapters/cloudflare/src/workers/__tests__/env-bridge.test.ts
+++ b/adapters/cloudflare/src/workers/__tests__/env-bridge.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Env bridge regression tests.
+ *
+ * The load-bearing guarantee: Worker bindings arrive per-request on `env`,
+ * and no resource instance may serve a request with a stale env. A request
+ * carrying a new env object must re-resolve every env-bound resource.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { cloudflareKv, createMemoryKv } from '../../kv/index.js';
+import { createWorkersHandler } from '../index.js';
+
+const flags = cloudflareKv('flags', { binding: 'FLAGS' });
+
+const showFlag = trail('flag.show', {
+  blaze: async (input, ctx) => {
+    const value = await flags.from(ctx).get(input.key);
+    return Result.ok({ value });
+  },
+  input: z.object({ key: z.string() }),
+  intent: 'read',
+  output: z.object({ value: z.string().nullable() }),
+  resources: [flags],
+});
+
+const buildGraph = () => topo('cf-env-bridge', { flags, showFlag });
+
+const flagRequest = (): Request =>
+  new Request('http://localhost/flag/show?key=color');
+
+const readValue = async (response: Response): Promise<unknown> => {
+  expect(response.status).toBe(200);
+  const body = (await response.json()) as { data: { value: unknown } };
+  return body.data.value;
+};
+
+let originalConsoleError = console.error;
+
+beforeEach(() => {
+  originalConsoleError = console.error;
+  console.error = mock(() => {});
+});
+
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+describe('workers env bridge', () => {
+  test('resolves env-bound resources from the per-request env, never a stale one', async () => {
+    const worker = createWorkersHandler(buildGraph());
+
+    const kvA = createMemoryKv();
+    await kvA.put('color', 'red');
+    const envA = { FLAGS: kvA };
+
+    const kvB = createMemoryKv();
+    await kvB.put('color', 'blue');
+    const envB = { FLAGS: kvB };
+
+    expect(await readValue(await worker.fetch(flagRequest(), envA))).toBe(
+      'red'
+    );
+    // A new env object must re-resolve the binding — regression guard for
+    // per-request binding freshness.
+    expect(await readValue(await worker.fetch(flagRequest(), envB))).toBe(
+      'blue'
+    );
+    // Flipping back proves neither materialization captured the other's env.
+    expect(await readValue(await worker.fetch(flagRequest(), envA))).toBe(
+      'red'
+    );
+  });
+
+  test('reuses one materialization while the env identity is stable', async () => {
+    let overrideCalls = 0;
+    const kv = createMemoryKv();
+    await kv.put('color', 'green');
+    const env = { FLAGS: kv };
+    const worker = createWorkersHandler(buildGraph(), {
+      resources: () => {
+        overrideCalls += 1;
+        return {};
+      },
+    });
+
+    expect(await readValue(await worker.fetch(flagRequest(), env))).toBe(
+      'green'
+    );
+    expect(await readValue(await worker.fetch(flagRequest(), env))).toBe(
+      'green'
+    );
+    expect(overrideCalls).toBe(1);
+
+    await worker.fetch(flagRequest(), { FLAGS: createMemoryKv() });
+    expect(overrideCalls).toBe(2);
+  });
+
+  test('maps a missing binding to a redacted 500 with diagnostics logged', async () => {
+    const worker = createWorkersHandler(buildGraph());
+
+    const response = await worker.fetch(flagRequest(), {});
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as {
+      error: { category: string; code: string };
+    };
+    expect(body.error.category).toBe('internal');
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  test('rejects an env binding that is not a KV namespace', async () => {
+    const worker = createWorkersHandler(buildGraph());
+
+    const response = await worker.fetch(flagRequest(), { FLAGS: 'not-a-kv' });
+
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: { category: string } };
+    expect(body.error.category).toBe('internal');
+  });
+
+  test('explicit resource overrides win over env-bound resolution', async () => {
+    const envKv = createMemoryKv();
+    await envKv.put('color', 'env');
+    const overrideKv = createMemoryKv();
+    await overrideKv.put('color', 'override');
+    const worker = createWorkersHandler(buildGraph(), {
+      resources: { flags: overrideKv },
+    });
+
+    const value = await readValue(
+      await worker.fetch(flagRequest(), { FLAGS: envKv })
+    );
+    expect(value).toBe('override');
+  });
+});

--- a/adapters/cloudflare/src/workers/index.ts
+++ b/adapters/cloudflare/src/workers/index.ts
@@ -34,7 +34,11 @@ export {
   getEnvBinding,
   registerEnvBinding,
 } from '../env.js';
-export type { EnvBindingSpec, WorkersEnv } from '../env.js';
+export type {
+  BuildEnvResourceOverridesOptions,
+  EnvBindingSpec,
+  WorkersEnv,
+} from '../env.js';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -124,14 +128,25 @@ const mapCaughtError = (error: unknown): Response => {
 const resolveResourceOverrides = (
   graph: Topo,
   env: WorkersEnv,
-  resources: WorkersResourceOverrides | undefined
+  options: CreateWorkersHandlerOptions
 ): ResourceOverrideMap => {
-  const envOverrides = buildEnvResourceOverrides(graph, env);
+  // Explicit overrides are the documented escape hatch, so they resolve
+  // first: an overridden resource never requires its env binding. Surface
+  // filters are forwarded so trails the handler does not expose never
+  // require theirs either.
+  const userOverrides =
+    typeof options.resources === 'function'
+      ? options.resources(env)
+      : (options.resources ?? {});
+  const envOverrides = buildEnvResourceOverrides(graph, env, {
+    except: Object.keys(userOverrides),
+    exclude: options.exclude,
+    include: options.include,
+    intent: options.intent,
+  });
   if (envOverrides.isErr()) {
     throw envOverrides.error;
   }
-  const userOverrides =
-    typeof resources === 'function' ? resources(env) : (resources ?? {});
   return { ...envOverrides.value, ...userOverrides };
 };
 
@@ -178,7 +193,7 @@ export const createWorkersHandler = (
       layers: options.layers,
       maxJsonBodyBytes: options.maxJsonBodyBytes,
       resolvePermit: options.resolvePermit,
-      resources: resolveResourceOverrides(graph, env ?? {}, options.resources),
+      resources: resolveResourceOverrides(graph, env ?? {}, options),
       validate: options.validate,
     });
     materialized = { env, handle };

--- a/adapters/cloudflare/src/workers/index.ts
+++ b/adapters/cloudflare/src/workers/index.ts
@@ -1,0 +1,197 @@
+/**
+ * Cloudflare Workers materializer for Trails HTTP routes.
+ *
+ * Produces the `{ fetch(request, env, ctx) }` Worker export by delegating to
+ * the shared HTTP fetch kernel (`createFetchHandler` from `@ontrails/http`),
+ * making Workers the kernel's third consumer after Bun and Hono.
+ *
+ * The env bridge: bindings arrive per-request on `env`, so the kernel handler
+ * is materialized per env identity — a request carrying a new `env` object
+ * re-resolves every env-bound resource before it executes. Resource overrides
+ * are checked before core's singleton resource cache, so no resource instance
+ * can serve a request with a stale env.
+ */
+
+import {
+  projectErrorDiagnostics,
+  projectPublicSurfaceError,
+} from '@ontrails/core';
+import type {
+  BaseSurfaceOptions,
+  Layer,
+  ResourceOverrideMap,
+  Topo,
+  TrailContextInit,
+} from '@ontrails/core';
+import { createFetchHandler } from '@ontrails/http';
+import type { ResolveHttpPermit } from '@ontrails/http';
+
+import { buildEnvResourceOverrides } from '../env.js';
+import type { WorkersEnv } from '../env.js';
+
+export {
+  buildEnvResourceOverrides,
+  getEnvBinding,
+  registerEnvBinding,
+} from '../env.js';
+export type { EnvBindingSpec, WorkersEnv } from '../env.js';
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/**
+ * Resource overrides for the Workers surface.
+ *
+ * A static map is applied as-is. A function receives the per-request Worker
+ * env and is re-invoked whenever a new env object arrives, so overrides that
+ * read bindings stay as fresh as the env bridge itself.
+ */
+export type WorkersResourceOverrides =
+  | ResourceOverrideMap
+  | ((env: WorkersEnv) => ResourceOverrideMap);
+
+/**
+ * Options for building a Trails Worker handler.
+ */
+export interface CreateWorkersHandlerOptions extends BaseSurfaceOptions {
+  readonly basePath?: string | undefined;
+  readonly createContext?:
+    | (() => TrailContextInit | Promise<TrailContextInit>)
+    | undefined;
+  readonly layers?: readonly Layer[] | undefined;
+  /** Maximum JSON request body size in bytes. Defaults to 1 MiB. */
+  readonly maxJsonBodyBytes?: number | undefined;
+  readonly resolvePermit?: ResolveHttpPermit | undefined;
+  readonly resources?: WorkersResourceOverrides | undefined;
+}
+
+/**
+ * The `ExecutionContext` shape the Workers runtime passes as the third
+ * `fetch` argument. Declared structurally so the adapter does not require
+ * `@cloudflare/workers-types` at runtime.
+ */
+export interface WorkersExecutionContext {
+  passThroughOnException(): void;
+  waitUntil(promise: Promise<unknown>): void;
+}
+
+/**
+ * The Worker module export produced by {@link createWorkersHandler}.
+ */
+export interface CloudflareWorker {
+  fetch(
+    request: Request,
+    env?: WorkersEnv | undefined,
+    executionCtx?: WorkersExecutionContext | undefined
+  ): Promise<Response>;
+}
+
+// ---------------------------------------------------------------------------
+// Error mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a materialization failure (route derivation, env bridge resolution) to
+ * a projected HTTP error response. Route execution errors never reach this
+ * path — the fetch kernel maps those itself.
+ */
+const mapCaughtError = (error: unknown): Response => {
+  const err = error instanceof Error ? error : new Error(String(error));
+  // Materialization failures are host bootstrap problems; surface their
+  // diagnostics to the Worker log while the response stays redacted.
+  console.error(
+    '[ontrails:cloudflare/workers] Failed to materialize request handler',
+    projectErrorDiagnostics(err)
+  );
+  const projection = projectPublicSurfaceError('http', err);
+  return Response.json(
+    {
+      error: {
+        category: projection.category,
+        code: projection.name,
+        message: projection.message,
+      },
+    },
+    { status: projection.code }
+  );
+};
+
+// ---------------------------------------------------------------------------
+// createWorkersHandler
+// ---------------------------------------------------------------------------
+
+const resolveResourceOverrides = (
+  graph: Topo,
+  env: WorkersEnv,
+  resources: WorkersResourceOverrides | undefined
+): ResourceOverrideMap => {
+  const envOverrides = buildEnvResourceOverrides(graph, env);
+  if (envOverrides.isErr()) {
+    throw envOverrides.error;
+  }
+  const userOverrides =
+    typeof resources === 'function' ? resources(env) : (resources ?? {});
+  return { ...envOverrides.value, ...userOverrides };
+};
+
+interface MaterializedHandler {
+  readonly env: WorkersEnv | undefined;
+  readonly handle: (request: Request) => Promise<Response>;
+}
+
+/**
+ * Build the `{ fetch }` Worker export for a topo.
+ *
+ * @remarks The kernel fetch handler is materialized lazily per env identity.
+ * The Workers runtime keeps `env` stable within an isolate, so steady-state
+ * requests reuse one materialization; any request carrying a different env
+ * object triggers a fresh resolution of every env-bound resource.
+ *
+ * @example
+ * ```ts
+ * import { createWorkersHandler } from '@ontrails/cloudflare/workers';
+ * import { graph } from './app.js';
+ *
+ * export default createWorkersHandler(graph, { basePath: '/api' });
+ * ```
+ */
+export const createWorkersHandler = (
+  graph: Topo,
+  options: CreateWorkersHandlerOptions = {}
+): CloudflareWorker => {
+  let materialized: MaterializedHandler | undefined;
+
+  const handlerFor = (
+    env: WorkersEnv | undefined
+  ): ((request: Request) => Promise<Response>) => {
+    if (materialized !== undefined && materialized.env === env) {
+      return materialized.handle;
+    }
+    const handle = createFetchHandler(graph, {
+      basePath: options.basePath,
+      configValues: options.configValues,
+      createContext: options.createContext,
+      exclude: options.exclude,
+      include: options.include,
+      intent: options.intent,
+      layers: options.layers,
+      maxJsonBodyBytes: options.maxJsonBodyBytes,
+      resolvePermit: options.resolvePermit,
+      resources: resolveResourceOverrides(graph, env ?? {}, options.resources),
+      validate: options.validate,
+    });
+    materialized = { env, handle };
+    return handle;
+  };
+
+  return {
+    fetch: async (request, env, _executionCtx) => {
+      try {
+        return await handlerFor(env)(request);
+      } catch (error: unknown) {
+        return mapCaughtError(error);
+      }
+    },
+  };
+};

--- a/adapters/cloudflare/tsconfig.json
+++ b/adapters/cloudflare/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
+}

--- a/adapters/cloudflare/tsconfig.tests.json
+++ b/adapters/cloudflare/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*.test.ts", "src/**/__tests__/**/*.ts"],
+  "exclude": []
+}

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,21 @@
         "zod": "catalog:",
       },
     },
+    "adapters/cloudflare": {
+      "name": "@ontrails/cloudflare",
+      "version": "1.0.0-beta.37",
+      "dependencies": {
+        "@ontrails/core": "workspace:^",
+      },
+      "devDependencies": {
+        "@ontrails/testing": "workspace:^",
+        "miniflare": "^4.20250617.4",
+      },
+      "peerDependencies": {
+        "@ontrails/http": "workspace:^",
+        "zod": "catalog:",
+      },
+    },
     "adapters/commander": {
       "name": "@ontrails/commander",
       "version": "1.0.0-beta.37",
@@ -413,6 +428,18 @@
 
     "@clack/prompts": ["@clack/prompts@1.2.0", "", { "dependencies": { "@clack/core": "1.2.0", "fast-string-width": "^1.1.0", "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w=="],
 
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260701.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Zd9Y1bah6DwwBN2RW8vJohffQrIUazb8UXnqSNecOxM+jJLhUuvv5IOG8dbHcV83TyZAubea6gsQXo2yH1lDdw=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260701.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-yBLsjS1qCWqFyCY37qRUrYfzHHvMGvjh8zRKJ6MvUivYDhkZTzqduppK38FoqYvayLJ5KbcxH7zo5rkxGqbsaA=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260701.1", "", { "os": "linux", "cpu": "x64" }, "sha512-vMfqSIMfoo4xmZXEuUVqLpSFS921YKjiR9q7kDXPi6Vld1PK74UHg9LZuBavT2KSyemHUCTpj9y/4JSYOEyQbQ=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260701.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-HRfwbKU2pK44V2NhoM0+iH0JJSj7nQ9Wv13ifIiGYCmTtDL8/zKtEhX7kQ3D4Vy/Cpjhttl0FkfqXj1aqLDPPg=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260701.1", "", { "os": "win32", "cpu": "x64" }, "sha512-ngxCiIN9s/fM2o1IBMD0o1/mcXrv2NJVdyznh51UH8sQuvrTrXvV2nM0Uj/qU2wMwF6prgNBcdcd7AZeZGiBQA=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -420,6 +447,56 @@
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -431,7 +508,7 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
@@ -450,6 +527,8 @@
     "@ontrails/adapter-kit": ["@ontrails/adapter-kit@workspace:packages/adapter-kit"],
 
     "@ontrails/cli": ["@ontrails/cli@workspace:packages/cli"],
+
+    "@ontrails/cloudflare": ["@ontrails/cloudflare@workspace:adapters/cloudflare"],
 
     "@ontrails/commander": ["@ontrails/commander@workspace:adapters/commander"],
 
@@ -655,7 +734,17 @@
 
     "@oxlint/plugins": ["@oxlint/plugins@1.62.0", "", {}, "sha512-BgKRw631mImmxuGuRoWaRT8AvNSJCfJvR7lDzP1jR3sBAa7q8P/Ii+lcEOEFZsfcfpkXLyUKGEQLYXWqb60wvw=="],
 
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
 
     "@turbo/darwin-64": ["@turbo/darwin-64@2.8.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-FQ9EX1xMU5nbwjxXxM3yU88AQQ6Sqc6S44exPRroMcx9XZHqqppl5ymJF0Ig/z3nvQNwDmz1Gsnvxubo+nXWjQ=="],
 
@@ -731,7 +820,7 @@
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
@@ -768,6 +857,8 @@
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -907,6 +998,8 @@
 
     "katex": ["katex@0.16.43", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-K7NL5JtGrFEglipOAjY4UYA69CnTuNmjArxeXF6+bw7h2OGySUPv6QWRjfb1gmutJ4Mw/qLeBqiROOEDULp4nA=="],
 
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
     "knip": ["knip@6.12.2", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "minimist": "^1.2.8", "oxc-parser": "^0.128.0", "oxc-resolver": "^11.19.1", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.16", "unbash": "^3.0.0", "yaml": "^2.8.2", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-RcZpT1sVziKZgDk1F0hAcp+bq71VJAF8vg1Y9ZLXc1+UXQaMm1rjiUqpJQTIj+lqwmiBQT19/u7ikgazs23cvA=="],
 
     "lefthook": ["lefthook@2.1.4", "", { "optionalDependencies": { "lefthook-darwin-arm64": "2.1.4", "lefthook-darwin-x64": "2.1.4", "lefthook-freebsd-arm64": "2.1.4", "lefthook-freebsd-x64": "2.1.4", "lefthook-linux-arm64": "2.1.4", "lefthook-linux-x64": "2.1.4", "lefthook-openbsd-arm64": "2.1.4", "lefthook-openbsd-x64": "2.1.4", "lefthook-windows-arm64": "2.1.4", "lefthook-windows-x64": "2.1.4" }, "bin": { "lefthook": "bin/index.js" } }, "sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w=="],
@@ -1018,6 +1111,8 @@
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "miniflare": ["miniflare@4.20260701.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260701.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-L6eAAi6IKtyb/7J6L+YsH2vb1yBrJWKRXI293JYDiMl70+6nncdAgigex58w6WBd+CwvdMsqOyNyGs95Op5gWQ=="],
 
     "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
@@ -1133,6 +1228,8 @@
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -1169,6 +1266,8 @@
 
     "strip-json-comments": ["strip-json-comments@5.0.3", "", {}, "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw=="],
 
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
     "switchback": ["switchback@workspace:examples/switchback"],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
@@ -1201,6 +1300,8 @@
 
     "unbash": ["unbash@3.0.0", "", {}, "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA=="],
 
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
@@ -1219,13 +1320,25 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "workerd": ["workerd@1.20260701.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260701.1", "@cloudflare/workerd-darwin-arm64": "1.20260701.1", "@cloudflare/workerd-linux-64": "1.20260701.1", "@cloudflare/workerd-linux-arm64": "1.20260701.1", "@cloudflare/workerd-windows-64": "1.20260701.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-uF813NG09JwNRRUfJ0zBomyTslSPM810dMj9LVvkQ7RAkLrQLzAlPU8Xh/3dIqZDo2bfd7tChbf2PtqLRARRJQ=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
+    "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -1242,6 +1355,8 @@
     "@napi-rs/wasm-runtime/@emnapi/runtime": ["@emnapi/runtime@1.9.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA=="],
 
     "bun-types/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
+
+    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -32,7 +32,7 @@ export default defineConfig({
     'require-await': 'off',
     'trails-local/no-console-in-packages': [
       'error',
-      { allowedPackages: ['drizzle', 'hono', 'http', 'observe'] },
+      { allowedPackages: ['cloudflare', 'drizzle', 'hono', 'http', 'observe'] },
     ],
     'trails-local/no-deep-relative-import': ['warn', { maxParentSegments: 2 }],
     'trails-local/no-nested-barrel': ['warn', { maxDepth: 2 }],

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -21,11 +21,25 @@ export const passthroughTrace: TraceFn = async <T>(
   fn: () => T | Promise<T>
 ): Promise<T> => await fn();
 
+const defaultCwd = (): string =>
+  typeof process === 'undefined' ? '/' : process.cwd();
+
+const defaultEnv = (): Record<string, string | undefined> =>
+  typeof process === 'undefined'
+    ? {}
+    : (process.env as Record<string, string | undefined>);
+
+const defaultRequestId = (): string =>
+  typeof Bun === 'undefined' ? crypto.randomUUID() : Bun.randomUUIDv7();
+
 /**
  * Create a TrailContext with sensible defaults.
  *
- * - `requestId` defaults to `Bun.randomUUIDv7()` (sortable v7 UUID)
+ * - `requestId` defaults to `Bun.randomUUIDv7()` (sortable v7 UUID), falling
+ *   back to `crypto.randomUUID()` on runtimes without the `Bun` global
  * - `abortSignal` defaults to a fresh, non-aborted `AbortSignal`
+ * - `cwd`/`env` default to the `process` globals when available, and to
+ *   `'/'`/`{}` on runtimes without `process` (for example Cloudflare Workers)
  * - All other fields come from `overrides`
  */
 export const createTrailContext = (
@@ -33,10 +47,10 @@ export const createTrailContext = (
 ): TrailContext => {
   const ctx = {
     abortSignal: new AbortController().signal,
-    cwd: process.cwd(),
+    cwd: defaultCwd(),
     dryRun: false,
-    env: process.env as Record<string, string | undefined>,
-    requestId: Bun.randomUUIDv7(),
+    env: defaultEnv(),
+    requestId: defaultRequestId(),
     trace: passthroughTrace,
     ...overrides,
   } as MutableTrailContext;

--- a/packages/warden/src/rules/public-export-example-coverage.ts
+++ b/packages/warden/src/rules/public-export-example-coverage.ts
@@ -113,6 +113,11 @@ export const PUBLIC_API_EXAMPLE_TARGETS: readonly PublicApiPackageTarget[] = [
     minimumExports: ['createApp', 'surface'],
     packageName: '@ontrails/hono',
   },
+  {
+    indexPath: 'adapters/cloudflare/src/index.ts',
+    minimumExports: ['createWorkersHandler', 'cloudflareKv'],
+    packageName: '@ontrails/cloudflare',
+  },
 ] as const;
 
 export interface ResolvedPublicApiTarget extends PublicApiPackageTarget {


### PR DESCRIPTION
Implements [TRL-1159](https://linear.app/outfitter/issue/TRL-1159/ontrailscloudflareworkers-fetch-handler-surface-materializer-env) and [TRL-1160](https://linear.app/outfitter/issue/TRL-1160/ontrailscloudflarekv-key-value-resource-feeds-the-switchback-edge-demo) per the track spec [Spec: adapters/cloudflare — the Cloudflare adapter collection](https://linear.app/outfitter/document/spec-adapterscloudflare-the-cloudflare-adapter-collection-eaf1c01f5553).

## What this adds

New publishable package `@ontrails/cloudflare` at `adapters/cloudflare` with service subpath exports, following the hono adapter conventions (extracted placement, `@ontrails/http` as peer, http conformance proof, root + `./package.json` exports).

**`/workers`** — `createWorkersHandler(graph, options)` produces the `{ fetch(request, env, ctx) }` Worker export by delegating to the shared HTTP fetch kernel (`createFetchHandler`), making Workers the kernel's third consumer after Bun and Hono. No kernel fork; options mirror the other HTTP surfaces.

**The env bridge** (the collection-wide seam, defined once in `src/env.ts`): subpaths register an `EnvBindingSpec` (`binding` name + `fromEnv` narrowing) per resource definition; the materializer walks the topo's declared resources and resolves each binding from the live `env` into resource overrides. The kernel handler is materialized per env identity — a request carrying a new `env` object re-resolves every env-bound resource, and overrides are checked before core's singleton resource cache, so no resource instance can serve a request with a stale env. Missing/mistyped bindings fail the request with a redacted 500 and full diagnostics in the Worker log.

**`/kv`** — `cloudflareKv(id, { binding })` authors an ordinary `resource()` wrapping the KV binding (`get`/`put`/`delete`/`list` with TTL options; a real `KVNamespace` satisfies the shape structurally). Ships `createMemoryKv` (in-memory Map, injectable clock, lazy TTL expiry, prefix/limit/cursor listing) as the mock factory, so `testAll(app)` runs configuration-free and `resource-mock-coverage` is clean.

## Runtime-constraint audit findings (fix-or-document, all filed)

- [TRL-1186](https://linear.app/outfitter/issue/TRL-1186/audit-createtrailcontext-crashed-on-runtimes-without-bunprocess) — `createTrailContext` evaluated `Bun.randomUUIDv7()` / `process.cwd()` / `process.env` unconditionally, crashing every execution on workerd. **Fixed in this PR** (guarded defaults in `packages/core/src/context.ts`; Bun behavior unchanged).
- [TRL-1187](https://linear.app/outfitter/issue/TRL-1187/audit-ontrailscore-barrel-eagerly-imports-bunsqlite-worker-bundles) — the core barrel eagerly imports `bun:sqlite` via `trails-db.js`; workerd refuses the module graph, so Worker bundles must stub it. **Documented** (README runtime notes + `bunSqliteStub` plugin in the miniflare lane); fix directions proposed in the issue.
- [TRL-1188](https://linear.app/outfitter/issue/TRL-1188/audit-core-execution-path-node-imports-gate-workers-on-nodejs-compat) — `node:` imports on the barrel path require `nodejs_compat` and a recent compatibility date (`node:fs` failed at `2025-05-01`, passes at `2026-06-01`). **Documented** (README + pinned compat date in the lane).

## Verification evidence

- `bun test` in `adapters/cloudflare`: **27 pass, 0 fail** across 4 files —
  - fetch-kernel conformance suite (`runConformance` + `createHttpAdapterConformanceCases` from `@ontrails/http/testing`) passes against the Workers materializer (6 cases incl. webhooks, permits, aborts, error redaction);
  - env-bridge per-request binding freshness regression test (env A → env B → env A flips values; same-env identity reuses one materialization; missing/mistyped binding → 500; explicit overrides win);
  - `/kv` unit tests (TTL via injected clock, absolute expiration, prefix/limit/cursor listing) + `testAll(graph)` running configuration-free on the mock;
  - miniflare integration lane: demo Worker (HTTP read/write, verified webhook, KV through the env bridge, projected 404) bundled with `Bun.build` and executed under workerd — local-first, no Cloudflare account.
- `bun run check` exits 0 — Warden **0 errors** (cloudflare barrel registered in the example-coverage policy), lint, format, knip, docs checks green.
- `bun run test` (repo-wide): all turbo tasks green.
- `bun run publish:check` exits 0 with `@ontrails/cloudflare@1.0.0-beta.37` pack check passed.
- `bun run wayfinder:dogfood` passed (66 trails inspected).
- Changeset `.changeset/cloudflare-workers-kv.md` covers `@ontrails/cloudflare` (minor) and `@ontrails/core` (patch).

## Waivers / not applicable

- **Switchback first-consumer proof (TRL-1160 acceptance line):** the switchback app does not exist in the repo yet (it is the separate flagship stretch, TRL-1156). The "first consumer proven under miniflare" line is satisfied here only at demo scale — the miniflare lane's flag save/show trails over KV. The real switchback edge-flags demo remains with TRL-1156.
- **wrangler dev:** integration runs under miniflare (workerd in-process), which the spec names as the local-first lane; no wrangler config is shipped since no deployable app lives in this PR.
