### PR TITLE
feat(examples): add lookout uptime showcase

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -145,6 +145,24 @@
     "examples/lookout": {
       "name": "lookout",
       "version": "0.0.0",
+      "bin": {
+        "lookout": "./bin/lookout.ts",
+      },
+      "dependencies": {
+        "@ontrails/commander": "workspace:^",
+        "@ontrails/core": "workspace:^",
+        "@ontrails/drizzle": "workspace:^",
+        "@ontrails/hono": "workspace:^",
+        "@ontrails/http": "workspace:^",
+        "@ontrails/mcp": "workspace:^",
+        "@ontrails/observe": "workspace:^",
+        "@ontrails/store": "workspace:^",
+        "@ontrails/tracing": "workspace:^",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@ontrails/testing": "workspace:^",
+      },
     },
     "examples/packlist": {
       "name": "packlist",

--- a/examples/lookout/.gitignore
+++ b/examples/lookout/.gitignore
@@ -1,0 +1,2 @@
+lookout.sqlite*
+.trails-tmp*

--- a/examples/lookout/README.md
+++ b/examples/lookout/README.md
@@ -1,0 +1,127 @@
+# lookout
+
+Uptime monitor with a public status page — the fire-lookout tower for your services, and the showcase app that proves Trails is a runtime, not just a router.
+
+## What this showcases
+
+| Capability | Where to look |
+| --- | --- |
+| Activation sources (cron) | [`src/trails/sweep.ts`](src/trails/sweep.ts) — `schedule.probe.sweep` ticks `probe.sweep`, which probes every due enabled check; [`src/dev.ts`](src/dev.ts) materializes the source with a cron factory |
+| Detours — real retry/recovery | [`src/trails/probe.ts`](src/trails/probe.ts) — timeout, connection-reset, and 502/503 replies recover through detour contracts with bounded retries and backoff, never inline retry loops |
+| The honest middle state | `probe.run` records `recovered-after-retry` when a retry saves the probe — visible in history instead of pretending the blip never happened |
+| Signals (`fires` / `on`) | [`src/signals/probe-signals.ts`](src/signals/probe-signals.ts) — up→down fires `probe.failed`, down→up fires `probe.recovered`; [`src/trails/incident.ts`](src/trails/incident.ts) consumes them with `on:` |
+| Transition-deduped incidents | [`src/trails/incident.ts`](src/trails/incident.ts) — one outage is one incident, no matter how many probes fail while it lasts ([`__tests__/incident-lifecycle.test.ts`](__tests__/incident-lifecycle.test.ts) proves it) |
+| Compose chains | `incident.open`/`incident.resolve` compose `notify.dispatch`; `status.summary` → `uptime.report` → `probe.history` is a three-level read chain ([`src/trails/status.ts`](src/trails/status.ts)) |
+| Observe / tracing | [`src/observe.ts`](src/observe.ts) — memory trace store + console log sink at topo scope; `tracing.query` answers "what ran and why did it fail" from the same records |
+| Scriptable resource mocks | [`src/resources/probe-http.ts`](src/resources/probe-http.ts) — the http mock plays per-URL reply sequences (fail, fail, succeed), which is what makes the detour tests possible offline |
+| Public + private surface split | Status reads declare `permit: 'public'`; check management, acknowledge, and prune carry the `lookout:admin` permit ([`src/permits.ts`](src/permits.ts)) |
+| Maintenance / retention | `probe.prune` reconciles stored probe volume against a retention cap, with real `--dry-run` support |
+| Store + reactive fixtures | [`src/store.ts`](src/store.ts) — four tables authored once, bound to SQLite through `@ontrails/drizzle`, mocked in memory for tests |
+
+22 trails, 3 surfaces (CLI, HTTP, MCP), `testAll(app)` green offline, committed `trails.lock`.
+
+## Quickstart
+
+From `examples/lookout/` in the Trails repo (`bun install` at the repo root first):
+
+Terminal 1 — the provided flaky local test server:
+
+```bash
+bun run flaky-server
+```
+
+Terminal 2 — add two checks, then start the fast-mode loop:
+
+```bash
+bun bin/lookout.ts check create --name steady --url http://localhost:4090/steady --interval-seconds 30
+bun bin/lookout.ts check create --name flaky --url http://localhost:4090/flaky --interval-seconds 30
+bun bin/lookout.ts dev --fast
+```
+
+`dev --fast` runs the probe intervals at seconds-scale. Within one terminal minute you will watch the entire reactive loop:
+
+```text
+[lookout dev] status page: http://0.0.0.0:4091/status/summary
+[lookout dev] schedule runtime running (fast, 2s tick) — ctrl-c to stop
+[lookout dev] probed 019f…ece -> up
+[lookout dev] probed 019f…8ba -> up
+[lookout dev] probed 019f…8ba -> recovered-after-retry        ← a 503 blip, saved by the detour retry
+{"…","message":"lookout notification: check \"flaky\" is down (upstream answered 503)","kind":"opened"}
+[lookout dev] probed 019f…8ba -> down                          ← retries exhausted, incident opened
+[lookout dev] probed 019f…8ba -> down                          ← still down: no new signal, no second incident
+{"…","message":"lookout notification: check \"flaky\" recovered","kind":"resolved"}
+[lookout dev] probed 019f…8ba -> recovered-after-retry         ← back up, incident resolved
+```
+
+While it runs, the status page updates live:
+
+```bash
+curl -s localhost:4091/status/summary
+# {"data":{"checks":[{"name":"steady","state":"up","uptime7d":100,…},
+#                    {"name":"flaky","state":"up","uptime7d":71.43,…}],
+#          "openIncidents":0,…}}
+```
+
+Poke around afterwards:
+
+```bash
+bun bin/lookout.ts status            # the same summary on the CLI
+bun bin/lookout.ts incident list
+bun bin/lookout.ts probe history --check-id <id>
+bun bin/lookout.ts probe prune --keep-per-check 100 --dry-run
+```
+
+The local CLI runs as the operator, so admin trails work directly. The HTTP and MCP surfaces keep admin behind a bearer token: set `LOOKOUT_ADMIN_TOKEN` and send `Authorization: Bearer <token>`; public status reads need no auth at all.
+
+## The activation model, plainly
+
+Trails declare *what* activates them; a runtime materializes *how*. `probe.sweep` declares `on: [schedule('schedule.probe.sweep', { cron: '* * * * *' })]` — that declaration is contract data, visible in the topo and the lock. `lookout dev` materializes it with `createScheduleRuntime(graph, { cron })`, handing in an interval-based cron factory (2s ticks in fast mode, 60s otherwise). The sweep then reads each enabled check's own `intervalSeconds` and composes `probe.run` for every check that is due — so pausing a check (`check pause`) flips `enabled` and removes it from scheduling without touching the schedule source, and `check resume` puts it back. Swap the materializer (say, Cloudflare Cron Triggers) and the same trails run unchanged.
+
+## MCP: "why did api.example.com fail last night?"
+
+Start the MCP surface with `bun src/mcp.ts` (stdio). An agent connecting to it sees `lookout_status_summary`, `lookout_probe_history`, `lookout_incident_list`, `lookout_incident_get`, `lookout_uptime_report`, `lookout_tracing_query`, and friends — enough to answer the question from incident, probe, and trace data. A real transcript against the demo run above:
+
+> **User:** why did the flaky check go down last night?
+>
+> **Agent:** *calls `lookout_incident_list {}`*
+>
+> ```json
+> {"incidents":[{"id":"019f2f6d-d44e-…","checkId":"019f2f6d-6462-…",
+>   "openedAt":"2026-07-04T23:19:14.756Z","resolvedAt":"2026-07-04T23:19:22.759Z",
+>   "status":"resolved","acknowledgedBy":null}],"total":1}
+> ```
+>
+> **Agent:** *calls `lookout_probe_history {"checkId":"019f2f6d-6462-…","sinceHours":24}`*
+>
+> ```json
+> {"probes":[
+>   {"outcome":"recovered-after-retry","attempts":2,"failureReason":null},
+>   {"outcome":"down","attempts":3,"failureReason":"upstream answered 503"},
+>   {"outcome":"down","attempts":3,"failureReason":"upstream answered 503"},
+>   {"outcome":"recovered-after-retry","attempts":2,"failureReason":null},
+>   …]}
+> ```
+>
+> **Agent:** *optionally calls `lookout_tracing_query {"errorsOnly":true}` for the runtime spans of the failing runs*
+>
+> **Agent:** The flaky check had one incident, open from 23:19:14 to 23:19:22 UTC. The upstream answered 503 on three consecutive attempts (initial probe plus two detour retries), so the check was marked down and the incident opened; the earlier and later 503 blips were absorbed by a single retry each and recorded as `recovered-after-retry` without ever opening an incident. The check recovered on its next probe and the incident auto-resolved.
+
+## Surfaces
+
+| Surface | Entry | Notes |
+| --- | --- | --- |
+| CLI | `bun bin/lookout.ts …` | Commands derive from trail ids (`check create`, `incident list`); `status` is the authored CLI path for `status.summary`; `dev [--fast]` is the runtime orchestrator |
+| HTTP | `bun src/http.ts` (or `bun run http`) | `GET /status/summary`, `GET /status/badge?checkId=…`, `GET /incident/list`, `GET /probe/history?checkId=…` public; admin routes behind `LOOKOUT_ADMIN_TOKEN` |
+| MCP | `bun src/mcp.ts` | Tools derive from the public trail contracts; same bearer token gates admin tools |
+
+## Testing
+
+```bash
+bun test
+```
+
+Everything runs offline: `testAll(app)` drives every trail example against the in-memory store mock and the scripted http mock, and the focused suites prove the detour money paths (fail-fail-succeed → `recovered-after-retry`; fail×3 → `down` + incident + notification; recovery → resolve), incident transition dedupe, uptime fixed vectors, and the HTTP public/admin split.
+
+## Storage
+
+SQLite via `@ontrails/drizzle`, at `lookout.sqlite` in the working directory (override with `LOOKOUT_DB`, including `:memory:`). The file is gitignored.

--- a/examples/lookout/__tests__/examples.test.ts
+++ b/examples/lookout/__tests__/examples.test.ts
@@ -1,0 +1,14 @@
+/**
+ * The one-liner contract suite: validates the topo, runs every trail example
+ * against the mocked resources, checks output contracts, and verifies detour
+ * targets — all offline.
+ */
+
+import { testAll } from '@ontrails/testing';
+
+import { graph } from '../src/app.js';
+
+// oxlint-disable-next-line require-hook -- testAll registers tests at module level by design
+testAll(graph, {
+  ctx: { permit: { id: 'test-permit', scopes: ['lookout:admin'] } },
+});

--- a/examples/lookout/__tests__/incident-lifecycle.test.ts
+++ b/examples/lookout/__tests__/incident-lifecycle.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Incident lifecycle money tests: probe transitions drive `probe.failed` /
+ * `probe.recovered`, incidents open exactly once per outage (transition
+ * dedupe), notifications dispatch, and recovery resolves.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { run } from '@ontrails/core';
+
+import { graph } from '../src/app.js';
+import { createScriptedProbeHttp } from '../src/resources/probe-http.js';
+import type { ProbeReply } from '../src/resources/probe-http.js';
+import { db } from '../src/store.js';
+
+const STEADY_URL = 'http://localhost:4090/steady';
+
+const ok = (): ProbeReply => ({ body: 'ok', kind: 'response', status: 200 });
+const fail = (): ProbeReply => ({ body: '', kind: 'response', status: 503 });
+
+const mockStore = async () => {
+  if (!db.mock) {
+    throw new Error('lookout.db mock factory missing');
+  }
+  return await db.mock();
+};
+
+const failedPayload = (at: string) => ({
+  at,
+  checkId: 'chk_steady',
+  checkName: 'steady',
+  failureReason: 'upstream answered 503',
+  probeId: 'prb_x',
+  url: STEADY_URL,
+});
+
+describe('incident lifecycle via probe transitions', () => {
+  test('an outage opens ONE incident across repeated failing probes, then resolves', async () => {
+    const store = await mockStore();
+    const resources = {
+      'lookout.db': store,
+      'lookout.probe-http': createScriptedProbeHttp({
+        // Run 1: hard outage (initial + 2 retries). Run 2: still out.
+        // Run 3: recovery.
+        [STEADY_URL]: [fail(), fail(), fail(), fail(), fail(), fail(), ok()],
+      }),
+    };
+
+    // First failing probe: unknown→down opens an incident and notifies.
+    const first = await run(
+      graph,
+      'probe.run',
+      { checkId: 'chk_steady' },
+      { resources }
+    );
+    expect(first.isOk()).toBe(true);
+    let incidents = await store.incidents.list({ checkId: 'chk_steady' });
+    expect(incidents).toHaveLength(1);
+    expect(incidents[0]?.status).toBe('open');
+
+    let notifications = await store.notifications.list();
+    const openedNotes = notifications.filter(
+      (note) => note.incidentId === incidents[0]?.id
+    );
+    expect(openedNotes).toHaveLength(1);
+    expect(openedNotes[0]?.channel).toBe('console');
+
+    // Second failing probe: down→down fires nothing — still ONE incident.
+    const second = await run(
+      graph,
+      'probe.run',
+      { checkId: 'chk_steady' },
+      { resources }
+    );
+    expect(second.isOk()).toBe(true);
+    incidents = await store.incidents.list({ checkId: 'chk_steady' });
+    expect(incidents).toHaveLength(1);
+
+    // Recovery: down→up resolves the incident and notifies again.
+    const third = await run(
+      graph,
+      'probe.run',
+      { checkId: 'chk_steady' },
+      { resources }
+    );
+    expect(third.isOk()).toBe(true);
+    incidents = await store.incidents.list({ checkId: 'chk_steady' });
+    expect(incidents).toHaveLength(1);
+    expect(incidents[0]?.status).toBe('resolved');
+    expect(incidents[0]?.resolvedAt).not.toBeNull();
+
+    notifications = await store.notifications.list();
+    const incidentNotes = notifications.filter(
+      (note) => note.incidentId === incidents[0]?.id
+    );
+    expect(incidentNotes).toHaveLength(2);
+  });
+
+  test('incident.open dedupes a duplicate failure payload', async () => {
+    const store = await mockStore();
+    const resources = { 'lookout.db': store };
+
+    const first = await run(
+      graph,
+      'incident.open',
+      failedPayload('2026-07-01T03:12:00.000Z'),
+      { resources }
+    );
+    expect(first.isOk()).toBe(true);
+    if (first.isOk()) {
+      expect((first.value as { deduped: boolean }).deduped).toBe(false);
+    }
+
+    const second = await run(
+      graph,
+      'incident.open',
+      failedPayload('2026-07-01T03:13:00.000Z'),
+      { resources }
+    );
+    expect(second.isOk()).toBe(true);
+    if (second.isOk()) {
+      expect((second.value as { deduped: boolean }).deduped).toBe(true);
+    }
+
+    const incidents = await store.incidents.list({ checkId: 'chk_steady' });
+    expect(incidents).toHaveLength(1);
+  });
+
+  test('a transient blip that recovers through detours never opens an incident', async () => {
+    const store = await mockStore();
+    const resources = {
+      'lookout.db': store,
+      'lookout.probe-http': createScriptedProbeHttp({
+        [STEADY_URL]: [fail(), fail(), ok()],
+      }),
+    };
+
+    const result = await run(
+      graph,
+      'probe.run',
+      { checkId: 'chk_steady' },
+      { resources }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect((result.value as { outcome: string }).outcome).toBe(
+        'recovered-after-retry'
+      );
+    }
+
+    const incidents = await store.incidents.list({ checkId: 'chk_steady' });
+    expect(incidents).toHaveLength(0);
+    expect(await store.notifications.list()).toHaveLength(0);
+  });
+});
+
+describe('probe.sweep scheduling', () => {
+  test('sweeps due enabled checks and respects pause/resume', async () => {
+    const store = await mockStore();
+    const resources = {
+      'lookout.db': store,
+      'lookout.probe-http': createScriptedProbeHttp(),
+    };
+    const adminPermit = { id: 'test', scopes: ['lookout:admin'] };
+
+    const first = await run(graph, 'probe.sweep', {}, { resources });
+    expect(first.isOk()).toBe(true);
+    if (first.isOk()) {
+      const value = first.value as { due: string[]; probed: number };
+      expect(value.probed).toBe(2);
+      expect(value.due.toSorted()).toEqual(['chk_flaky', 'chk_steady']);
+    }
+
+    // Immediately after, nothing is due (intervals are 30s).
+    const second = await run(graph, 'probe.sweep', {}, { resources });
+    expect(second.isOk()).toBe(true);
+    if (second.isOk()) {
+      expect((second.value as { probed: number }).probed).toBe(0);
+    }
+
+    // Pausing removes a check from scheduling even when due again.
+    const paused = await run(
+      graph,
+      'check.pause',
+      { id: 'chk_flaky' },
+      { permit: adminPermit, resources }
+    );
+    expect(paused.isOk()).toBe(true);
+
+    // Make everything due again by aging the recorded probes.
+    const probes = await store.probes.list();
+    for (const probe of probes) {
+      await store.probes.update(probe.id, {
+        startedAt: '2026-07-01T00:00:00.000Z',
+      });
+    }
+
+    const third = await run(graph, 'probe.sweep', {}, { resources });
+    expect(third.isOk()).toBe(true);
+    if (third.isOk()) {
+      expect((third.value as { due: string[] }).due).toEqual(['chk_steady']);
+    }
+
+    // Resuming puts the check back into scheduling.
+    const resumed = await run(
+      graph,
+      'check.resume',
+      { id: 'chk_flaky' },
+      { permit: adminPermit, resources }
+    );
+    expect(resumed.isOk()).toBe(true);
+
+    const fourth = await run(graph, 'probe.sweep', {}, { resources });
+    expect(fourth.isOk()).toBe(true);
+    if (fourth.isOk()) {
+      expect((fourth.value as { due: string[] }).due).toContain('chk_flaky');
+    }
+  });
+});

--- a/examples/lookout/__tests__/probe-run.test.ts
+++ b/examples/lookout/__tests__/probe-run.test.ts
@@ -1,0 +1,303 @@
+/**
+ * The money tests for `probe.run`: scripted per-URL reply sequences prove the
+ * detour contracts recover transient failures with bounded retries, record
+ * the honest `recovered-after-retry` middle state, and classify exhausted or
+ * definitive failures as `down`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { run } from '@ontrails/core';
+
+import { graph } from '../src/app.js';
+import { createScriptedProbeHttp } from '../src/resources/probe-http.js';
+import type { ProbeReply } from '../src/resources/probe-http.js';
+import { db } from '../src/store.js';
+import type { ProbeRunOutput } from '../src/trails/probe.js';
+
+const FLAKY_URL = 'http://localhost:4090/flaky';
+
+const ok = (body = 'ok'): ProbeReply => ({
+  body,
+  kind: 'response',
+  status: 200,
+});
+const status = (code: number): ProbeReply => ({
+  body: '',
+  kind: 'response',
+  status: code,
+});
+const timeout = (): ProbeReply => ({ kind: 'timeout' });
+const reset = (): ProbeReply => ({
+  kind: 'connection-reset',
+  message: 'read ECONNRESET',
+});
+
+const mockStore = async () => {
+  if (!db.mock) {
+    throw new Error('lookout.db mock factory missing');
+  }
+  return await db.mock();
+};
+
+const createHarness = async (script: Record<string, readonly ProbeReply[]>) => {
+  const store = await mockStore();
+  return {
+    resources: {
+      'lookout.db': store,
+      'lookout.probe-http': createScriptedProbeHttp(script),
+    },
+    store,
+  };
+};
+
+const runProbe = async (
+  resources: Record<string, unknown>,
+  checkId: string
+): Promise<ProbeRunOutput> => {
+  const result = await run(graph, 'probe.run', { checkId }, { resources });
+  expect(result.isOk()).toBe(true);
+  if (result.isErr()) {
+    throw result.error;
+  }
+  return result.value as ProbeRunOutput;
+};
+
+describe('probe.run detour recovery', () => {
+  test('fail, fail, succeed records recovered-after-retry', async () => {
+    const { resources, store } = await createHarness({
+      [FLAKY_URL]: [status(503), status(503), ok()],
+    });
+
+    const output = await runProbe(resources, 'chk_flaky');
+
+    expect(output.outcome).toBe('recovered-after-retry');
+    expect(output.attempts).toBe(3);
+    expect(output.state).toBe('up');
+    expect(output.failureReason).toBeNull();
+    // unknown → up is not a recovery transition.
+    expect(output.transition).toBe('none');
+
+    const rows = await store.probes.list({ checkId: 'chk_flaky' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.outcome).toBe('recovered-after-retry');
+    expect(rows[0]?.attempts).toBe(3);
+    const check = await store.checks.get('chk_flaky');
+    expect(check?.state).toBe('up');
+  });
+
+  test('a single transient blip recovers on the first retry', async () => {
+    const { resources } = await createHarness({
+      [FLAKY_URL]: [status(502), ok()],
+    });
+
+    const output = await runProbe(resources, 'chk_flaky');
+
+    expect(output.outcome).toBe('recovered-after-retry');
+    expect(output.attempts).toBe(2);
+  });
+
+  test('timeouts recover through the timeout detour', async () => {
+    const { resources } = await createHarness({
+      [FLAKY_URL]: [timeout(), ok()],
+    });
+
+    const output = await runProbe(resources, 'chk_flaky');
+
+    expect(output.outcome).toBe('recovered-after-retry');
+    expect(output.attempts).toBe(2);
+  });
+
+  test('connection resets recover through the network detour', async () => {
+    const { resources } = await createHarness({
+      [FLAKY_URL]: [reset(), ok()],
+    });
+
+    const output = await runProbe(resources, 'chk_flaky');
+
+    expect(output.outcome).toBe('recovered-after-retry');
+    expect(output.attempts).toBe(2);
+  });
+
+  test('three transient failures exhaust retries and record down', async () => {
+    const { resources, store } = await createHarness({
+      [FLAKY_URL]: [status(503), status(503), status(503)],
+    });
+
+    const output = await runProbe(resources, 'chk_flaky');
+
+    expect(output.outcome).toBe('down');
+    expect(output.attempts).toBe(3);
+    expect(output.state).toBe('down');
+    expect(output.failureReason).toContain('503');
+    expect(output.transition).toBe('failed');
+
+    const rows = await store.probes.list({ checkId: 'chk_flaky' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.outcome).toBe('down');
+    const check = await store.checks.get('chk_flaky');
+    expect(check?.state).toBe('down');
+  });
+
+  test('a definitive failure records down without retrying', async () => {
+    const { resources } = await createHarness({
+      [FLAKY_URL]: [status(404)],
+    });
+
+    const output = await runProbe(resources, 'chk_flaky');
+
+    expect(output.outcome).toBe('down');
+    expect(output.attempts).toBe(1);
+    expect(output.failureReason).toContain('404');
+  });
+
+  test('a body expectation miss records down without retrying', async () => {
+    const store = await mockStore();
+    await store.checks.update('chk_flaky', {
+      expect: { bodyIncludes: 'healthy', status: 200 },
+    });
+    const resources = {
+      'lookout.db': store,
+      'lookout.probe-http': createScriptedProbeHttp({
+        [FLAKY_URL]: [ok('degraded')],
+      }),
+    };
+
+    const output = await runProbe(resources, 'chk_flaky');
+
+    expect(output.outcome).toBe('down');
+    expect(output.attempts).toBe(1);
+    expect(output.failureReason).toContain('healthy');
+  });
+});
+
+describe('probe.run state transitions', () => {
+  test('up to down flags a failed transition; down stays down silently', async () => {
+    const { resources } = await createHarness({
+      [FLAKY_URL]: [
+        ok(),
+        // Second run: hard outage (three transient failures).
+        status(503),
+        status(503),
+        status(503),
+        // Third run: still out.
+        status(503),
+        status(503),
+        status(503),
+      ],
+    });
+
+    const first = await runProbe(resources, 'chk_flaky');
+    expect(first.state).toBe('up');
+    expect(first.transition).toBe('none');
+
+    const second = await runProbe(resources, 'chk_flaky');
+    expect(second.previousState).toBe('up');
+    expect(second.state).toBe('down');
+    expect(second.transition).toBe('failed');
+
+    // Transition semantics, not per-probe: a still-down probe is not a new
+    // failure transition.
+    const third = await runProbe(resources, 'chk_flaky');
+    expect(third.state).toBe('down');
+    expect(third.transition).toBe('none');
+  });
+
+  test('down to up flags a recovered transition', async () => {
+    const { resources } = await createHarness({
+      [FLAKY_URL]: [status(503), status(503), status(503), ok()],
+    });
+
+    const outage = await runProbe(resources, 'chk_flaky');
+    expect(outage.state).toBe('down');
+
+    const recovery = await runProbe(resources, 'chk_flaky');
+    expect(recovery.previousState).toBe('down');
+    expect(recovery.state).toBe('up');
+    expect(recovery.transition).toBe('recovered');
+    expect(recovery.outcome).toBe('up');
+  });
+
+  test('a recovery via detour from a down state is a recovered transition', async () => {
+    const { resources } = await createHarness({
+      [FLAKY_URL]: [
+        status(503),
+        status(503),
+        status(503),
+        // Second run: one blip, then healthy — recovered-after-retry.
+        status(503),
+        ok(),
+      ],
+    });
+
+    const outage = await runProbe(resources, 'chk_flaky');
+    expect(outage.state).toBe('down');
+
+    const recovery = await runProbe(resources, 'chk_flaky');
+    expect(recovery.outcome).toBe('recovered-after-retry');
+    expect(recovery.transition).toBe('recovered');
+  });
+});
+
+describe('probe.prune retention', () => {
+  test('prunes the oldest rows beyond the retention cap', async () => {
+    const store = await mockStore();
+    for (let index = 0; index < 7; index += 1) {
+      await store.probes.insert({
+        attempts: 1,
+        checkId: 'chk_steady',
+        durationMs: 5,
+        failureReason: null,
+        outcome: 'up',
+        startedAt: new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString(),
+      });
+    }
+    const resources = { 'lookout.db': store };
+
+    const pruned = await run(
+      graph,
+      'probe.prune',
+      { keepPerCheck: 3 },
+      { permit: { id: 'test', scopes: ['lookout:admin'] }, resources }
+    );
+    expect(pruned.isOk()).toBe(true);
+
+    const remaining = await store.probes.list({ checkId: 'chk_steady' });
+    expect(remaining).toHaveLength(3);
+    const startedAts = remaining.map((probe) => probe.startedAt).toSorted();
+    expect(startedAts[0]).toContain('00:04');
+  });
+
+  test('dry run reports without deleting', async () => {
+    const store = await mockStore();
+    for (let index = 0; index < 5; index += 1) {
+      await store.probes.insert({
+        attempts: 1,
+        checkId: 'chk_steady',
+        durationMs: 5,
+        failureReason: null,
+        outcome: 'up',
+        startedAt: new Date(Date.UTC(2026, 0, 1, 0, index)).toISOString(),
+      });
+    }
+    const resources = { 'lookout.db': store };
+
+    const result = await run(
+      graph,
+      'probe.prune',
+      { keepPerCheck: 2 },
+      {
+        dryRun: true,
+        permit: { id: 'test', scopes: ['lookout:admin'] },
+        resources,
+      }
+    );
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toEqual({ dryRun: true, removed: 3 });
+    }
+
+    const remaining = await store.probes.list({ checkId: 'chk_steady' });
+    expect(remaining).toHaveLength(5);
+  });
+});

--- a/examples/lookout/__tests__/status.test.ts
+++ b/examples/lookout/__tests__/status.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Fixed-vector uptime math tests plus the HTTP surface split: public status
+ * reads need no auth, admin trails reject without the bearer token and work
+ * with it.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { run } from '@ontrails/core';
+import { createHttpHarness } from '@ontrails/testing/http';
+
+import { graph } from '../src/app.js';
+import { resolveHttpPermit } from '../src/permits.js';
+import { db } from '../src/store.js';
+import { computeUptime } from '../src/trails/status.js';
+
+const mockStore = async () => {
+  if (!db.mock) {
+    throw new Error('lookout.db mock factory missing');
+  }
+  return await db.mock();
+};
+
+describe('uptime math fixed vectors', () => {
+  test('no probes means no uptime claim', () => {
+    expect(computeUptime([])).toEqual({
+      downCount: 0,
+      probeCount: 0,
+      recoveredCount: 0,
+      upCount: 0,
+      uptimePercent: null,
+    });
+  });
+
+  test('all up is 100%', () => {
+    const probes = [{ outcome: 'up' as const }, { outcome: 'up' as const }];
+    expect(computeUptime(probes).uptimePercent).toBe(100);
+  });
+
+  test('recovered-after-retry counts as healthy', () => {
+    const probes = [
+      { outcome: 'up' as const },
+      { outcome: 'recovered-after-retry' as const },
+      { outcome: 'down' as const },
+      { outcome: 'up' as const },
+    ];
+    const stats = computeUptime(probes);
+    expect(stats).toEqual({
+      downCount: 1,
+      probeCount: 4,
+      recoveredCount: 1,
+      upCount: 2,
+      uptimePercent: 75,
+    });
+  });
+
+  test('percentages round to two decimals', () => {
+    const probes = [
+      { outcome: 'up' as const },
+      { outcome: 'up' as const },
+      { outcome: 'down' as const },
+    ];
+    expect(computeUptime(probes).uptimePercent).toBe(66.67);
+  });
+});
+
+describe('uptime.report windowing', () => {
+  test('only probes inside the window count', async () => {
+    const store = await mockStore();
+    const recent = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+    await store.probes.insert({
+      attempts: 1,
+      checkId: 'chk_steady',
+      durationMs: 5,
+      failureReason: null,
+      outcome: 'up',
+      startedAt: recent,
+    });
+    await store.probes.insert({
+      attempts: 3,
+      checkId: 'chk_steady',
+      durationMs: 900,
+      failureReason: 'upstream answered 503',
+      outcome: 'down',
+      // Far outside any 7-day window.
+      startedAt: '2020-01-01T00:00:00.000Z',
+    });
+
+    const report = await run(
+      graph,
+      'uptime.report',
+      { checkId: 'chk_steady', days: 7 },
+      { resources: { 'lookout.db': store } }
+    );
+    expect(report.isOk()).toBe(true);
+    if (report.isOk()) {
+      expect(report.value).toMatchObject({
+        probeCount: 1,
+        uptimePercent: 100,
+      });
+    }
+  });
+});
+
+describe('HTTP surface: public status page vs admin permit', () => {
+  const createHarness = async () => {
+    const store = await mockStore();
+    return createHttpHarness({
+      graph,
+      resolvePermit: resolveHttpPermit,
+      resources: { 'lookout.db': store },
+    });
+  };
+
+  test('status summary and badge respond without auth', async () => {
+    const http = await createHarness();
+
+    const summary = await http.get('/status/summary');
+    expect(summary.status).toBe(200);
+
+    const badge = await http.get('/status/badge', { checkId: 'chk_steady' });
+    expect(badge.status).toBe(200);
+    expect(badge.body).toMatchObject({
+      data: { label: 'steady', state: 'unknown' },
+    });
+
+    const incidents = await http.get('/incident/list');
+    expect(incidents.status).toBe(200);
+  });
+
+  test('admin trails reject without a token and work with one', async () => {
+    process.env['LOOKOUT_ADMIN_TOKEN'] = 'secret-test-token';
+    try {
+      const http = await createHarness();
+      const input = {
+        intervalSeconds: 60,
+        name: 'api',
+        url: 'https://api.example.com/health',
+      };
+
+      const denied = await http.post('/check/create', input);
+      expect(denied.status).toBe(403);
+
+      const wrongToken = await http.post('/check/create', input, {
+        headers: { authorization: 'Bearer not-the-token' },
+      });
+      expect(wrongToken.status).toBe(403);
+
+      const allowed = await http.post('/check/create', input, {
+        headers: { authorization: 'Bearer secret-test-token' },
+      });
+      expect(allowed.status).toBe(200);
+      expect(allowed.body).toMatchObject({ data: { name: 'api' } });
+    } finally {
+      delete process.env['LOOKOUT_ADMIN_TOKEN'];
+    }
+  });
+});

--- a/examples/lookout/bin/lookout.ts
+++ b/examples/lookout/bin/lookout.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env bun
+
+/**
+ * CLI entry point for lookout.
+ *
+ * Usage:
+ *   bun bin/lookout.ts check create --name api --url https://example.com --interval-seconds 60
+ *   bun bin/lookout.ts status
+ *   bun bin/lookout.ts incident list
+ *   bun bin/lookout.ts dev --fast
+ *
+ * `dev` is the runtime orchestrator (schedule runtime + HTTP status page),
+ * not a trail; everything else derives from the trail contracts. The local
+ * CLI runs as the operator, so admin-permit trails work without token
+ * ceremony — the HTTP surface keeps admin behind a bearer token.
+ */
+
+import { surface } from '@ontrails/commander';
+import { createTrailContext } from '@ontrails/core';
+
+import { graph } from '../src/app.js';
+import { runDev } from '../src/dev.js';
+
+const OPERATOR_PERMIT = {
+  id: 'local-operator',
+  scopes: ['lookout:admin'],
+};
+
+await (process.argv[2] === 'dev'
+  ? runDev({ fast: process.argv.includes('--fast') })
+  : surface(graph, {
+      createContext: () => createTrailContext({ permit: OPERATOR_PERMIT }),
+    }));

--- a/examples/lookout/package.json
+++ b/examples/lookout/package.json
@@ -2,12 +2,33 @@
   "name": "lookout",
   "version": "0.0.0",
   "private": true,
+  "bin": {
+    "lookout": "./bin/lookout.ts"
+  },
   "type": "module",
   "scripts": {
     "build": "tsc -b",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint ./src",
-    "clean": "rm -rf dist *.tsbuildinfo"
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "dev": "bun bin/lookout.ts dev",
+    "http": "bun src/http.ts",
+    "flaky-server": "bun scripts/flaky-server.ts"
+  },
+  "dependencies": {
+    "@ontrails/commander": "workspace:^",
+    "@ontrails/core": "workspace:^",
+    "@ontrails/drizzle": "workspace:^",
+    "@ontrails/hono": "workspace:^",
+    "@ontrails/http": "workspace:^",
+    "@ontrails/mcp": "workspace:^",
+    "@ontrails/observe": "workspace:^",
+    "@ontrails/store": "workspace:^",
+    "@ontrails/tracing": "workspace:^",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@ontrails/testing": "workspace:^"
   }
 }

--- a/examples/lookout/scripts/flaky-server.ts
+++ b/examples/lookout/scripts/flaky-server.ts
@@ -1,0 +1,75 @@
+/**
+ * Flaky local test server for the lookout fast-mode demo.
+ *
+ * Serves two endpoints so the quickstart can watch the full reactive loop:
+ *
+ * - `/steady` always answers 200 — a check against it stays up.
+ * - `/flaky` cycles through a scripted phase pattern: healthy for a few
+ *   requests, then a transient blip (one 503 followed by recovery — the
+ *   detour demo), then a hard outage (sustained 503s — the incident demo),
+ *   then healthy again (incident resolves).
+ *
+ * Run with: bun run flaky-server (defaults to port 4090).
+ */
+
+const port = Number(process.env['PORT'] ?? 4090);
+
+/**
+ * Response script for `/flaky`, consumed one entry per request and repeated
+ * from the start when exhausted. `ok` answers 200, `fail` answers 503.
+ *
+ * The shape is tuned for fast mode (2s probe interval): a transient blip that
+ * a single retry clears, then an outage long enough to open an incident, then
+ * recovery.
+ */
+const phases: readonly ('ok' | 'fail')[] = [
+  'ok',
+  'ok',
+  // Transient blip: the probe's first attempt sees 503, its detour retry
+  // lands on the next entry (ok) → recovered-after-retry.
+  'fail',
+  'ok',
+  'ok',
+  // Hard outage: every attempt fails → check goes down, incident opens.
+  'fail',
+  'fail',
+  'fail',
+  'fail',
+  'fail',
+  'fail',
+  'fail',
+  'fail',
+  // Recovery: check comes back up, incident resolves.
+  'ok',
+  'ok',
+  'ok',
+];
+
+let cursor = 0;
+
+const server = Bun.serve({
+  fetch(request) {
+    const path = new URL(request.url).pathname;
+    if (path === '/steady') {
+      return new Response('steady: ok\n', { status: 200 });
+    }
+    if (path === '/flaky') {
+      const phase = phases[cursor % phases.length] ?? 'ok';
+      cursor += 1;
+      if (phase === 'fail') {
+        console.log(`flaky-server: /flaky #${cursor} -> 503`);
+        return new Response('flaky: unavailable\n', { status: 503 });
+      }
+      console.log(`flaky-server: /flaky #${cursor} -> 200`);
+      return new Response('flaky: ok\n', { status: 200 });
+    }
+    return new Response('not found\n', { status: 404 });
+  },
+  port,
+});
+
+console.log(`flaky-server listening on http://localhost:${server.port}`);
+console.log('  /steady  always 200');
+console.log(
+  '  /flaky   scripted: ok, blip (one 503), outage (503 x8), recovery'
+);

--- a/examples/lookout/src/__tests__/placeholder.test.ts
+++ b/examples/lookout/src/__tests__/placeholder.test.ts
@@ -1,9 +1,0 @@
-import { describe, expect, test } from 'bun:test';
-
-import { workspaceName } from '../index.js';
-
-describe('lookout workspace placeholder', () => {
-  test('reserves the workspace name', () => {
-    expect(workspaceName).toBe('lookout');
-  });
-});

--- a/examples/lookout/src/app.ts
+++ b/examples/lookout/src/app.ts
@@ -1,0 +1,47 @@
+/**
+ * lookout — uptime monitor & status page.
+ *
+ * Wires the check, probe, incident, notification, and status trails plus the
+ * store and probe HTTP client into one queryable topo.
+ */
+
+import { topo } from '@ontrails/core';
+import {
+  tracingQuery,
+  tracingResource,
+  tracingStatus,
+} from '@ontrails/tracing';
+
+import { observeConfig } from './observe.js';
+import * as probeHttp from './resources/probe-http.js';
+import * as probeSignals from './signals/probe-signals.js';
+import * as storeModule from './store.js';
+import * as check from './trails/check.js';
+import * as incident from './trails/incident.js';
+import * as notify from './trails/notify.js';
+import * as probe from './trails/probe.js';
+import * as status from './trails/status.js';
+import * as sweep from './trails/sweep.js';
+
+export const graph = topo(
+  {
+    description:
+      'Uptime monitor & status page — the fire-lookout tower for your services.',
+    name: 'lookout',
+    version: '0.1.0',
+  },
+  { db: storeModule.db },
+  { probeHttp: probeHttp.probeHttp },
+  {
+    probeFailed: probeSignals.probeFailed,
+    probeRecovered: probeSignals.probeRecovered,
+  },
+  check,
+  probe,
+  sweep,
+  incident,
+  notify,
+  status,
+  { tracingQuery, tracingResource, tracingStatus },
+  topo.options({ observe: observeConfig })
+);

--- a/examples/lookout/src/dev.ts
+++ b/examples/lookout/src/dev.ts
@@ -1,0 +1,130 @@
+/**
+ * `lookout dev` — the watchable runtime loop.
+ *
+ * Materializes the `schedule.probe.sweep` activation source with an
+ * interval-based cron factory, serves the public status page over HTTP, and
+ * narrates each sweep. `--fast` drops the tick to two seconds and scales the
+ * per-check intervals down (`LOOKOUT_INTERVAL_SCALE`), so probes, a detour
+ * recovery, an incident opening, its notification, and the status page
+ * update are all visible in one terminal minute.
+ *
+ * This module is surface-side orchestration, not trail logic — console
+ * output is fine here.
+ */
+
+import { createScheduleRuntime, createTrailContext } from '@ontrails/core';
+import type {
+  ScheduleCronFactory,
+  ScheduleRuntimeRunRecord,
+} from '@ontrails/core';
+import { surface as httpSurface } from '@ontrails/hono';
+
+import { graph } from './app.js';
+import { resolveHttpPermit } from './permits.js';
+
+const OPERATOR_PERMIT = {
+  id: 'dev-runtime',
+  scopes: ['lookout:admin'],
+};
+
+const FAST_TICK_MS = 2000;
+const NORMAL_TICK_MS = 60_000;
+
+/**
+ * Interval-based materializer for the sweep's `* * * * *` source. The
+ * runtime's default factory needs `Bun.cron`; an interval is the honest
+ * equivalent for a single every-minute source and lets fast mode tick at
+ * seconds-scale.
+ */
+const intervalCron =
+  (everyMs: number): ScheduleCronFactory =>
+  (cron, handler) => {
+    const timer = setInterval(() => {
+      void handler();
+    }, everyMs);
+    return {
+      cron,
+      stop: () => clearInterval(timer),
+      unref: () => timer.unref(),
+    };
+  };
+
+interface SweepSummary {
+  readonly probed: number;
+  readonly results: readonly {
+    readonly checkId: string;
+    readonly ok: boolean;
+    readonly outcome: string | null;
+  }[];
+}
+
+const narrateRun = (record: ScheduleRuntimeRunRecord): void => {
+  if (record.status === 'skipped') {
+    return;
+  }
+  if (record.error || (record.result && record.result.isErr())) {
+    console.log(`[lookout dev] sweep errored: ${record.error?.message ?? ''}`);
+    return;
+  }
+  if (!record.result?.isOk()) {
+    return;
+  }
+  const summary = record.result.value as SweepSummary;
+  if (summary.probed === 0) {
+    console.log('[lookout dev] sweep: nothing due');
+    return;
+  }
+  for (const result of summary.results) {
+    console.log(
+      `[lookout dev] probed ${result.checkId} -> ${result.outcome ?? 'error'}`
+    );
+  }
+};
+
+export const runDev = async (options: { fast: boolean }): Promise<void> => {
+  if (options.fast && process.env['LOOKOUT_INTERVAL_SCALE'] === undefined) {
+    // 30s minimum intervals tick every 2s in fast mode.
+    process.env['LOOKOUT_INTERVAL_SCALE'] = '15';
+  }
+
+  const port = Number(process.env['PORT'] ?? 4091);
+  const http = await httpSurface(graph, {
+    port,
+    resolvePermit: resolveHttpPermit,
+  });
+  console.log(
+    `[lookout dev] status page: ${http.url.replace(/\/$/, '')}/status/summary`
+  );
+
+  const runtime = createScheduleRuntime(graph, {
+    createContext: () => createTrailContext({ permit: OPERATOR_PERMIT }),
+    cron: intervalCron(options.fast ? FAST_TICK_MS : NORMAL_TICK_MS),
+    onRun: narrateRun,
+  });
+
+  const started = await runtime.start();
+  if (started.isErr()) {
+    console.error(`[lookout dev] failed to start: ${started.error.message}`);
+    await http.close();
+    process.exitCode = 1;
+    return;
+  }
+  console.log(
+    `[lookout dev] schedule runtime running (${options.fast ? 'fast, 2s tick' : 'normal, 60s tick'}) — ctrl-c to stop`
+  );
+
+  const { promise: stopped, resolve } = Promise.withResolvers<boolean>();
+  const shutdown = async (): Promise<void> => {
+    console.log('[lookout dev] stopping');
+    await runtime.stop();
+    await http.close();
+    resolve(true);
+  };
+  process.once('SIGINT', () => {
+    void shutdown();
+  });
+  process.once('SIGTERM', () => {
+    void shutdown();
+  });
+  await stopped;
+};

--- a/examples/lookout/src/http.ts
+++ b/examples/lookout/src/http.ts
@@ -1,0 +1,24 @@
+/**
+ * HTTP surface — the public status page plus the permit-gated admin API.
+ *
+ * Routes derive from trail ids: `GET /status` (via the status.summary cli/http
+ * projection `/status/summary`), `GET /status/badge?checkId=...`,
+ * `GET /incident/list`, `GET /probe/history?checkId=...`. Public reads need
+ * no auth; check management and acknowledge require the
+ * `LOOKOUT_ADMIN_TOKEN` bearer token.
+ */
+
+import { surface } from '@ontrails/hono';
+
+import { graph } from './app.js';
+import { resolveHttpPermit } from './permits.js';
+
+const port = Number(process.env['PORT'] ?? 4091);
+
+// oxlint-disable-next-line require-hook -- HTTP entry point, not a test file
+const { url } = await surface(graph, {
+  port,
+  resolvePermit: resolveHttpPermit,
+});
+
+console.log(`lookout status page serving at ${url}`);

--- a/examples/lookout/src/index.ts
+++ b/examples/lookout/src/index.ts
@@ -1,8 +1,0 @@
-/**
- * Placeholder module for the `lookout` showcase app.
- *
- * The real app lands in its own build run confined to `examples/lookout/`.
- * This placeholder only reserves the workspace so `bun.lock` takes the
- * membership churn once, before the parallel builds start.
- */
-export const workspaceName = 'lookout';

--- a/examples/lookout/src/mcp.ts
+++ b/examples/lookout/src/mcp.ts
@@ -1,0 +1,19 @@
+/**
+ * MCP surface — the agent's window into lookout.
+ *
+ * Tools derive from the public trail contracts (`lookout_status_summary`,
+ * `lookout_probe_history`, `lookout_incident_list`, `lookout_tracing_query`,
+ * ...), so an agent can answer "why did api.example.com go down last night?"
+ * from incident, probe, and trace data. Admin tools require the
+ * `LOOKOUT_ADMIN_TOKEN` bearer token.
+ */
+
+import { surface } from '@ontrails/mcp';
+
+import { graph } from './app.js';
+import { resolveTokenPermit } from './permits.js';
+
+// oxlint-disable-next-line require-hook -- MCP entry point, not a test file
+await surface(graph, {
+  resolvePermit: ({ bearerToken }) => resolveTokenPermit(bearerToken),
+});

--- a/examples/lookout/src/observe.ts
+++ b/examples/lookout/src/observe.ts
@@ -1,0 +1,23 @@
+/**
+ * Observe wiring: one in-memory trace store plus a console log sink.
+ *
+ * The dev store doubles as the memory trace sink for the topo and the
+ * queryable backend behind `tracing.query`, so the MCP surface can answer
+ * "what ran last night and why did it fail" from the same records the
+ * runtime wrote.
+ */
+
+import { createConsoleSink } from '@ontrails/observe';
+import type { ObserveConfig } from '@ontrails/observe';
+import { createDevStore, registerTraceStore } from '@ontrails/tracing';
+
+export const traceStore = createDevStore();
+
+// Register the store so tracingResource (behind tracing.query/tracing.status)
+// reads the same records the topo's trace sink writes.
+registerTraceStore(traceStore);
+
+export const observeConfig: ObserveConfig = {
+  log: createConsoleSink(),
+  trace: traceStore,
+};

--- a/examples/lookout/src/permits.ts
+++ b/examples/lookout/src/permits.ts
@@ -1,0 +1,29 @@
+/**
+ * Permit resolution for the network surfaces.
+ *
+ * Public reads (`permit: 'public'`) need no auth. Admin trails require the
+ * bearer token from `LOOKOUT_ADMIN_TOKEN`; without a matching token the
+ * request carries no permit and permit-gated trails reject.
+ */
+
+import { Result } from '@ontrails/core';
+import type { BasePermit } from '@ontrails/core';
+
+const ADMIN_PERMIT: BasePermit = {
+  id: 'lookout-admin',
+  scopes: ['lookout:admin'],
+};
+
+export const resolveTokenPermit = (
+  token: string | undefined
+): Result<BasePermit | null, Error> => {
+  const adminToken = process.env['LOOKOUT_ADMIN_TOKEN'];
+  if (token !== undefined && adminToken !== undefined && token === adminToken) {
+    return Result.ok(ADMIN_PERMIT);
+  }
+  return Result.ok(null);
+};
+
+export const resolveHttpPermit = (input: {
+  readonly bearerToken?: string | undefined;
+}): Result<BasePermit | null, Error> => resolveTokenPermit(input.bearerToken);

--- a/examples/lookout/src/resources/probe-http.ts
+++ b/examples/lookout/src/resources/probe-http.ts
@@ -1,0 +1,123 @@
+/**
+ * HTTP probe client resource.
+ *
+ * The client answers every request with a data-shaped {@link ProbeReply}
+ * instead of throwing, so `probe.run` can classify transient failure classes
+ * (timeout, connection reset, 502/503) for its detour contracts.
+ *
+ * The mock is scriptable per URL: tests queue a sequence of replies (fail,
+ * fail, succeed) and each request consumes the next entry. An unscripted or
+ * exhausted URL answers 200 so `testAll(app)` runs green offline.
+ */
+
+import { Result, resource } from '@ontrails/core';
+
+export interface ProbeRequest {
+  readonly method: 'GET' | 'HEAD';
+  readonly timeoutMs: number;
+  readonly url: string;
+}
+
+export type ProbeReply =
+  | {
+      readonly kind: 'response';
+      readonly status: number;
+      readonly body: string;
+    }
+  | { readonly kind: 'timeout' }
+  | { readonly kind: 'connection-reset'; readonly message: string };
+
+export interface WebhookPost {
+  readonly body: Readonly<Record<string, unknown>>;
+  readonly url: string;
+}
+
+export interface ProbeHttpClient {
+  /** Deliver a JSON webhook payload. Used by the notify.dispatch webhook channel. */
+  post(input: WebhookPost): Promise<ProbeReply>;
+  request(input: ProbeRequest): Promise<ProbeReply>;
+}
+
+const BODY_PREVIEW_LIMIT = 4096;
+
+const isTimeoutCause = (error: unknown): boolean =>
+  error instanceof DOMException &&
+  (error.name === 'TimeoutError' || error.name === 'AbortError');
+
+const liveRequest = async (input: ProbeRequest): Promise<ProbeReply> => {
+  try {
+    const response = await fetch(input.url, {
+      method: input.method,
+      redirect: 'follow',
+      signal: AbortSignal.timeout(input.timeoutMs),
+    });
+    const fullBody = input.method === 'HEAD' ? '' : await response.text();
+    return {
+      body: fullBody.slice(0, BODY_PREVIEW_LIMIT),
+      kind: 'response',
+      status: response.status,
+    };
+  } catch (error) {
+    if (isTimeoutCause(error) || isTimeoutCause((error as Error).cause)) {
+      return { kind: 'timeout' };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return { kind: 'connection-reset', message };
+  }
+};
+
+const WEBHOOK_TIMEOUT_MS = 5000;
+
+const livePost = async (input: WebhookPost): Promise<ProbeReply> => {
+  try {
+    const response = await fetch(input.url, {
+      body: JSON.stringify(input.body),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST',
+      signal: AbortSignal.timeout(WEBHOOK_TIMEOUT_MS),
+    });
+    const fullBody = await response.text();
+    return {
+      body: fullBody.slice(0, BODY_PREVIEW_LIMIT),
+      kind: 'response',
+      status: response.status,
+    };
+  } catch (error) {
+    if (isTimeoutCause(error) || isTimeoutCause((error as Error).cause)) {
+      return { kind: 'timeout' };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return { kind: 'connection-reset', message };
+  }
+};
+
+/**
+ * Scriptable probe client. Each URL key holds a queue of replies consumed one
+ * per request; unscripted or exhausted URLs answer `200 ok`.
+ */
+export const createScriptedProbeHttp = (
+  script: Readonly<Record<string, readonly ProbeReply[]>> = {}
+): ProbeHttpClient => {
+  const queues = new Map<string, ProbeReply[]>(
+    Object.entries(script).map(([url, replies]) => [url, [...replies]])
+  );
+  const nextReply = (url: string): ProbeReply => {
+    const queue = queues.get(url);
+    return queue?.shift() ?? { body: 'ok', kind: 'response', status: 200 };
+  };
+  return {
+    post(input: WebhookPost): Promise<ProbeReply> {
+      return Promise.resolve(nextReply(input.url));
+    },
+    request(input: ProbeRequest): Promise<ProbeReply> {
+      return Promise.resolve(nextReply(input.url));
+    },
+  };
+};
+
+export const probeHttp = resource<ProbeHttpClient>('lookout.probe-http', {
+  create: () => Result.ok({ post: livePost, request: liveRequest }),
+  description:
+    'Outbound HTTP client used by probe.run; the mock plays scripted per-URL reply sequences.',
+  mock: () => createScriptedProbeHttp(),
+});

--- a/examples/lookout/src/signals/probe-signals.ts
+++ b/examples/lookout/src/signals/probe-signals.ts
@@ -1,0 +1,56 @@
+/**
+ * Probe transition signals.
+ *
+ * `probe.run` fires these on state *transitions*, never per probe: up→down
+ * fires `probe.failed`, down→up fires `probe.recovered`. A check that stays
+ * down probes silently — that is the transition dedupe the incident
+ * lifecycle depends on.
+ */
+
+import { signal } from '@ontrails/core';
+import { z } from 'zod';
+
+export const probeTransitionPayloadSchema = z.object({
+  at: z.string().describe('ISO timestamp of the resolving probe'),
+  checkId: z.string().describe('Check that changed state'),
+  checkName: z.string().describe('Human-readable check name'),
+  failureReason: z
+    .string()
+    .nullable()
+    .describe('Why the probe failed, null on recovery'),
+  probeId: z.string().describe('Probe row that resolved the transition'),
+  url: z.string().describe('Probed URL'),
+});
+
+export const probeFailed = signal('probe.failed', {
+  description:
+    'A check transitioned up→down (fired once per outage, not per probe).',
+  examples: [
+    {
+      at: '2026-07-01T03:12:00.000Z',
+      checkId: 'chk_flaky',
+      checkName: 'flaky',
+      failureReason: 'upstream answered 503',
+      probeId: 'prb_1',
+      url: 'http://localhost:4090/flaky',
+    },
+  ],
+  from: ['probe.run'],
+  payload: probeTransitionPayloadSchema,
+});
+
+export const probeRecovered = signal('probe.recovered', {
+  description: 'A check transitioned down→up.',
+  examples: [
+    {
+      at: '2026-07-01T03:20:00.000Z',
+      checkId: 'chk_flaky',
+      checkName: 'flaky',
+      failureReason: null,
+      probeId: 'prb_2',
+      url: 'http://localhost:4090/flaky',
+    },
+  ],
+  from: ['probe.run'],
+  payload: probeTransitionPayloadSchema,
+});

--- a/examples/lookout/src/store.ts
+++ b/examples/lookout/src/store.ts
@@ -1,0 +1,190 @@
+/**
+ * Schema-derived store for the lookout uptime monitor.
+ *
+ * Four tables carry the whole domain: monitored checks, high-volume probe
+ * results, transition-scoped incidents, and dispatched notifications. The
+ * contract is authored once here and bound to SQLite through
+ * `@ontrails/drizzle`; tests and examples run against the in-memory mock.
+ */
+
+import { store as defineStore } from '@ontrails/store';
+import { connectDrizzle } from '@ontrails/drizzle';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Entity schemas
+// ---------------------------------------------------------------------------
+
+export const checkStateValues = ['up', 'down', 'unknown'] as const;
+
+export const checkSchema = z.object({
+  createdAt: z.string(),
+  enabled: z.boolean(),
+  expect: z.object({
+    bodyIncludes: z.string().optional(),
+    status: z.number().int().optional(),
+  }),
+  id: z.string(),
+  intervalSeconds: z.number().int(),
+  method: z.enum(['GET', 'HEAD']),
+  name: z.string(),
+  state: z.enum(checkStateValues),
+  timeoutMs: z.number().int(),
+  updatedAt: z.string(),
+  url: z.string(),
+});
+
+export const probeOutcomeValues = [
+  'up',
+  'down',
+  'recovered-after-retry',
+] as const;
+
+export const probeSchema = z.object({
+  attempts: z.number().int(),
+  checkId: z.string(),
+  durationMs: z.number().int(),
+  failureReason: z.string().nullable(),
+  id: z.string(),
+  outcome: z.enum(probeOutcomeValues),
+  startedAt: z.string(),
+});
+
+export const incidentStatusValues = [
+  'open',
+  'acknowledged',
+  'resolved',
+] as const;
+
+export const incidentSchema = z.object({
+  acknowledgedBy: z.string().nullable(),
+  checkId: z.string(),
+  id: z.string(),
+  openedAt: z.string(),
+  probeCount: z.number().int(),
+  resolvedAt: z.string().nullable(),
+  status: z.enum(incidentStatusValues),
+});
+
+export const notificationSchema = z.object({
+  channel: z.enum(['console', 'webhook']),
+  id: z.string(),
+  incidentId: z.string(),
+  ok: z.boolean(),
+  sentAt: z.string(),
+});
+
+export type Check = z.output<typeof checkSchema>;
+export type Probe = z.output<typeof probeSchema>;
+export type Incident = z.output<typeof incidentSchema>;
+export type CheckState = Check['state'];
+
+// ---------------------------------------------------------------------------
+// Store definition
+// ---------------------------------------------------------------------------
+
+/**
+ * Demo checks seeded into the mock store so examples and the quickstart have
+ * something to probe without any setup. The URLs point at the flaky local
+ * test server (`bun run flaky-server`).
+ */
+const checkFixtures = [
+  {
+    enabled: true,
+    expect: { status: 200 },
+    id: 'chk_steady',
+    intervalSeconds: 30,
+    method: 'GET',
+    name: 'steady',
+    state: 'unknown',
+    timeoutMs: 2000,
+    url: 'http://localhost:4090/steady',
+  },
+  {
+    enabled: true,
+    expect: { status: 200 },
+    id: 'chk_flaky',
+    intervalSeconds: 30,
+    method: 'GET',
+    name: 'flaky',
+    state: 'unknown',
+    timeoutMs: 2000,
+    url: 'http://localhost:4090/flaky',
+  },
+  {
+    enabled: false,
+    expect: { status: 200 },
+    id: 'chk_retired',
+    intervalSeconds: 30,
+    method: 'GET',
+    name: 'retired',
+    state: 'unknown',
+    timeoutMs: 2000,
+    url: 'http://localhost:4090/steady',
+  },
+] as const;
+
+/**
+ * One open incident on the retired demo check so incident reads, dedupe, and
+ * resolve examples have deterministic data without touching the checks the
+ * probe tests script against.
+ */
+const incidentFixtures = [
+  {
+    acknowledgedBy: null,
+    checkId: 'chk_retired',
+    id: 'inc_demo',
+    openedAt: '2026-07-01T03:12:00.000Z',
+    probeCount: 1,
+    resolvedAt: null,
+    status: 'open',
+  },
+] as const;
+
+export const lookoutStoreDefinition = defineStore({
+  checks: {
+    fixtures: checkFixtures,
+    generated: ['id', 'createdAt', 'updatedAt'],
+    indexes: ['enabled'],
+    primaryKey: 'id',
+    schema: checkSchema,
+  },
+  incidents: {
+    fixtures: incidentFixtures,
+    generated: ['id'],
+    indexes: ['checkId', 'status'],
+    primaryKey: 'id',
+    schema: incidentSchema,
+  },
+  notifications: {
+    generated: ['id'],
+    indexes: ['incidentId'],
+    primaryKey: 'id',
+    schema: notificationSchema,
+  },
+  probes: {
+    generated: ['id'],
+    indexes: ['checkId'],
+    primaryKey: 'id',
+    schema: probeSchema,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Bound resource
+// ---------------------------------------------------------------------------
+
+const databaseUrl = Bun.env['LOOKOUT_DB'] ?? 'lookout.sqlite';
+
+/**
+ * SQLite-backed lookout store. Real runs persist to `lookout.sqlite` in the
+ * working directory (override with `LOOKOUT_DB`, including `:memory:` for
+ * single-process demo runs); tests and examples use the in-memory mock with
+ * the demo check fixtures.
+ */
+export const db = connectDrizzle(lookoutStoreDefinition, {
+  description:
+    'SQLite store for lookout checks, probes, incidents, and notifications.',
+  id: 'lookout.db',
+  url: databaseUrl,
+});

--- a/examples/lookout/src/trails/check.ts
+++ b/examples/lookout/src/trails/check.ts
@@ -1,0 +1,331 @@
+/**
+ * Check trails — CRUD and scheduling toggles for monitored endpoints.
+ *
+ * Management trails carry the admin permit; the schema enforces the 30-second
+ * interval floor at the boundary so blazes never re-validate it. Pause and
+ * resume flip `enabled`, which is the flag the cron sweep reads — flipping it
+ * is what starts and stops probe scheduling for a check.
+ */
+
+import { NotFoundError, Result, trail } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import { checkSchema, db } from '../store.js';
+
+const ADMIN_SCOPES = ['lookout:admin'] as const;
+
+const checkIdInput = z.object({
+  id: z.string().describe('Check id'),
+});
+
+// ---------------------------------------------------------------------------
+// check.create
+// ---------------------------------------------------------------------------
+
+export const createCheck = trail('check.create', {
+  blaze: async (input, ctx) => {
+    const created = await db.from(ctx).checks.insert({
+      enabled: true,
+      expect: {
+        ...(input.expectStatus === undefined
+          ? {}
+          : { status: input.expectStatus }),
+        ...(input.expectBodyIncludes === undefined
+          ? {}
+          : { bodyIncludes: input.expectBodyIncludes }),
+      },
+      intervalSeconds: input.intervalSeconds,
+      method: input.method,
+      name: input.name,
+      state: 'unknown',
+      timeoutMs: input.timeoutMs,
+      url: input.url,
+    });
+    return Result.ok(created);
+  },
+  description: 'Register a new endpoint check and start monitoring it.',
+  examples: [
+    {
+      description: 'Register a check with the default expectations',
+      expectedMatch: {
+        enabled: true,
+        intervalSeconds: 60,
+        name: 'api',
+        state: 'unknown',
+        url: 'https://api.example.com/health',
+      },
+      input: {
+        intervalSeconds: 60,
+        name: 'api',
+        url: 'https://api.example.com/health',
+      },
+      name: 'Create a check',
+    },
+  ],
+  input: z.object({
+    expectBodyIncludes: z
+      .string()
+      .optional()
+      .describe('Substring the response body must contain'),
+    expectStatus: z
+      .number()
+      .int()
+      .optional()
+      .default(200)
+      .describe('HTTP status the probe expects'),
+    intervalSeconds: z
+      .number()
+      .int()
+      .min(30)
+      .describe('Probe interval in seconds (minimum 30)'),
+    method: z
+      .enum(['GET', 'HEAD'])
+      .optional()
+      .default('GET')
+      .describe('HTTP method'),
+    name: z.string().min(1).describe('Human-readable check name'),
+    timeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .default(2000)
+      .describe('Per-attempt timeout in milliseconds'),
+    url: z.url().describe('URL to probe'),
+  }),
+  intent: 'write',
+  output: checkSchema,
+  permit: { scopes: ADMIN_SCOPES },
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// check.list
+// ---------------------------------------------------------------------------
+
+export const listChecks = trail('check.list', {
+  blaze: async (input, ctx) => {
+    const filters =
+      input.enabled === undefined ? undefined : { enabled: input.enabled };
+    const checks = await db.from(ctx).checks.list(filters);
+    return Result.ok({ checks: [...checks], total: checks.length });
+  },
+  description: 'List registered checks.',
+  examples: [
+    {
+      description: 'List every registered check',
+      input: {},
+      name: 'List checks',
+    },
+  ],
+  input: z.object({
+    enabled: z.boolean().optional().describe('Filter by enabled state'),
+  }),
+  intent: 'read',
+  output: z.object({
+    checks: z.array(checkSchema),
+    total: z.number().int(),
+  }),
+  permit: 'public',
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// check.get
+// ---------------------------------------------------------------------------
+
+export const getCheck = trail('check.get', {
+  blaze: async (input, ctx) => {
+    const check = await db.from(ctx).checks.get(input.id);
+    if (!check) {
+      return Result.err(new NotFoundError(`Check "${input.id}" not found`));
+    }
+    return Result.ok(check);
+  },
+  description: 'Show one check by id.',
+  examples: [
+    {
+      description: 'Look up a seeded demo check',
+      expectedMatch: { id: 'chk_steady', name: 'steady' },
+      input: { id: 'chk_steady' },
+      name: 'Get a check',
+    },
+    {
+      description: 'Unknown ids return NotFoundError',
+      error: 'NotFoundError',
+      input: { id: 'chk_missing' },
+      name: 'Get a missing check',
+    },
+  ],
+  input: checkIdInput,
+  intent: 'read',
+  output: checkSchema,
+  permit: 'public',
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// check.update
+// ---------------------------------------------------------------------------
+
+export const updateCheck = trail('check.update', {
+  blaze: async (input, ctx) => {
+    const { id, expectBodyIncludes, expectStatus, ...patch } = input;
+    const existing = await db.from(ctx).checks.get(id);
+    if (!existing) {
+      return Result.err(new NotFoundError(`Check "${id}" not found`));
+    }
+    const expect =
+      expectStatus === undefined && expectBodyIncludes === undefined
+        ? existing.expect
+        : {
+            ...(expectStatus === undefined ? {} : { status: expectStatus }),
+            ...(expectBodyIncludes === undefined
+              ? {}
+              : { bodyIncludes: expectBodyIncludes }),
+          };
+    const updated = await db.from(ctx).checks.update(id, {
+      ...Object.fromEntries(
+        Object.entries(patch).filter(([, value]) => value !== undefined)
+      ),
+      expect,
+    });
+    if (!updated) {
+      return Result.err(new NotFoundError(`Check "${id}" not found`));
+    }
+    return Result.ok(updated);
+  },
+  description: 'Update fields on an existing check.',
+  examples: [
+    {
+      description: 'Tighten the probe interval on a seeded check',
+      expectedMatch: { id: 'chk_flaky', intervalSeconds: 45 },
+      input: { id: 'chk_flaky', intervalSeconds: 45 },
+      name: 'Update a check interval',
+    },
+  ],
+  input: z.object({
+    expectBodyIncludes: z
+      .string()
+      .optional()
+      .describe('Substring the response body must contain'),
+    expectStatus: z
+      .number()
+      .int()
+      .optional()
+      .describe('HTTP status the probe expects'),
+    id: z.string().describe('Check id'),
+    intervalSeconds: z
+      .number()
+      .int()
+      .min(30)
+      .optional()
+      .describe('Probe interval in seconds (minimum 30)'),
+    method: z.enum(['GET', 'HEAD']).optional().describe('HTTP method'),
+    name: z.string().min(1).optional().describe('Human-readable check name'),
+    timeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe('Per-attempt timeout in milliseconds'),
+    url: z.url().optional().describe('URL to probe'),
+  }),
+  intent: 'write',
+  output: checkSchema,
+  permit: { scopes: ADMIN_SCOPES },
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// check.delete
+// ---------------------------------------------------------------------------
+
+export const deleteCheck = trail('check.delete', {
+  blaze: async (input, ctx) => {
+    const removed = await db.from(ctx).checks.remove(input.id);
+    if (!removed.deleted) {
+      return Result.err(new NotFoundError(`Check "${input.id}" not found`));
+    }
+    return Result.ok({ deleted: true, id: input.id });
+  },
+  description: 'Delete a check and stop monitoring it.',
+  examples: [
+    {
+      description: 'Delete a seeded demo check',
+      expected: { deleted: true, id: 'chk_retired' },
+      input: { id: 'chk_retired' },
+      name: 'Delete a check',
+    },
+    {
+      description: 'Unknown ids return NotFoundError',
+      error: 'NotFoundError',
+      input: { id: 'chk_missing' },
+      name: 'Delete a missing check',
+    },
+  ],
+  input: checkIdInput,
+  intent: 'destroy',
+  output: z.object({
+    deleted: z.boolean(),
+    id: z.string(),
+  }),
+  permit: { scopes: ADMIN_SCOPES },
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// check.pause / check.resume
+// ---------------------------------------------------------------------------
+
+const setEnabled = async (ctx: TrailContext, id: string, enabled: boolean) =>
+  await db.from(ctx).checks.update(id, { enabled });
+
+export const pauseCheck = trail('check.pause', {
+  blaze: async (input, ctx) => {
+    const updated = await setEnabled(ctx, input.id, false);
+    if (!updated) {
+      return Result.err(new NotFoundError(`Check "${input.id}" not found`));
+    }
+    return Result.ok(updated);
+  },
+  description: 'Pause a check — the cron sweep stops scheduling probes for it.',
+  examples: [
+    {
+      description: 'Pause a seeded demo check',
+      expectedMatch: { enabled: false, id: 'chk_flaky' },
+      input: { id: 'chk_flaky' },
+      name: 'Pause a check',
+    },
+  ],
+  input: checkIdInput,
+  intent: 'write',
+  output: checkSchema,
+  permit: { scopes: ADMIN_SCOPES },
+  resources: [db],
+});
+
+export const resumeCheck = trail('check.resume', {
+  blaze: async (input, ctx) => {
+    const updated = await setEnabled(ctx, input.id, true);
+    if (!updated) {
+      return Result.err(new NotFoundError(`Check "${input.id}" not found`));
+    }
+    return Result.ok(updated);
+  },
+  description: 'Resume a paused check — the cron sweep schedules probes again.',
+  examples: [
+    {
+      description: 'Resume a seeded demo check',
+      expectedMatch: { enabled: true, id: 'chk_flaky' },
+      input: { id: 'chk_flaky' },
+      name: 'Resume a check',
+    },
+  ],
+  input: checkIdInput,
+  intent: 'write',
+  output: checkSchema,
+  permit: { scopes: ADMIN_SCOPES },
+  resources: [db],
+});

--- a/examples/lookout/src/trails/incident.ts
+++ b/examples/lookout/src/trails/incident.ts
@@ -1,0 +1,275 @@
+/**
+ * Incident lifecycle — the reactive consumers of probe transition signals.
+ *
+ * `incident.open` reacts to `probe.failed`, `incident.resolve` reacts to
+ * `probe.recovered`. Incidents track transitions, not probes: a check that
+ * keeps failing while already down produces no new signal, and even a
+ * repeated `probe.failed` payload dedupes against the already-open incident.
+ * Both lifecycle trails compose `notify.dispatch`.
+ */
+
+import { NotFoundError, Result, trail } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import {
+  probeFailed,
+  probeRecovered,
+  probeTransitionPayloadSchema,
+} from '../signals/probe-signals.js';
+import { db, incidentSchema } from '../store.js';
+import type { Incident } from '../store.js';
+
+import { dispatchNotification } from './notify.js';
+
+const ADMIN_SCOPES = ['lookout:admin'] as const;
+
+const openIncidentFor = async (
+  ctx: TrailContext,
+  checkId: string
+): Promise<Incident | undefined> => {
+  const incidents = await db.from(ctx).incidents.list({ checkId });
+  return incidents.find((incident) => incident.status !== 'resolved');
+};
+
+// ---------------------------------------------------------------------------
+// incident.open — on: probe.failed
+// ---------------------------------------------------------------------------
+
+export const openIncident = trail('incident.open', {
+  blaze: async (input, ctx) => {
+    const existing = await openIncidentFor(ctx, input.checkId);
+    if (existing) {
+      // Transition dedupe: a failure signal for an already-open incident is
+      // a no-op, never a second incident.
+      return Result.ok({ deduped: true, incident: existing, notified: false });
+    }
+    const incident = await db.from(ctx).incidents.insert({
+      acknowledgedBy: null,
+      checkId: input.checkId,
+      openedAt: input.at,
+      probeCount: 1,
+      resolvedAt: null,
+      status: 'open',
+    });
+    const notify = await ctx.compose(dispatchNotification, {
+      incidentId: incident.id,
+      kind: 'opened',
+      message: `check "${input.checkName}" is down (${input.failureReason ?? 'unknown reason'})`,
+    });
+    return Result.ok({ deduped: false, incident, notified: notify.isOk() });
+  },
+  composes: [dispatchNotification],
+  description:
+    'Open an incident when a check transitions to down; dedupes when one is already open.',
+  examples: [
+    {
+      description: 'A fresh up→down transition opens an incident and notifies',
+      expectedMatch: { deduped: false, notified: true },
+      input: {
+        at: '2026-07-01T03:12:00.000Z',
+        checkId: 'chk_steady',
+        checkName: 'steady',
+        failureReason: 'upstream answered 503',
+        probeId: 'prb_1',
+        url: 'http://localhost:4090/steady',
+      },
+      name: 'Open an incident',
+    },
+    {
+      description:
+        'A failure signal for a check with an open incident dedupes to a no-op',
+      expectedMatch: { deduped: true, notified: false },
+      input: {
+        at: '2026-07-01T03:13:00.000Z',
+        checkId: 'chk_retired',
+        checkName: 'retired',
+        failureReason: 'upstream answered 503',
+        probeId: 'prb_2',
+        url: 'http://localhost:4090/flaky',
+      },
+      name: 'Dedupe against an open incident',
+    },
+  ],
+  input: probeTransitionPayloadSchema,
+  intent: 'write',
+  on: [probeFailed],
+  output: z.object({
+    deduped: z.boolean(),
+    incident: incidentSchema,
+    notified: z.boolean(),
+  }),
+  resources: [db],
+  visibility: 'internal',
+});
+
+// ---------------------------------------------------------------------------
+// incident.resolve — on: probe.recovered
+// ---------------------------------------------------------------------------
+
+export const resolveIncident = trail('incident.resolve', {
+  blaze: async (input, ctx) => {
+    const existing = await openIncidentFor(ctx, input.checkId);
+    if (!existing) {
+      return Result.ok({ incident: null, notified: false, resolved: false });
+    }
+    const incident = await db.from(ctx).incidents.update(existing.id, {
+      resolvedAt: input.at,
+      status: 'resolved',
+    });
+    if (!incident) {
+      return Result.ok({ incident: null, notified: false, resolved: false });
+    }
+    const notify = await ctx.compose(dispatchNotification, {
+      incidentId: incident.id,
+      kind: 'resolved',
+      message: `check "${input.checkName}" recovered`,
+    });
+    return Result.ok({ incident, notified: notify.isOk(), resolved: true });
+  },
+  composes: [dispatchNotification],
+  description: 'Resolve the open incident when a check transitions back to up.',
+  examples: [
+    {
+      description: 'A down→up transition resolves the open incident',
+      expectedMatch: { notified: true, resolved: true },
+      input: {
+        at: '2026-07-01T03:20:00.000Z',
+        checkId: 'chk_retired',
+        checkName: 'retired',
+        failureReason: null,
+        probeId: 'prb_3',
+        url: 'http://localhost:4090/steady',
+      },
+      name: 'Resolve an incident',
+    },
+    {
+      description: 'A recovery with no open incident is a no-op',
+      expectedMatch: { notified: false, resolved: false },
+      input: {
+        at: '2026-07-01T03:21:00.000Z',
+        checkId: 'chk_steady',
+        checkName: 'steady',
+        failureReason: null,
+        probeId: 'prb_4',
+        url: 'http://localhost:4090/steady',
+      },
+      name: 'Recovery without an incident',
+    },
+  ],
+  input: probeTransitionPayloadSchema,
+  intent: 'write',
+  on: [probeRecovered],
+  output: z.object({
+    incident: incidentSchema.nullable(),
+    notified: z.boolean(),
+    resolved: z.boolean(),
+  }),
+  resources: [db],
+  visibility: 'internal',
+});
+
+// ---------------------------------------------------------------------------
+// incident.list / incident.get / incident.acknowledge
+// ---------------------------------------------------------------------------
+
+export const listIncidents = trail('incident.list', {
+  blaze: async (input, ctx) => {
+    const filters =
+      input.status === undefined ? undefined : { status: input.status };
+    const incidents = await db.from(ctx).incidents.list(filters);
+    const sorted = [...incidents].toSorted((a, b) =>
+      b.openedAt.localeCompare(a.openedAt)
+    );
+    return Result.ok({ incidents: sorted, total: sorted.length });
+  },
+  description: 'List incidents, newest first.',
+  examples: [
+    {
+      description: 'The demo store seeds one open incident',
+      expectedMatch: { total: 1 },
+      input: {},
+      name: 'List incidents',
+    },
+  ],
+  input: z.object({
+    status: z
+      .enum(['open', 'acknowledged', 'resolved'])
+      .optional()
+      .describe('Filter by incident status'),
+  }),
+  intent: 'read',
+  output: z.object({
+    incidents: z.array(incidentSchema),
+    total: z.number().int(),
+  }),
+  permit: 'public',
+  resources: [db],
+});
+
+export const getIncident = trail('incident.get', {
+  blaze: async (input, ctx) => {
+    const incident = await db.from(ctx).incidents.get(input.id);
+    if (!incident) {
+      return Result.err(new NotFoundError(`Incident "${input.id}" not found`));
+    }
+    return Result.ok(incident);
+  },
+  description: 'Show one incident by id.',
+  examples: [
+    {
+      description: 'Look up the seeded demo incident',
+      expectedMatch: { checkId: 'chk_retired', id: 'inc_demo' },
+      input: { id: 'inc_demo' },
+      name: 'Get an incident',
+    },
+    {
+      description: 'Unknown ids return NotFoundError',
+      error: 'NotFoundError',
+      input: { id: 'inc_missing' },
+      name: 'Get a missing incident',
+    },
+  ],
+  input: z.object({
+    id: z.string().describe('Incident id'),
+  }),
+  intent: 'read',
+  output: incidentSchema,
+  permit: 'public',
+  resources: [db],
+});
+
+export const acknowledgeIncident = trail('incident.acknowledge', {
+  blaze: async (input, ctx) => {
+    const existing = await db.from(ctx).incidents.get(input.id);
+    if (!existing) {
+      return Result.err(new NotFoundError(`Incident "${input.id}" not found`));
+    }
+    const acknowledgedBy = input.by ?? ctx.permit?.id ?? 'operator';
+    const incident = await db.from(ctx).incidents.update(input.id, {
+      acknowledgedBy,
+      status: existing.status === 'resolved' ? 'resolved' : 'acknowledged',
+    });
+    if (!incident) {
+      return Result.err(new NotFoundError(`Incident "${input.id}" not found`));
+    }
+    return Result.ok(incident);
+  },
+  description: 'Acknowledge an incident so on-call knows it is being handled.',
+  examples: [
+    {
+      description: 'Acknowledge the seeded demo incident',
+      expectedMatch: { id: 'inc_demo', status: 'acknowledged' },
+      input: { by: 'matt', id: 'inc_demo' },
+      name: 'Acknowledge an incident',
+    },
+  ],
+  input: z.object({
+    by: z.string().optional().describe('Who is acknowledging'),
+    id: z.string().describe('Incident id'),
+  }),
+  intent: 'write',
+  output: incidentSchema,
+  permit: { scopes: ADMIN_SCOPES },
+  resources: [db],
+});

--- a/examples/lookout/src/trails/notify.ts
+++ b/examples/lookout/src/trails/notify.ts
@@ -1,0 +1,92 @@
+/**
+ * Notification dispatch — channel fan-out for incident lifecycle events.
+ *
+ * The console channel reports through the structured logger (blazes stay
+ * pure — no direct console output); the webhook channel posts JSON through
+ * the shared HTTP resource when `LOOKOUT_WEBHOOK_URL` is configured. Every
+ * delivery records a notification row.
+ */
+
+import { Result, trail } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import { probeHttp } from '../resources/probe-http.js';
+import { db } from '../store.js';
+
+const deliverySchema = z.object({
+  channel: z.enum(['console', 'webhook']),
+  ok: z.boolean(),
+});
+
+const webhookUrl = (ctx: TrailContext): string | undefined =>
+  ctx.env?.['LOOKOUT_WEBHOOK_URL'];
+
+export const dispatchNotification = trail('notify.dispatch', {
+  blaze: async (input, ctx) => {
+    const store = db.from(ctx);
+    const sentAt = new Date().toISOString();
+    const deliveries: z.output<typeof deliverySchema>[] = [];
+
+    ctx.logger?.info(`lookout notification: ${input.message}`, {
+      incidentId: input.incidentId,
+      kind: input.kind,
+    });
+    await store.notifications.insert({
+      channel: 'console',
+      incidentId: input.incidentId,
+      ok: true,
+      sentAt,
+    });
+    deliveries.push({ channel: 'console', ok: true });
+
+    const url = webhookUrl(ctx);
+    if (url !== undefined) {
+      const reply = await probeHttp.from(ctx).post({
+        body: {
+          incidentId: input.incidentId,
+          kind: input.kind,
+          message: input.message,
+        },
+        url,
+      });
+      const ok = reply.kind === 'response' && reply.status < 300;
+      await store.notifications.insert({
+        channel: 'webhook',
+        incidentId: input.incidentId,
+        ok,
+        sentAt,
+      });
+      deliveries.push({ channel: 'webhook', ok });
+    }
+
+    return Result.ok({ deliveries });
+  },
+  description:
+    'Fan an incident lifecycle event out to the configured channels and record each delivery.',
+  examples: [
+    {
+      description: 'Console delivery always runs; webhook only when configured',
+      expected: { deliveries: [{ channel: 'console', ok: true }] },
+      input: {
+        incidentId: 'inc_demo',
+        kind: 'opened',
+        message: 'check "flaky" is down',
+      },
+      name: 'Dispatch to console',
+    },
+  ],
+  input: z.object({
+    incidentId: z.string().describe('Incident this notification belongs to'),
+    kind: z
+      .enum(['opened', 'resolved'])
+      .describe('Incident lifecycle event being announced'),
+    message: z.string().describe('Human-readable notification text'),
+  }),
+  intent: 'write',
+  output: z.object({
+    deliveries: z.array(deliverySchema),
+  }),
+  resources: [db, probeHttp],
+  visibility: 'internal',
+});

--- a/examples/lookout/src/trails/probe.ts
+++ b/examples/lookout/src/trails/probe.ts
@@ -1,0 +1,454 @@
+/**
+ * Probe trails — the runtime heart of lookout.
+ *
+ * `probe.run` fetches a check's URL once; transient failure classes (timeout,
+ * connection reset, 502/503) recover through detour contracts with bounded
+ * retries and backoff. A success inside the detour records the honest
+ * `recovered-after-retry` middle state most monitors hide. Exhausted retries
+ * and definitive failures (wrong status, missing body text) record `down`.
+ * Every resolved probe writes a row and moves the check's derived state.
+ */
+
+import {
+  NetworkError,
+  NotFoundError,
+  Result,
+  TimeoutError,
+  trail,
+} from '@ontrails/core';
+import type { Detour, TrailContext, TrailsError } from '@ontrails/core';
+import { z } from 'zod';
+
+import { probeHttp } from '../resources/probe-http.js';
+import type { ProbeReply } from '../resources/probe-http.js';
+import { probeFailed, probeRecovered } from '../signals/probe-signals.js';
+import { db, probeOutcomeValues, probeSchema } from '../store.js';
+import type { Check, CheckState } from '../store.js';
+
+/** Retries after the initial attempt; three attempts total before `down`. */
+export const PROBE_MAX_RETRIES = 2;
+
+/** Linear backoff base between detour attempts. */
+export const PROBE_BACKOFF_MS = 150;
+
+const TRANSIENT_STATUSES = new Set([502, 503]);
+
+// ---------------------------------------------------------------------------
+// Attempt classification
+// ---------------------------------------------------------------------------
+
+type AttemptOutcome =
+  | { readonly kind: 'healthy' }
+  | { readonly kind: 'definitive-failure'; readonly reason: string }
+  | {
+      readonly kind: 'transient-failure';
+      readonly transient: 'timeout' | 'network';
+      readonly reason: string;
+    };
+
+const classifyReply = (
+  reply: ProbeReply,
+  expect: Check['expect']
+): AttemptOutcome => {
+  if (reply.kind === 'timeout') {
+    return {
+      kind: 'transient-failure',
+      reason: 'request timed out',
+      transient: 'timeout',
+    };
+  }
+  if (reply.kind === 'connection-reset') {
+    return {
+      kind: 'transient-failure',
+      reason: `connection failed: ${reply.message}`,
+      transient: 'network',
+    };
+  }
+  if (TRANSIENT_STATUSES.has(reply.status)) {
+    return {
+      kind: 'transient-failure',
+      reason: `upstream answered ${reply.status}`,
+      transient: 'network',
+    };
+  }
+  const expectedStatus = expect.status ?? 200;
+  if (reply.status !== expectedStatus) {
+    return {
+      kind: 'definitive-failure',
+      reason: `expected status ${expectedStatus}, got ${reply.status}`,
+    };
+  }
+  if (
+    expect.bodyIncludes !== undefined &&
+    !reply.body.includes(expect.bodyIncludes)
+  ) {
+    return {
+      kind: 'definitive-failure',
+      reason: `response body does not include "${expect.bodyIncludes}"`,
+    };
+  }
+  return { kind: 'healthy' };
+};
+
+const attemptProbe = async (
+  ctx: TrailContext,
+  check: Check
+): Promise<AttemptOutcome> => {
+  const reply = await probeHttp.from(ctx).request({
+    method: check.method,
+    timeoutMs: check.timeoutMs,
+    url: check.url,
+  });
+  return classifyReply(reply, check.expect);
+};
+
+const transientError = (
+  transient: 'timeout' | 'network',
+  reason: string,
+  checkId: string
+): TrailsError =>
+  transient === 'timeout'
+    ? new TimeoutError(reason, { context: { checkId } })
+    : new NetworkError(reason, { context: { checkId } });
+
+// ---------------------------------------------------------------------------
+// Probe finalization — one resolved probe row + derived check state
+// ---------------------------------------------------------------------------
+
+const transitionValues = ['none', 'failed', 'recovered'] as const;
+
+const probeRunOutputSchema = z.object({
+  attempts: z.number().int(),
+  checkId: z.string(),
+  durationMs: z.number().int(),
+  failureReason: z.string().nullable(),
+  outcome: z.enum(probeOutcomeValues),
+  previousState: z.enum(['up', 'down', 'unknown']),
+  probeId: z.string(),
+  startedAt: z.string(),
+  state: z.enum(['up', 'down']),
+  transition: z.enum(transitionValues),
+});
+
+export type ProbeRunOutput = z.output<typeof probeRunOutputSchema>;
+
+interface ResolvedAttempt {
+  readonly attempts: number;
+  readonly failureReason: string | null;
+  readonly outcome: (typeof probeOutcomeValues)[number];
+}
+
+/** Signal payload for a resolved probe that produced a state transition. */
+const transitionPayload = (check: Check, output: ProbeRunOutput) => ({
+  at: output.startedAt,
+  checkId: check.id,
+  checkName: check.name,
+  failureReason: output.failureReason,
+  probeId: output.probeId,
+  url: check.url,
+});
+
+const deriveTransition = (
+  previousState: CheckState,
+  state: 'up' | 'down'
+): (typeof transitionValues)[number] => {
+  if (state === 'down' && previousState !== 'down') {
+    return 'failed';
+  }
+  if (state === 'up' && previousState === 'down') {
+    return 'recovered';
+  }
+  return 'none';
+};
+
+const finalizeProbe = async (
+  ctx: TrailContext,
+  check: Check,
+  resolved: ResolvedAttempt,
+  startedAt: string,
+  startedAtMs: number
+): Promise<Result<ProbeRunOutput, TrailsError>> => {
+  const store = db.from(ctx);
+  const durationMs = Math.max(0, Math.round(performance.now() - startedAtMs));
+  const probe = await store.probes.insert({
+    attempts: resolved.attempts,
+    checkId: check.id,
+    durationMs,
+    failureReason: resolved.failureReason,
+    outcome: resolved.outcome,
+    startedAt,
+  });
+  const state = resolved.outcome === 'down' ? 'down' : 'up';
+  const transition = deriveTransition(check.state, state);
+  await store.checks.update(check.id, { state });
+  return Result.ok({
+    attempts: resolved.attempts,
+    checkId: check.id,
+    durationMs,
+    failureReason: resolved.failureReason,
+    outcome: resolved.outcome,
+    previousState: check.state,
+    probeId: probe.id,
+    startedAt,
+    state,
+    transition,
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Detour recovery — bounded retries with backoff
+// ---------------------------------------------------------------------------
+
+const probeRunInputSchema = z.object({
+  checkId: z.string().describe('Check to probe'),
+});
+
+type ProbeRunInput = z.output<typeof probeRunInputSchema>;
+
+const recoverTransientProbe = async (
+  attempt: { readonly attempt: number; readonly input: ProbeRunInput },
+  ctx: TrailContext,
+  chain: 'timeout' | 'network'
+): Promise<Result<ProbeRunOutput, TrailsError>> => {
+  await Bun.sleep(PROBE_BACKOFF_MS * attempt.attempt);
+  const check = await db.from(ctx).checks.get(attempt.input.checkId);
+  if (!check) {
+    return Result.err(
+      new NotFoundError(`Check "${attempt.input.checkId}" not found`)
+    );
+  }
+  const startedAt = new Date().toISOString();
+  const startedAtMs = performance.now();
+  const outcome = await attemptProbe(ctx, check);
+  const attempts = attempt.attempt + 1;
+  if (
+    outcome.kind === 'transient-failure' &&
+    attempt.attempt < PROBE_MAX_RETRIES
+  ) {
+    // Still transient with retries left: rethrow the chain's error class so
+    // the detour loop schedules the next bounded attempt.
+    return Result.err(transientError(chain, outcome.reason, check.id));
+  }
+  const resolved: ResolvedAttempt =
+    outcome.kind === 'healthy'
+      ? { attempts, failureReason: null, outcome: 'recovered-after-retry' }
+      : { attempts, failureReason: outcome.reason, outcome: 'down' };
+  const final = await finalizeProbe(
+    ctx,
+    check,
+    resolved,
+    startedAt,
+    startedAtMs
+  );
+  if (final.isOk() && final.value.transition === 'failed') {
+    await ctx.fire?.(probeFailed, transitionPayload(check, final.value));
+  }
+  if (final.isOk() && final.value.transition === 'recovered') {
+    await ctx.fire?.(probeRecovered, transitionPayload(check, final.value));
+  }
+  return final;
+};
+
+const probeDetours: readonly Detour<
+  ProbeRunInput,
+  ProbeRunOutput,
+  TrailsError
+>[] = [
+  {
+    maxAttempts: PROBE_MAX_RETRIES,
+    on: TimeoutError,
+    recover: async (attempt, ctx) =>
+      await recoverTransientProbe(attempt, ctx, 'timeout'),
+  },
+  {
+    maxAttempts: PROBE_MAX_RETRIES,
+    on: NetworkError,
+    recover: async (attempt, ctx) =>
+      await recoverTransientProbe(attempt, ctx, 'network'),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// probe.run
+// ---------------------------------------------------------------------------
+
+export const runProbe = trail('probe.run', {
+  blaze: async (input, ctx) => {
+    const check = await db.from(ctx).checks.get(input.checkId);
+    if (!check) {
+      return Result.err(
+        new NotFoundError(`Check "${input.checkId}" not found`)
+      );
+    }
+    const startedAt = new Date().toISOString();
+    const startedAtMs = performance.now();
+    const outcome = await attemptProbe(ctx, check);
+    if (outcome.kind === 'transient-failure') {
+      // Hand transient classes to the detour contracts — retries and backoff
+      // live there, never inline.
+      return Result.err(
+        transientError(outcome.transient, outcome.reason, check.id)
+      );
+    }
+    const resolved: ResolvedAttempt =
+      outcome.kind === 'healthy'
+        ? { attempts: 1, failureReason: null, outcome: 'up' }
+        : { attempts: 1, failureReason: outcome.reason, outcome: 'down' };
+    const final = await finalizeProbe(
+      ctx,
+      check,
+      resolved,
+      startedAt,
+      startedAtMs
+    );
+    if (final.isOk() && final.value.transition === 'failed') {
+      await ctx.fire?.(probeFailed, transitionPayload(check, final.value));
+    }
+    if (final.isOk() && final.value.transition === 'recovered') {
+      await ctx.fire?.(probeRecovered, transitionPayload(check, final.value));
+    }
+    return final;
+  },
+  description:
+    'Probe one check: transient failures recover through detours, resolved probes record a row and move the derived check state. Fires probe.failed on up→down and probe.recovered on down→up.',
+  detours: probeDetours,
+  examples: [
+    {
+      description: 'A healthy endpoint resolves up on the first attempt',
+      expectedMatch: {
+        attempts: 1,
+        checkId: 'chk_steady',
+        failureReason: null,
+        outcome: 'up',
+        state: 'up',
+        transition: 'none',
+      },
+      input: { checkId: 'chk_steady' },
+      name: 'Probe an up check',
+    },
+    {
+      description: 'Unknown check ids return NotFoundError',
+      error: 'NotFoundError',
+      input: { checkId: 'chk_missing' },
+      name: 'Probe a missing check',
+    },
+  ],
+  fires: [probeFailed, probeRecovered],
+  input: probeRunInputSchema,
+  intent: 'write',
+  output: probeRunOutputSchema,
+  resources: [db, probeHttp],
+  visibility: 'internal',
+});
+
+// ---------------------------------------------------------------------------
+// probe.history
+// ---------------------------------------------------------------------------
+
+export const probeHistory = trail('probe.history', {
+  blaze: async (input, ctx) => {
+    const all = await db.from(ctx).probes.list({ checkId: input.checkId });
+    const cutoff =
+      input.sinceHours === undefined
+        ? undefined
+        : new Date(Date.now() - input.sinceHours * 3_600_000).toISOString();
+    const windowed = [...all]
+      .filter((probe) => cutoff === undefined || probe.startedAt >= cutoff)
+      .toSorted((a, b) => b.startedAt.localeCompare(a.startedAt));
+    return Result.ok({
+      probes: windowed.slice(input.offset, input.offset + input.limit),
+      total: windowed.length,
+    });
+  },
+  description:
+    'Probe history for one check, newest first, windowed and paginated.',
+  examples: [
+    {
+      description: 'A fresh check has no probe history yet',
+      expected: { probes: [], total: 0 },
+      input: { checkId: 'chk_steady' },
+      name: 'Empty history',
+    },
+  ],
+  input: z.object({
+    checkId: z.string().describe('Check id'),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .default(50)
+      .describe('Maximum results'),
+    offset: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .default(0)
+      .describe('Pagination offset'),
+    sinceHours: z
+      .number()
+      .positive()
+      .optional()
+      .describe('Only include probes from the last N hours'),
+  }),
+  intent: 'read',
+  output: z.object({
+    probes: z.array(probeSchema),
+    total: z.number().int(),
+  }),
+  permit: 'public',
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// probe.prune — retention enforcement
+// ---------------------------------------------------------------------------
+
+export const pruneProbes = trail('probe.prune', {
+  blaze: async (input, ctx) => {
+    const store = db.from(ctx);
+    const checks = await store.checks.list();
+    let removed = 0;
+    for (const check of checks) {
+      const probes = await store.probes.list({ checkId: check.id });
+      const excess = [...probes]
+        .toSorted((a, b) => b.startedAt.localeCompare(a.startedAt))
+        .slice(input.keepPerCheck);
+      for (const probe of excess) {
+        if (ctx.dryRun !== true) {
+          await store.probes.remove(probe.id);
+        }
+        removed += 1;
+      }
+    }
+    return Result.ok({ dryRun: ctx.dryRun === true, removed });
+  },
+  description:
+    'Reconcile stored probe volume against the retention cap, pruning the oldest rows per check.',
+  dryRun: true,
+  examples: [
+    {
+      description: 'Nothing to prune when history is within retention',
+      expected: { dryRun: false, removed: 0 },
+      input: {},
+      name: 'Prune within retention',
+    },
+  ],
+  input: z.object({
+    keepPerCheck: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .default(100)
+      .describe('Probe rows to keep per check'),
+  }),
+  intent: 'destroy',
+  output: z.object({
+    dryRun: z.boolean(),
+    removed: z.number().int(),
+  }),
+  permit: { scopes: ['lookout:admin'] },
+  resources: [db],
+});

--- a/examples/lookout/src/trails/status.ts
+++ b/examples/lookout/src/trails/status.ts
@@ -1,0 +1,240 @@
+/**
+ * Public status trails — the computed reads behind the status page.
+ *
+ * `uptime.report` composes `probe.history` and does the math;
+ * `status.summary` composes the check, incident, and uptime reads into the
+ * page payload; `status.badge` is the tiny per-check payload. All three are
+ * public reads that fire nothing.
+ */
+
+import { NotFoundError, Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { checkStateValues, db } from '../store.js';
+import type { Probe } from '../store.js';
+
+import { listIncidents } from './incident.js';
+import { probeHistory } from './probe.js';
+
+// ---------------------------------------------------------------------------
+// Uptime math — pure and fixed-vector testable
+// ---------------------------------------------------------------------------
+
+export interface UptimeStats {
+  readonly downCount: number;
+  readonly probeCount: number;
+  readonly recoveredCount: number;
+  readonly upCount: number;
+  /** Percentage of resolved probes that ended healthy; null with no probes. */
+  readonly uptimePercent: number | null;
+}
+
+export const computeUptime = (
+  probes: readonly Pick<Probe, 'outcome'>[]
+): UptimeStats => {
+  let upCount = 0;
+  let downCount = 0;
+  let recoveredCount = 0;
+  for (const probe of probes) {
+    if (probe.outcome === 'up') {
+      upCount += 1;
+    } else if (probe.outcome === 'recovered-after-retry') {
+      recoveredCount += 1;
+    } else {
+      downCount += 1;
+    }
+  }
+  const probeCount = probes.length;
+  const uptimePercent =
+    probeCount === 0
+      ? null
+      : Math.round(((upCount + recoveredCount) / probeCount) * 10_000) / 100;
+  return { downCount, probeCount, recoveredCount, upCount, uptimePercent };
+};
+
+const uptimeReportOutputSchema = z.object({
+  checkId: z.string(),
+  days: z.number(),
+  downCount: z.number().int(),
+  probeCount: z.number().int(),
+  recoveredCount: z.number().int(),
+  upCount: z.number().int(),
+  uptimePercent: z.number().nullable(),
+});
+
+// ---------------------------------------------------------------------------
+// uptime.report
+// ---------------------------------------------------------------------------
+
+const HISTORY_WINDOW_LIMIT = 10_000;
+
+export const uptimeReport = trail('uptime.report', {
+  blaze: async (input, ctx) => {
+    const history = await ctx.compose(probeHistory, {
+      checkId: input.checkId,
+      limit: HISTORY_WINDOW_LIMIT,
+      sinceHours: input.days * 24,
+    });
+    if (history.isErr()) {
+      return history;
+    }
+    const stats = computeUptime(history.value.probes);
+    return Result.ok({ checkId: input.checkId, days: input.days, ...stats });
+  },
+  composes: [probeHistory],
+  description:
+    'Windowed uptime percentages computed from recorded probe outcomes.',
+  examples: [
+    {
+      description: 'No probes yet means no uptime claim — null, not 100%',
+      expected: {
+        checkId: 'chk_steady',
+        days: 7,
+        downCount: 0,
+        probeCount: 0,
+        recoveredCount: 0,
+        upCount: 0,
+        uptimePercent: null,
+      },
+      input: { checkId: 'chk_steady' },
+      name: 'Uptime with no history',
+    },
+  ],
+  input: z.object({
+    checkId: z.string().describe('Check id'),
+    days: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .default(7)
+      .describe('Window size in days'),
+  }),
+  intent: 'read',
+  output: uptimeReportOutputSchema,
+  permit: 'public',
+});
+
+// ---------------------------------------------------------------------------
+// status.summary
+// ---------------------------------------------------------------------------
+
+const summaryCheckSchema = z.object({
+  checkId: z.string(),
+  enabled: z.boolean(),
+  name: z.string(),
+  state: z.enum(checkStateValues),
+  uptime30d: z.number().nullable(),
+  uptime7d: z.number().nullable(),
+  url: z.string(),
+});
+
+export const statusSummary = trail('status.summary', {
+  blaze: async (_input, ctx) => {
+    const checks = await db.from(ctx).checks.list();
+    const incidents = await ctx.compose(listIncidents, {});
+    if (incidents.isErr()) {
+      return incidents;
+    }
+
+    const rows: z.output<typeof summaryCheckSchema>[] = [];
+    for (const check of checks) {
+      const [week, month] = await ctx.compose([
+        [uptimeReport, { checkId: check.id, days: 7 }],
+        [uptimeReport, { checkId: check.id, days: 30 }],
+      ]);
+      rows.push({
+        checkId: check.id,
+        enabled: check.enabled,
+        name: check.name,
+        state: check.state,
+        uptime30d: month.isOk() ? month.value.uptimePercent : null,
+        uptime7d: week.isOk() ? week.value.uptimePercent : null,
+        url: check.url,
+      });
+    }
+
+    const openIncidents = incidents.value.incidents.filter(
+      (incident) => incident.status !== 'resolved'
+    );
+    return Result.ok({
+      checks: rows,
+      generatedAt: new Date().toISOString(),
+      openIncidents: openIncidents.length,
+    });
+  },
+  cli: ['status'],
+  composes: [listIncidents, uptimeReport],
+  description:
+    'The public status page payload: per-check state, 7d/30d uptime, and open incident count.',
+  examples: [
+    {
+      description: 'The demo store seeds three checks and one open incident',
+      expectedMatch: { openIncidents: 1 },
+      input: {},
+      name: 'Status summary',
+    },
+  ],
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({
+    checks: z.array(summaryCheckSchema),
+    generatedAt: z.string(),
+    openIncidents: z.number().int(),
+  }),
+  permit: 'public',
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// status.badge
+// ---------------------------------------------------------------------------
+
+export const statusBadge = trail('status.badge', {
+  blaze: async (input, ctx) => {
+    const check = await db.from(ctx).checks.get(input.checkId);
+    if (!check) {
+      return Result.err(
+        new NotFoundError(`Check "${input.checkId}" not found`)
+      );
+    }
+    const uptime = await ctx.compose(uptimeReport, {
+      checkId: check.id,
+      days: 7,
+    });
+    return Result.ok({
+      checkId: check.id,
+      label: check.name,
+      state: check.state,
+      uptime7d: uptime.isOk() ? uptime.value.uptimePercent : null,
+    });
+  },
+  composes: [uptimeReport],
+  description:
+    'Tiny per-check JSON payload for embedding (badge-shaped, JSON in v1).',
+  examples: [
+    {
+      description: 'A fresh check reports its state with no uptime claim',
+      expected: {
+        checkId: 'chk_steady',
+        label: 'steady',
+        state: 'unknown',
+        uptime7d: null,
+      },
+      input: { checkId: 'chk_steady' },
+      name: 'Badge for a check',
+    },
+  ],
+  input: z.object({
+    checkId: z.string().describe('Check id'),
+  }),
+  intent: 'read',
+  output: z.object({
+    checkId: z.string(),
+    label: z.string(),
+    state: z.enum(checkStateValues),
+    uptime7d: z.number().nullable(),
+  }),
+  permit: 'public',
+  resources: [db],
+});

--- a/examples/lookout/src/trails/sweep.ts
+++ b/examples/lookout/src/trails/sweep.ts
@@ -1,0 +1,109 @@
+/**
+ * Cron-activated probe scheduling.
+ *
+ * One schedule source ticks `probe.sweep` every minute. The sweep reads the
+ * enabled checks, works out which are due from each check's own
+ * `intervalSeconds` and latest probe, and composes `probe.run` for every due
+ * check. Pausing a check flips `enabled`, which is exactly what removes it
+ * from scheduling; resuming puts it back.
+ *
+ * `lookout dev --fast` materializes the same source with a seconds-scale
+ * cron factory and `LOOKOUT_INTERVAL_SCALE`, so the whole reactive loop is
+ * watchable in one terminal minute.
+ */
+
+import { Result, schedule, trail } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import { db } from '../store.js';
+import type { Check } from '../store.js';
+
+import { runProbe } from './probe.js';
+
+export const probeSweepSchedule = schedule('schedule.probe.sweep', {
+  cron: '* * * * *',
+  input: {},
+});
+
+const intervalScale = (ctx: TrailContext): number => {
+  const raw = ctx.env?.['LOOKOUT_INTERVAL_SCALE'];
+  const parsed = raw === undefined ? 1 : Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+};
+
+const isDue = async (
+  ctx: TrailContext,
+  check: Check,
+  nowMs: number,
+  scale: number
+): Promise<boolean> => {
+  const probes = await db.from(ctx).probes.list({ checkId: check.id });
+  const latest = [...probes]
+    .map((probe) => probe.startedAt)
+    .toSorted()
+    .at(-1);
+  if (latest === undefined) {
+    return true;
+  }
+  const intervalMs = (check.intervalSeconds * 1000) / scale;
+  return nowMs - Date.parse(latest) >= intervalMs;
+};
+
+const sweepResultSchema = z.object({
+  checkId: z.string(),
+  ok: z.boolean(),
+  outcome: z.string().nullable(),
+});
+
+export const sweepProbes = trail('probe.sweep', {
+  blaze: async (_input, ctx) => {
+    const store = db.from(ctx);
+    const enabled = await store.checks.list({ enabled: true });
+    const nowMs = Date.now();
+    const scale = intervalScale(ctx);
+
+    const due: Check[] = [];
+    for (const check of enabled) {
+      if (await isDue(ctx, check, nowMs, scale)) {
+        due.push(check);
+      }
+    }
+
+    const results: z.output<typeof sweepResultSchema>[] = [];
+    for (const check of due) {
+      const result = await ctx.compose(runProbe, { checkId: check.id });
+      results.push({
+        checkId: check.id,
+        ok: result.isOk(),
+        outcome: result.isOk() ? result.value.outcome : null,
+      });
+    }
+
+    return Result.ok({
+      due: due.map((check) => check.id),
+      probed: results.length,
+      results,
+    });
+  },
+  composes: [runProbe],
+  description:
+    'Probe every enabled check that is due per its own interval; the cron source ticks this each minute.',
+  examples: [
+    {
+      description: 'Both enabled demo checks are due on a fresh store',
+      expectedMatch: { probed: 2 },
+      input: {},
+      name: 'Sweep due checks',
+    },
+  ],
+  input: z.object({}),
+  intent: 'write',
+  on: [probeSweepSchedule],
+  output: z.object({
+    due: z.array(z.string()),
+    probed: z.number().int(),
+    results: z.array(sweepResultSchema),
+  }),
+  resources: [db],
+});

--- a/examples/lookout/trails.lock
+++ b/examples/lookout/trails.lock
@@ -1,0 +1,6172 @@
+{
+  "scope": {
+    "app": "lookout"
+  },
+  "summary": {
+    "contours": 0,
+    "resources": 3,
+    "signals": 14,
+    "trails": 22
+  },
+  "topoGraph": {
+    "activationGraph": {
+      "edgeCount": 3,
+      "edges": [
+        {
+          "hasWhere": false,
+          "sourceId": "schedule.probe.sweep",
+          "sourceKey": "schedule:schedule.probe.sweep",
+          "sourceKind": "schedule",
+          "trailId": "probe.sweep"
+        },
+        {
+          "hasWhere": false,
+          "sourceId": "probe.failed",
+          "sourceKey": "signal:probe.failed",
+          "sourceKind": "signal",
+          "trailId": "incident.open"
+        },
+        {
+          "hasWhere": false,
+          "sourceId": "probe.recovered",
+          "sourceKey": "signal:probe.recovered",
+          "sourceKind": "signal",
+          "trailId": "incident.resolve"
+        }
+      ],
+      "sourceCount": 3,
+      "sourceKeys": [
+        "schedule:schedule.probe.sweep",
+        "signal:probe.failed",
+        "signal:probe.recovered"
+      ],
+      "trailIds": [
+        "incident.open",
+        "incident.resolve",
+        "probe.sweep"
+      ]
+    },
+    "activationSources": {
+      "schedule:schedule.probe.sweep": {
+        "cron": "* * * * *",
+        "id": "schedule.probe.sweep",
+        "input": {},
+        "key": "schedule:schedule.probe.sweep",
+        "kind": "schedule"
+      },
+      "signal:probe.failed": {
+        "id": "probe.failed",
+        "key": "signal:probe.failed",
+        "kind": "signal"
+      },
+      "signal:probe.recovered": {
+        "id": "probe.recovered",
+        "key": "signal:probe.recovered",
+        "kind": "signal"
+      }
+    },
+    "entries": [
+      {
+        "exampleCount": 1,
+        "id": "check.create",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "check",
+            "create"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "check",
+                "create"
+              ],
+              "source": "derived",
+              "target": "check.create"
+            }
+          ]
+        },
+        "description": "Register a new endpoint check and start monitoring it.",
+        "examples": [
+          {
+            "input": {
+              "intervalSeconds": 60,
+              "name": "api",
+              "url": "https://api.example.com/health"
+            },
+            "kind": "success",
+            "name": "Create a check",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Register a check with the default expectations",
+            "expectedMatch": {
+              "enabled": true,
+              "intervalSeconds": 60,
+              "name": "api",
+              "state": "unknown",
+              "url": "https://api.example.com/health"
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "expectBodyIncludes": {
+              "description": "Substring the response body must contain",
+              "type": "string"
+            },
+            "expectStatus": {
+              "default": 200,
+              "description": "HTTP status the probe expects",
+              "type": "number"
+            },
+            "intervalSeconds": {
+              "description": "Probe interval in seconds (minimum 30)",
+              "type": "number"
+            },
+            "method": {
+              "default": "GET",
+              "description": "HTTP method",
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Human-readable check name",
+              "type": "string"
+            },
+            "timeoutMs": {
+              "default": 2000,
+              "description": "Per-attempt timeout in milliseconds",
+              "type": "number"
+            },
+            "url": {
+              "description": "URL to probe",
+              "type": "string"
+            }
+          },
+          "required": [
+            "intervalSeconds",
+            "name",
+            "url"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "expect": {
+              "properties": {
+                "bodyIncludes": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "intervalSeconds": {
+              "type": "number"
+            },
+            "method": {
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "enabled",
+            "expect",
+            "id",
+            "intervalSeconds",
+            "method",
+            "name",
+            "state",
+            "timeoutMs",
+            "updatedAt",
+            "url"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "lookout:admin"
+          ]
+        },
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "check.delete",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "check",
+            "delete"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "check",
+                "delete"
+              ],
+              "source": "derived",
+              "target": "check.delete"
+            }
+          ]
+        },
+        "description": "Delete a check and stop monitoring it.",
+        "examples": [
+          {
+            "input": {
+              "id": "chk_retired"
+            },
+            "kind": "success",
+            "name": "Delete a check",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Delete a seeded demo check",
+            "expected": {
+              "deleted": true,
+              "id": "chk_retired"
+            }
+          },
+          {
+            "input": {
+              "id": "chk_missing"
+            },
+            "kind": "error",
+            "name": "Delete a missing check",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown ids return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Check id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "intent": "destroy",
+        "output": {
+          "properties": {
+            "deleted": {
+              "type": "boolean"
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "deleted",
+            "id"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "lookout:admin"
+          ]
+        },
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "check.get",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "check",
+            "get"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "check",
+                "get"
+              ],
+              "source": "derived",
+              "target": "check.get"
+            }
+          ]
+        },
+        "description": "Show one check by id.",
+        "examples": [
+          {
+            "input": {
+              "id": "chk_steady"
+            },
+            "kind": "success",
+            "name": "Get a check",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Look up a seeded demo check",
+            "expectedMatch": {
+              "id": "chk_steady",
+              "name": "steady"
+            }
+          },
+          {
+            "input": {
+              "id": "chk_missing"
+            },
+            "kind": "error",
+            "name": "Get a missing check",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown ids return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Check id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "expect": {
+              "properties": {
+                "bodyIncludes": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "intervalSeconds": {
+              "type": "number"
+            },
+            "method": {
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "enabled",
+            "expect",
+            "id",
+            "intervalSeconds",
+            "method",
+            "name",
+            "state",
+            "timeoutMs",
+            "updatedAt",
+            "url"
+          ],
+          "type": "object"
+        },
+        "permit": "public",
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "check.list",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "check",
+            "list"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "check",
+                "list"
+              ],
+              "source": "derived",
+              "target": "check.list"
+            }
+          ]
+        },
+        "description": "List registered checks.",
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "List checks",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "List every registered check"
+          }
+        ],
+        "input": {
+          "properties": {
+            "enabled": {
+              "description": "Filter by enabled state",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "checks": {
+              "items": {
+                "properties": {
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "expect": {
+                    "properties": {
+                      "bodyIncludes": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "type": "number"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "intervalSeconds": {
+                    "type": "number"
+                  },
+                  "method": {
+                    "enum": [
+                      "GET",
+                      "HEAD"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "state": {
+                    "enum": [
+                      "up",
+                      "down",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "timeoutMs": {
+                    "type": "number"
+                  },
+                  "updatedAt": {
+                    "type": "string"
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "createdAt",
+                  "enabled",
+                  "expect",
+                  "id",
+                  "intervalSeconds",
+                  "method",
+                  "name",
+                  "state",
+                  "timeoutMs",
+                  "updatedAt",
+                  "url"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "total": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "checks",
+            "total"
+          ],
+          "type": "object"
+        },
+        "permit": "public",
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "check.pause",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "check",
+            "pause"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "check",
+                "pause"
+              ],
+              "source": "derived",
+              "target": "check.pause"
+            }
+          ]
+        },
+        "description": "Pause a check — the cron sweep stops scheduling probes for it.",
+        "examples": [
+          {
+            "input": {
+              "id": "chk_flaky"
+            },
+            "kind": "success",
+            "name": "Pause a check",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Pause a seeded demo check",
+            "expectedMatch": {
+              "enabled": false,
+              "id": "chk_flaky"
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Check id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "expect": {
+              "properties": {
+                "bodyIncludes": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "intervalSeconds": {
+              "type": "number"
+            },
+            "method": {
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "enabled",
+            "expect",
+            "id",
+            "intervalSeconds",
+            "method",
+            "name",
+            "state",
+            "timeoutMs",
+            "updatedAt",
+            "url"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "lookout:admin"
+          ]
+        },
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "check.resume",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "check",
+            "resume"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "check",
+                "resume"
+              ],
+              "source": "derived",
+              "target": "check.resume"
+            }
+          ]
+        },
+        "description": "Resume a paused check — the cron sweep schedules probes again.",
+        "examples": [
+          {
+            "input": {
+              "id": "chk_flaky"
+            },
+            "kind": "success",
+            "name": "Resume a check",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Resume a seeded demo check",
+            "expectedMatch": {
+              "enabled": true,
+              "id": "chk_flaky"
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Check id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "expect": {
+              "properties": {
+                "bodyIncludes": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "intervalSeconds": {
+              "type": "number"
+            },
+            "method": {
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "enabled",
+            "expect",
+            "id",
+            "intervalSeconds",
+            "method",
+            "name",
+            "state",
+            "timeoutMs",
+            "updatedAt",
+            "url"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "lookout:admin"
+          ]
+        },
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "check.update",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "check",
+            "update"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "check",
+                "update"
+              ],
+              "source": "derived",
+              "target": "check.update"
+            }
+          ]
+        },
+        "description": "Update fields on an existing check.",
+        "examples": [
+          {
+            "input": {
+              "id": "chk_flaky",
+              "intervalSeconds": 45
+            },
+            "kind": "success",
+            "name": "Update a check interval",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Tighten the probe interval on a seeded check",
+            "expectedMatch": {
+              "id": "chk_flaky",
+              "intervalSeconds": 45
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "expectBodyIncludes": {
+              "description": "Substring the response body must contain",
+              "type": "string"
+            },
+            "expectStatus": {
+              "description": "HTTP status the probe expects",
+              "type": "number"
+            },
+            "id": {
+              "description": "Check id",
+              "type": "string"
+            },
+            "intervalSeconds": {
+              "description": "Probe interval in seconds (minimum 30)",
+              "type": "number"
+            },
+            "method": {
+              "description": "HTTP method",
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "description": "Human-readable check name",
+              "type": "string"
+            },
+            "timeoutMs": {
+              "description": "Per-attempt timeout in milliseconds",
+              "type": "number"
+            },
+            "url": {
+              "description": "URL to probe",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "expect": {
+              "properties": {
+                "bodyIncludes": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "intervalSeconds": {
+              "type": "number"
+            },
+            "method": {
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "enabled",
+            "expect",
+            "id",
+            "intervalSeconds",
+            "method",
+            "name",
+            "state",
+            "timeoutMs",
+            "updatedAt",
+            "url"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "lookout:admin"
+          ]
+        },
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "incident.acknowledge",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "incident",
+            "acknowledge"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "incident",
+                "acknowledge"
+              ],
+              "source": "derived",
+              "target": "incident.acknowledge"
+            }
+          ]
+        },
+        "description": "Acknowledge an incident so on-call knows it is being handled.",
+        "examples": [
+          {
+            "input": {
+              "by": "matt",
+              "id": "inc_demo"
+            },
+            "kind": "success",
+            "name": "Acknowledge an incident",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Acknowledge the seeded demo incident",
+            "expectedMatch": {
+              "id": "inc_demo",
+              "status": "acknowledged"
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "by": {
+              "description": "Who is acknowledging",
+              "type": "string"
+            },
+            "id": {
+              "description": "Incident id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "acknowledgedBy": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "openedAt": {
+              "type": "string"
+            },
+            "probeCount": {
+              "type": "number"
+            },
+            "resolvedAt": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "enum": [
+                "open",
+                "acknowledged",
+                "resolved"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "acknowledgedBy",
+            "checkId",
+            "id",
+            "openedAt",
+            "probeCount",
+            "resolvedAt",
+            "status"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "lookout:admin"
+          ]
+        },
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "incident.get",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "incident",
+            "get"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "incident",
+                "get"
+              ],
+              "source": "derived",
+              "target": "incident.get"
+            }
+          ]
+        },
+        "description": "Show one incident by id.",
+        "examples": [
+          {
+            "input": {
+              "id": "inc_demo"
+            },
+            "kind": "success",
+            "name": "Get an incident",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Look up the seeded demo incident",
+            "expectedMatch": {
+              "checkId": "chk_retired",
+              "id": "inc_demo"
+            }
+          },
+          {
+            "input": {
+              "id": "inc_missing"
+            },
+            "kind": "error",
+            "name": "Get a missing incident",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown ids return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Incident id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "acknowledgedBy": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "openedAt": {
+              "type": "string"
+            },
+            "probeCount": {
+              "type": "number"
+            },
+            "resolvedAt": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "enum": [
+                "open",
+                "acknowledged",
+                "resolved"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "acknowledgedBy",
+            "checkId",
+            "id",
+            "openedAt",
+            "probeCount",
+            "resolvedAt",
+            "status"
+          ],
+          "type": "object"
+        },
+        "permit": "public",
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "incident.list",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "incident",
+            "list"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "incident",
+                "list"
+              ],
+              "source": "derived",
+              "target": "incident.list"
+            }
+          ]
+        },
+        "description": "List incidents, newest first.",
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "List incidents",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "The demo store seeds one open incident",
+            "expectedMatch": {
+              "total": 1
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "status": {
+              "description": "Filter by incident status",
+              "enum": [
+                "open",
+                "acknowledged",
+                "resolved"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "incidents": {
+              "items": {
+                "properties": {
+                  "acknowledgedBy": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "checkId": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "openedAt": {
+                    "type": "string"
+                  },
+                  "probeCount": {
+                    "type": "number"
+                  },
+                  "resolvedAt": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "status": {
+                    "enum": [
+                      "open",
+                      "acknowledged",
+                      "resolved"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "acknowledgedBy",
+                  "checkId",
+                  "id",
+                  "openedAt",
+                  "probeCount",
+                  "resolvedAt",
+                  "status"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "total": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "incidents",
+            "total"
+          ],
+          "type": "object"
+        },
+        "permit": "public",
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "incident.open",
+        "kind": "trail",
+        "surfaces": [],
+        "activationSources": [
+          {
+            "source": {
+              "id": "probe.failed",
+              "key": "signal:probe.failed",
+              "kind": "signal"
+            }
+          }
+        ],
+        "cli": {
+          "path": [
+            "incident",
+            "open"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "incident",
+                "open"
+              ],
+              "source": "derived",
+              "target": "incident.open"
+            }
+          ]
+        },
+        "composes": [
+          "notify.dispatch"
+        ],
+        "description": "Open an incident when a check transitions to down; dedupes when one is already open.",
+        "examples": [
+          {
+            "input": {
+              "at": "2026-07-01T03:12:00.000Z",
+              "checkId": "chk_steady",
+              "checkName": "steady",
+              "failureReason": "upstream answered 503",
+              "probeId": "prb_1",
+              "url": "http://localhost:4090/steady"
+            },
+            "kind": "success",
+            "name": "Open an incident",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "A fresh up→down transition opens an incident and notifies",
+            "expectedMatch": {
+              "deduped": false,
+              "notified": true
+            }
+          },
+          {
+            "input": {
+              "at": "2026-07-01T03:13:00.000Z",
+              "checkId": "chk_retired",
+              "checkName": "retired",
+              "failureReason": "upstream answered 503",
+              "probeId": "prb_2",
+              "url": "http://localhost:4090/flaky"
+            },
+            "kind": "success",
+            "name": "Dedupe against an open incident",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "A failure signal for a check with an open incident dedupes to a no-op",
+            "expectedMatch": {
+              "deduped": true,
+              "notified": false
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "at": {
+              "description": "ISO timestamp of the resolving probe",
+              "type": "string"
+            },
+            "checkId": {
+              "description": "Check that changed state",
+              "type": "string"
+            },
+            "checkName": {
+              "description": "Human-readable check name",
+              "type": "string"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Why the probe failed, null on recovery"
+            },
+            "probeId": {
+              "description": "Probe row that resolved the transition",
+              "type": "string"
+            },
+            "url": {
+              "description": "Probed URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "at",
+            "checkId",
+            "checkName",
+            "failureReason",
+            "probeId",
+            "url"
+          ],
+          "type": "object"
+        },
+        "on": [
+          "probe.failed"
+        ],
+        "output": {
+          "properties": {
+            "deduped": {
+              "type": "boolean"
+            },
+            "incident": {
+              "properties": {
+                "acknowledgedBy": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "checkId": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "openedAt": {
+                  "type": "string"
+                },
+                "probeCount": {
+                  "type": "number"
+                },
+                "resolvedAt": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "status": {
+                  "enum": [
+                    "open",
+                    "acknowledged",
+                    "resolved"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "acknowledgedBy",
+                "checkId",
+                "id",
+                "openedAt",
+                "probeCount",
+                "resolvedAt",
+                "status"
+              ],
+              "type": "object"
+            },
+            "notified": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "deduped",
+            "incident",
+            "notified"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "incident.resolve",
+        "kind": "trail",
+        "surfaces": [],
+        "activationSources": [
+          {
+            "source": {
+              "id": "probe.recovered",
+              "key": "signal:probe.recovered",
+              "kind": "signal"
+            }
+          }
+        ],
+        "cli": {
+          "path": [
+            "incident",
+            "resolve"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "incident",
+                "resolve"
+              ],
+              "source": "derived",
+              "target": "incident.resolve"
+            }
+          ]
+        },
+        "composes": [
+          "notify.dispatch"
+        ],
+        "description": "Resolve the open incident when a check transitions back to up.",
+        "examples": [
+          {
+            "input": {
+              "at": "2026-07-01T03:20:00.000Z",
+              "checkId": "chk_retired",
+              "checkName": "retired",
+              "failureReason": null,
+              "probeId": "prb_3",
+              "url": "http://localhost:4090/steady"
+            },
+            "kind": "success",
+            "name": "Resolve an incident",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "A down→up transition resolves the open incident",
+            "expectedMatch": {
+              "notified": true,
+              "resolved": true
+            }
+          },
+          {
+            "input": {
+              "at": "2026-07-01T03:21:00.000Z",
+              "checkId": "chk_steady",
+              "checkName": "steady",
+              "failureReason": null,
+              "probeId": "prb_4",
+              "url": "http://localhost:4090/steady"
+            },
+            "kind": "success",
+            "name": "Recovery without an incident",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "A recovery with no open incident is a no-op",
+            "expectedMatch": {
+              "notified": false,
+              "resolved": false
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "at": {
+              "description": "ISO timestamp of the resolving probe",
+              "type": "string"
+            },
+            "checkId": {
+              "description": "Check that changed state",
+              "type": "string"
+            },
+            "checkName": {
+              "description": "Human-readable check name",
+              "type": "string"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Why the probe failed, null on recovery"
+            },
+            "probeId": {
+              "description": "Probe row that resolved the transition",
+              "type": "string"
+            },
+            "url": {
+              "description": "Probed URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "at",
+            "checkId",
+            "checkName",
+            "failureReason",
+            "probeId",
+            "url"
+          ],
+          "type": "object"
+        },
+        "on": [
+          "probe.recovered"
+        ],
+        "output": {
+          "properties": {
+            "incident": {
+              "anyOf": [
+                {
+                  "properties": {
+                    "acknowledgedBy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "checkId": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "openedAt": {
+                      "type": "string"
+                    },
+                    "probeCount": {
+                      "type": "number"
+                    },
+                    "resolvedAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "status": {
+                      "enum": [
+                        "open",
+                        "acknowledged",
+                        "resolved"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "acknowledgedBy",
+                    "checkId",
+                    "id",
+                    "openedAt",
+                    "probeCount",
+                    "resolvedAt",
+                    "status"
+                  ],
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "notified": {
+              "type": "boolean"
+            },
+            "resolved": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "incident",
+            "notified",
+            "resolved"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db",
+        "kind": "resource",
+        "surfaces": [],
+        "description": "SQLite store for lookout checks, probes, incidents, and notifications.",
+        "healthcheck": true
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db:checks.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"checks\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "expect": {
+              "properties": {
+                "bodyIncludes": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "intervalSeconds": {
+              "type": "number"
+            },
+            "method": {
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "enabled",
+            "expect",
+            "id",
+            "intervalSeconds",
+            "method",
+            "name",
+            "state",
+            "timeoutMs",
+            "updatedAt",
+            "url"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "expect": {
+              "properties": {
+                "bodyIncludes": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "intervalSeconds": {
+              "type": "number"
+            },
+            "method": {
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "enabled",
+            "expect",
+            "id",
+            "intervalSeconds",
+            "method",
+            "name",
+            "state",
+            "timeoutMs",
+            "updatedAt",
+            "url"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db:checks.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"checks\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "expect": {
+              "properties": {
+                "bodyIncludes": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "intervalSeconds": {
+              "type": "number"
+            },
+            "method": {
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "enabled",
+            "expect",
+            "id",
+            "intervalSeconds",
+            "method",
+            "name",
+            "state",
+            "timeoutMs",
+            "updatedAt",
+            "url"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "expect": {
+              "properties": {
+                "bodyIncludes": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "intervalSeconds": {
+              "type": "number"
+            },
+            "method": {
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "enabled",
+            "expect",
+            "id",
+            "intervalSeconds",
+            "method",
+            "name",
+            "state",
+            "timeoutMs",
+            "updatedAt",
+            "url"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db:checks.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"checks\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "expect": {
+              "properties": {
+                "bodyIncludes": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "intervalSeconds": {
+              "type": "number"
+            },
+            "method": {
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "enabled",
+            "expect",
+            "id",
+            "intervalSeconds",
+            "method",
+            "name",
+            "state",
+            "timeoutMs",
+            "updatedAt",
+            "url"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "enabled": {
+              "type": "boolean"
+            },
+            "expect": {
+              "properties": {
+                "bodyIncludes": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "number"
+                }
+              },
+              "type": "object"
+            },
+            "id": {
+              "type": "string"
+            },
+            "intervalSeconds": {
+              "type": "number"
+            },
+            "method": {
+              "enum": [
+                "GET",
+                "HEAD"
+              ],
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "timeoutMs": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "enabled",
+            "expect",
+            "id",
+            "intervalSeconds",
+            "method",
+            "name",
+            "state",
+            "timeoutMs",
+            "updatedAt",
+            "url"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db:incidents.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"incidents\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "acknowledgedBy": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "openedAt": {
+              "type": "string"
+            },
+            "probeCount": {
+              "type": "number"
+            },
+            "resolvedAt": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "enum": [
+                "open",
+                "acknowledged",
+                "resolved"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "acknowledgedBy",
+            "checkId",
+            "id",
+            "openedAt",
+            "probeCount",
+            "resolvedAt",
+            "status"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "acknowledgedBy": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "openedAt": {
+              "type": "string"
+            },
+            "probeCount": {
+              "type": "number"
+            },
+            "resolvedAt": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "enum": [
+                "open",
+                "acknowledged",
+                "resolved"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "acknowledgedBy",
+            "checkId",
+            "id",
+            "openedAt",
+            "probeCount",
+            "resolvedAt",
+            "status"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db:incidents.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"incidents\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "acknowledgedBy": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "openedAt": {
+              "type": "string"
+            },
+            "probeCount": {
+              "type": "number"
+            },
+            "resolvedAt": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "enum": [
+                "open",
+                "acknowledged",
+                "resolved"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "acknowledgedBy",
+            "checkId",
+            "id",
+            "openedAt",
+            "probeCount",
+            "resolvedAt",
+            "status"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "acknowledgedBy": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "openedAt": {
+              "type": "string"
+            },
+            "probeCount": {
+              "type": "number"
+            },
+            "resolvedAt": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "enum": [
+                "open",
+                "acknowledged",
+                "resolved"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "acknowledgedBy",
+            "checkId",
+            "id",
+            "openedAt",
+            "probeCount",
+            "resolvedAt",
+            "status"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db:incidents.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"incidents\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "acknowledgedBy": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "openedAt": {
+              "type": "string"
+            },
+            "probeCount": {
+              "type": "number"
+            },
+            "resolvedAt": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "enum": [
+                "open",
+                "acknowledged",
+                "resolved"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "acknowledgedBy",
+            "checkId",
+            "id",
+            "openedAt",
+            "probeCount",
+            "resolvedAt",
+            "status"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "acknowledgedBy": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "openedAt": {
+              "type": "string"
+            },
+            "probeCount": {
+              "type": "number"
+            },
+            "resolvedAt": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "status": {
+              "enum": [
+                "open",
+                "acknowledged",
+                "resolved"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "acknowledgedBy",
+            "checkId",
+            "id",
+            "openedAt",
+            "probeCount",
+            "resolvedAt",
+            "status"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db:notifications.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"notifications\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "channel": {
+              "enum": [
+                "console",
+                "webhook"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "incidentId": {
+              "type": "string"
+            },
+            "ok": {
+              "type": "boolean"
+            },
+            "sentAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "channel",
+            "id",
+            "incidentId",
+            "ok",
+            "sentAt"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "channel": {
+              "enum": [
+                "console",
+                "webhook"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "incidentId": {
+              "type": "string"
+            },
+            "ok": {
+              "type": "boolean"
+            },
+            "sentAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "channel",
+            "id",
+            "incidentId",
+            "ok",
+            "sentAt"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db:notifications.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"notifications\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "channel": {
+              "enum": [
+                "console",
+                "webhook"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "incidentId": {
+              "type": "string"
+            },
+            "ok": {
+              "type": "boolean"
+            },
+            "sentAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "channel",
+            "id",
+            "incidentId",
+            "ok",
+            "sentAt"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "channel": {
+              "enum": [
+                "console",
+                "webhook"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "incidentId": {
+              "type": "string"
+            },
+            "ok": {
+              "type": "boolean"
+            },
+            "sentAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "channel",
+            "id",
+            "incidentId",
+            "ok",
+            "sentAt"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db:notifications.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"notifications\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "channel": {
+              "enum": [
+                "console",
+                "webhook"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "incidentId": {
+              "type": "string"
+            },
+            "ok": {
+              "type": "boolean"
+            },
+            "sentAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "channel",
+            "id",
+            "incidentId",
+            "ok",
+            "sentAt"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "channel": {
+              "enum": [
+                "console",
+                "webhook"
+              ],
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "incidentId": {
+              "type": "string"
+            },
+            "ok": {
+              "type": "boolean"
+            },
+            "sentAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "channel",
+            "id",
+            "incidentId",
+            "ok",
+            "sentAt"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db:probes.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"probes\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "attempts": {
+              "type": "number"
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "durationMs": {
+              "type": "number"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "outcome": {
+              "enum": [
+                "up",
+                "down",
+                "recovered-after-retry"
+              ],
+              "type": "string"
+            },
+            "startedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "attempts",
+            "checkId",
+            "durationMs",
+            "failureReason",
+            "id",
+            "outcome",
+            "startedAt"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "attempts": {
+              "type": "number"
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "durationMs": {
+              "type": "number"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "outcome": {
+              "enum": [
+                "up",
+                "down",
+                "recovered-after-retry"
+              ],
+              "type": "string"
+            },
+            "startedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "attempts",
+            "checkId",
+            "durationMs",
+            "failureReason",
+            "id",
+            "outcome",
+            "startedAt"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db:probes.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"probes\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "attempts": {
+              "type": "number"
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "durationMs": {
+              "type": "number"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "outcome": {
+              "enum": [
+                "up",
+                "down",
+                "recovered-after-retry"
+              ],
+              "type": "string"
+            },
+            "startedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "attempts",
+            "checkId",
+            "durationMs",
+            "failureReason",
+            "id",
+            "outcome",
+            "startedAt"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "attempts": {
+              "type": "number"
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "durationMs": {
+              "type": "number"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "outcome": {
+              "enum": [
+                "up",
+                "down",
+                "recovered-after-retry"
+              ],
+              "type": "string"
+            },
+            "startedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "attempts",
+            "checkId",
+            "durationMs",
+            "failureReason",
+            "id",
+            "outcome",
+            "startedAt"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.db:probes.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"probes\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "attempts": {
+              "type": "number"
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "durationMs": {
+              "type": "number"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "outcome": {
+              "enum": [
+                "up",
+                "down",
+                "recovered-after-retry"
+              ],
+              "type": "string"
+            },
+            "startedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "attempts",
+            "checkId",
+            "durationMs",
+            "failureReason",
+            "id",
+            "outcome",
+            "startedAt"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "attempts": {
+              "type": "number"
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "durationMs": {
+              "type": "number"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "outcome": {
+              "enum": [
+                "up",
+                "down",
+                "recovered-after-retry"
+              ],
+              "type": "string"
+            },
+            "startedAt": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "attempts",
+            "checkId",
+            "durationMs",
+            "failureReason",
+            "id",
+            "outcome",
+            "startedAt"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "lookout.probe-http",
+        "kind": "resource",
+        "surfaces": [],
+        "description": "Outbound HTTP client used by probe.run; the mock plays scripted per-URL reply sequences."
+      },
+      {
+        "exampleCount": 1,
+        "id": "notify.dispatch",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "notify",
+            "dispatch"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "notify",
+                "dispatch"
+              ],
+              "source": "derived",
+              "target": "notify.dispatch"
+            }
+          ]
+        },
+        "description": "Fan an incident lifecycle event out to the configured channels and record each delivery.",
+        "examples": [
+          {
+            "input": {
+              "incidentId": "inc_demo",
+              "kind": "opened",
+              "message": "check \"flaky\" is down"
+            },
+            "kind": "success",
+            "name": "Dispatch to console",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Console delivery always runs; webhook only when configured",
+            "expected": {
+              "deliveries": [
+                {
+                  "channel": "console",
+                  "ok": true
+                }
+              ]
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "incidentId": {
+              "description": "Incident this notification belongs to",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Incident lifecycle event being announced",
+              "enum": [
+                "opened",
+                "resolved"
+              ],
+              "type": "string"
+            },
+            "message": {
+              "description": "Human-readable notification text",
+              "type": "string"
+            }
+          },
+          "required": [
+            "incidentId",
+            "kind",
+            "message"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "deliveries": {
+              "items": {
+                "properties": {
+                  "channel": {
+                    "enum": [
+                      "console",
+                      "webhook"
+                    ],
+                    "type": "string"
+                  },
+                  "ok": {
+                    "type": "boolean"
+                  }
+                },
+                "required": [
+                  "channel",
+                  "ok"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "deliveries"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "lookout.db",
+          "lookout.probe-http"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "probe.failed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [
+          "incident.open"
+        ],
+        "description": "A check transitioned up→down (fired once per outage, not per probe).",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "examples": [
+          {
+            "kind": "payload",
+            "payload": {
+              "at": "2026-07-01T03:12:00.000Z",
+              "checkId": "chk_flaky",
+              "checkName": "flaky",
+              "failureReason": "upstream answered 503",
+              "probeId": "prb_1",
+              "url": "http://localhost:4090/flaky"
+            },
+            "provenance": {
+              "source": "signal.examples"
+            }
+          }
+        ],
+        "from": [
+          "probe.run"
+        ],
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "at": {
+              "description": "ISO timestamp of the resolving probe",
+              "type": "string"
+            },
+            "checkId": {
+              "description": "Check that changed state",
+              "type": "string"
+            },
+            "checkName": {
+              "description": "Human-readable check name",
+              "type": "string"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Why the probe failed, null on recovery"
+            },
+            "probeId": {
+              "description": "Probe row that resolved the transition",
+              "type": "string"
+            },
+            "url": {
+              "description": "Probed URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "at",
+            "checkId",
+            "checkName",
+            "failureReason",
+            "probeId",
+            "url"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "at": {
+              "description": "ISO timestamp of the resolving probe",
+              "type": "string"
+            },
+            "checkId": {
+              "description": "Check that changed state",
+              "type": "string"
+            },
+            "checkName": {
+              "description": "Human-readable check name",
+              "type": "string"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Why the probe failed, null on recovery"
+            },
+            "probeId": {
+              "description": "Probe row that resolved the transition",
+              "type": "string"
+            },
+            "url": {
+              "description": "Probed URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "at",
+            "checkId",
+            "checkName",
+            "failureReason",
+            "probeId",
+            "url"
+          ],
+          "type": "object"
+        },
+        "producers": [
+          "probe.run"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "probe.history",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "probe",
+            "history"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "probe",
+                "history"
+              ],
+              "source": "derived",
+              "target": "probe.history"
+            }
+          ]
+        },
+        "description": "Probe history for one check, newest first, windowed and paginated.",
+        "examples": [
+          {
+            "input": {
+              "checkId": "chk_steady"
+            },
+            "kind": "success",
+            "name": "Empty history",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "A fresh check has no probe history yet",
+            "expected": {
+              "probes": [],
+              "total": 0
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "checkId": {
+              "description": "Check id",
+              "type": "string"
+            },
+            "limit": {
+              "default": 50,
+              "description": "Maximum results",
+              "type": "number"
+            },
+            "offset": {
+              "default": 0,
+              "description": "Pagination offset",
+              "type": "number"
+            },
+            "sinceHours": {
+              "description": "Only include probes from the last N hours",
+              "type": "number"
+            }
+          },
+          "required": [
+            "checkId"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "probes": {
+              "items": {
+                "properties": {
+                  "attempts": {
+                    "type": "number"
+                  },
+                  "checkId": {
+                    "type": "string"
+                  },
+                  "durationMs": {
+                    "type": "number"
+                  },
+                  "failureReason": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "outcome": {
+                    "enum": [
+                      "up",
+                      "down",
+                      "recovered-after-retry"
+                    ],
+                    "type": "string"
+                  },
+                  "startedAt": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "attempts",
+                  "checkId",
+                  "durationMs",
+                  "failureReason",
+                  "id",
+                  "outcome",
+                  "startedAt"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "total": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "probes",
+            "total"
+          ],
+          "type": "object"
+        },
+        "permit": "public",
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "probe.prune",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "probe",
+            "prune"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "probe",
+                "prune"
+              ],
+              "source": "derived",
+              "target": "probe.prune"
+            }
+          ]
+        },
+        "description": "Reconcile stored probe volume against the retention cap, pruning the oldest rows per check.",
+        "dryRunCapable": true,
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "Prune within retention",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Nothing to prune when history is within retention",
+            "expected": {
+              "dryRun": false,
+              "removed": 0
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "keepPerCheck": {
+              "default": 100,
+              "description": "Probe rows to keep per check",
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "intent": "destroy",
+        "output": {
+          "properties": {
+            "dryRun": {
+              "type": "boolean"
+            },
+            "removed": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "dryRun",
+            "removed"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "lookout:admin"
+          ]
+        },
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "probe.recovered",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [
+          "incident.resolve"
+        ],
+        "description": "A check transitioned down→up.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "examples": [
+          {
+            "kind": "payload",
+            "payload": {
+              "at": "2026-07-01T03:20:00.000Z",
+              "checkId": "chk_flaky",
+              "checkName": "flaky",
+              "failureReason": null,
+              "probeId": "prb_2",
+              "url": "http://localhost:4090/flaky"
+            },
+            "provenance": {
+              "source": "signal.examples"
+            }
+          }
+        ],
+        "from": [
+          "probe.run"
+        ],
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "at": {
+              "description": "ISO timestamp of the resolving probe",
+              "type": "string"
+            },
+            "checkId": {
+              "description": "Check that changed state",
+              "type": "string"
+            },
+            "checkName": {
+              "description": "Human-readable check name",
+              "type": "string"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Why the probe failed, null on recovery"
+            },
+            "probeId": {
+              "description": "Probe row that resolved the transition",
+              "type": "string"
+            },
+            "url": {
+              "description": "Probed URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "at",
+            "checkId",
+            "checkName",
+            "failureReason",
+            "probeId",
+            "url"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "at": {
+              "description": "ISO timestamp of the resolving probe",
+              "type": "string"
+            },
+            "checkId": {
+              "description": "Check that changed state",
+              "type": "string"
+            },
+            "checkName": {
+              "description": "Human-readable check name",
+              "type": "string"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Why the probe failed, null on recovery"
+            },
+            "probeId": {
+              "description": "Probe row that resolved the transition",
+              "type": "string"
+            },
+            "url": {
+              "description": "Probed URL",
+              "type": "string"
+            }
+          },
+          "required": [
+            "at",
+            "checkId",
+            "checkName",
+            "failureReason",
+            "probeId",
+            "url"
+          ],
+          "type": "object"
+        },
+        "producers": [
+          "probe.run"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "probe.run",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "probe",
+            "run"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "probe",
+                "run"
+              ],
+              "source": "derived",
+              "target": "probe.run"
+            }
+          ]
+        },
+        "description": "Probe one check: transient failures recover through detours, resolved probes record a row and move the derived check state. Fires probe.failed on up→down and probe.recovered on down→up.",
+        "detours": [
+          {
+            "maxAttempts": 2,
+            "on": "TimeoutError"
+          },
+          {
+            "maxAttempts": 2,
+            "on": "NetworkError"
+          }
+        ],
+        "examples": [
+          {
+            "input": {
+              "checkId": "chk_steady"
+            },
+            "kind": "success",
+            "name": "Probe an up check",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "A healthy endpoint resolves up on the first attempt",
+            "expectedMatch": {
+              "attempts": 1,
+              "checkId": "chk_steady",
+              "failureReason": null,
+              "outcome": "up",
+              "state": "up",
+              "transition": "none"
+            }
+          },
+          {
+            "input": {
+              "checkId": "chk_missing"
+            },
+            "kind": "error",
+            "name": "Probe a missing check",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown check ids return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "fires": [
+          "probe.failed",
+          "probe.recovered"
+        ],
+        "input": {
+          "properties": {
+            "checkId": {
+              "description": "Check to probe",
+              "type": "string"
+            }
+          },
+          "required": [
+            "checkId"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "attempts": {
+              "type": "number"
+            },
+            "checkId": {
+              "type": "string"
+            },
+            "durationMs": {
+              "type": "number"
+            },
+            "failureReason": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "outcome": {
+              "enum": [
+                "up",
+                "down",
+                "recovered-after-retry"
+              ],
+              "type": "string"
+            },
+            "previousState": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "probeId": {
+              "type": "string"
+            },
+            "startedAt": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down"
+              ],
+              "type": "string"
+            },
+            "transition": {
+              "enum": [
+                "none",
+                "failed",
+                "recovered"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "attempts",
+            "checkId",
+            "durationMs",
+            "failureReason",
+            "outcome",
+            "previousState",
+            "probeId",
+            "startedAt",
+            "state",
+            "transition"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "lookout.db",
+          "lookout.probe-http"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "probe.sweep",
+        "kind": "trail",
+        "surfaces": [],
+        "activationSources": [
+          {
+            "source": {
+              "cron": "* * * * *",
+              "id": "schedule.probe.sweep",
+              "input": {},
+              "key": "schedule:schedule.probe.sweep",
+              "kind": "schedule"
+            }
+          }
+        ],
+        "cli": {
+          "path": [
+            "probe",
+            "sweep"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "probe",
+                "sweep"
+              ],
+              "source": "derived",
+              "target": "probe.sweep"
+            }
+          ]
+        },
+        "composes": [
+          "probe.run"
+        ],
+        "description": "Probe every enabled check that is due per its own interval; the cron source ticks this each minute.",
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "Sweep due checks",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Both enabled demo checks are due on a fresh store",
+            "expectedMatch": {
+              "probed": 2
+            }
+          }
+        ],
+        "input": {
+          "properties": {},
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "due": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "probed": {
+              "type": "number"
+            },
+            "results": {
+              "items": {
+                "properties": {
+                  "checkId": {
+                    "type": "string"
+                  },
+                  "ok": {
+                    "type": "boolean"
+                  },
+                  "outcome": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "checkId",
+                  "ok",
+                  "outcome"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "due",
+            "probed",
+            "results"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "status.badge",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "status",
+            "badge"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "status",
+                "badge"
+              ],
+              "source": "derived",
+              "target": "status.badge"
+            }
+          ]
+        },
+        "composes": [
+          "uptime.report"
+        ],
+        "description": "Tiny per-check JSON payload for embedding (badge-shaped, JSON in v1).",
+        "examples": [
+          {
+            "input": {
+              "checkId": "chk_steady"
+            },
+            "kind": "success",
+            "name": "Badge for a check",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "A fresh check reports its state with no uptime claim",
+            "expected": {
+              "checkId": "chk_steady",
+              "label": "steady",
+              "state": "unknown",
+              "uptime7d": null
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "checkId": {
+              "description": "Check id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "checkId"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "checkId": {
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            },
+            "state": {
+              "enum": [
+                "up",
+                "down",
+                "unknown"
+              ],
+              "type": "string"
+            },
+            "uptime7d": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "checkId",
+            "label",
+            "state",
+            "uptime7d"
+          ],
+          "type": "object"
+        },
+        "permit": "public",
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "status.summary",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "status"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "status"
+              ],
+              "source": "trail",
+              "target": "status.summary"
+            }
+          ]
+        },
+        "composes": [
+          "incident.list",
+          "uptime.report"
+        ],
+        "description": "The public status page payload: per-check state, 7d/30d uptime, and open incident count.",
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "Status summary",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "The demo store seeds three checks and one open incident",
+            "expectedMatch": {
+              "openIncidents": 1
+            }
+          }
+        ],
+        "input": {
+          "properties": {},
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "checks": {
+              "items": {
+                "properties": {
+                  "checkId": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "state": {
+                    "enum": [
+                      "up",
+                      "down",
+                      "unknown"
+                    ],
+                    "type": "string"
+                  },
+                  "uptime30d": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "uptime7d": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "url": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "checkId",
+                  "enabled",
+                  "name",
+                  "state",
+                  "uptime30d",
+                  "uptime7d",
+                  "url"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "generatedAt": {
+              "type": "string"
+            },
+            "openIncidents": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "checks",
+            "generatedAt",
+            "openIncidents"
+          ],
+          "type": "object"
+        },
+        "permit": "public",
+        "resources": [
+          "lookout.db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "tracing",
+        "kind": "resource",
+        "surfaces": [],
+        "description": "Telemetry query resource"
+      },
+      {
+        "exampleCount": 3,
+        "id": "tracing.query",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "tracing",
+            "query"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "tracing",
+                "query"
+              ],
+              "source": "derived",
+              "target": "tracing.query"
+            }
+          ]
+        },
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "Recent traces",
+            "provenance": {
+              "source": "trail.examples"
+            }
+          },
+          {
+            "input": {
+              "trailId": "user.create"
+            },
+            "kind": "success",
+            "name": "Filter by trail",
+            "provenance": {
+              "source": "trail.examples"
+            }
+          },
+          {
+            "input": {
+              "errorsOnly": true
+            },
+            "kind": "success",
+            "name": "Errors only",
+            "provenance": {
+              "source": "trail.examples"
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "errorsOnly": {
+              "default": false,
+              "description": "Show only failed traces",
+              "type": "boolean"
+            },
+            "limit": {
+              "default": 20,
+              "description": "Max results",
+              "type": "number"
+            },
+            "traceId": {
+              "description": "Show full trace tree",
+              "type": "string"
+            },
+            "trailId": {
+              "description": "Filter by trail ID",
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "count": {
+              "type": "number"
+            },
+            "records": {
+              "items": {
+                "properties": {
+                  "attrs": {},
+                  "endedAt": {
+                    "type": "number"
+                  },
+                  "errorCategory": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "intent": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "enum": [
+                      "activation",
+                      "signal",
+                      "span",
+                      "trail"
+                    ],
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "parentId": {
+                    "type": "string"
+                  },
+                  "rootId": {
+                    "type": "string"
+                  },
+                  "startedAt": {
+                    "type": "number"
+                  },
+                  "status": {
+                    "enum": [
+                      "ok",
+                      "err",
+                      "cancelled"
+                    ],
+                    "type": "string"
+                  },
+                  "surface": {
+                    "type": "string"
+                  },
+                  "traceId": {
+                    "type": "string"
+                  },
+                  "trailId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "attrs",
+                  "id",
+                  "kind",
+                  "name",
+                  "rootId",
+                  "startedAt",
+                  "status",
+                  "traceId"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "count",
+            "records"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "tracing"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "tracing.status",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "tracing",
+            "status"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "tracing",
+                "status"
+              ],
+              "source": "derived",
+              "target": "tracing.status"
+            }
+          ]
+        },
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "Check tracing status",
+            "provenance": {
+              "source": "trail.examples"
+            }
+          }
+        ],
+        "input": {
+          "properties": {},
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "active": {
+              "type": "boolean"
+            },
+            "recordCount": {
+              "type": "number"
+            },
+            "samplingConfig": {
+              "properties": {
+                "destroy": {
+                  "type": "number"
+                },
+                "read": {
+                  "type": "number"
+                },
+                "write": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "destroy",
+                "read",
+                "write"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "active",
+            "recordCount",
+            "samplingConfig"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "tracing"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "uptime.report",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "uptime",
+            "report"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "uptime",
+                "report"
+              ],
+              "source": "derived",
+              "target": "uptime.report"
+            }
+          ]
+        },
+        "composes": [
+          "probe.history"
+        ],
+        "description": "Windowed uptime percentages computed from recorded probe outcomes.",
+        "examples": [
+          {
+            "input": {
+              "checkId": "chk_steady"
+            },
+            "kind": "success",
+            "name": "Uptime with no history",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "No probes yet means no uptime claim — null, not 100%",
+            "expected": {
+              "checkId": "chk_steady",
+              "days": 7,
+              "downCount": 0,
+              "probeCount": 0,
+              "recoveredCount": 0,
+              "upCount": 0,
+              "uptimePercent": null
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "checkId": {
+              "description": "Check id",
+              "type": "string"
+            },
+            "days": {
+              "default": 7,
+              "description": "Window size in days",
+              "type": "number"
+            }
+          },
+          "required": [
+            "checkId"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "checkId": {
+              "type": "string"
+            },
+            "days": {
+              "type": "number"
+            },
+            "downCount": {
+              "type": "number"
+            },
+            "probeCount": {
+              "type": "number"
+            },
+            "recoveredCount": {
+              "type": "number"
+            },
+            "upCount": {
+              "type": "number"
+            },
+            "uptimePercent": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "checkId",
+            "days",
+            "downCount",
+            "probeCount",
+            "recoveredCount",
+            "upCount",
+            "uptimePercent"
+          ],
+          "type": "object"
+        },
+        "permit": "public"
+      }
+    ],
+    "library": {
+      "app": "lookout",
+      "collisions": [],
+      "excluded": [
+        {
+          "reason": "activation",
+          "trailId": "incident.open"
+        },
+        {
+          "reason": "activation",
+          "trailId": "incident.resolve"
+        },
+        {
+          "reason": "internal",
+          "trailId": "notify.dispatch"
+        },
+        {
+          "reason": "internal",
+          "trailId": "probe.run"
+        },
+        {
+          "reason": "activation",
+          "trailId": "probe.sweep"
+        }
+      ],
+      "exports": [
+        {
+          "description": "Register a new endpoint check and start monitoring it.",
+          "exportName": "checkCreate",
+          "input": {
+            "properties": {
+              "expectBodyIncludes": {
+                "description": "Substring the response body must contain",
+                "type": "string"
+              },
+              "expectStatus": {
+                "default": 200,
+                "description": "HTTP status the probe expects",
+                "type": "number"
+              },
+              "intervalSeconds": {
+                "description": "Probe interval in seconds (minimum 30)",
+                "type": "number"
+              },
+              "method": {
+                "default": "GET",
+                "description": "HTTP method",
+                "enum": [
+                  "GET",
+                  "HEAD"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Human-readable check name",
+                "type": "string"
+              },
+              "timeoutMs": {
+                "default": 2000,
+                "description": "Per-attempt timeout in milliseconds",
+                "type": "number"
+              },
+              "url": {
+                "description": "URL to probe",
+                "type": "string"
+              }
+            },
+            "required": [
+              "intervalSeconds",
+              "name",
+              "url"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "expect": {
+                "properties": {
+                  "bodyIncludes": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              },
+              "id": {
+                "type": "string"
+              },
+              "intervalSeconds": {
+                "type": "number"
+              },
+              "method": {
+                "enum": [
+                  "GET",
+                  "HEAD"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "up",
+                  "down",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "timeoutMs": {
+                "type": "number"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "createdAt",
+              "enabled",
+              "expect",
+              "id",
+              "intervalSeconds",
+              "method",
+              "name",
+              "state",
+              "timeoutMs",
+              "updatedAt",
+              "url"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "check.create"
+        },
+        {
+          "description": "Delete a check and stop monitoring it.",
+          "exportName": "checkDelete",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Check id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "destroy",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "deleted": {
+                "type": "boolean"
+              },
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "deleted",
+              "id"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "check.delete"
+        },
+        {
+          "description": "Show one check by id.",
+          "exportName": "checkGet",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Check id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "expect": {
+                "properties": {
+                  "bodyIncludes": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              },
+              "id": {
+                "type": "string"
+              },
+              "intervalSeconds": {
+                "type": "number"
+              },
+              "method": {
+                "enum": [
+                  "GET",
+                  "HEAD"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "up",
+                  "down",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "timeoutMs": {
+                "type": "number"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "createdAt",
+              "enabled",
+              "expect",
+              "id",
+              "intervalSeconds",
+              "method",
+              "name",
+              "state",
+              "timeoutMs",
+              "updatedAt",
+              "url"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "check.get"
+        },
+        {
+          "description": "List registered checks.",
+          "exportName": "checkList",
+          "input": {
+            "properties": {
+              "enabled": {
+                "description": "Filter by enabled state",
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "checks": {
+                "items": {
+                  "properties": {
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "expect": {
+                      "properties": {
+                        "bodyIncludes": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "number"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "intervalSeconds": {
+                      "type": "number"
+                    },
+                    "method": {
+                      "enum": [
+                        "GET",
+                        "HEAD"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "enum": [
+                        "up",
+                        "down",
+                        "unknown"
+                      ],
+                      "type": "string"
+                    },
+                    "timeoutMs": {
+                      "type": "number"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "createdAt",
+                    "enabled",
+                    "expect",
+                    "id",
+                    "intervalSeconds",
+                    "method",
+                    "name",
+                    "state",
+                    "timeoutMs",
+                    "updatedAt",
+                    "url"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "total": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "checks",
+              "total"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "check.list"
+        },
+        {
+          "description": "Pause a check — the cron sweep stops scheduling probes for it.",
+          "exportName": "checkPause",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Check id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "expect": {
+                "properties": {
+                  "bodyIncludes": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              },
+              "id": {
+                "type": "string"
+              },
+              "intervalSeconds": {
+                "type": "number"
+              },
+              "method": {
+                "enum": [
+                  "GET",
+                  "HEAD"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "up",
+                  "down",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "timeoutMs": {
+                "type": "number"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "createdAt",
+              "enabled",
+              "expect",
+              "id",
+              "intervalSeconds",
+              "method",
+              "name",
+              "state",
+              "timeoutMs",
+              "updatedAt",
+              "url"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "check.pause"
+        },
+        {
+          "description": "Resume a paused check — the cron sweep schedules probes again.",
+          "exportName": "checkResume",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Check id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "expect": {
+                "properties": {
+                  "bodyIncludes": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              },
+              "id": {
+                "type": "string"
+              },
+              "intervalSeconds": {
+                "type": "number"
+              },
+              "method": {
+                "enum": [
+                  "GET",
+                  "HEAD"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "up",
+                  "down",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "timeoutMs": {
+                "type": "number"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "createdAt",
+              "enabled",
+              "expect",
+              "id",
+              "intervalSeconds",
+              "method",
+              "name",
+              "state",
+              "timeoutMs",
+              "updatedAt",
+              "url"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "check.resume"
+        },
+        {
+          "description": "Update fields on an existing check.",
+          "exportName": "checkUpdate",
+          "input": {
+            "properties": {
+              "expectBodyIncludes": {
+                "description": "Substring the response body must contain",
+                "type": "string"
+              },
+              "expectStatus": {
+                "description": "HTTP status the probe expects",
+                "type": "number"
+              },
+              "id": {
+                "description": "Check id",
+                "type": "string"
+              },
+              "intervalSeconds": {
+                "description": "Probe interval in seconds (minimum 30)",
+                "type": "number"
+              },
+              "method": {
+                "description": "HTTP method",
+                "enum": [
+                  "GET",
+                  "HEAD"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "description": "Human-readable check name",
+                "type": "string"
+              },
+              "timeoutMs": {
+                "description": "Per-attempt timeout in milliseconds",
+                "type": "number"
+              },
+              "url": {
+                "description": "URL to probe",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "enabled": {
+                "type": "boolean"
+              },
+              "expect": {
+                "properties": {
+                  "bodyIncludes": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "number"
+                  }
+                },
+                "type": "object"
+              },
+              "id": {
+                "type": "string"
+              },
+              "intervalSeconds": {
+                "type": "number"
+              },
+              "method": {
+                "enum": [
+                  "GET",
+                  "HEAD"
+                ],
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "up",
+                  "down",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "timeoutMs": {
+                "type": "number"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "createdAt",
+              "enabled",
+              "expect",
+              "id",
+              "intervalSeconds",
+              "method",
+              "name",
+              "state",
+              "timeoutMs",
+              "updatedAt",
+              "url"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "check.update"
+        },
+        {
+          "description": "Acknowledge an incident so on-call knows it is being handled.",
+          "exportName": "incidentAcknowledge",
+          "input": {
+            "properties": {
+              "by": {
+                "description": "Who is acknowledging",
+                "type": "string"
+              },
+              "id": {
+                "description": "Incident id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "acknowledgedBy": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "checkId": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "openedAt": {
+                "type": "string"
+              },
+              "probeCount": {
+                "type": "number"
+              },
+              "resolvedAt": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "status": {
+                "enum": [
+                  "open",
+                  "acknowledged",
+                  "resolved"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "acknowledgedBy",
+              "checkId",
+              "id",
+              "openedAt",
+              "probeCount",
+              "resolvedAt",
+              "status"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "incident.acknowledge"
+        },
+        {
+          "description": "Show one incident by id.",
+          "exportName": "incidentGet",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Incident id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "acknowledgedBy": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "checkId": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "openedAt": {
+                "type": "string"
+              },
+              "probeCount": {
+                "type": "number"
+              },
+              "resolvedAt": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "status": {
+                "enum": [
+                  "open",
+                  "acknowledged",
+                  "resolved"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "acknowledgedBy",
+              "checkId",
+              "id",
+              "openedAt",
+              "probeCount",
+              "resolvedAt",
+              "status"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "incident.get"
+        },
+        {
+          "description": "List incidents, newest first.",
+          "exportName": "incidentList",
+          "input": {
+            "properties": {
+              "status": {
+                "description": "Filter by incident status",
+                "enum": [
+                  "open",
+                  "acknowledged",
+                  "resolved"
+                ],
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "incidents": {
+                "items": {
+                  "properties": {
+                    "acknowledgedBy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "checkId": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "openedAt": {
+                      "type": "string"
+                    },
+                    "probeCount": {
+                      "type": "number"
+                    },
+                    "resolvedAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "status": {
+                      "enum": [
+                        "open",
+                        "acknowledged",
+                        "resolved"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "acknowledgedBy",
+                    "checkId",
+                    "id",
+                    "openedAt",
+                    "probeCount",
+                    "resolvedAt",
+                    "status"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "total": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "incidents",
+              "total"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "incident.list"
+        },
+        {
+          "description": "Probe history for one check, newest first, windowed and paginated.",
+          "exportName": "probeHistory",
+          "input": {
+            "properties": {
+              "checkId": {
+                "description": "Check id",
+                "type": "string"
+              },
+              "limit": {
+                "default": 50,
+                "description": "Maximum results",
+                "type": "number"
+              },
+              "offset": {
+                "default": 0,
+                "description": "Pagination offset",
+                "type": "number"
+              },
+              "sinceHours": {
+                "description": "Only include probes from the last N hours",
+                "type": "number"
+              }
+            },
+            "required": [
+              "checkId"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "probes": {
+                "items": {
+                  "properties": {
+                    "attempts": {
+                      "type": "number"
+                    },
+                    "checkId": {
+                      "type": "string"
+                    },
+                    "durationMs": {
+                      "type": "number"
+                    },
+                    "failureReason": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "outcome": {
+                      "enum": [
+                        "up",
+                        "down",
+                        "recovered-after-retry"
+                      ],
+                      "type": "string"
+                    },
+                    "startedAt": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "attempts",
+                    "checkId",
+                    "durationMs",
+                    "failureReason",
+                    "id",
+                    "outcome",
+                    "startedAt"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "total": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "probes",
+              "total"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "probe.history"
+        },
+        {
+          "description": "Reconcile stored probe volume against the retention cap, pruning the oldest rows per check.",
+          "exportName": "probePrune",
+          "input": {
+            "properties": {
+              "keepPerCheck": {
+                "default": 100,
+                "description": "Probe rows to keep per check",
+                "type": "number"
+              }
+            },
+            "type": "object"
+          },
+          "intent": "destroy",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "dryRun": {
+                "type": "boolean"
+              },
+              "removed": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "dryRun",
+              "removed"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "probe.prune"
+        },
+        {
+          "description": "Tiny per-check JSON payload for embedding (badge-shaped, JSON in v1).",
+          "exportName": "statusBadge",
+          "input": {
+            "properties": {
+              "checkId": {
+                "description": "Check id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "checkId"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "checkId": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              },
+              "state": {
+                "enum": [
+                  "up",
+                  "down",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "uptime7d": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "checkId",
+              "label",
+              "state",
+              "uptime7d"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "status.badge"
+        },
+        {
+          "description": "The public status page payload: per-check state, 7d/30d uptime, and open incident count.",
+          "exportName": "statusSummary",
+          "input": {
+            "properties": {},
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "checks": {
+                "items": {
+                  "properties": {
+                    "checkId": {
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "enum": [
+                        "up",
+                        "down",
+                        "unknown"
+                      ],
+                      "type": "string"
+                    },
+                    "uptime30d": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "uptime7d": {
+                      "anyOf": [
+                        {
+                          "type": "number"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "checkId",
+                    "enabled",
+                    "name",
+                    "state",
+                    "uptime30d",
+                    "uptime7d",
+                    "url"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "generatedAt": {
+                "type": "string"
+              },
+              "openIncidents": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "checks",
+              "generatedAt",
+              "openIncidents"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "lookout.db"
+          ],
+          "trailId": "status.summary"
+        },
+        {
+          "exportName": "tracingQuery",
+          "input": {
+            "properties": {
+              "errorsOnly": {
+                "default": false,
+                "description": "Show only failed traces",
+                "type": "boolean"
+              },
+              "limit": {
+                "default": 20,
+                "description": "Max results",
+                "type": "number"
+              },
+              "traceId": {
+                "description": "Show full trace tree",
+                "type": "string"
+              },
+              "trailId": {
+                "description": "Filter by trail ID",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "count": {
+                "type": "number"
+              },
+              "records": {
+                "items": {
+                  "properties": {
+                    "attrs": {},
+                    "endedAt": {
+                      "type": "number"
+                    },
+                    "errorCategory": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "intent": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "enum": [
+                        "activation",
+                        "signal",
+                        "span",
+                        "trail"
+                      ],
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "parentId": {
+                      "type": "string"
+                    },
+                    "rootId": {
+                      "type": "string"
+                    },
+                    "startedAt": {
+                      "type": "number"
+                    },
+                    "status": {
+                      "enum": [
+                        "ok",
+                        "err",
+                        "cancelled"
+                      ],
+                      "type": "string"
+                    },
+                    "surface": {
+                      "type": "string"
+                    },
+                    "traceId": {
+                      "type": "string"
+                    },
+                    "trailId": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "attrs",
+                    "id",
+                    "kind",
+                    "name",
+                    "rootId",
+                    "startedAt",
+                    "status",
+                    "traceId"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "count",
+              "records"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "tracing"
+          ],
+          "trailId": "tracing.query"
+        },
+        {
+          "exportName": "tracingStatus",
+          "input": {
+            "properties": {},
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "active": {
+                "type": "boolean"
+              },
+              "recordCount": {
+                "type": "number"
+              },
+              "samplingConfig": {
+                "properties": {
+                  "destroy": {
+                    "type": "number"
+                  },
+                  "read": {
+                    "type": "number"
+                  },
+                  "write": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "destroy",
+                  "read",
+                  "write"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "active",
+              "recordCount",
+              "samplingConfig"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "tracing"
+          ],
+          "trailId": "tracing.status"
+        },
+        {
+          "description": "Windowed uptime percentages computed from recorded probe outcomes.",
+          "exportName": "uptimeReport",
+          "input": {
+            "properties": {
+              "checkId": {
+                "description": "Check id",
+                "type": "string"
+              },
+              "days": {
+                "default": 7,
+                "description": "Window size in days",
+                "type": "number"
+              }
+            },
+            "required": [
+              "checkId"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "checkId": {
+                "type": "string"
+              },
+              "days": {
+                "type": "number"
+              },
+              "downCount": {
+                "type": "number"
+              },
+              "probeCount": {
+                "type": "number"
+              },
+              "recoveredCount": {
+                "type": "number"
+              },
+              "upCount": {
+                "type": "number"
+              },
+              "uptimePercent": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "checkId",
+              "days",
+              "downCount",
+              "probeCount",
+              "recoveredCount",
+              "upCount",
+              "uptimePercent"
+            ],
+            "type": "object"
+          },
+          "resources": [],
+          "trailId": "uptime.report"
+        }
+      ]
+    },
+    "topoGraphSchemaVersion": 3
+  },
+  "topoGraphHash": "526e6f3b3e26a6d50ddea1a32d70d9644793f44fadb75af1dc74829ac37840fc",
+  "version": 4
+}

--- a/examples/lookout/tsconfig.json
+++ b/examples/lookout/tsconfig.json
@@ -4,6 +4,6 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["src"],
+  "include": ["src", "bin", "scripts"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
 }

--- a/examples/lookout/tsconfig.tests.json
+++ b/examples/lookout/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["bun"]
+  },
+  "include": ["__tests__/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Context

Builds the `lookout` showcase app — uptime monitor & public status page, the runtime/reactive showcase that proves Trails is a runtime, not just a router. Replaces the placeholder workspace at `examples/lookout/`.

- Issue: [TRL-1153](https://linear.app/outfitter/issue/TRL-1153/build-lookout-per-prd-fable-goal-run)
- PRD: [PRD: lookout — uptime monitor & status page (runtime/reactive showcase)](https://linear.app/outfitter/document/prd-lookout-uptime-monitor-and-status-page-runtimereactive-showcase-49a0947ae373)

22 trails, 2 signals, 3 resources, 3 surfaces (CLI, HTTP, MCP), committed `trails.lock`. Three commits: (1) entities + store + `probe.run` with the scripted http mock, (2) signals + incident lifecycle + cron sweep + notify, (3) surfaces + observe wiring + fast-mode demo + tests + README.

## What it showcases

- **Detours as real retry/recovery:** `probe.run` hands transient classes (timeout, connection reset, 502/503) to detour contracts with bounded retries (`maxAttempts: 2`) and linear backoff — no inline retry logic. A success inside the detour records the honest `recovered-after-retry` middle state.
- **Signals with transition dedupe:** up→down fires `probe.failed`, down→up fires `probe.recovered`; a check that stays down probes silently. `incident.open` (`on: probe.failed`) additionally dedupes against an already-open incident; both lifecycle trails compose `notify.dispatch`.
- **Cron activation:** `schedule.probe.sweep` (`* * * * *`) activates `probe.sweep`, which probes every due enabled check per its own `intervalSeconds`; `check.pause`/`check.resume` flip scheduling. `lookout dev --fast` materializes the source with a 2s cron factory + `LOOKOUT_INTERVAL_SCALE` so the whole loop is watchable in one terminal minute against the provided flaky test server.
- **Observe/tracing:** memory trace store + console log sink wired at topo scope; `tracing.query`/`tracing.status` mounted so MCP can answer "why did it fail last night" from incident + probe + trace data.
- **Public/private split:** status reads are `permit: 'public'` (no auth on HTTP); check management, acknowledge, and prune carry the `lookout:admin` permit (bearer token on HTTP/MCP, operator context on the local CLI).

## Verification

- `bun test` in `examples/lookout`: **92 pass, 0 fail** — includes the scripted-mock money tests (fail-fail-succeed → `recovered-after-retry`; fail×3 → `down` + incident + notification; recovery → resolve), the two-failed-probes-→-ONE-incident dedupe test (both at the transition layer and in `incident.open`), pause/resume sweep tests, uptime fixed vectors, and HTTP public-vs-admin permit tests. `testAll(app)` runs green offline (52 contract tests).
- `bun run check` at repo root: **passes** — Warden `PASS | 0 errors` (including `fires-declarations`, `orphaned-signal`, `read-intent-fires`), lint, typecheck, format, knip, docs checks.
- `trails.lock` committed; `trails validate --module src/app.ts --root-dir .` reports `stale: false`; `trails wayfind --overview` reads the lock with `drift: aligned`.
- Live smoke: flaky server + `lookout dev --fast` produced the full visible loop in under a minute — probes, a `recovered-after-retry` detour save, incident open + console notification, still-down silence (no duplicate incident), recovery + resolution, and the status page serving live uptime over HTTP. The README quickstart commands were executed verbatim during the smoke.

## Waivers / notes

- **HTTP route shapes:** the PRD sketches `GET /status` and `GET /status/:check`; the shipped routes are the framework-derived projections `GET /status/summary` and `GET /status/badge?checkId=…` (plus `/incident/list`, `/probe/history`). Custom HTTP path overrides are not an authored trail field today, and the derived routes keep the contract-first story honest.
- **`dead-public-trail` warnings:** example workspaces cannot join root `trails.config.ts`'s `warden.apps` (root config is frozen for app builds), so lookout's public trails draw warn-level `dead-public-trail` findings, matching the pre-existing pattern for `packages/config`/`packages/tracing`. Filed as [TRL-1190](https://linear.app/outfitter/issue/TRL-1190/example-workspaces-cannot-join-wardens-app-topo-registry-so-their). Warden error count stays 0.
- **Framework gap found while building:** `trails compile` reused a stale stored export from `~/.local/state/trails/projects/…` after source edits, writing an outdated lock that `trails validate` then rejected. Filed as [TRL-1189](https://linear.app/outfitter/issue/TRL-1189/trails-compile-reuses-stale-stored-export-from-the-xdg-topo-store) with the workaround used here.
- **wayfinder-dogfood:** not applicable — example-only PR, no framework surfaces changed (per `examples/README.md`).
- **Changeset:** not applicable — `lookout` is a private example workspace; the release check only tracks publishable `@ontrails/*` workspaces.
