### PR TITLE
feat(examples): add stash gists showcase (mega app)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -207,6 +207,25 @@
     "examples/stash": {
       "name": "stash",
       "version": "0.0.0",
+      "bin": {
+        "stash": "./bin/stash.ts",
+      },
+      "dependencies": {
+        "@ontrails/cli": "workspace:^",
+        "@ontrails/commander": "workspace:^",
+        "@ontrails/core": "workspace:^",
+        "@ontrails/drizzle": "workspace:^",
+        "@ontrails/hono": "workspace:^",
+        "@ontrails/http": "workspace:^",
+        "@ontrails/mcp": "workspace:^",
+        "@ontrails/permits": "workspace:^",
+        "@ontrails/store": "workspace:^",
+        "hono": "^4.7.0",
+        "zod": "catalog:",
+      },
+      "devDependencies": {
+        "@ontrails/testing": "workspace:^",
+      },
     },
     "examples/switchback": {
       "name": "switchback",

--- a/examples/stash/README.md
+++ b/examples/stash/README.md
@@ -1,0 +1,153 @@
+# stash
+
+Self-hosted GitHub-Gists-style snippet service — the showcase suite's deliberate kitchen sink. One authored contract per trail; MCP, HTTP, and CLI are renderings of it.
+
+## What this showcases
+
+| Capability | Where it appears |
+| --- | --- |
+| Trailheads | [src/mcp-options.ts](src/mcp-options.ts) groups the dense topo into `snippets`, `history`, `search`, and `account` entries for MCP; member trail identity is preserved per ADR-0050 ([`__tests__/trailheads.test.ts`](__tests__/trailheads.test.ts)) |
+| Permits | [src/resources/auth.ts](src/resources/auth.ts) resolves bearer tokens against the `tokens` table on every surface; owner checks live in the blazes ([src/trails/snippet.ts](src/trails/snippet.ts)) |
+| Secret snippets without existence leaks | [src/trails/shared.ts](src/trails/shared.ts) — one visibility choke point; proven per surface in [`__tests__/permit-parity.test.ts`](__tests__/permit-parity.test.ts) |
+| Domain revisions | [src/store.ts](src/store.ts) + [src/trails/revision.ts](src/trails/revision.ts) — immutable revision rows; immutability proven in [`__tests__/revisions.test.ts`](__tests__/revisions.test.ts) |
+| Compose | [src/trails/fork.ts](src/trails/fork.ts) — `snippet.fork` composes `snippet.get`, `revision.get`, and `snippet.create`, carrying lineage through the composition-only `composeInput` field |
+| Signals | [src/signals/snippet-signals.ts](src/signals/snippet-signals.ts) fire → [src/trails/search.ts](src/trails/search.ts) `search.index` consumes with `on:` ([`__tests__/search-loop.test.ts`](__tests__/search-loop.test.ts)) |
+| Raw content over HTTP | [src/trails/file.ts](src/trails/file.ts) returns a `BlobRef`, and the framework-derived `GET /file/raw` route streams the bytes with extension-derived content types — no hand-mounted route ([`__tests__/raw.test.ts`](__tests__/raw.test.ts)) |
+| Multi-entity graph | snippets → revisions, stars, forks, tokens, users, search entries — walk it with `trails wayfind` over the committed [trails.lock](trails.lock) |
+| Store + reconcile | [src/resources/db.ts](src/resources/db.ts) schema-derived SQLite store; the versioned `snippets` table takes a factory `reconcile` trail ([src/trails/reconcile.ts](src/trails/reconcile.ts)) |
+
+Twenty trails, two resources, twenty signals, all mocked-db testable with one `testAllEstablished(graph)` line plus focused tests for the correctness spine.
+
+## The agent story (MCP first)
+
+Agents are the primary user here: "save this snippet," "find my sqlite snippets," "fork and modify." The MCP surface exposes the hot-path tools directly and groups the rest behind four trailheads, so a dense topo reads as a short tool list.
+
+A real tool-call transcript, captured against the seeded app (`stash_snippet_create` with alice's bearer token, then `stash_search_query` — no reindex step in between; the `snippet.created` signal drove `search.index` reactively):
+
+```text
+→ tools/call stash_snippet_create
+{
+  "description": "Bun SQLite quickstart",
+  "files": [
+    {
+      "content": "import { Database } from \"bun:sqlite\";\nconst db = new Database(\":memory:\");\n",
+      "language": "typescript",
+      "name": "db.ts"
+    }
+  ],
+  "visibility": "public"
+}
+← structuredContent
+{
+  "createdAt": "2026-07-04T23:31:54.454Z",
+  "description": "Bun SQLite quickstart",
+  "forkOf": null,
+  "id": "019f2f79-6bd6-7000-b03f-3bfb3274c020",
+  "ownerId": "usr_alice",
+  "starCount": 0,
+  "updatedAt": "2026-07-04T23:31:54.454Z",
+  "version": 1,
+  "visibility": "public",
+  "latestRevision": {
+    "createdAt": "2026-07-04T23:31:54.455Z",
+    "fileNames": ["db.ts"],
+    "message": null,
+    "seq": 1
+  }
+}
+
+→ tools/call stash_search_query
+{ "query": "sqlite" }
+← structuredContent
+{
+  "query": "sqlite",
+  "results": [
+    {
+      "id": "019f2f79-6bd6-7000-b03f-3bfb3274c020",
+      "description": "Bun SQLite quickstart",
+      "ownerId": "usr_alice",
+      "starCount": 0,
+      "version": 1,
+      "visibility": "public",
+      "forkOf": null,
+      "createdAt": "2026-07-04T23:31:54.454Z",
+      "updatedAt": "2026-07-04T23:31:54.454Z"
+    }
+  ],
+  "total": 1
+}
+```
+
+To point an MCP client at stash, register the stdio server:
+
+```json
+{
+  "mcpServers": {
+    "stash": {
+      "command": "bun",
+      "args": ["run", "src/mcp.ts"],
+      "cwd": "examples/stash"
+    }
+  }
+}
+```
+
+## Quickstart
+
+From the repo root, on a fresh checkout:
+
+```bash
+cd examples/stash
+bun test
+```
+
+The CLI runs against a freshly seeded in-memory database per invocation (set `STASH_DB_PATH=./stash.db` to persist between runs):
+
+```bash
+bun run bin/stash.ts snippet list
+bun run bin/stash.ts snippet get --id snip_hello
+bun run bin/stash.ts search query --query greet
+bun run bin/stash.ts snippet star --id snip_hello --token stash_bob_dev_token
+bun run bin/stash.ts snippet get --id snip_secret --token stash_alice_dev_token
+```
+
+Start the HTTP surface (JSON API plus raw byte serving):
+
+```bash
+bun run src/http.ts
+```
+
+Then, in another terminal:
+
+```bash
+curl -s 'http://localhost:4280/snippet/get?id=snip_hello'
+curl -s 'http://localhost:4280/file/raw?snippetId=snip_hello&seq=1&name=greet.ts'
+curl -s -X POST 'http://localhost:4280/snippet/create' \
+  -H 'Authorization: Bearer stash_alice_dev_token' \
+  -H 'Content-Type: application/json' \
+  -d '{"description":"curl-made snippet","files":[{"name":"hi.txt","content":"hello\n"}]}'
+```
+
+Seeded identities: `alice` (token `stash_alice_dev_token`, all scopes) and `bob` (token `stash_bob_dev_token`, `snippet:write` + `snippet:interact`). Seeded snippets: `snip_hello` (public), `snip_secret` (alice's, secret), `snip_scratch` (public).
+
+## Domain revisions are not trail versions
+
+Stash carries three distinct version-shaped concepts, on purpose:
+
+- **Domain revisions** are *data*. Every `snippet.update` inserts a new `revisions` row with the next `seq` and never mutates an earlier one — history is immutable by construction, and `revision.get`/`revision.diff` are ordinary reads over it. This is the app's business domain, authored in the store schema.
+- **Trail versioning** is *contract evolution*: how a trail's own input/output contract changes over time (version entries, deprecation guidance, migration notes). None of stash's trails have needed a v2 yet, so the topo carries no version entries — which is itself the point: revising your data model daily does not touch your trail contracts.
+- The store's `version` column on `snippets` is a third thing: framework-managed optimistic concurrency for the versioned table, which is what lets the factory-built `snippets.reconcile` maintenance trail retry conflicting upserts.
+
+If you find yourself encoding data history into trail versions (or contract changes into data rows), this example is the counter-pattern.
+
+## Secret snippets return NotFound, not Forbidden
+
+A secret snippet read by anyone but its owner behaves exactly like a snippet that does not exist — same error class, same message shape — on MCP, HTTP, and CLI alike. A `403` would confirm the id is taken; `404` leaks nothing. Non-owner *writes* to a *public* snippet fail with `PermissionError`, because public existence is not a secret. Every read path funnels through one helper (`loadVisibleSnippet`) so the rule cannot drift per trail, and [`__tests__/permit-parity.test.ts`](__tests__/permit-parity.test.ts) proves it per surface with real bearer tokens.
+
+Search cannot leak either: `search.index` only indexes public snippets, so a secret snippet's terms are never in the index to begin with.
+
+## The mega app
+
+The other showcase apps stay small and forkable. Stash is the one that keeps growing: every future framework capability gets dogfooded here first, on top of a domain that is already dense enough (multi-entity graph, permits, signals, composition, raw bytes) to exercise it honestly.
+
+Deferred beyond this version, deliberately: web UI, syntax highlighting, markdown rendering, comments, orgs/teams, OAuth, embeds, and import-from-gist.

--- a/examples/stash/__tests__/contract.test.ts
+++ b/examples/stash/__tests__/contract.test.ts
@@ -1,0 +1,23 @@
+/**
+ * The one-liner contract suite: topo validation, every example, output
+ * contracts, detours, and CLI/MCP projection builds — with the mocked db.
+ */
+
+import { testAllEstablished } from '@ontrails/testing/established';
+
+import { graph } from '../src/app.js';
+
+// oxlint-disable-next-line require-hook -- testAllEstablished registers tests at module level by design
+testAllEstablished(graph, {
+  ctx: {
+    permit: {
+      id: 'usr_alice',
+      scopes: [
+        'snippet:write',
+        'snippet:interact',
+        'token:manage',
+        'search:admin',
+      ],
+    },
+  },
+});

--- a/examples/stash/__tests__/fork.test.ts
+++ b/examples/stash/__tests__/fork.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Fork lineage and fork visibility rules.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { run } from '@ontrails/core';
+
+import { graph } from '../src/app.js';
+import { createMockDb, db } from '../src/resources/db.js';
+
+const options = (
+  conn: ReturnType<typeof createMockDb>,
+  subject: 'usr_alice' | 'usr_bob'
+) => ({
+  ctx: {
+    extensions: { [db.id]: conn },
+    permit: { id: subject, scopes: ['snippet:write', 'snippet:interact'] },
+  },
+});
+
+describe('snippet.fork', () => {
+  test('fork copies the latest revision and records lineage', async () => {
+    const conn = createMockDb();
+    const forked = await run(
+      graph,
+      'snippet.fork',
+      { id: 'snip_hello' },
+      options(conn, 'usr_bob')
+    );
+    expect(forked.isOk()).toBe(true);
+    expect(forked.isOk() && forked.value).toMatchObject({
+      description: 'Greet the trail crew from TypeScript',
+      forkOf: 'snip_hello',
+      ownerId: 'usr_bob',
+      starCount: 0,
+      visibility: 'public',
+    });
+
+    // The source snippet is untouched.
+    const source = await run(
+      graph,
+      'snippet.get',
+      { id: 'snip_hello' },
+      options(conn, 'usr_bob')
+    );
+    expect(source.isOk() && source.value).toMatchObject({
+      forkOf: null,
+      ownerId: 'usr_alice',
+    });
+  });
+
+  test('another user’s secret snippet is unforkable and reads as missing', async () => {
+    const conn = createMockDb();
+    const forked = await run(
+      graph,
+      'snippet.fork',
+      { id: 'snip_secret' },
+      options(conn, 'usr_bob')
+    );
+    expect(forked.isErr()).toBe(true);
+    expect(forked.isErr() && forked.error.name).toBe('NotFoundError');
+    expect(forked.isErr() && forked.error.message).toBe(
+      'Snippet "snip_secret" not found'
+    );
+  });
+
+  test('owners can fork their own secret snippets, staying secret', async () => {
+    const conn = createMockDb();
+    const forked = await run(
+      graph,
+      'snippet.fork',
+      { id: 'snip_secret' },
+      options(conn, 'usr_alice')
+    );
+    expect(forked.isOk()).toBe(true);
+    expect(forked.isOk() && forked.value).toMatchObject({
+      forkOf: 'snip_secret',
+      ownerId: 'usr_alice',
+      visibility: 'secret',
+    });
+  });
+});

--- a/examples/stash/__tests__/permit-parity.test.ts
+++ b/examples/stash/__tests__/permit-parity.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Permit parity and the secret-snippet non-leak guarantee, proven per
+ * surface with real bearer tokens.
+ *
+ * Every surface resolves tokens through the same db-backed auth adapter:
+ * HTTP reads the Authorization header, MCP reads the request authorization,
+ * and the CLI resolves `--token`. On each of them, another user's secret
+ * snippet is indistinguishable from a missing one — `NotFoundError`, never a
+ * permission error — while non-owner writes to a *public* snippet fail with
+ * a plain `PermissionError`.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { tokenPreset } from '@ontrails/cli';
+import type { ActionResultContext } from '@ontrails/cli';
+import { createProgram } from '@ontrails/commander';
+import {
+  AuthError,
+  NotFoundError,
+  PermissionError,
+  Result,
+} from '@ontrails/core';
+import type { BasePermit } from '@ontrails/core';
+import { MCP_TOOL_ERROR_META_KEY, deriveToolName } from '@ontrails/mcp';
+import { createHttpHarness } from '@ontrails/testing/http';
+import { createMcpHarness } from '@ontrails/testing/mcp';
+
+import { graph } from '../src/app.js';
+import { createStashAuthAdapter } from '../src/resources/auth.js';
+import { createMockDb, db } from '../src/resources/db.js';
+
+const ALICE_TOKEN = 'stash_alice_dev_token';
+const BOB_TOKEN = 'stash_bob_dev_token';
+
+interface Setup {
+  adapter: ReturnType<typeof createStashAuthAdapter>;
+  conn: ReturnType<typeof createMockDb>;
+}
+
+const setup = (): Setup => {
+  const conn = createMockDb();
+  return { adapter: createStashAuthAdapter(conn), conn };
+};
+
+/**
+ * Adapt the permits-package adapter result (whose error side is a plain
+ * `{ code, message }` shape) to the surface resolver contract, which wants
+ * an `Error` on the failure side.
+ */
+const resolveThroughAdapter = async (
+  adapter: Setup['adapter'],
+  bearerToken: string | undefined,
+  surface: 'http' | 'mcp' | 'cli',
+  requestId: string
+): Promise<Result<BasePermit | null, Error>> => {
+  const authed = await adapter.authenticate({
+    ...(bearerToken === undefined ? {} : { bearerToken }),
+    requestId,
+    surface,
+  });
+  if (authed.isErr()) {
+    return Result.err(new AuthError(authed.error.message));
+  }
+  return Result.ok(authed.value);
+};
+
+// ---------------------------------------------------------------------------
+// HTTP surface
+// ---------------------------------------------------------------------------
+
+const httpHarness = ({ adapter, conn }: Setup) =>
+  createHttpHarness({
+    graph,
+    resolvePermit: ({ bearerToken, requestId }) =>
+      resolveThroughAdapter(
+        adapter,
+        bearerToken,
+        'http',
+        requestId ?? 'test-http'
+      ),
+    resources: { [db.id]: conn },
+  });
+
+const bearer = (token: string) => ({
+  headers: { authorization: `Bearer ${token}` },
+});
+
+describe('HTTP: secret snippets never leak', () => {
+  test('non-owner and anonymous reads are indistinguishable from missing ids', async () => {
+    const harness = httpHarness(setup());
+
+    const asBob = await harness.get(
+      '/snippet/get',
+      { id: 'snip_secret' },
+      bearer(BOB_TOKEN)
+    );
+    expect(asBob.status).toBe(404);
+    expect(asBob.error?.message).toBe('Snippet "snip_secret" not found');
+
+    const anonymous = await harness.get('/snippet/get', { id: 'snip_secret' });
+    expect(anonymous.status).toBe(404);
+
+    const missing = await harness.get(
+      '/snippet/get',
+      { id: 'snip_missing' },
+      bearer(BOB_TOKEN)
+    );
+    expect(missing.status).toBe(404);
+    // Same category and code as the hidden snippet — nothing distinguishes them.
+    expect(missing.error?.category).toBe(asBob.error?.category);
+    expect(missing.error?.code).toBe(asBob.error?.code);
+
+    const asOwner = await harness.get(
+      '/snippet/get',
+      { id: 'snip_secret' },
+      bearer(ALICE_TOKEN)
+    );
+    expect(asOwner.status).toBe(200);
+    expect(asOwner.data).toMatchObject({ id: 'snip_secret' });
+  });
+
+  test('non-owner writes: public snippets are forbidden, secret snippets are not-found', async () => {
+    const harness = httpHarness(setup());
+
+    const publicWrite = await harness.delete(
+      '/snippet/delete',
+      { id: 'snip_hello' },
+      bearer(BOB_TOKEN)
+    );
+    expect(publicWrite.status).toBe(403);
+
+    const secretWrite = await harness.delete(
+      '/snippet/delete',
+      { id: 'snip_secret' },
+      bearer(BOB_TOKEN)
+    );
+    expect(secretWrite.status).toBe(404);
+  });
+
+  test('revoked tokens stop authenticating', async () => {
+    const state = setup();
+    await state.conn.tokens.update('tok_bob', { revoked: true });
+    const harness = httpHarness(state);
+
+    const read = await harness.get(
+      '/snippet/get',
+      { id: 'snip_secret' },
+      bearer(BOB_TOKEN)
+    );
+    expect(read.status).toBe(404);
+
+    const write = await harness.delete(
+      '/snippet/delete',
+      { id: 'snip_hello' },
+      bearer(BOB_TOKEN)
+    );
+    expect(write.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MCP surface
+// ---------------------------------------------------------------------------
+
+const mcpCall = async (
+  state: Setup,
+  trailId: string,
+  args: Record<string, unknown>,
+  token?: string
+) => {
+  const harness = createMcpHarness({
+    graph,
+    ...(token === undefined
+      ? {}
+      : { extra: { authorization: `Bearer ${token}` } }),
+    resolvePermit: ({ bearerToken }) =>
+      resolveThroughAdapter(state.adapter, bearerToken, 'mcp', 'test-mcp'),
+    resources: { [db.id]: state.conn },
+  });
+  return await harness.callTool(deriveToolName(graph.name, trailId), args);
+};
+
+const mcpErrorName = (result: {
+  meta?: Record<string, unknown> | undefined;
+}) => {
+  const meta = result.meta?.[MCP_TOOL_ERROR_META_KEY];
+  return meta !== null && typeof meta === 'object' && 'name' in meta
+    ? meta.name
+    : undefined;
+};
+
+describe('MCP: secret snippets never leak', () => {
+  test('non-owner reads report NotFoundError, owner reads succeed', async () => {
+    const state = setup();
+
+    const asBob = await mcpCall(
+      state,
+      'snippet.get',
+      { id: 'snip_secret' },
+      BOB_TOKEN
+    );
+    expect(asBob.isError).toBe(true);
+    expect(mcpErrorName(asBob)).toBe('NotFoundError');
+
+    const missing = await mcpCall(
+      state,
+      'snippet.get',
+      { id: 'snip_missing' },
+      BOB_TOKEN
+    );
+    expect(mcpErrorName(missing)).toBe(mcpErrorName(asBob));
+
+    const asOwner = await mcpCall(
+      state,
+      'snippet.get',
+      { id: 'snip_secret' },
+      ALICE_TOKEN
+    );
+    expect(asOwner.isError ?? false).toBe(false);
+    expect(asOwner.structuredContent).toMatchObject({ id: 'snip_secret' });
+  });
+
+  test('non-owner writes: forbidden on public, not-found on secret', async () => {
+    const state = setup();
+
+    const publicWrite = await mcpCall(
+      state,
+      'snippet.delete',
+      { id: 'snip_hello' },
+      BOB_TOKEN
+    );
+    expect(mcpErrorName(publicWrite)).toBe('PermissionError');
+
+    const secretWrite = await mcpCall(
+      state,
+      'snippet.delete',
+      { id: 'snip_secret' },
+      BOB_TOKEN
+    );
+    expect(mcpErrorName(secretWrite)).toBe('NotFoundError');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLI surface
+// ---------------------------------------------------------------------------
+
+const cliRun = async (state: Setup, argv: readonly string[]) => {
+  const results: ActionResultContext[] = [];
+  const program = createProgram(graph, {
+    name: 'stash',
+    onResult: (resultCtx) => {
+      results.push(resultCtx);
+      return Promise.resolve();
+    },
+    presets: [tokenPreset()],
+    resolvePermitFromToken: async ({ requestId, token }) => {
+      const authed = await resolveThroughAdapter(
+        state.adapter,
+        token,
+        'cli',
+        requestId
+      );
+      if (authed.isErr()) {
+        return authed;
+      }
+      return authed.value === null
+        ? Result.err(new AuthError('Unknown or revoked token'))
+        : Result.ok(authed.value);
+    },
+    resources: { [db.id]: state.conn },
+  });
+  program.exitOverride();
+  await program.parseAsync([...argv], { from: 'user' });
+  const [outcome] = results;
+  if (outcome === undefined) {
+    throw new Error(`CLI produced no result for: ${argv.join(' ')}`);
+  }
+  return outcome;
+};
+
+describe('CLI: secret snippets never leak', () => {
+  test('non-owner --token reads report NotFoundError, owner reads succeed', async () => {
+    const state = setup();
+
+    const asBob = await cliRun(state, [
+      'snippet',
+      'get',
+      '--id',
+      'snip_secret',
+      '--token',
+      BOB_TOKEN,
+    ]);
+    expect(asBob.result.isErr()).toBe(true);
+    expect(asBob.result.isErr() && asBob.result.error).toBeInstanceOf(
+      NotFoundError
+    );
+
+    const asOwner = await cliRun(state, [
+      'snippet',
+      'get',
+      '--id',
+      'snip_secret',
+      '--token',
+      ALICE_TOKEN,
+    ]);
+    expect(asOwner.result.isOk()).toBe(true);
+  });
+
+  test('non-owner writes: forbidden on public, not-found on secret', async () => {
+    const state = setup();
+
+    const publicWrite = await cliRun(state, [
+      'snippet',
+      'delete',
+      '--id',
+      'snip_hello',
+      '--token',
+      BOB_TOKEN,
+    ]);
+    expect(
+      publicWrite.result.isErr() && publicWrite.result.error
+    ).toBeInstanceOf(PermissionError);
+
+    const secretWrite = await cliRun(state, [
+      'snippet',
+      'delete',
+      '--id',
+      'snip_secret',
+      '--token',
+      BOB_TOKEN,
+    ]);
+    expect(
+      secretWrite.result.isErr() && secretWrite.result.error
+    ).toBeInstanceOf(NotFoundError);
+  });
+});

--- a/examples/stash/__tests__/raw.test.ts
+++ b/examples/stash/__tests__/raw.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Raw byte serving through the derived HTTP route.
+ *
+ * `file.raw` declares a `blobRefSchema` output, so the framework-derived
+ * `GET /file/raw` route streams the bytes with the extension-derived content
+ * type — six-plus common types including one binary, plus the same
+ * visibility rules as every other read. No hand-mounted route exists.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { run } from '@ontrails/core';
+
+import { graph } from '../src/app.js';
+import { createMockDb, db } from '../src/resources/db.js';
+import { createStashApp } from '../src/server.js';
+
+const PNG_BASE64 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+
+const rawUrl = (snippetId: string, seq: number, name: string): string =>
+  `/file/raw?snippetId=${encodeURIComponent(snippetId)}&seq=${String(seq)}&name=${encodeURIComponent(name)}`;
+
+const RAW_FILES = [
+  { content: 'export const n = 1;\n', name: 'mod.ts' },
+  { content: 'module.exports = 1;\n', name: 'mod.js' },
+  { content: '{ "ok": true }\n', name: 'data.json' },
+  { content: '# Notes\n', name: 'notes.md' },
+  { content: 'plain text\n', name: 'notes.txt' },
+  { content: PNG_BASE64, encoding: 'base64', name: 'pixel.png' },
+  { content: PNG_BASE64, encoding: 'base64', name: 'blob.bin' },
+];
+
+const EXPECTED_TYPES: readonly (readonly [string, string])[] = [
+  ['mod.ts', 'application/typescript; charset=utf-8'],
+  ['mod.js', 'text/javascript; charset=utf-8'],
+  ['data.json', 'application/json; charset=utf-8'],
+  ['notes.md', 'text/markdown; charset=utf-8'],
+  ['notes.txt', 'text/plain; charset=utf-8'],
+  ['pixel.png', 'image/png'],
+  ['blob.bin', 'application/octet-stream'],
+];
+
+describe('GET /file/raw', () => {
+  test('serves six-plus content types including binary, byte-exact', async () => {
+    const conn = createMockDb();
+    const app = createStashApp(conn);
+
+    const created = await run(
+      graph,
+      'snippet.create',
+      {
+        description: 'content-type fixture snippet',
+        files: RAW_FILES,
+        visibility: 'public',
+      },
+      {
+        ctx: {
+          extensions: { [db.id]: conn },
+          permit: { id: 'usr_alice', scopes: ['snippet:write'] },
+        },
+      }
+    );
+    expect(created.isOk()).toBe(true);
+    const { id } = created.isOk()
+      ? (created.value as { id: string })
+      : { id: '' };
+
+    for (const [name, contentType] of EXPECTED_TYPES) {
+      const response = await app.request(rawUrl(id, 1, name));
+      expect(`${name}:${response.status}`).toBe(`${name}:200`);
+      expect(`${name}:${response.headers.get('content-type') ?? ''}`).toBe(
+        `${name}:${contentType}`
+      );
+    }
+
+    // Binary round-trip: served bytes equal the decoded base64 source.
+    const png = await app.request(rawUrl(id, 1, 'pixel.png'));
+    const served = new Uint8Array(await png.arrayBuffer());
+    const source = Uint8Array.from(atob(PNG_BASE64), (char) =>
+      char.codePointAt(0)
+    );
+    expect(served).toEqual(source);
+
+    // Text round-trip.
+    const text = await app.request(rawUrl(id, 1, 'notes.txt'));
+    expect(await text.text()).toBe('plain text\n');
+  });
+
+  test('secret snippet files honor the non-leak rule over raw HTTP', async () => {
+    const conn = createMockDb();
+    const app = createStashApp(conn);
+
+    const anonymous = await app.request(
+      rawUrl('snip_secret', 1, 'checklist.md')
+    );
+    expect(anonymous.status).toBe(404);
+
+    const asBob = await app.request(rawUrl('snip_secret', 1, 'checklist.md'), {
+      headers: { authorization: 'Bearer stash_bob_dev_token' },
+    });
+    expect(asBob.status).toBe(404);
+
+    const asOwner = await app.request(
+      rawUrl('snip_secret', 1, 'checklist.md'),
+      {
+        headers: { authorization: 'Bearer stash_alice_dev_token' },
+      }
+    );
+    expect(asOwner.status).toBe(200);
+    expect(asOwner.headers.get('content-type')).toBe(
+      'text/markdown; charset=utf-8'
+    );
+
+    const missingFile = await app.request(
+      rawUrl('snip_hello', 1, 'absent.txt')
+    );
+    expect(missingFile.status).toBe(404);
+
+    const missingRevision = await app.request(
+      rawUrl('snip_hello', 9, 'greet.ts')
+    );
+    expect(missingRevision.status).toBe(404);
+  });
+});

--- a/examples/stash/__tests__/revisions.test.ts
+++ b/examples/stash/__tests__/revisions.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Revision immutability by construction.
+ *
+ * `snippet.update` inserts a new revision and never mutates an existing one.
+ * These tests drive updates through the real topo and then assert — both
+ * through the read trails and directly against the store — that earlier
+ * revisions are byte-identical to what was first written.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { run } from '@ontrails/core';
+
+import { seedRevisions } from '../src/fixtures.js';
+import { createMockDb, db } from '../src/resources/db.js';
+import { graph } from '../src/app.js';
+
+const alicePermit = {
+  id: 'usr_alice',
+  scopes: ['snippet:write'],
+} as const;
+
+const options = (conn: ReturnType<typeof createMockDb>) => ({
+  ctx: {
+    extensions: { [db.id]: conn },
+    permit: alicePermit,
+  },
+});
+
+const updateInput = (marker: string) => ({
+  files: [
+    {
+      content: `export const greet = (): string => 'rev ${marker}';\n`,
+      language: 'typescript',
+      name: 'greet.ts',
+    },
+  ],
+  id: 'snip_hello',
+  message: `revision ${marker}`,
+});
+
+const originalContent = seedRevisions[0]?.files[0]?.content ?? '';
+
+describe('revision immutability', () => {
+  test('updates create new revisions and never mutate earlier ones', async () => {
+    const conn = createMockDb();
+
+    const first = await run(
+      graph,
+      'snippet.update',
+      updateInput('two'),
+      options(conn)
+    );
+    expect(first.isOk()).toBe(true);
+    expect(first.isOk() && first.value).toMatchObject({ seq: 2 });
+
+    const second = await run(
+      graph,
+      'snippet.update',
+      updateInput('three'),
+      options(conn)
+    );
+    expect(second.isOk()).toBe(true);
+    expect(second.isOk() && second.value).toMatchObject({ seq: 3 });
+
+    // Revision 1 read back through the trail is byte-identical to the seed.
+    const rev1 = await run(
+      graph,
+      'revision.get',
+      { seq: 1, snippetId: 'snip_hello' },
+      options(conn)
+    );
+    expect(rev1.isOk()).toBe(true);
+    expect(rev1.isOk() && rev1.value).toMatchObject({
+      files: [
+        {
+          content: originalContent,
+          encoding: 'utf8',
+          language: 'typescript',
+          name: 'greet.ts',
+        },
+      ],
+      message: 'initial revision',
+      seq: 1,
+    });
+
+    // Revision 2 survives revision 3 unchanged.
+    const rev2 = await run(
+      graph,
+      'revision.get',
+      { seq: 2, snippetId: 'snip_hello' },
+      options(conn)
+    );
+    expect(rev2.isOk()).toBe(true);
+    expect(rev2.isOk() && rev2.value).toMatchObject({
+      message: 'revision two',
+      seq: 2,
+    });
+
+    // History is contiguous and seq-ordered.
+    const listed = await run(
+      graph,
+      'revision.list',
+      { snippetId: 'snip_hello' },
+      options(conn)
+    );
+    expect(listed.isOk()).toBe(true);
+    expect(listed.isOk() && listed.value).toMatchObject({ total: 3 });
+
+    // Straight-to-store proof: the seeded revision row is untouched.
+    const stored = await conn.revisions.get('rev_hello_1');
+    const seeded = seedRevisions.find((row) => row.id === 'rev_hello_1');
+    expect(stored).toEqual(seeded ?? null);
+  });
+
+  test('the store path for updates is insert-only in app code', async () => {
+    const conn = createMockDb();
+    const before = await conn.revisions.list({ snippetId: 'snip_hello' });
+    expect(before).toHaveLength(1);
+
+    const updated = await run(
+      graph,
+      'snippet.update',
+      updateInput('two'),
+      options(conn)
+    );
+    expect(updated.isOk()).toBe(true);
+
+    const after = await conn.revisions.list({ snippetId: 'snip_hello' });
+    expect(after).toHaveLength(2);
+    const kept = after.find((row) => row.id === 'rev_hello_1');
+    expect(kept?.files).toEqual(before[0]?.files ?? []);
+  });
+});

--- a/examples/stash/__tests__/search-loop.test.ts
+++ b/examples/stash/__tests__/search-loop.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The signal-driven search loop.
+ *
+ * Producers fire `snippet.created` / `snippet.updated`; the internal
+ * `search.index` consumer re-derives that snippet's index rows. These tests
+ * drive real trails through `run()` (which wires signal fan-out) and assert
+ * the index state that `search.query` sees afterward.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { run } from '@ontrails/core';
+
+import { graph } from '../src/app.js';
+import { seedSearchEntries } from '../src/fixtures.js';
+import { createMockDb, db } from '../src/resources/db.js';
+
+const options = (
+  conn: ReturnType<typeof createMockDb>,
+  subject = 'usr_alice',
+  scopes: readonly string[] = [
+    'snippet:write',
+    'snippet:interact',
+    'search:admin',
+  ]
+) => ({
+  ctx: {
+    extensions: { [db.id]: conn },
+    permit: { id: subject, scopes: [...scopes] },
+  },
+});
+
+const queryTotal = async (
+  conn: ReturnType<typeof createMockDb>,
+  query: string
+): Promise<number> => {
+  const found = await run(graph, 'search.query', { query }, options(conn));
+  if (found.isErr()) {
+    throw found.error;
+  }
+  const { total } = found.value as { total: number };
+  return total;
+};
+
+describe('signal-driven indexing', () => {
+  test('snippet.create fires snippet.created and the consumer indexes it', async () => {
+    const conn = createMockDb();
+    expect(await queryTotal(conn, 'xylophone')).toBe(0);
+
+    const created = await run(
+      graph,
+      'snippet.create',
+      {
+        description: 'A xylophone tuning table',
+        files: [{ content: 'c4 d4 e4\n', name: 'notes.txt' }],
+        visibility: 'public',
+      },
+      options(conn)
+    );
+    expect(created.isOk()).toBe(true);
+
+    expect(await queryTotal(conn, 'xylophone')).toBe(1);
+  });
+
+  test('snippet.update reindexes; snippet.delete deindexes', async () => {
+    const conn = createMockDb();
+
+    const updated = await run(
+      graph,
+      'snippet.update',
+      {
+        files: [{ content: 'quokka census data\n', name: 'greet.ts' }],
+        id: 'snip_hello',
+        message: 'now about quokkas',
+      },
+      options(conn)
+    );
+    expect(updated.isOk()).toBe(true);
+    expect(await queryTotal(conn, 'quokka')).toBe(1);
+
+    const deleted = await run(
+      graph,
+      'snippet.delete',
+      { id: 'snip_hello' },
+      options(conn)
+    );
+    expect(deleted.isOk()).toBe(true);
+    expect(await queryTotal(conn, 'quokka')).toBe(0);
+    expect(await queryTotal(conn, 'greet')).toBe(0);
+  });
+
+  test('secret snippets are never indexed', async () => {
+    const conn = createMockDb();
+    const created = await run(
+      graph,
+      'snippet.create',
+      {
+        description: 'a very wombat secret',
+        files: [{ content: 'wombat\n', name: 'w.txt' }],
+        visibility: 'secret',
+      },
+      options(conn)
+    );
+    expect(created.isOk()).toBe(true);
+    // Not even the owner finds it through search — the index is public-only.
+    expect(await queryTotal(conn, 'wombat')).toBe(0);
+  });
+
+  test('seeded index rows match a from-scratch reindex', async () => {
+    const conn = createMockDb();
+    const rebuilt = await run(graph, 'search.reindex', {}, options(conn));
+    expect(rebuilt.isOk()).toBe(true);
+
+    const rows = await conn.searchEntries.list();
+    const rebuiltSet = new Set(
+      rows.map((row) => `${row.snippetId}::${row.term}`)
+    );
+    const seededSet = new Set(
+      seedSearchEntries.map((row) => `${row.snippetId}::${row.term}`)
+    );
+    expect(rebuiltSet).toEqual(seededSet);
+  });
+});

--- a/examples/stash/__tests__/trailheads.test.ts
+++ b/examples/stash/__tests__/trailheads.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Trailheads on the MCP surface preserve member trail identity (ADR-0050).
+ *
+ * A trailhead tool accepts `{ trail, input }`, dispatches the selected member
+ * through the ordinary tool pipeline, and answers `{ trail, output }`. Its
+ * tool metadata names the trailhead and its member trail ids so clients can
+ * inspect the grouping before selecting.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { MCP_TOOL_TRAILHEAD_META_KEY, deriveMcpTools } from '@ontrails/mcp';
+import type { McpToolDefinition } from '@ontrails/mcp';
+
+import { graph } from '../src/app.js';
+import { stashTrailheads } from '../src/mcp-options.js';
+import { createMockDb, db } from '../src/resources/db.js';
+
+const deriveTools = (conn: ReturnType<typeof createMockDb>) => {
+  const tools = deriveMcpTools(graph, {
+    resources: { [db.id]: conn },
+    trailheads: stashTrailheads,
+  });
+  if (tools.isErr()) {
+    throw tools.error;
+  }
+  return tools.value;
+};
+
+const trailheadTool = (
+  tools: readonly McpToolDefinition[],
+  trailheadId: string
+): McpToolDefinition => {
+  const tool = tools.find((candidate) => candidate.trailheadId === trailheadId);
+  if (tool === undefined) {
+    throw new Error(`No trailhead tool derived for "${trailheadId}"`);
+  }
+  return tool;
+};
+
+describe('MCP trailheads', () => {
+  test('every configured trailhead derives a grouped tool with member ids', () => {
+    const tools = deriveTools(createMockDb());
+    for (const [id, definition] of Object.entries(stashTrailheads)) {
+      const tool = trailheadTool(tools, id);
+      expect([...(tool.memberTrailIds ?? [])].toSorted()).toEqual(
+        [...definition.trails].toSorted()
+      );
+      expect(tool._meta?.[MCP_TOOL_TRAILHEAD_META_KEY]).toBeDefined();
+    }
+  });
+
+  test('a trailhead call dispatches the selected member and names it in the response', async () => {
+    const tools = deriveTools(createMockDb());
+    const snippets = trailheadTool(tools, 'snippets');
+
+    const result = await snippets.handler(
+      { input: { id: 'snip_hello' }, trail: 'snippet.get' },
+      {}
+    );
+    expect(result.isError ?? false).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      output: { id: 'snip_hello' },
+      trail: 'snippet.get',
+    });
+  });
+
+  test('a member outside the trailhead cannot be smuggled through it', async () => {
+    const tools = deriveTools(createMockDb());
+    const search = trailheadTool(tools, 'search');
+
+    const result = await search.handler(
+      { input: { id: 'snip_hello' }, trail: 'snippet.delete' },
+      {}
+    );
+    expect(result.isError).toBe(true);
+  });
+});

--- a/examples/stash/bin/stash.ts
+++ b/examples/stash/bin/stash.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env bun
+
+/**
+ * CLI entry point for stash.
+ *
+ * Usage:
+ *   bun run bin/stash.ts snippet list
+ *   bun run bin/stash.ts snippet get --id snip_hello
+ *   bun run bin/stash.ts search query --query greet
+ *   bun run bin/stash.ts snippet star --id snip_hello --token stash_bob_dev_token
+ *
+ * Set STASH_DB_PATH to persist snippets between invocations; the default is
+ * a freshly seeded in-memory database per run.
+ */
+
+import { outputModePreset, tokenPreset } from '@ontrails/cli';
+import { surface } from '@ontrails/commander';
+import { AuthError, Result } from '@ontrails/core';
+
+import { graph } from '../src/app.js';
+import { createStashAuthAdapter } from '../src/resources/auth.js';
+import { db } from '../src/resources/db.js';
+import { openStashDb } from '../src/server.js';
+
+const conn = await openStashDb();
+const adapter = createStashAuthAdapter(conn);
+
+// oxlint-disable-next-line require-hook -- CLI entry point, not a test file
+await surface(graph, {
+  description: 'Self-hosted gists: snippets with immutable revision history',
+  name: 'stash',
+  presets: [outputModePreset(), tokenPreset()],
+  resolvePermitFromToken: async ({ requestId, token }) => {
+    const authed = await adapter.authenticate({
+      bearerToken: token,
+      requestId,
+      surface: 'cli',
+    });
+    if (authed.isErr()) {
+      return Result.err(new AuthError(authed.error.message));
+    }
+    return authed.value === null
+      ? Result.err(new AuthError('Unknown or revoked token'))
+      : Result.ok(authed.value);
+  },
+  resources: { [db.id]: conn, auth: adapter },
+  version: '0.1.0',
+});

--- a/examples/stash/package.json
+++ b/examples/stash/package.json
@@ -2,12 +2,33 @@
   "name": "stash",
   "version": "0.0.0",
   "private": true,
+  "bin": {
+    "stash": "./bin/stash.ts"
+  },
   "type": "module",
+  "main": "./src/index.ts",
   "scripts": {
     "build": "tsc -b",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint ./src",
-    "clean": "rm -rf dist *.tsbuildinfo"
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "http": "bun src/http.ts"
+  },
+  "dependencies": {
+    "@ontrails/cli": "workspace:^",
+    "@ontrails/commander": "workspace:^",
+    "@ontrails/core": "workspace:^",
+    "@ontrails/drizzle": "workspace:^",
+    "@ontrails/hono": "workspace:^",
+    "@ontrails/http": "workspace:^",
+    "@ontrails/mcp": "workspace:^",
+    "@ontrails/permits": "workspace:^",
+    "@ontrails/store": "workspace:^",
+    "hono": "^4.7.0",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@ontrails/testing": "workspace:^"
   }
 }

--- a/examples/stash/src/__tests__/placeholder.test.ts
+++ b/examples/stash/src/__tests__/placeholder.test.ts
@@ -1,9 +1,0 @@
-import { describe, expect, test } from 'bun:test';
-
-import { workspaceName } from '../index.js';
-
-describe('stash workspace placeholder', () => {
-  test('reserves the workspace name', () => {
-    expect(workspaceName).toBe('stash');
-  });
-});

--- a/examples/stash/src/app.ts
+++ b/examples/stash/src/app.ts
@@ -1,0 +1,38 @@
+/**
+ * stash application — wires trails, signals, and resources into a topo.
+ */
+
+import { topo } from '@ontrails/core';
+
+import * as authResource from './resources/auth.js';
+import * as dbResource from './resources/db.js';
+import * as snippetSignals from './signals/snippet-signals.js';
+import * as fileTrails from './trails/file.js';
+import * as forkTrails from './trails/fork.js';
+import * as reconcileTrails from './trails/reconcile.js';
+import * as revisionTrails from './trails/revision.js';
+import * as searchTrails from './trails/search.js';
+import * as snippetTrails from './trails/snippet.js';
+import * as starTrails from './trails/star.js';
+import * as tokenTrails from './trails/token.js';
+import * as userTrails from './trails/user.js';
+
+export const graph = topo(
+  {
+    description: 'Self-hosted gists: snippets with immutable revisions',
+    name: 'stash',
+    version: '0.1.0',
+  },
+  dbResource,
+  authResource,
+  snippetSignals,
+  snippetTrails,
+  revisionTrails,
+  forkTrails,
+  starTrails,
+  searchTrails,
+  fileTrails,
+  tokenTrails,
+  userTrails,
+  reconcileTrails
+);

--- a/examples/stash/src/fixtures.ts
+++ b/examples/stash/src/fixtures.ts
@@ -1,0 +1,181 @@
+/**
+ * Deterministic seed fixtures shared by the db resource's mock and runtime
+ * paths, trail examples, and tests.
+ *
+ * Every id and timestamp is pinned so trail examples can assert full expected
+ * outputs — the deterministic-seed-id convention from the Trails testing
+ * guidance.
+ */
+
+import { deriveSearchTerms } from './search/terms.js';
+import type {
+  Revision,
+  SearchEntry,
+  SnippetRow,
+  Star,
+  Token,
+  User,
+} from './store.js';
+
+const AT = '2026-01-01T00:00:00.000Z';
+const LATER = '2026-01-02T00:00:00.000Z';
+
+export const seedUsers: readonly User[] = [
+  { createdAt: AT, id: 'usr_alice', name: 'alice' },
+  { createdAt: AT, id: 'usr_bob', name: 'bob' },
+];
+
+export const seedTokens: readonly Token[] = [
+  {
+    createdAt: AT,
+    id: 'tok_alice',
+    name: 'alice-dev',
+    revoked: false,
+    scopes: [
+      'snippet:write',
+      'snippet:interact',
+      'token:manage',
+      'search:admin',
+    ],
+    secret: 'stash_alice_dev_token',
+    userId: 'usr_alice',
+  },
+  {
+    createdAt: AT,
+    id: 'tok_alice_spare',
+    name: 'alice-spare',
+    revoked: false,
+    scopes: ['snippet:write'],
+    secret: 'stash_alice_spare_token',
+    userId: 'usr_alice',
+  },
+  {
+    createdAt: AT,
+    id: 'tok_bob',
+    name: 'bob-dev',
+    revoked: false,
+    scopes: ['snippet:write', 'snippet:interact'],
+    secret: 'stash_bob_dev_token',
+    userId: 'usr_bob',
+  },
+];
+
+export const seedSnippets: readonly SnippetRow[] = [
+  {
+    createdAt: AT,
+    description: 'Greet the trail crew from TypeScript',
+    forkOf: null,
+    id: 'snip_hello',
+    ownerId: 'usr_alice',
+    updatedAt: AT,
+    version: 1,
+    visibility: 'public',
+  },
+  {
+    createdAt: LATER,
+    description: 'Release checklist (owner eyes only)',
+    forkOf: null,
+    id: 'snip_secret',
+    ownerId: 'usr_alice',
+    updatedAt: LATER,
+    version: 1,
+    visibility: 'secret',
+  },
+  {
+    createdAt: LATER,
+    description: 'Scratch snippet the delete example removes',
+    forkOf: null,
+    id: 'snip_scratch',
+    ownerId: 'usr_alice',
+    updatedAt: LATER,
+    version: 1,
+    visibility: 'public',
+  },
+];
+
+export const seedRevisions: readonly Revision[] = [
+  {
+    createdAt: AT,
+    files: [
+      {
+        content: `export const greet = (name: string): string => \`Hello, \${name}!\`;\n`,
+        encoding: 'utf8',
+        language: 'typescript',
+        name: 'greet.ts',
+      },
+    ],
+    id: 'rev_hello_1',
+    message: 'initial revision',
+    seq: 1,
+    snippetId: 'snip_hello',
+  },
+  {
+    createdAt: LATER,
+    files: [
+      {
+        content:
+          '# Release checklist\n\n- run the smoke tests\n- tag the release\n',
+        encoding: 'utf8',
+        language: 'markdown',
+        name: 'checklist.md',
+      },
+    ],
+    id: 'rev_secret_1',
+    message: 'initial revision',
+    seq: 1,
+    snippetId: 'snip_secret',
+  },
+  {
+    createdAt: LATER,
+    files: [
+      {
+        content: 'scratch content\n',
+        encoding: 'utf8',
+        name: 'scratch.txt',
+      },
+    ],
+    id: 'rev_scratch_1',
+    message: 'initial revision',
+    seq: 1,
+    snippetId: 'snip_scratch',
+  },
+];
+
+export const seedStars: readonly Star[] = [
+  {
+    createdAt: LATER,
+    id: 'star_bob_hello',
+    snippetId: 'snip_hello',
+    userId: 'usr_bob',
+  },
+];
+
+/**
+ * Seed index rows derived through the same tokenizer `search.index` uses, so
+ * the seeded index matches a from-scratch `search.reindex` exactly. Secret
+ * snippets are never indexed.
+ */
+export const seedSearchEntries: readonly SearchEntry[] = seedSnippets
+  .filter((snippet) => snippet.visibility === 'public')
+  .flatMap((snippet) => {
+    const files =
+      seedRevisions.find((revision) => revision.snippetId === snippet.id)
+        ?.files ?? [];
+    return deriveSearchTerms(snippet.description, files).map(
+      (term, position) => ({
+        id: `sea_${snippet.id}_${String(position)}`,
+        snippetId: snippet.id,
+        term,
+      })
+    );
+  });
+
+/** Full seed set keyed by table name, in reference-safe insert order. */
+export const seedTables = {
+  revisions: seedRevisions.map((row) => ({ ...row, files: [...row.files] })),
+  searchEntries: [...seedSearchEntries],
+  snippets: [...seedSnippets],
+  stars: [...seedStars],
+  tokens: seedTokens.map((row) => ({ ...row, scopes: [...row.scopes] })),
+  users: [...seedUsers],
+};

--- a/examples/stash/src/http.ts
+++ b/examples/stash/src/http.ts
@@ -1,0 +1,18 @@
+/**
+ * HTTP entry point for stash.
+ *
+ * Usage:
+ *   bun run src/http.ts            # port 4280
+ *   STASH_PORT=8080 bun run src/http.ts
+ */
+
+import { createStashServer } from './server.js';
+
+const { app } = await createStashServer();
+
+const server = Bun.serve({
+  fetch: app.fetch,
+  port: Number(process.env['STASH_PORT'] ?? 4280),
+});
+
+process.stdout.write(`stash HTTP surface listening on ${server.url.href}\n`);

--- a/examples/stash/src/index.ts
+++ b/examples/stash/src/index.ts
@@ -1,8 +1,19 @@
 /**
- * Placeholder module for the `stash` showcase app.
+ * stash — self-hosted gists on Trails.
  *
- * The real app lands in its own build run confined to `examples/stash/`.
- * This placeholder only reserves the workspace so `bun.lock` takes the
- * membership churn once, before the parallel builds start.
+ * The topo is the public entry: compile it, surface it, or embed it.
  */
-export const workspaceName = 'stash';
+
+/**
+ * The stash topo: snippets, immutable revisions, forks, stars, tokens, and
+ * the signal-driven search index.
+ *
+ * @example
+ * ```typescript
+ * import { run } from '@ontrails/core';
+ * import { graph } from 'stash';
+ *
+ * const result = await run(graph, 'snippet.get', { id: 'snip_hello' });
+ * ```
+ */
+export { graph } from './app.js';

--- a/examples/stash/src/mcp-options.ts
+++ b/examples/stash/src/mcp-options.ts
@@ -1,0 +1,53 @@
+/**
+ * MCP surface options — the hero surface.
+ *
+ * Trailheads group the dense topo into four entries an agent can scan in one
+ * tool listing. A trailhead call is `{ trail, input }` and the response
+ * carries `{ trail, output }`: member trail identity is preserved at
+ * invocation and response time (ADR-0050), never merged away.
+ */
+
+import type {
+  CreateServerOptions,
+  McpSurfaceTrailheadMap,
+} from '@ontrails/mcp';
+
+export const stashTrailheads = {
+  account: {
+    description:
+      'Token self-service and identity: mint, list, and revoke API tokens; check who a token belongs to.',
+    trails: ['token.create', 'token.list', 'token.revoke', 'user.me'],
+  },
+  history: {
+    description:
+      'Immutable revision history: list revisions, read one in full, diff two seqs, fetch raw file bytes.',
+    trails: ['revision.list', 'revision.get', 'revision.diff', 'file.raw'],
+  },
+  search: {
+    description:
+      'Keyword search over the signal-maintained index of public snippets.',
+    trails: ['search.query'],
+  },
+  snippets: {
+    description:
+      'Create, read, update, fork, star, and delete snippets. Updates append revisions; secret snippets are owner-only.',
+    trails: [
+      'snippet.create',
+      'snippet.get',
+      'snippet.list',
+      'snippet.update',
+      'snippet.delete',
+      'snippet.fork',
+      'snippet.star',
+      'snippet.unstar',
+    ],
+  },
+} satisfies McpSurfaceTrailheadMap;
+
+export const stashMcpOptions = {
+  description:
+    'Self-hosted gists for agents: save, search, fork, and retrieve snippets with immutable revision history.',
+  name: 'stash',
+  trailheads: stashTrailheads,
+  version: '0.1.0',
+} satisfies CreateServerOptions;

--- a/examples/stash/src/mcp.ts
+++ b/examples/stash/src/mcp.ts
@@ -1,0 +1,34 @@
+/**
+ * MCP entry point for stash — the hero surface.
+ *
+ * Usage:
+ *   bun run src/mcp.ts
+ */
+
+import { AuthError, Result } from '@ontrails/core';
+import { surface } from '@ontrails/mcp';
+
+import { graph } from './app.js';
+import { stashMcpOptions } from './mcp-options.js';
+import { createStashAuthAdapter } from './resources/auth.js';
+import { db } from './resources/db.js';
+import { openStashDb } from './server.js';
+
+const conn = await openStashDb();
+const adapter = createStashAuthAdapter(conn);
+
+await surface(graph, {
+  ...stashMcpOptions,
+  resolvePermit: async ({ bearerToken }) => {
+    const authed = await adapter.authenticate({
+      ...(bearerToken === undefined ? {} : { bearerToken }),
+      requestId: 'stash-mcp',
+      surface: 'mcp',
+    });
+    if (authed.isErr()) {
+      return Result.err(new AuthError(authed.error.message));
+    }
+    return Result.ok(authed.value);
+  },
+  resources: { [db.id]: conn, auth: adapter },
+});

--- a/examples/stash/src/resources/auth.ts
+++ b/examples/stash/src/resources/auth.ts
@@ -1,0 +1,39 @@
+/**
+ * Token authentication for stash.
+ *
+ * The topo registers the framework `authResource`; each surface entry
+ * overrides it with {@link createStashAuthAdapter}, a db-backed adapter that
+ * resolves a bearer token against the `tokens` table and shares the same
+ * store connection the trails use. One adapter, three surfaces: the CLI
+ * `--token` flag, the HTTP `Authorization` header, and MCP authorization all
+ * resolve permits through this lookup.
+ */
+
+import { Result } from '@ontrails/core';
+import { authResource } from '@ontrails/permits';
+import type { AuthAdapter } from '@ontrails/permits';
+
+import type { StashConnection } from './db.js';
+
+export const auth = authResource;
+
+/**
+ * Build an auth adapter over a live stash connection.
+ *
+ * Unknown and revoked tokens resolve to a null permit — the caller proceeds
+ * anonymously (or the surface rejects, for flows that require a permit).
+ */
+export const createStashAuthAdapter = (conn: StashConnection): AuthAdapter => ({
+  authenticate: async (input) => {
+    const secret = input.bearerToken;
+    if (secret === undefined || secret.length === 0) {
+      return Result.ok(null);
+    }
+    const matches = await conn.tokens.list({ secret });
+    const [token] = matches;
+    if (token === undefined || token.revoked) {
+      return Result.ok(null);
+    }
+    return Result.ok({ id: token.userId, scopes: [...token.scopes] });
+  },
+});

--- a/examples/stash/src/resources/db.ts
+++ b/examples/stash/src/resources/db.ts
@@ -1,0 +1,63 @@
+/**
+ * SQLite-backed stash store resource.
+ *
+ * `db.from(ctx)` hands trails a typed connection whose write methods fire the
+ * store's scoped table signals through the trail context. The mock path seeds
+ * the deterministic fixtures so `testAll(graph)` and trail examples run with
+ * zero configuration; the runtime path seeds the same fixtures so the README
+ * quickstart finds data on a fresh boot.
+ *
+ * Set `STASH_DB_PATH` to persist between CLI invocations; the default is an
+ * in-memory database per process.
+ */
+
+import { connectDrizzle } from '@ontrails/drizzle';
+
+import { seedTables } from '../fixtures.js';
+import { stashStoreDefinition } from '../store.js';
+
+const cloneSeed = () => ({
+  revisions: seedTables.revisions.map((row) => ({
+    ...row,
+    files: row.files.map((file) => ({ ...file })),
+  })),
+  searchEntries: seedTables.searchEntries.map((row) => ({ ...row })),
+  snippets: seedTables.snippets.map((row) => ({ ...row })),
+  stars: seedTables.stars.map((row) => ({ ...row })),
+  tokens: seedTables.tokens.map((row) => ({ ...row, scopes: [...row.scopes] })),
+  users: seedTables.users.map((row) => ({ ...row })),
+});
+
+export const db = connectDrizzle(stashStoreDefinition, {
+  description:
+    'SQLite snippet store: snippets, revisions, stars, users, tokens, and the derived search index.',
+  id: 'stash.db',
+  mockSeed: cloneSeed(),
+  seed: cloneSeed(),
+  url: process.env['STASH_DB_PATH'] ?? ':memory:',
+});
+
+/** Typed connection shape for the stash store. */
+export type StashConnection = ReturnType<(typeof db)['from']>;
+
+/**
+ * Construct a freshly seeded in-memory connection for tests.
+ *
+ * Each call returns independent state, so per-test resource factories never
+ * leak writes across tests.
+ */
+export const createMockDb = () => {
+  const bound = connectDrizzle(stashStoreDefinition, {
+    id: 'stash.db',
+    mockSeed: cloneSeed(),
+    url: ':memory:',
+  });
+  if (bound.mock === undefined) {
+    throw new Error('stash db resource requires a mock factory');
+  }
+  const created = bound.mock();
+  if (created instanceof Promise) {
+    throw new TypeError('stash db mock must resolve synchronously');
+  }
+  return created;
+};

--- a/examples/stash/src/search/terms.ts
+++ b/examples/stash/src/search/terms.ts
@@ -1,0 +1,54 @@
+/**
+ * Naive tokenizer shared by the search-index consumer, the full reindex, and
+ * the seeded fixtures — one term source, so the seeded index can never drift
+ * from what `search.index` would derive.
+ *
+ * Deliberately simple: the showcase is the reactive indexing pattern, not
+ * search quality.
+ */
+
+import type { Revision, StashFile } from '../store.js';
+
+/** Cap on indexed characters per file so seeds and reindex stay cheap. */
+const CONTENT_INDEX_LIMIT = 2000;
+
+const MIN_TERM_LENGTH = 2;
+
+const tokenize = (text: string): string[] =>
+  text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((term) => term.length >= MIN_TERM_LENGTH);
+
+/** Tokenize a user query with the same rules the index uses. */
+export const tokenizeQuery = (query: string): string[] => [
+  ...new Set(tokenize(query)),
+];
+
+const fileTerms = (file: StashFile): string[] => {
+  const terms = [file.name.toLowerCase(), ...tokenize(file.name)];
+  if (file.language !== undefined) {
+    terms.push(...tokenize(file.language));
+  }
+  if (file.encoding !== 'base64') {
+    terms.push(...tokenize(file.content.slice(0, CONTENT_INDEX_LIMIT)));
+  }
+  return terms;
+};
+
+/**
+ * Derive the deduplicated, sorted term set for a snippet from its description
+ * and the files of its latest revision.
+ */
+export const deriveSearchTerms = (
+  description: string,
+  files: Revision['files']
+): readonly string[] => {
+  const terms = new Set<string>(tokenize(description));
+  for (const file of files) {
+    for (const term of fileTerms(file)) {
+      terms.add(term);
+    }
+  }
+  return [...terms].toSorted();
+};

--- a/examples/stash/src/server.ts
+++ b/examples/stash/src/server.ts
@@ -1,0 +1,74 @@
+/**
+ * HTTP app builder.
+ *
+ * `createApp` projects every public trail as a route, and `file.raw`'s
+ * `blobRefSchema` output is streamed as real bytes with its `mimeType` as
+ * the Content-Type — the framework derives byte serving from the trail
+ * contract, so the app mounts nothing by hand.
+ */
+
+import { AuthError, Result } from '@ontrails/core';
+import { createApp } from '@ontrails/hono';
+import type { Hono } from 'hono';
+
+import { graph } from './app.js';
+import { createStashAuthAdapter } from './resources/auth.js';
+import type { StashConnection } from './resources/db.js';
+import { db } from './resources/db.js';
+
+export interface StashServer {
+  readonly app: Hono;
+  readonly conn: StashConnection;
+}
+
+/** Open the runtime store connection declared by the db resource. */
+export const openStashDb = async (): Promise<StashConnection> => {
+  const created = await db.create({
+    config: undefined,
+    cwd: process.cwd(),
+    env: process.env,
+    workspaceRoot: process.cwd(),
+  });
+  if (created.isErr()) {
+    throw created.error;
+  }
+  return created.value;
+};
+
+/**
+ * Build the stash Hono app over an existing connection.
+ *
+ * Exported separately from the listening entry so tests can drive it with
+ * `app.request()` and a seeded mock connection.
+ */
+export const createStashApp = (conn: StashConnection): Hono => {
+  const adapter = createStashAuthAdapter(conn);
+  const resolvePermit = async (input: {
+    readonly bearerToken?: string | undefined;
+    readonly requestId?: string | undefined;
+  }) => {
+    const authed = await adapter.authenticate({
+      ...(input.bearerToken === undefined
+        ? {}
+        : { bearerToken: input.bearerToken }),
+      requestId: input.requestId ?? 'stash-http',
+      surface: 'http',
+    });
+    if (authed.isErr()) {
+      return Result.err(new AuthError(authed.error.message));
+    }
+    return Result.ok(authed.value);
+  };
+
+  return createApp(graph, {
+    name: 'stash',
+    resolvePermit,
+    resources: { [db.id]: conn, auth: adapter },
+  });
+};
+
+/** Build the full runtime server: real connection + app. */
+export const createStashServer = async (): Promise<StashServer> => {
+  const conn = await openStashDb();
+  return { app: createStashApp(conn), conn };
+};

--- a/examples/stash/src/signals/snippet-signals.ts
+++ b/examples/stash/src/signals/snippet-signals.ts
@@ -1,0 +1,30 @@
+/**
+ * Snippet domain signals.
+ *
+ * `snippet.create` and `snippet.fork` fire `snippet.created`;
+ * `snippet.update` and `snippet.delete` fire `snippet.updated`. The
+ * `search.index` consumer trail lists both in its `on:` array, closing the
+ * reactive indexing loop.
+ */
+
+import { signal } from '@ontrails/core';
+import { z } from 'zod';
+
+export const snippetCreated = signal('snippet.created', {
+  description: 'Fired when a snippet is created, including forks',
+  from: ['snippet.create'],
+  payload: z.object({
+    ownerId: z.string(),
+    snippetId: z.string(),
+    visibility: z.enum(['public', 'secret']),
+  }),
+});
+
+export const snippetUpdated = signal('snippet.updated', {
+  description: 'Fired when a snippet gains a revision or is deleted',
+  from: ['snippet.update', 'snippet.delete'],
+  payload: z.object({
+    action: z.enum(['updated', 'deleted']),
+    snippetId: z.string(),
+  }),
+});

--- a/examples/stash/src/store.ts
+++ b/examples/stash/src/store.ts
@@ -1,0 +1,149 @@
+/**
+ * Schema-derived store for stash.
+ *
+ * One Zod schema per entity, projected into SQLite tables through
+ * `@ontrails/store` + `@ontrails/drizzle`. Domain revisions are modeled as
+ * their own table: `snippet.update` inserts a new `revisions` row and never
+ * mutates an existing one, so revision history is immutable by construction.
+ *
+ * The `snippets` table is `versioned` so the framework manages an optimistic
+ * concurrency `version` column and the store's `reconcile` factory can cover
+ * it. That framework-managed version is a third, separate concept from both
+ * domain revisions (data history) and trail versioning (contract evolution).
+ */
+
+import { store as defineStore } from '@ontrails/store';
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Entity schemas
+// ---------------------------------------------------------------------------
+
+export const fileSchema = z.object({
+  content: z
+    .string()
+    .describe('File content: UTF-8 text, or base64 when encoding is "base64"'),
+  encoding: z
+    .enum(['utf8', 'base64'])
+    .default('utf8')
+    .describe('Content encoding; use "base64" for binary files'),
+  language: z
+    .string()
+    .optional()
+    .describe('Language hint, e.g. "typescript" (optional)'),
+  name: z.string().min(1).describe('File name including extension'),
+});
+
+export const visibilitySchema = z
+  .enum(['public', 'secret'])
+  .describe('Snippet visibility: public, or secret (owner-only)');
+
+export const userSchema = z.object({
+  createdAt: z.string(),
+  id: z.string(),
+  name: z.string(),
+});
+
+export const tokenSchema = z.object({
+  createdAt: z.string(),
+  id: z.string(),
+  name: z.string(),
+  revoked: z.boolean().default(false),
+  scopes: z.array(z.string()),
+  secret: z.string(),
+  userId: z.string(),
+});
+
+export const snippetSchema = z.object({
+  createdAt: z.string(),
+  description: z.string(),
+  forkOf: z
+    .string()
+    .nullable()
+    .describe('Snippet id this snippet was forked from, or null'),
+  id: z.string(),
+  ownerId: z.string(),
+  updatedAt: z.string(),
+  visibility: visibilitySchema,
+});
+
+export const revisionSchema = z.object({
+  createdAt: z.string(),
+  files: z.array(fileSchema),
+  id: z.string(),
+  message: z.string().nullable(),
+  seq: z.number().int().min(1),
+  snippetId: z.string(),
+});
+
+export const starSchema = z.object({
+  createdAt: z.string(),
+  id: z.string(),
+  snippetId: z.string(),
+  userId: z.string(),
+});
+
+export const searchEntrySchema = z.object({
+  id: z.string(),
+  snippetId: z.string(),
+  term: z.string(),
+});
+
+export type StashFile = z.output<typeof fileSchema>;
+export type User = z.output<typeof userSchema>;
+export type Token = z.output<typeof tokenSchema>;
+export type Revision = z.output<typeof revisionSchema>;
+export type Star = z.output<typeof starSchema>;
+export type SearchEntry = z.output<typeof searchEntrySchema>;
+
+// ---------------------------------------------------------------------------
+// Store definition
+// ---------------------------------------------------------------------------
+
+export const stashStoreDefinition = defineStore({
+  revisions: {
+    generated: ['id', 'createdAt'],
+    identity: 'id',
+    indexed: ['snippetId'],
+    references: { snippetId: 'snippets' },
+    schema: revisionSchema,
+  },
+  searchEntries: {
+    generated: ['id'],
+    identity: 'id',
+    indexed: ['term', 'snippetId'],
+    schema: searchEntrySchema,
+  },
+  snippets: {
+    generated: ['id', 'createdAt', 'updatedAt'],
+    identity: 'id',
+    indexed: ['ownerId', 'visibility'],
+    references: { ownerId: 'users' },
+    schema: snippetSchema,
+    versioned: true,
+  },
+  stars: {
+    generated: ['id', 'createdAt'],
+    identity: 'id',
+    indexed: ['snippetId', 'userId'],
+    references: { snippetId: 'snippets', userId: 'users' },
+    schema: starSchema,
+  },
+  tokens: {
+    generated: ['id', 'createdAt'],
+    identity: 'id',
+    indexed: ['secret', 'userId'],
+    references: { userId: 'users' },
+    schema: tokenSchema,
+  },
+  users: {
+    generated: ['id', 'createdAt'],
+    identity: 'id',
+    schema: userSchema,
+  },
+});
+
+/** Snippet row as stored, including the framework-managed `version` column. */
+export type SnippetRow = z.output<
+  (typeof stashStoreDefinition)['tables']['snippets']['schema']
+>;

--- a/examples/stash/src/trails/file.ts
+++ b/examples/stash/src/trails/file.ts
@@ -1,0 +1,115 @@
+/**
+ * file.raw — real bytes off the contract.
+ *
+ * The trail returns a `BlobRef` (name, mimeType, size, bytes) with the
+ * content type derived from the file extension. Because the output schema is
+ * `blobRefSchema`, the derived HTTP route (`GET /file/raw`) streams the bytes
+ * with that content-type header — byte serving is a projection of the
+ * contract, not app wiring. Visibility applies here exactly as everywhere
+ * else: a secret snippet's files read as not-found to anyone but the owner.
+ */
+
+import {
+  NotFoundError,
+  Result,
+  blobRefSchema,
+  createBlobRef,
+  trail,
+} from '@ontrails/core';
+import { z } from 'zod';
+
+import { db } from '../resources/db.js';
+import type { StashFile } from '../store.js';
+import { loadVisibleSnippet, snippetNotFound, viewerId } from './shared.js';
+
+const CONTENT_TYPE_BY_EXTENSION: Readonly<Record<string, string>> = {
+  css: 'text/css; charset=utf-8',
+  html: 'text/html; charset=utf-8',
+  js: 'text/javascript; charset=utf-8',
+  json: 'application/json; charset=utf-8',
+  md: 'text/markdown; charset=utf-8',
+  png: 'image/png',
+  ts: 'application/typescript; charset=utf-8',
+  txt: 'text/plain; charset=utf-8',
+};
+
+/** Content type for a file name, by extension; unknown maps to octet-stream. */
+export const contentTypeFor = (name: string): string => {
+  const extension = name.toLowerCase().split('.').at(-1) ?? '';
+  return CONTENT_TYPE_BY_EXTENSION[extension] ?? 'application/octet-stream';
+};
+
+const fileBytes = (file: StashFile): Uint8Array => {
+  if (file.encoding === 'base64') {
+    return Uint8Array.from(
+      atob(file.content),
+      (char) => char.codePointAt(0) ?? 0
+    );
+  }
+  return new TextEncoder().encode(file.content);
+};
+
+export const raw = trail('file.raw', {
+  blaze: async (input, ctx) => {
+    const conn = db.from(ctx);
+    const snippet = await loadVisibleSnippet(
+      conn,
+      input.snippetId,
+      viewerId(ctx)
+    );
+    if (snippet === null) {
+      return Result.err(snippetNotFound(input.snippetId));
+    }
+    const revisions = await conn.revisions.list({
+      snippetId: input.snippetId,
+    });
+    const revision = revisions.find((row) => row.seq === input.seq);
+    if (revision === undefined) {
+      return Result.err(
+        new NotFoundError(
+          `Snippet "${input.snippetId}" has no revision ${String(input.seq)}`
+        )
+      );
+    }
+    const file = revision.files.find((entry) => entry.name === input.name);
+    if (file === undefined) {
+      return Result.err(
+        new NotFoundError(
+          `File "${input.name}" not found in revision ${String(input.seq)} of snippet "${input.snippetId}"`
+        )
+      );
+    }
+    const bytes = fileBytes(file);
+    return Result.ok(
+      createBlobRef({
+        data: bytes,
+        mimeType: contentTypeFor(file.name),
+        name: file.name,
+        size: bytes.length,
+      })
+    );
+  },
+  description:
+    'Serve one file of one revision as raw bytes with a content type derived from its extension',
+  examples: [
+    {
+      description: 'Fetch the raw bytes of a seeded file',
+      input: { name: 'greet.ts', seq: 1, snippetId: 'snip_hello' },
+      name: 'Raw file bytes',
+    },
+    {
+      description: 'Unknown file names return NotFoundError',
+      error: 'NotFoundError',
+      input: { name: 'nope.ts', seq: 1, snippetId: 'snip_hello' },
+      name: 'Raw missing file',
+    },
+  ],
+  input: z.object({
+    name: z.string().describe('File name within the revision'),
+    seq: z.coerce.number().int().min(1).describe('Revision sequence number'),
+    snippetId: z.string().describe('Snippet id'),
+  }),
+  intent: 'read',
+  output: blobRefSchema,
+  resources: [db],
+});

--- a/examples/stash/src/trails/fork.ts
+++ b/examples/stash/src/trails/fork.ts
@@ -1,0 +1,69 @@
+/**
+ * snippet.fork — composition with lineage.
+ *
+ * Forking composes `snippet.get` (visibility applies: another user's secret
+ * snippet reads as not-found, so it is unforkable without leaking existence),
+ * `revision.get` (full files of the latest revision), and `snippet.create`
+ * with the composition-only `forkOf` field carrying lineage. The public
+ * create contract never exposes `forkOf`; only composition can set it.
+ */
+
+import { InternalError, Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { snippetDetailSchema } from './shared.js';
+import type { revisionDetailSchema } from './shared.js';
+
+type SnippetDetail = z.output<typeof snippetDetailSchema>;
+type RevisionDetail = z.output<typeof revisionDetailSchema>;
+
+export const fork = trail('snippet.fork', {
+  blaze: async (input, ctx) => {
+    if (!ctx.compose) {
+      return Result.err(new InternalError('Trail requires a compose function'));
+    }
+    const source = await ctx.compose<SnippetDetail>('snippet.get', {
+      id: input.id,
+    });
+    if (source.isErr()) {
+      return source;
+    }
+    const revision = await ctx.compose<RevisionDetail>('revision.get', {
+      seq: source.value.latestRevision.seq,
+      snippetId: input.id,
+    });
+    if (revision.isErr()) {
+      return revision;
+    }
+    return await ctx.compose<SnippetDetail>('snippet.create', {
+      description: source.value.description,
+      files: revision.value.files,
+      forkOf: input.id,
+      message: `forked from ${input.id}`,
+      visibility: source.value.visibility,
+    });
+  },
+  composes: ['snippet.get', 'revision.get', 'snippet.create'],
+  description:
+    'Fork a snippet you can see into your own account, preserving lineage',
+  examples: [
+    {
+      description: 'Fork a public snippet',
+      input: { id: 'snip_hello' },
+      name: 'Fork a snippet',
+    },
+    {
+      description:
+        'Unknown ids — and other users’ secret snippets — return NotFoundError',
+      error: 'NotFoundError',
+      input: { id: 'snip_missing' },
+      name: 'Fork a missing snippet',
+    },
+  ],
+  input: z.object({
+    id: z.string().describe('Snippet id to fork'),
+  }),
+  intent: 'write',
+  output: snippetDetailSchema,
+  permit: { scopes: ['snippet:write'] },
+});

--- a/examples/stash/src/trails/reconcile.ts
+++ b/examples/stash/src/trails/reconcile.ts
@@ -1,0 +1,20 @@
+/**
+ * Maintenance reconcile trail from the store factory.
+ *
+ * `snippets` is the store's one versioned table, so it is the one that takes
+ * reconcile coverage: a versioned upsert that retries once on optimistic
+ * concurrency conflicts using last-write-wins.
+ */
+
+import { reconcile } from '@ontrails/store/trails';
+
+import { db } from '../resources/db.js';
+import { stashStoreDefinition } from '../store.js';
+
+export const reconcileSnippet = reconcile({
+  description:
+    'Reconcile a snippet row by versioned upsert (last-write-wins on conflict)',
+  resource: db,
+  strategy: 'last-write-wins',
+  table: stashStoreDefinition.tables.snippets,
+});

--- a/examples/stash/src/trails/revision.ts
+++ b/examples/stash/src/trails/revision.ts
@@ -1,0 +1,275 @@
+/**
+ * Revision history trails — reads over the immutable revision log.
+ *
+ * `revision.diff` is a computed read: a naive line diff between two seqs,
+ * kept deliberately simple.
+ */
+
+import { NotFoundError, Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { db } from '../resources/db.js';
+import type { StashConnection } from '../resources/db.js';
+import type { Revision, StashFile } from '../store.js';
+import {
+  loadVisibleSnippet,
+  revisionDetailSchema,
+  revisionSummarySchema,
+  snippetNotFound,
+  toRevisionDetail,
+  toRevisionSummary,
+  viewerId,
+} from './shared.js';
+
+const orderedRevisions = async (
+  conn: StashConnection,
+  snippetId: string
+): Promise<Revision[]> => {
+  const revisions = await conn.revisions.list({ snippetId });
+  return revisions.toSorted((a, b) => a.seq - b.seq);
+};
+
+const revisionNotFound = (snippetId: string, seq: number): NotFoundError =>
+  new NotFoundError(`Snippet "${snippetId}" has no revision ${String(seq)}`);
+
+// ---------------------------------------------------------------------------
+// revision.list
+// ---------------------------------------------------------------------------
+
+export const list = trail('revision.list', {
+  blaze: async (input, ctx) => {
+    const conn = db.from(ctx);
+    const snippet = await loadVisibleSnippet(
+      conn,
+      input.snippetId,
+      viewerId(ctx)
+    );
+    if (snippet === null) {
+      return Result.err(snippetNotFound(input.snippetId));
+    }
+    const revisions = await orderedRevisions(conn, input.snippetId);
+    return Result.ok({
+      revisions: revisions.map(toRevisionSummary),
+      total: revisions.length,
+    });
+  },
+  description: 'List a snippet’s revisions in seq order',
+  examples: [
+    {
+      description: 'List the revision history for a snippet',
+      expected: {
+        revisions: [
+          {
+            createdAt: '2026-01-01T00:00:00.000Z',
+            fileNames: ['greet.ts'],
+            message: 'initial revision',
+            seq: 1,
+          },
+        ],
+        total: 1,
+      },
+      input: { snippetId: 'snip_hello' },
+      name: 'List revisions',
+    },
+    {
+      description: 'Unknown snippet ids return NotFoundError',
+      error: 'NotFoundError',
+      input: { snippetId: 'snip_missing' },
+      name: 'List revisions of a missing snippet',
+    },
+  ],
+  input: z.object({
+    snippetId: z.string().describe('Snippet id'),
+  }),
+  intent: 'read',
+  output: z.object({
+    revisions: z.array(revisionSummarySchema),
+    total: z.number().int(),
+  }),
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// revision.get
+// ---------------------------------------------------------------------------
+
+export const get = trail('revision.get', {
+  blaze: async (input, ctx) => {
+    const conn = db.from(ctx);
+    const snippet = await loadVisibleSnippet(
+      conn,
+      input.snippetId,
+      viewerId(ctx)
+    );
+    if (snippet === null) {
+      return Result.err(snippetNotFound(input.snippetId));
+    }
+    const revisions = await orderedRevisions(conn, input.snippetId);
+    const revision = revisions.find((row) => row.seq === input.seq);
+    if (revision === undefined) {
+      return Result.err(revisionNotFound(input.snippetId, input.seq));
+    }
+    return Result.ok(toRevisionDetail(revision));
+  },
+  description: 'Read one revision of a snippet, including full file contents',
+  examples: [
+    {
+      description: 'Read revision 1 of a snippet',
+      expected: {
+        createdAt: '2026-01-01T00:00:00.000Z',
+        files: [
+          {
+            content: `export const greet = (name: string): string => \`Hello, \${name}!\`;\n`,
+            encoding: 'utf8',
+            language: 'typescript',
+            name: 'greet.ts',
+          },
+        ],
+        message: 'initial revision',
+        seq: 1,
+        snippetId: 'snip_hello',
+      },
+      input: { seq: 1, snippetId: 'snip_hello' },
+      name: 'Get a revision',
+    },
+    {
+      description: 'Unknown seqs return NotFoundError',
+      error: 'NotFoundError',
+      input: { seq: 99, snippetId: 'snip_hello' },
+      name: 'Get a missing revision',
+    },
+  ],
+  input: z.object({
+    seq: z.coerce.number().int().min(1).describe('Revision sequence number'),
+    snippetId: z.string().describe('Snippet id'),
+  }),
+  intent: 'read',
+  output: revisionDetailSchema,
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// revision.diff
+// ---------------------------------------------------------------------------
+
+const fileDiffSchema = z.object({
+  addedLines: z.array(z.string()),
+  name: z.string(),
+  removedLines: z.array(z.string()),
+  status: z.enum(['added', 'removed', 'modified', 'unchanged']),
+});
+
+const textLines = (file: StashFile | undefined): string[] => {
+  if (file === undefined || file.encoding === 'base64') {
+    return [];
+  }
+  return file.content.split('\n');
+};
+
+const diffStatus = (
+  before: StashFile | undefined,
+  after: StashFile | undefined,
+  changedLines: number
+): 'added' | 'removed' | 'modified' | 'unchanged' => {
+  if (before === undefined) {
+    return 'added';
+  }
+  if (after === undefined) {
+    return 'removed';
+  }
+  return changedLines === 0 ? 'unchanged' : 'modified';
+};
+
+const diffFile = (
+  name: string,
+  before: StashFile | undefined,
+  after: StashFile | undefined
+) => {
+  const beforeLines = textLines(before);
+  const afterLines = textLines(after);
+  const beforeSet = new Set(beforeLines);
+  const afterSet = new Set(afterLines);
+  const addedLines = afterLines.filter((line) => !beforeSet.has(line));
+  const removedLines = beforeLines.filter((line) => !afterSet.has(line));
+  return {
+    addedLines,
+    name,
+    removedLines,
+    status: diffStatus(before, after, addedLines.length + removedLines.length),
+  };
+};
+
+export const diff = trail('revision.diff', {
+  blaze: async (input, ctx) => {
+    const conn = db.from(ctx);
+    const snippet = await loadVisibleSnippet(
+      conn,
+      input.snippetId,
+      viewerId(ctx)
+    );
+    if (snippet === null) {
+      return Result.err(snippetNotFound(input.snippetId));
+    }
+    const revisions = await orderedRevisions(conn, input.snippetId);
+    const fromRevision = revisions.find((row) => row.seq === input.from);
+    if (fromRevision === undefined) {
+      return Result.err(revisionNotFound(input.snippetId, input.from));
+    }
+    const toRevision = revisions.find((row) => row.seq === input.to);
+    if (toRevision === undefined) {
+      return Result.err(revisionNotFound(input.snippetId, input.to));
+    }
+    const names = [
+      ...new Set([
+        ...fromRevision.files.map((file) => file.name),
+        ...toRevision.files.map((file) => file.name),
+      ]),
+    ].toSorted();
+    const files = names.map((name) =>
+      diffFile(
+        name,
+        fromRevision.files.find((file) => file.name === name),
+        toRevision.files.find((file) => file.name === name)
+      )
+    );
+    return Result.ok({ files, from: input.from, to: input.to });
+  },
+  description: 'Naive line diff between two revisions of a snippet',
+  examples: [
+    {
+      description: 'Diff a revision against itself',
+      expected: {
+        files: [
+          {
+            addedLines: [],
+            name: 'greet.ts',
+            removedLines: [],
+            status: 'unchanged',
+          },
+        ],
+        from: 1,
+        to: 1,
+      },
+      input: { from: 1, snippetId: 'snip_hello', to: 1 },
+      name: 'Diff identical revisions',
+    },
+    {
+      description: 'Unknown seqs return NotFoundError',
+      error: 'NotFoundError',
+      input: { from: 1, snippetId: 'snip_hello', to: 99 },
+      name: 'Diff a missing revision',
+    },
+  ],
+  input: z.object({
+    from: z.coerce.number().int().min(1).describe('Base revision seq'),
+    snippetId: z.string().describe('Snippet id'),
+    to: z.coerce.number().int().min(1).describe('Target revision seq'),
+  }),
+  intent: 'read',
+  output: z.object({
+    files: z.array(fileDiffSchema),
+    from: z.number().int(),
+    to: z.number().int(),
+  }),
+  resources: [db],
+});

--- a/examples/stash/src/trails/search.ts
+++ b/examples/stash/src/trails/search.ts
@@ -1,0 +1,209 @@
+/**
+ * Signal-driven search.
+ *
+ * `search.index` is the reactive consumer: it lists `snippet.created` and
+ * `snippet.updated` in its `on:` array, so every create, fork, update, and
+ * delete re-derives that snippet's rows in the `searchEntries` table. Secret
+ * snippets are never indexed — search cannot leak what reads cannot see.
+ * `search.reindex` is the admin-permit full rebuild over the same tokenizer.
+ */
+
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { db } from '../resources/db.js';
+import type { StashConnection } from '../resources/db.js';
+import { deriveSearchTerms, tokenizeQuery } from '../search/terms.js';
+import { snippetCreated, snippetUpdated } from '../signals/snippet-signals.js';
+import {
+  isVisibleTo,
+  latestRevisionFor,
+  snippetSummarySchema,
+  starCountFor,
+  toSnippetSummary,
+  viewerId,
+} from './shared.js';
+
+const indexSnippet = async (
+  conn: StashConnection,
+  snippetId: string
+): Promise<{ indexed: boolean; terms: number }> => {
+  const stale = await conn.searchEntries.list({ snippetId });
+  for (const row of stale) {
+    await conn.searchEntries.remove(row.id);
+  }
+  const snippet = await conn.snippets.get(snippetId);
+  if (snippet === null || snippet.visibility !== 'public') {
+    return { indexed: false, terms: 0 };
+  }
+  const latest = await latestRevisionFor(conn, snippetId);
+  const terms = deriveSearchTerms(snippet.description, latest?.files ?? []);
+  for (const term of terms) {
+    await conn.searchEntries.insert({ snippetId, term });
+  }
+  return { indexed: true, terms: terms.length };
+};
+
+// ---------------------------------------------------------------------------
+// search.index
+// ---------------------------------------------------------------------------
+
+export const index = trail('search.index', {
+  blaze: async (input, ctx) => {
+    const conn = db.from(ctx);
+    const outcome = await indexSnippet(conn, input.snippetId);
+    return Result.ok({ snippetId: input.snippetId, ...outcome });
+  },
+  description:
+    'Re-derive the search index rows for one snippet; deletes and secret snippets deindex',
+  examples: [
+    {
+      description: 'Reindex a seeded public snippet',
+      input: { snippetId: 'snip_hello' },
+      name: 'Index a snippet',
+    },
+  ],
+  input: z.object({
+    snippetId: z.string().describe('Snippet id to (re)index'),
+  }),
+  intent: 'write',
+  on: [snippetCreated, snippetUpdated],
+  output: z.object({
+    indexed: z.boolean(),
+    snippetId: z.string(),
+    terms: z.number().int(),
+  }),
+  permit: { scopes: [] },
+  resources: [db],
+  visibility: 'internal',
+});
+
+// ---------------------------------------------------------------------------
+// search.query
+// ---------------------------------------------------------------------------
+
+export const query = trail('search.query', {
+  blaze: async (input, ctx) => {
+    const conn = db.from(ctx);
+    const tokens = tokenizeQuery(input.query);
+    if (tokens.length === 0) {
+      return Result.ok({ query: input.query, results: [], total: 0 });
+    }
+    let matched: Set<string> | null = null;
+    for (const token of tokens) {
+      const rows = await conn.searchEntries.list({ term: token });
+      const ids = new Set(rows.map((row) => row.snippetId));
+      if (matched === null) {
+        matched = ids;
+        continue;
+      }
+      const previous: readonly string[] = [...matched];
+      matched = new Set(previous.filter((id) => ids.has(id)));
+    }
+    const viewer = viewerId(ctx);
+    const orderedIds = [...(matched ?? new Set<string>())].toSorted();
+    const summaries = [];
+    for (const id of orderedIds) {
+      const snippet = await conn.snippets.get(id);
+      if (snippet === null || !isVisibleTo(snippet, viewer)) {
+        continue;
+      }
+      summaries.push(toSnippetSummary(snippet, await starCountFor(conn, id)));
+    }
+    return Result.ok({
+      query: input.query,
+      results: summaries.slice(0, input.limit),
+      total: summaries.length,
+    });
+  },
+  description: 'Search public snippets by keyword over the derived index',
+  examples: [
+    {
+      description: 'Find a snippet by a word in its description',
+      expected: {
+        query: 'greet',
+        results: [
+          {
+            createdAt: '2026-01-01T00:00:00.000Z',
+            description: 'Greet the trail crew from TypeScript',
+            forkOf: null,
+            id: 'snip_hello',
+            ownerId: 'usr_alice',
+            starCount: 1,
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            version: 1,
+            visibility: 'public',
+          },
+        ],
+        total: 1,
+      },
+      input: { limit: 10, query: 'greet' },
+      name: 'Search finds a match',
+    },
+    {
+      description: 'Queries with no matches return an empty result set',
+      expected: { query: 'zebra', results: [], total: 0 },
+      input: { limit: 10, query: 'zebra' },
+      name: 'Search finds nothing',
+    },
+  ],
+  input: z.object({
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(50)
+      .default(10)
+      .describe('Maximum results'),
+    query: z.string().min(1).describe('Search terms (AND across words)'),
+  }),
+  intent: 'read',
+  output: z.object({
+    query: z.string(),
+    results: z.array(snippetSummarySchema),
+    total: z.number().int(),
+  }),
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// search.reindex
+// ---------------------------------------------------------------------------
+
+export const reindex = trail('search.reindex', {
+  blaze: async (_input, ctx) => {
+    const conn = db.from(ctx);
+    const stale = await conn.searchEntries.list();
+    for (const row of stale) {
+      await conn.searchEntries.remove(row.id);
+    }
+    const snippets = await conn.snippets.list();
+    let indexed = 0;
+    let terms = 0;
+    for (const snippet of snippets) {
+      const outcome = await indexSnippet(conn, snippet.id);
+      if (outcome.indexed) {
+        indexed += 1;
+        terms += outcome.terms;
+      }
+    }
+    return Result.ok({ snippets: indexed, terms });
+  },
+  description:
+    'Rebuild the entire search index from scratch; requires the search:admin scope',
+  examples: [
+    {
+      description: 'Full rebuild over every public snippet',
+      input: {},
+      name: 'Reindex everything',
+    },
+  ],
+  input: z.object({}),
+  intent: 'write',
+  output: z.object({
+    snippets: z.number().int(),
+    terms: z.number().int(),
+  }),
+  permit: { scopes: ['search:admin'] },
+  resources: [db],
+});

--- a/examples/stash/src/trails/shared.ts
+++ b/examples/stash/src/trails/shared.ts
@@ -1,0 +1,164 @@
+/**
+ * Shared projections and the visibility choke point for snippet trails.
+ *
+ * Every read of a snippet goes through {@link loadVisibleSnippet}: a secret
+ * snippet read by anyone but its owner behaves exactly like a snippet that
+ * does not exist. Trails answer with the same `NotFoundError` (same message
+ * shape) in both cases, so no surface can leak that a secret id is taken —
+ * this is the deliberate NotFound-not-Forbidden choice the README documents.
+ */
+
+import { NotFoundError, PermitError, Result } from '@ontrails/core';
+import type { TrailContext } from '@ontrails/core';
+import { z } from 'zod';
+
+import type { StashConnection } from '../resources/db.js';
+import { fileSchema } from '../store.js';
+import type { Revision, SnippetRow } from '../store.js';
+
+// ---------------------------------------------------------------------------
+// Output schemas
+// ---------------------------------------------------------------------------
+
+export const snippetSummarySchema = z.object({
+  createdAt: z.string(),
+  description: z.string(),
+  forkOf: z.string().nullable(),
+  id: z.string(),
+  ownerId: z.string(),
+  starCount: z.number().int(),
+  updatedAt: z.string(),
+  version: z.number().int(),
+  visibility: z.enum(['public', 'secret']),
+});
+
+export const revisionSummarySchema = z.object({
+  createdAt: z.string(),
+  fileNames: z.array(z.string()),
+  message: z.string().nullable(),
+  seq: z.number().int(),
+});
+
+export const revisionDetailSchema = z.object({
+  createdAt: z.string(),
+  files: z.array(fileSchema),
+  message: z.string().nullable(),
+  seq: z.number().int(),
+  snippetId: z.string(),
+});
+
+export const snippetDetailSchema = snippetSummarySchema.extend({
+  latestRevision: revisionSummarySchema,
+});
+
+export type SnippetSummary = z.output<typeof snippetSummarySchema>;
+
+// ---------------------------------------------------------------------------
+// Visibility
+// ---------------------------------------------------------------------------
+
+/** The permit subject id for the current caller, if authenticated. */
+export const viewerId = (ctx: TrailContext): string | undefined =>
+  ctx.permit?.id;
+
+/**
+ * The permit subject for a mutation. Enforcement rejects unauthenticated
+ * callers before the blaze runs; this narrows the type and keeps a truthful
+ * error if a caller ever reaches the blaze without one.
+ */
+export const requireSubject = (ctx: TrailContext): Result<string, Error> => {
+  const subject = viewerId(ctx);
+  return subject === undefined
+    ? Result.err(new PermitError('An authenticated permit is required'))
+    : Result.ok(subject);
+};
+
+/**
+ * One error shape for "missing" and "hidden" so responses are
+ * indistinguishable across every surface.
+ */
+export const snippetNotFound = (id: string): NotFoundError =>
+  new NotFoundError(`Snippet "${id}" not found`);
+
+/** Whether a snippet row is visible to the given viewer. */
+export const isVisibleTo = (
+  snippet: SnippetRow,
+  viewer: string | undefined
+): boolean => snippet.visibility === 'public' || snippet.ownerId === viewer;
+
+/**
+ * Load a snippet the viewer is allowed to see.
+ *
+ * Returns `null` both when the id does not exist and when it names a secret
+ * snippet owned by someone else.
+ */
+export const loadVisibleSnippet = async (
+  conn: StashConnection,
+  id: string,
+  viewer: string | undefined
+): Promise<SnippetRow | null> => {
+  const snippet = await conn.snippets.get(id);
+  if (snippet === null || !isVisibleTo(snippet, viewer)) {
+    return null;
+  }
+  return snippet;
+};
+
+// ---------------------------------------------------------------------------
+// Projections
+// ---------------------------------------------------------------------------
+
+export const starCountFor = async (
+  conn: StashConnection,
+  snippetId: string
+): Promise<number> => {
+  const stars = await conn.stars.list({ snippetId });
+  return stars.length;
+};
+
+export const latestRevisionFor = async (
+  conn: StashConnection,
+  snippetId: string
+): Promise<Revision | null> => {
+  const revisions = await conn.revisions.list({ snippetId });
+  const latest = revisions.toSorted((a, b) => a.seq - b.seq).at(-1);
+  return latest ?? null;
+};
+
+export const nextRevisionSeq = async (
+  conn: StashConnection,
+  snippetId: string
+): Promise<number> => {
+  const latest = await latestRevisionFor(conn, snippetId);
+  return latest === null ? 1 : latest.seq + 1;
+};
+
+export const toSnippetSummary = (
+  snippet: SnippetRow,
+  starCount: number
+): SnippetSummary => ({
+  createdAt: snippet.createdAt,
+  description: snippet.description,
+  forkOf: snippet.forkOf,
+  id: snippet.id,
+  ownerId: snippet.ownerId,
+  starCount,
+  updatedAt: snippet.updatedAt,
+  version: snippet.version,
+  visibility: snippet.visibility,
+});
+
+export const toRevisionSummary = (revision: Revision) => ({
+  createdAt: revision.createdAt,
+  fileNames: revision.files.map((file) => file.name),
+  message: revision.message,
+  seq: revision.seq,
+});
+
+export const toRevisionDetail = (revision: Revision) => ({
+  createdAt: revision.createdAt,
+  files: revision.files.map((file) => ({ ...file })),
+  message: revision.message,
+  seq: revision.seq,
+  snippetId: revision.snippetId,
+});

--- a/examples/stash/src/trails/snippet.ts
+++ b/examples/stash/src/trails/snippet.ts
@@ -1,0 +1,418 @@
+/**
+ * Snippet CRUD trails.
+ *
+ * Updates never mutate revision history: `snippet.update` inserts a new
+ * `revisions` row with the next `seq` and leaves every earlier revision
+ * untouched. Secret snippets answer `NotFoundError` — never a permission
+ * error — to any caller but their owner, on every surface.
+ */
+
+import { InternalError, PermissionError, Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { db } from '../resources/db.js';
+import type { StashConnection } from '../resources/db.js';
+import { snippetCreated, snippetUpdated } from '../signals/snippet-signals.js';
+import { fileSchema, visibilitySchema } from '../store.js';
+import type { SnippetRow } from '../store.js';
+import {
+  latestRevisionFor,
+  loadVisibleSnippet,
+  nextRevisionSeq,
+  requireSubject,
+  revisionDetailSchema,
+  snippetDetailSchema,
+  snippetNotFound,
+  snippetSummarySchema,
+  starCountFor,
+  toRevisionDetail,
+  toRevisionSummary,
+  toSnippetSummary,
+  viewerId,
+} from './shared.js';
+
+/**
+ * Load a snippet for an owner mutation. Missing ids and other owners'
+ * secret snippets read as not-found; non-owner writes to a public snippet
+ * are a plain permission failure.
+ */
+const loadOwnedSnippet = async (
+  conn: StashConnection,
+  id: string,
+  owner: string
+): Promise<Result<SnippetRow, Error>> => {
+  const snippet = await conn.snippets.get(id);
+  if (snippet === null) {
+    return Result.err(snippetNotFound(id));
+  }
+  if (snippet.ownerId !== owner) {
+    return snippet.visibility === 'secret'
+      ? Result.err(snippetNotFound(id))
+      : Result.err(
+          new PermissionError(`Snippet "${id}" belongs to another user`)
+        );
+  }
+  return Result.ok(snippet);
+};
+
+const buildDetail = async (conn: StashConnection, snippet: SnippetRow) => {
+  const [starCount, latest] = await Promise.all([
+    starCountFor(conn, snippet.id),
+    latestRevisionFor(conn, snippet.id),
+  ]);
+  if (latest === null) {
+    return null;
+  }
+  return {
+    ...toSnippetSummary(snippet, starCount),
+    latestRevision: toRevisionSummary(latest),
+  };
+};
+
+const noRevisions = (id: string): InternalError =>
+  new InternalError(`Snippet "${id}" has no revisions`);
+
+// ---------------------------------------------------------------------------
+// snippet.create
+// ---------------------------------------------------------------------------
+
+export const create = trail('snippet.create', {
+  blaze: async (input, ctx) => {
+    const subject = requireSubject(ctx);
+    if (subject.isErr()) {
+      return subject;
+    }
+    const conn = db.from(ctx);
+    const snippet = await conn.snippets.insert({
+      description: input.description,
+      forkOf: input.forkOf ?? null,
+      ownerId: subject.value,
+      visibility: input.visibility,
+    });
+    await conn.revisions.insert({
+      files: input.files,
+      message: input.message ?? null,
+      seq: 1,
+      snippetId: snippet.id,
+    });
+    await ctx.fire?.(snippetCreated, {
+      ownerId: snippet.ownerId,
+      snippetId: snippet.id,
+      visibility: snippet.visibility,
+    });
+    const detail = await buildDetail(conn, snippet);
+    if (detail === null) {
+      return Result.err(noRevisions(snippet.id));
+    }
+    return Result.ok(detail);
+  },
+  composeInput: z.object({
+    forkOf: z
+      .string()
+      .optional()
+      .describe('Composition-only lineage pointer set by snippet.fork'),
+  }),
+  description: 'Create a snippet with its first revision',
+  examples: [
+    {
+      description: 'Create a public snippet with one file',
+      input: {
+        description: 'A tiny JSON config example',
+        files: [
+          {
+            content: '{ "retries": 3 }\n',
+            language: 'json',
+            name: 'config.json',
+          },
+        ],
+        message: 'initial revision',
+        visibility: 'public',
+      },
+      name: 'Create a snippet',
+    },
+  ],
+  fires: [snippetCreated],
+  input: z.object({
+    description: z.string().min(1).describe('What this snippet is about'),
+    files: z
+      .array(fileSchema)
+      .min(1)
+      .describe('Files for revision 1 (at least one)'),
+    message: z
+      .string()
+      .optional()
+      .describe('Optional revision message for revision 1'),
+    visibility: visibilitySchema.default('public'),
+  }),
+  intent: 'write',
+  output: snippetDetailSchema,
+  permit: { scopes: ['snippet:write'] },
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// snippet.get
+// ---------------------------------------------------------------------------
+
+export const get = trail('snippet.get', {
+  blaze: async (input, ctx) => {
+    const conn = db.from(ctx);
+    const snippet = await loadVisibleSnippet(conn, input.id, viewerId(ctx));
+    if (snippet === null) {
+      return Result.err(snippetNotFound(input.id));
+    }
+    const detail = await buildDetail(conn, snippet);
+    if (detail === null) {
+      return Result.err(noRevisions(input.id));
+    }
+    return Result.ok(detail);
+  },
+  description:
+    'Show a snippet with its latest revision; secret snippets are owner-only',
+  examples: [
+    {
+      description: 'Read a public snippet by id',
+      expected: {
+        createdAt: '2026-01-01T00:00:00.000Z',
+        description: 'Greet the trail crew from TypeScript',
+        forkOf: null,
+        id: 'snip_hello',
+        latestRevision: {
+          createdAt: '2026-01-01T00:00:00.000Z',
+          fileNames: ['greet.ts'],
+          message: 'initial revision',
+          seq: 1,
+        },
+        ownerId: 'usr_alice',
+        starCount: 1,
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        version: 1,
+        visibility: 'public',
+      },
+      input: { id: 'snip_hello' },
+      name: 'Get a public snippet',
+    },
+    {
+      description: 'Unknown ids return NotFoundError',
+      error: 'NotFoundError',
+      input: { id: 'snip_missing' },
+      name: 'Get a missing snippet',
+    },
+  ],
+  input: z.object({
+    id: z.string().describe('Snippet id'),
+  }),
+  intent: 'read',
+  output: snippetDetailSchema,
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// snippet.list
+// ---------------------------------------------------------------------------
+
+export const list = trail('snippet.list', {
+  blaze: async (input, ctx) => {
+    const conn = db.from(ctx);
+    const viewer = viewerId(ctx);
+    const filters = {
+      ...(input.owner === undefined ? {} : { ownerId: input.owner }),
+      ...(input.visibility === undefined
+        ? {}
+        : { visibility: input.visibility }),
+    };
+    const rows = await conn.snippets.list(
+      Object.keys(filters).length === 0 ? undefined : filters
+    );
+    const visible = rows.filter(
+      (row) => row.visibility === 'public' || row.ownerId === viewer
+    );
+    const page = visible.slice(input.offset, input.offset + input.limit);
+    const snippets = await Promise.all(
+      page.map(async (row) =>
+        toSnippetSummary(row, await starCountFor(conn, row.id))
+      )
+    );
+    return Result.ok({ snippets, total: visible.length });
+  },
+  description:
+    'List snippets with owner and visibility filters; secret snippets appear only for their owner',
+  examples: [
+    {
+      description: 'List every snippet visible to the caller',
+      input: { limit: 20, offset: 0 },
+      name: 'List snippets',
+    },
+    {
+      description: 'Filter by owner',
+      input: { limit: 20, offset: 0, owner: 'usr_alice' },
+      name: 'List snippets by owner',
+    },
+  ],
+  input: z.object({
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .default(20)
+      .describe('Page size'),
+    offset: z.coerce
+      .number()
+      .int()
+      .min(0)
+      .default(0)
+      .describe('Pagination offset'),
+    owner: z.string().optional().describe('Filter by owner user id'),
+    visibility: visibilitySchema
+      .optional()
+      .describe('Filter by visibility (secret only matches your own)'),
+  }),
+  intent: 'read',
+  output: z.object({
+    snippets: z.array(snippetSummarySchema),
+    total: z.number().int(),
+  }),
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// snippet.update
+// ---------------------------------------------------------------------------
+
+export const update = trail('snippet.update', {
+  blaze: async (input, ctx) => {
+    const subject = requireSubject(ctx);
+    if (subject.isErr()) {
+      return subject;
+    }
+    const conn = db.from(ctx);
+    const owned = await loadOwnedSnippet(conn, input.id, subject.value);
+    if (owned.isErr()) {
+      return owned;
+    }
+    const seq = await nextRevisionSeq(conn, input.id);
+    const revision = await conn.revisions.insert({
+      files: input.files,
+      message: input.message ?? null,
+      seq,
+      snippetId: input.id,
+    });
+    // Touch the snippet row so `updatedAt` and the concurrency `version`
+    // advance; revision rows themselves are insert-only.
+    await conn.snippets.update(input.id, {
+      description: owned.value.description,
+    });
+    await ctx.fire?.(snippetUpdated, {
+      action: 'updated',
+      snippetId: input.id,
+    });
+    return Result.ok(toRevisionDetail(revision));
+  },
+  description:
+    'Add a new revision to a snippet; earlier revisions are never mutated',
+  examples: [
+    {
+      description: 'Publish a second revision of a snippet',
+      input: {
+        files: [
+          {
+            content: `export const greet = (name: string): string => \`Hello again, \${name}!\`;\n`,
+            language: 'typescript',
+            name: 'greet.ts',
+          },
+        ],
+        id: 'snip_hello',
+        message: 'friendlier greeting',
+      },
+      name: 'Update a snippet',
+    },
+    {
+      description: 'Unknown ids return NotFoundError',
+      error: 'NotFoundError',
+      input: {
+        files: [{ content: 'x\n', name: 'x.txt' }],
+        id: 'snip_missing',
+      },
+      name: 'Update a missing snippet',
+    },
+  ],
+  fires: [snippetUpdated],
+  input: z.object({
+    files: z
+      .array(fileSchema)
+      .min(1)
+      .describe('Full file set for the new revision'),
+    id: z.string().describe('Snippet id'),
+    message: z.string().optional().describe('Optional revision message'),
+  }),
+  intent: 'write',
+  output: revisionDetailSchema,
+  permit: { scopes: ['snippet:write'] },
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// snippet.delete
+// ---------------------------------------------------------------------------
+
+export const remove = trail('snippet.delete', {
+  blaze: async (input, ctx) => {
+    const subject = requireSubject(ctx);
+    if (subject.isErr()) {
+      return subject;
+    }
+    const conn = db.from(ctx);
+    const owned = await loadOwnedSnippet(conn, input.id, subject.value);
+    if (owned.isErr()) {
+      return owned;
+    }
+    const [revisions, stars, entries] = await Promise.all([
+      conn.revisions.list({ snippetId: input.id }),
+      conn.stars.list({ snippetId: input.id }),
+      conn.searchEntries.list({ snippetId: input.id }),
+    ]);
+    for (const revision of revisions) {
+      await conn.revisions.remove(revision.id);
+    }
+    for (const star of stars) {
+      await conn.stars.remove(star.id);
+    }
+    for (const entry of entries) {
+      await conn.searchEntries.remove(entry.id);
+    }
+    await conn.snippets.remove(input.id);
+    await ctx.fire?.(snippetUpdated, {
+      action: 'deleted',
+      snippetId: input.id,
+    });
+    return Result.ok({ deleted: true, id: input.id });
+  },
+  description:
+    'Delete a snippet and cascade its revisions, stars, and index entries',
+  examples: [
+    {
+      description: 'Delete a snippet you own',
+      expected: { deleted: true, id: 'snip_scratch' },
+      input: { id: 'snip_scratch' },
+      name: 'Delete a snippet',
+    },
+    {
+      description: 'Unknown ids return NotFoundError',
+      error: 'NotFoundError',
+      input: { id: 'snip_missing' },
+      name: 'Delete a missing snippet',
+    },
+  ],
+  fires: [snippetUpdated],
+  input: z.object({
+    id: z.string().describe('Snippet id'),
+  }),
+  intent: 'destroy',
+  output: z.object({
+    deleted: z.boolean(),
+    id: z.string(),
+  }),
+  permit: { scopes: ['snippet:write'] },
+  resources: [db],
+});

--- a/examples/stash/src/trails/star.ts
+++ b/examples/stash/src/trails/star.ts
@@ -1,0 +1,123 @@
+/**
+ * Star trails — idempotent toggles for any authenticated user.
+ *
+ * Starring goes through the same visibility choke point as reads: another
+ * user's secret snippet is unstarrable because it is unseeable.
+ */
+
+import { Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { db } from '../resources/db.js';
+import {
+  loadVisibleSnippet,
+  requireSubject,
+  snippetNotFound,
+  starCountFor,
+} from './shared.js';
+
+const starOutputSchema = z.object({
+  snippetId: z.string(),
+  starCount: z.number().int(),
+  starred: z.boolean(),
+});
+
+const starInputSchema = z.object({
+  id: z.string().describe('Snippet id'),
+});
+
+// ---------------------------------------------------------------------------
+// snippet.star
+// ---------------------------------------------------------------------------
+
+export const star = trail('snippet.star', {
+  blaze: async (input, ctx) => {
+    const subject = requireSubject(ctx);
+    if (subject.isErr()) {
+      return subject;
+    }
+    const conn = db.from(ctx);
+    const snippet = await loadVisibleSnippet(conn, input.id, subject.value);
+    if (snippet === null) {
+      return Result.err(snippetNotFound(input.id));
+    }
+    const existing = await conn.stars.list({
+      snippetId: input.id,
+      userId: subject.value,
+    });
+    if (existing.length === 0) {
+      await conn.stars.insert({ snippetId: input.id, userId: subject.value });
+    }
+    return Result.ok({
+      snippetId: input.id,
+      starCount: await starCountFor(conn, input.id),
+      starred: true,
+    });
+  },
+  description: 'Star a snippet (idempotent)',
+  examples: [
+    {
+      description: 'Star a public snippet',
+      expected: { snippetId: 'snip_hello', starCount: 2, starred: true },
+      input: { id: 'snip_hello' },
+      name: 'Star a snippet',
+    },
+    {
+      description: 'Unknown ids return NotFoundError',
+      error: 'NotFoundError',
+      input: { id: 'snip_missing' },
+      name: 'Star a missing snippet',
+    },
+  ],
+  idempotent: true,
+  input: starInputSchema,
+  intent: 'write',
+  output: starOutputSchema,
+  permit: { scopes: ['snippet:interact'] },
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// snippet.unstar
+// ---------------------------------------------------------------------------
+
+export const unstar = trail('snippet.unstar', {
+  blaze: async (input, ctx) => {
+    const subject = requireSubject(ctx);
+    if (subject.isErr()) {
+      return subject;
+    }
+    const conn = db.from(ctx);
+    const snippet = await loadVisibleSnippet(conn, input.id, subject.value);
+    if (snippet === null) {
+      return Result.err(snippetNotFound(input.id));
+    }
+    const existing = await conn.stars.list({
+      snippetId: input.id,
+      userId: subject.value,
+    });
+    for (const row of existing) {
+      await conn.stars.remove(row.id);
+    }
+    return Result.ok({
+      snippetId: input.id,
+      starCount: await starCountFor(conn, input.id),
+      starred: false,
+    });
+  },
+  description: 'Remove your star from a snippet (idempotent)',
+  examples: [
+    {
+      description: 'Unstar a snippet you have not starred is a no-op',
+      expected: { snippetId: 'snip_hello', starCount: 1, starred: false },
+      input: { id: 'snip_hello' },
+      name: 'Unstar a snippet',
+    },
+  ],
+  idempotent: true,
+  input: starInputSchema,
+  intent: 'write',
+  output: starOutputSchema,
+  permit: { scopes: ['snippet:interact'] },
+  resources: [db],
+});

--- a/examples/stash/src/trails/token.ts
+++ b/examples/stash/src/trails/token.ts
@@ -1,0 +1,191 @@
+/**
+ * Token self-service trails.
+ *
+ * `token.create` returns the secret exactly once; `token.list` never includes
+ * it. Other users' token ids read as not-found — token existence is private,
+ * the same non-leak posture as secret snippets.
+ */
+
+import { NotFoundError, Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { db } from '../resources/db.js';
+import { requireSubject } from './shared.js';
+
+const redactedTokenSchema = z.object({
+  createdAt: z.string(),
+  id: z.string(),
+  name: z.string(),
+  revoked: z.boolean(),
+  scopes: z.array(z.string()),
+});
+
+const tokenNotFound = (id: string): NotFoundError =>
+  new NotFoundError(`Token "${id}" not found`);
+
+// ---------------------------------------------------------------------------
+// token.create
+// ---------------------------------------------------------------------------
+
+export const create = trail('token.create', {
+  blaze: async (input, ctx) => {
+    const subject = requireSubject(ctx);
+    if (subject.isErr()) {
+      return subject;
+    }
+    const conn = db.from(ctx);
+    const token = await conn.tokens.insert({
+      name: input.name,
+      revoked: false,
+      scopes: input.scopes,
+      secret: `stash_tok_${crypto.randomUUID()}`,
+      userId: subject.value,
+    });
+    return Result.ok({
+      createdAt: token.createdAt,
+      id: token.id,
+      name: token.name,
+      revoked: token.revoked,
+      scopes: [...token.scopes],
+      secret: token.secret,
+    });
+  },
+  description:
+    'Create an API token; the secret is returned once and never again',
+  examples: [
+    {
+      description: 'Mint a read-write token',
+      input: {
+        name: 'ci-publisher',
+        scopes: ['snippet:write', 'snippet:interact'],
+      },
+      name: 'Create a token',
+    },
+  ],
+  input: z.object({
+    name: z.string().min(1).describe('Label for this token'),
+    scopes: z
+      .array(z.string())
+      .min(1)
+      .describe(
+        'Scopes to grant: snippet:write, snippet:interact, token:manage, search:admin'
+      ),
+  }),
+  intent: 'write',
+  output: redactedTokenSchema.extend({
+    secret: z.string(),
+  }),
+  permit: { scopes: ['token:manage'] },
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// token.list
+// ---------------------------------------------------------------------------
+
+export const list = trail('token.list', {
+  blaze: async (_input, ctx) => {
+    const subject = requireSubject(ctx);
+    if (subject.isErr()) {
+      return subject;
+    }
+    const conn = db.from(ctx);
+    const rows = await conn.tokens.list({ userId: subject.value });
+    const tokens = rows
+      .toSorted((a, b) => a.id.localeCompare(b.id))
+      .map((row) => ({
+        createdAt: row.createdAt,
+        id: row.id,
+        name: row.name,
+        revoked: row.revoked,
+        scopes: [...row.scopes],
+      }));
+    return Result.ok({ tokens, total: tokens.length });
+  },
+  description: 'List your tokens with secrets redacted',
+  examples: [
+    {
+      description: 'List tokens for the calling user',
+      expected: {
+        tokens: [
+          {
+            createdAt: '2026-01-01T00:00:00.000Z',
+            id: 'tok_alice',
+            name: 'alice-dev',
+            revoked: false,
+            scopes: [
+              'snippet:write',
+              'snippet:interact',
+              'token:manage',
+              'search:admin',
+            ],
+          },
+          {
+            createdAt: '2026-01-01T00:00:00.000Z',
+            id: 'tok_alice_spare',
+            name: 'alice-spare',
+            revoked: false,
+            scopes: ['snippet:write'],
+          },
+        ],
+        total: 2,
+      },
+      input: {},
+      name: 'List tokens',
+    },
+  ],
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({
+    tokens: z.array(redactedTokenSchema),
+    total: z.number().int(),
+  }),
+  permit: { scopes: ['token:manage'] },
+  resources: [db],
+});
+
+// ---------------------------------------------------------------------------
+// token.revoke
+// ---------------------------------------------------------------------------
+
+export const revoke = trail('token.revoke', {
+  blaze: async (input, ctx) => {
+    const subject = requireSubject(ctx);
+    if (subject.isErr()) {
+      return subject;
+    }
+    const conn = db.from(ctx);
+    const token = await conn.tokens.get(input.id);
+    if (token === null || token.userId !== subject.value) {
+      return Result.err(tokenNotFound(input.id));
+    }
+    await conn.tokens.update(input.id, { revoked: true });
+    return Result.ok({ id: input.id, revoked: true });
+  },
+  description: 'Revoke one of your tokens; revoked tokens stop authenticating',
+  examples: [
+    {
+      description: 'Revoke a spare token',
+      expected: { id: 'tok_alice_spare', revoked: true },
+      input: { id: 'tok_alice_spare' },
+      name: 'Revoke a token',
+    },
+    {
+      description:
+        'Unknown ids — and other users’ tokens — return NotFoundError',
+      error: 'NotFoundError',
+      input: { id: 'tok_missing' },
+      name: 'Revoke a missing token',
+    },
+  ],
+  input: z.object({
+    id: z.string().describe('Token id to revoke'),
+  }),
+  intent: 'write',
+  output: z.object({
+    id: z.string(),
+    revoked: z.boolean(),
+  }),
+  permit: { scopes: ['token:manage'] },
+  resources: [db],
+});

--- a/examples/stash/src/trails/user.ts
+++ b/examples/stash/src/trails/user.ts
@@ -1,0 +1,61 @@
+/**
+ * user.me — whoami for a token.
+ *
+ * The empty-scope permit requirement means "any authenticated permit": the
+ * pipeline rejects anonymous callers before the blaze runs, and any valid
+ * token qualifies regardless of scopes.
+ */
+
+import { AuthError, Result, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { db } from '../resources/db.js';
+import { requireSubject } from './shared.js';
+
+export const me = trail('user.me', {
+  blaze: async (_input, ctx) => {
+    const subject = requireSubject(ctx);
+    if (subject.isErr()) {
+      return subject;
+    }
+    const conn = db.from(ctx);
+    const user = await conn.users.get(subject.value);
+    if (user === null) {
+      return Result.err(
+        new AuthError(`Permit subject "${subject.value}" has no user record`)
+      );
+    }
+    return Result.ok({
+      id: user.id,
+      name: user.name,
+      scopes: [...(ctx.permit?.scopes ?? [])],
+    });
+  },
+  description: 'Show the user and scopes behind the calling token',
+  examples: [
+    {
+      description: 'Identify the calling token',
+      expected: {
+        id: 'usr_alice',
+        name: 'alice',
+        scopes: [
+          'snippet:write',
+          'snippet:interact',
+          'token:manage',
+          'search:admin',
+        ],
+      },
+      input: {},
+      name: 'Who am I',
+    },
+  ],
+  input: z.object({}),
+  intent: 'read',
+  output: z.object({
+    id: z.string(),
+    name: z.string(),
+    scopes: z.array(z.string()),
+  }),
+  permit: { scopes: [] },
+  resources: [db],
+});

--- a/examples/stash/trails.lock
+++ b/examples/stash/trails.lock
@@ -1,0 +1,6041 @@
+{
+  "scope": {
+    "app": "stash"
+  },
+  "summary": {
+    "contours": 1,
+    "resources": 2,
+    "signals": 20,
+    "trails": 20
+  },
+  "topoGraph": {
+    "activationGraph": {
+      "edgeCount": 2,
+      "edges": [
+        {
+          "hasWhere": false,
+          "sourceId": "snippet.created",
+          "sourceKey": "signal:snippet.created",
+          "sourceKind": "signal",
+          "trailId": "search.index"
+        },
+        {
+          "hasWhere": false,
+          "sourceId": "snippet.updated",
+          "sourceKey": "signal:snippet.updated",
+          "sourceKind": "signal",
+          "trailId": "search.index"
+        }
+      ],
+      "sourceCount": 2,
+      "sourceKeys": [
+        "signal:snippet.created",
+        "signal:snippet.updated"
+      ],
+      "trailIds": [
+        "search.index"
+      ]
+    },
+    "activationSources": {
+      "signal:snippet.created": {
+        "id": "snippet.created",
+        "key": "signal:snippet.created",
+        "kind": "signal"
+      },
+      "signal:snippet.updated": {
+        "id": "snippet.updated",
+        "key": "signal:snippet.updated",
+        "kind": "signal"
+      }
+    },
+    "entries": [
+      {
+        "exampleCount": 0,
+        "id": "auth",
+        "kind": "resource",
+        "surfaces": [],
+        "description": "Authentication adapter"
+      },
+      {
+        "exampleCount": 2,
+        "id": "file.raw",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "file",
+            "raw"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "file",
+                "raw"
+              ],
+              "source": "derived",
+              "target": "file.raw"
+            }
+          ]
+        },
+        "description": "Serve one file of one revision as raw bytes with a content type derived from its extension",
+        "examples": [
+          {
+            "input": {
+              "name": "greet.ts",
+              "seq": 1,
+              "snippetId": "snip_hello"
+            },
+            "kind": "success",
+            "name": "Raw file bytes",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Fetch the raw bytes of a seeded file"
+          },
+          {
+            "input": {
+              "name": "nope.ts",
+              "seq": 1,
+              "snippetId": "snip_hello"
+            },
+            "kind": "error",
+            "name": "Raw missing file",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown file names return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "name": {
+              "description": "File name within the revision",
+              "type": "string"
+            },
+            "seq": {
+              "description": "Revision sequence number",
+              "type": "number"
+            },
+            "snippetId": {
+              "description": "Snippet id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "seq",
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "kind": {
+              "const": "blob"
+            },
+            "mimeType": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "size": {
+              "type": "number"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "mimeType",
+            "name",
+            "size",
+            "uri"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "revision.diff",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "revision",
+            "diff"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "revision",
+                "diff"
+              ],
+              "source": "derived",
+              "target": "revision.diff"
+            }
+          ]
+        },
+        "description": "Naive line diff between two revisions of a snippet",
+        "examples": [
+          {
+            "input": {
+              "from": 1,
+              "snippetId": "snip_hello",
+              "to": 1
+            },
+            "kind": "success",
+            "name": "Diff identical revisions",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Diff a revision against itself",
+            "expected": {
+              "files": [
+                {
+                  "addedLines": [],
+                  "name": "greet.ts",
+                  "removedLines": [],
+                  "status": "unchanged"
+                }
+              ],
+              "from": 1,
+              "to": 1
+            }
+          },
+          {
+            "input": {
+              "from": 1,
+              "snippetId": "snip_hello",
+              "to": 99
+            },
+            "kind": "error",
+            "name": "Diff a missing revision",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown seqs return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "from": {
+              "description": "Base revision seq",
+              "type": "number"
+            },
+            "snippetId": {
+              "description": "Snippet id",
+              "type": "string"
+            },
+            "to": {
+              "description": "Target revision seq",
+              "type": "number"
+            }
+          },
+          "required": [
+            "from",
+            "snippetId",
+            "to"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "files": {
+              "items": {
+                "properties": {
+                  "addedLines": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "removedLines": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "status": {
+                    "enum": [
+                      "added",
+                      "removed",
+                      "modified",
+                      "unchanged"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "addedLines",
+                  "name",
+                  "removedLines",
+                  "status"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "from": {
+              "type": "number"
+            },
+            "to": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "files",
+            "from",
+            "to"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "revision.get",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "revision",
+            "get"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "revision",
+                "get"
+              ],
+              "source": "derived",
+              "target": "revision.get"
+            }
+          ]
+        },
+        "description": "Read one revision of a snippet, including full file contents",
+        "examples": [
+          {
+            "input": {
+              "seq": 1,
+              "snippetId": "snip_hello"
+            },
+            "kind": "success",
+            "name": "Get a revision",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Read revision 1 of a snippet",
+            "expected": {
+              "createdAt": "2026-01-01T00:00:00.000Z",
+              "files": [
+                {
+                  "content": "export const greet = (name: string): string => `Hello, ${name}!`;\n",
+                  "encoding": "utf8",
+                  "language": "typescript",
+                  "name": "greet.ts"
+                }
+              ],
+              "message": "initial revision",
+              "seq": 1,
+              "snippetId": "snip_hello"
+            }
+          },
+          {
+            "input": {
+              "seq": 99,
+              "snippetId": "snip_hello"
+            },
+            "kind": "error",
+            "name": "Get a missing revision",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown seqs return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "seq": {
+              "description": "Revision sequence number",
+              "type": "number"
+            },
+            "snippetId": {
+              "description": "Snippet id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "seq",
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "files": {
+              "items": {
+                "properties": {
+                  "content": {
+                    "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "default": "utf8",
+                    "description": "Content encoding; use \"base64\" for binary files",
+                    "enum": [
+                      "utf8",
+                      "base64"
+                    ],
+                    "type": "string"
+                  },
+                  "language": {
+                    "description": "Language hint, e.g. \"typescript\" (optional)",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "File name including extension",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "message": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "seq": {
+              "type": "number"
+            },
+            "snippetId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "files",
+            "message",
+            "seq",
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "revision.list",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "revision",
+            "list"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "revision",
+                "list"
+              ],
+              "source": "derived",
+              "target": "revision.list"
+            }
+          ]
+        },
+        "description": "List a snippet’s revisions in seq order",
+        "examples": [
+          {
+            "input": {
+              "snippetId": "snip_hello"
+            },
+            "kind": "success",
+            "name": "List revisions",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "List the revision history for a snippet",
+            "expected": {
+              "revisions": [
+                {
+                  "createdAt": "2026-01-01T00:00:00.000Z",
+                  "fileNames": [
+                    "greet.ts"
+                  ],
+                  "message": "initial revision",
+                  "seq": 1
+                }
+              ],
+              "total": 1
+            }
+          },
+          {
+            "input": {
+              "snippetId": "snip_missing"
+            },
+            "kind": "error",
+            "name": "List revisions of a missing snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown snippet ids return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "snippetId": {
+              "description": "Snippet id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "revisions": {
+              "items": {
+                "properties": {
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "fileNames": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "message": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "seq": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "createdAt",
+                  "fileNames",
+                  "message",
+                  "seq"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "total": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "revisions",
+            "total"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "search.index",
+        "kind": "trail",
+        "surfaces": [],
+        "activationSources": [
+          {
+            "source": {
+              "id": "snippet.created",
+              "key": "signal:snippet.created",
+              "kind": "signal"
+            }
+          },
+          {
+            "source": {
+              "id": "snippet.updated",
+              "key": "signal:snippet.updated",
+              "kind": "signal"
+            }
+          }
+        ],
+        "cli": {
+          "path": [
+            "search",
+            "index"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "search",
+                "index"
+              ],
+              "source": "derived",
+              "target": "search.index"
+            }
+          ]
+        },
+        "description": "Re-derive the search index rows for one snippet; deletes and secret snippets deindex",
+        "examples": [
+          {
+            "input": {
+              "snippetId": "snip_hello"
+            },
+            "kind": "success",
+            "name": "Index a snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Reindex a seeded public snippet"
+          }
+        ],
+        "input": {
+          "properties": {
+            "snippetId": {
+              "description": "Snippet id to (re)index",
+              "type": "string"
+            }
+          },
+          "required": [
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "on": [
+          "snippet.created",
+          "snippet.updated"
+        ],
+        "output": {
+          "properties": {
+            "indexed": {
+              "type": "boolean"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "terms": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "indexed",
+            "snippetId",
+            "terms"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": []
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "search.query",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "search",
+            "query"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "search",
+                "query"
+              ],
+              "source": "derived",
+              "target": "search.query"
+            }
+          ]
+        },
+        "description": "Search public snippets by keyword over the derived index",
+        "examples": [
+          {
+            "input": {
+              "limit": 10,
+              "query": "greet"
+            },
+            "kind": "success",
+            "name": "Search finds a match",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Find a snippet by a word in its description",
+            "expected": {
+              "query": "greet",
+              "results": [
+                {
+                  "createdAt": "2026-01-01T00:00:00.000Z",
+                  "description": "Greet the trail crew from TypeScript",
+                  "forkOf": null,
+                  "id": "snip_hello",
+                  "ownerId": "usr_alice",
+                  "starCount": 1,
+                  "updatedAt": "2026-01-01T00:00:00.000Z",
+                  "version": 1,
+                  "visibility": "public"
+                }
+              ],
+              "total": 1
+            }
+          },
+          {
+            "input": {
+              "limit": 10,
+              "query": "zebra"
+            },
+            "kind": "success",
+            "name": "Search finds nothing",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Queries with no matches return an empty result set",
+            "expected": {
+              "query": "zebra",
+              "results": [],
+              "total": 0
+            }
+          }
+        ],
+        "input": {
+          "properties": {
+            "limit": {
+              "default": 10,
+              "description": "Maximum results",
+              "type": "number"
+            },
+            "query": {
+              "description": "Search terms (AND across words)",
+              "type": "string"
+            }
+          },
+          "required": [
+            "query"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "query": {
+              "type": "string"
+            },
+            "results": {
+              "items": {
+                "properties": {
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "forkOf": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "ownerId": {
+                    "type": "string"
+                  },
+                  "starCount": {
+                    "type": "number"
+                  },
+                  "updatedAt": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "number"
+                  },
+                  "visibility": {
+                    "enum": [
+                      "public",
+                      "secret"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "createdAt",
+                  "description",
+                  "forkOf",
+                  "id",
+                  "ownerId",
+                  "starCount",
+                  "updatedAt",
+                  "version",
+                  "visibility"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "total": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "query",
+            "results",
+            "total"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "search.reindex",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "search",
+            "reindex"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "search",
+                "reindex"
+              ],
+              "source": "derived",
+              "target": "search.reindex"
+            }
+          ]
+        },
+        "description": "Rebuild the entire search index from scratch; requires the search:admin scope",
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "Reindex everything",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Full rebuild over every public snippet"
+          }
+        ],
+        "input": {
+          "properties": {},
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "snippets": {
+              "type": "number"
+            },
+            "terms": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "snippets",
+            "terms"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "search:admin"
+          ]
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "snippet.create",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "snippet",
+            "create"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "snippet",
+                "create"
+              ],
+              "source": "derived",
+              "target": "snippet.create"
+            }
+          ]
+        },
+        "description": "Create a snippet with its first revision",
+        "examples": [
+          {
+            "input": {
+              "description": "A tiny JSON config example",
+              "files": [
+                {
+                  "content": "{ \"retries\": 3 }\n",
+                  "language": "json",
+                  "name": "config.json"
+                }
+              ],
+              "message": "initial revision",
+              "visibility": "public"
+            },
+            "kind": "success",
+            "name": "Create a snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Create a public snippet with one file"
+          }
+        ],
+        "fires": [
+          "snippet.created"
+        ],
+        "input": {
+          "properties": {
+            "description": {
+              "description": "What this snippet is about",
+              "type": "string"
+            },
+            "files": {
+              "description": "Files for revision 1 (at least one)",
+              "items": {
+                "properties": {
+                  "content": {
+                    "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "default": "utf8",
+                    "description": "Content encoding; use \"base64\" for binary files",
+                    "enum": [
+                      "utf8",
+                      "base64"
+                    ],
+                    "type": "string"
+                  },
+                  "language": {
+                    "description": "Language hint, e.g. \"typescript\" (optional)",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "File name including extension",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "message": {
+              "description": "Optional revision message for revision 1",
+              "type": "string"
+            },
+            "visibility": {
+              "default": "public",
+              "description": "Snippet visibility: public, or secret (owner-only)",
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "description",
+            "files"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "forkOf": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "latestRevision": {
+              "properties": {
+                "createdAt": {
+                  "type": "string"
+                },
+                "fileNames": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "seq": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "createdAt",
+                "fileNames",
+                "message",
+                "seq"
+              ],
+              "type": "object"
+            },
+            "ownerId": {
+              "type": "string"
+            },
+            "starCount": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "visibility": {
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "description",
+            "forkOf",
+            "id",
+            "ownerId",
+            "starCount",
+            "updatedAt",
+            "version",
+            "visibility",
+            "latestRevision"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "snippet:write"
+          ]
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "snippet.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [
+          "search.index"
+        ],
+        "description": "Fired when a snippet is created, including forks",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "from": [
+          "snippet.create"
+        ],
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "ownerId": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "visibility": {
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "ownerId",
+            "snippetId",
+            "visibility"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "ownerId": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "visibility": {
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "ownerId",
+            "snippetId",
+            "visibility"
+          ],
+          "type": "object"
+        },
+        "producers": [
+          "snippet.create"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "snippet.delete",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "snippet",
+            "delete"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "snippet",
+                "delete"
+              ],
+              "source": "derived",
+              "target": "snippet.delete"
+            }
+          ]
+        },
+        "description": "Delete a snippet and cascade its revisions, stars, and index entries",
+        "examples": [
+          {
+            "input": {
+              "id": "snip_scratch"
+            },
+            "kind": "success",
+            "name": "Delete a snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Delete a snippet you own",
+            "expected": {
+              "deleted": true,
+              "id": "snip_scratch"
+            }
+          },
+          {
+            "input": {
+              "id": "snip_missing"
+            },
+            "kind": "error",
+            "name": "Delete a missing snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown ids return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "fires": [
+          "snippet.updated"
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Snippet id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "intent": "destroy",
+        "output": {
+          "properties": {
+            "deleted": {
+              "type": "boolean"
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "deleted",
+            "id"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "snippet:write"
+          ]
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "snippet.fork",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "snippet",
+            "fork"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "snippet",
+                "fork"
+              ],
+              "source": "derived",
+              "target": "snippet.fork"
+            }
+          ]
+        },
+        "composes": [
+          "revision.get",
+          "snippet.create",
+          "snippet.get"
+        ],
+        "description": "Fork a snippet you can see into your own account, preserving lineage",
+        "examples": [
+          {
+            "input": {
+              "id": "snip_hello"
+            },
+            "kind": "success",
+            "name": "Fork a snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Fork a public snippet"
+          },
+          {
+            "input": {
+              "id": "snip_missing"
+            },
+            "kind": "error",
+            "name": "Fork a missing snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown ids — and other users’ secret snippets — return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Snippet id to fork",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "forkOf": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "latestRevision": {
+              "properties": {
+                "createdAt": {
+                  "type": "string"
+                },
+                "fileNames": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "seq": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "createdAt",
+                "fileNames",
+                "message",
+                "seq"
+              ],
+              "type": "object"
+            },
+            "ownerId": {
+              "type": "string"
+            },
+            "starCount": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "visibility": {
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "description",
+            "forkOf",
+            "id",
+            "ownerId",
+            "starCount",
+            "updatedAt",
+            "version",
+            "visibility",
+            "latestRevision"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "snippet:write"
+          ]
+        }
+      },
+      {
+        "exampleCount": 2,
+        "id": "snippet.get",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "snippet",
+            "get"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "snippet",
+                "get"
+              ],
+              "source": "derived",
+              "target": "snippet.get"
+            }
+          ]
+        },
+        "description": "Show a snippet with its latest revision; secret snippets are owner-only",
+        "examples": [
+          {
+            "input": {
+              "id": "snip_hello"
+            },
+            "kind": "success",
+            "name": "Get a public snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Read a public snippet by id",
+            "expected": {
+              "createdAt": "2026-01-01T00:00:00.000Z",
+              "description": "Greet the trail crew from TypeScript",
+              "forkOf": null,
+              "id": "snip_hello",
+              "latestRevision": {
+                "createdAt": "2026-01-01T00:00:00.000Z",
+                "fileNames": [
+                  "greet.ts"
+                ],
+                "message": "initial revision",
+                "seq": 1
+              },
+              "ownerId": "usr_alice",
+              "starCount": 1,
+              "updatedAt": "2026-01-01T00:00:00.000Z",
+              "version": 1,
+              "visibility": "public"
+            }
+          },
+          {
+            "input": {
+              "id": "snip_missing"
+            },
+            "kind": "error",
+            "name": "Get a missing snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown ids return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Snippet id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "forkOf": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "id": {
+              "type": "string"
+            },
+            "latestRevision": {
+              "properties": {
+                "createdAt": {
+                  "type": "string"
+                },
+                "fileNames": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "message": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "seq": {
+                  "type": "number"
+                }
+              },
+              "required": [
+                "createdAt",
+                "fileNames",
+                "message",
+                "seq"
+              ],
+              "type": "object"
+            },
+            "ownerId": {
+              "type": "string"
+            },
+            "starCount": {
+              "type": "number"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "visibility": {
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "description",
+            "forkOf",
+            "id",
+            "ownerId",
+            "starCount",
+            "updatedAt",
+            "version",
+            "visibility",
+            "latestRevision"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "snippet.list",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "snippet",
+            "list"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "snippet",
+                "list"
+              ],
+              "source": "derived",
+              "target": "snippet.list"
+            }
+          ]
+        },
+        "description": "List snippets with owner and visibility filters; secret snippets appear only for their owner",
+        "examples": [
+          {
+            "input": {
+              "limit": 20,
+              "offset": 0
+            },
+            "kind": "success",
+            "name": "List snippets",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "List every snippet visible to the caller"
+          },
+          {
+            "input": {
+              "limit": 20,
+              "offset": 0,
+              "owner": "usr_alice"
+            },
+            "kind": "success",
+            "name": "List snippets by owner",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Filter by owner"
+          }
+        ],
+        "input": {
+          "properties": {
+            "limit": {
+              "default": 20,
+              "description": "Page size",
+              "type": "number"
+            },
+            "offset": {
+              "default": 0,
+              "description": "Pagination offset",
+              "type": "number"
+            },
+            "owner": {
+              "description": "Filter by owner user id",
+              "type": "string"
+            },
+            "visibility": {
+              "description": "Filter by visibility (secret only matches your own)",
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "snippets": {
+              "items": {
+                "properties": {
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "forkOf": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "ownerId": {
+                    "type": "string"
+                  },
+                  "starCount": {
+                    "type": "number"
+                  },
+                  "updatedAt": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "number"
+                  },
+                  "visibility": {
+                    "enum": [
+                      "public",
+                      "secret"
+                    ],
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "createdAt",
+                  "description",
+                  "forkOf",
+                  "id",
+                  "ownerId",
+                  "starCount",
+                  "updatedAt",
+                  "version",
+                  "visibility"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "total": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "snippets",
+            "total"
+          ],
+          "type": "object"
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "snippet.star",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "snippet",
+            "star"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "snippet",
+                "star"
+              ],
+              "source": "derived",
+              "target": "snippet.star"
+            }
+          ]
+        },
+        "description": "Star a snippet (idempotent)",
+        "examples": [
+          {
+            "input": {
+              "id": "snip_hello"
+            },
+            "kind": "success",
+            "name": "Star a snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Star a public snippet",
+            "expected": {
+              "snippetId": "snip_hello",
+              "starCount": 2,
+              "starred": true
+            }
+          },
+          {
+            "input": {
+              "id": "snip_missing"
+            },
+            "kind": "error",
+            "name": "Star a missing snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown ids return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "idempotent": true,
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Snippet id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "snippetId": {
+              "type": "string"
+            },
+            "starCount": {
+              "type": "number"
+            },
+            "starred": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "snippetId",
+            "starCount",
+            "starred"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "snippet:interact"
+          ]
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "snippet.unstar",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "snippet",
+            "unstar"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "snippet",
+                "unstar"
+              ],
+              "source": "derived",
+              "target": "snippet.unstar"
+            }
+          ]
+        },
+        "description": "Remove your star from a snippet (idempotent)",
+        "examples": [
+          {
+            "input": {
+              "id": "snip_hello"
+            },
+            "kind": "success",
+            "name": "Unstar a snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unstar a snippet you have not starred is a no-op",
+            "expected": {
+              "snippetId": "snip_hello",
+              "starCount": 1,
+              "starred": false
+            }
+          }
+        ],
+        "idempotent": true,
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Snippet id",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "snippetId": {
+              "type": "string"
+            },
+            "starCount": {
+              "type": "number"
+            },
+            "starred": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "snippetId",
+            "starCount",
+            "starred"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "snippet:interact"
+          ]
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "snippet.update",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "snippet",
+            "update"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "snippet",
+                "update"
+              ],
+              "source": "derived",
+              "target": "snippet.update"
+            }
+          ]
+        },
+        "description": "Add a new revision to a snippet; earlier revisions are never mutated",
+        "examples": [
+          {
+            "input": {
+              "files": [
+                {
+                  "content": "export const greet = (name: string): string => `Hello again, ${name}!`;\n",
+                  "language": "typescript",
+                  "name": "greet.ts"
+                }
+              ],
+              "id": "snip_hello",
+              "message": "friendlier greeting"
+            },
+            "kind": "success",
+            "name": "Update a snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Publish a second revision of a snippet"
+          },
+          {
+            "input": {
+              "files": [
+                {
+                  "content": "x\n",
+                  "name": "x.txt"
+                }
+              ],
+              "id": "snip_missing"
+            },
+            "kind": "error",
+            "name": "Update a missing snippet",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown ids return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "fires": [
+          "snippet.updated"
+        ],
+        "input": {
+          "properties": {
+            "files": {
+              "description": "Full file set for the new revision",
+              "items": {
+                "properties": {
+                  "content": {
+                    "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "default": "utf8",
+                    "description": "Content encoding; use \"base64\" for binary files",
+                    "enum": [
+                      "utf8",
+                      "base64"
+                    ],
+                    "type": "string"
+                  },
+                  "language": {
+                    "description": "Language hint, e.g. \"typescript\" (optional)",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "File name including extension",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "id": {
+              "description": "Snippet id",
+              "type": "string"
+            },
+            "message": {
+              "description": "Optional revision message",
+              "type": "string"
+            }
+          },
+          "required": [
+            "files",
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "files": {
+              "items": {
+                "properties": {
+                  "content": {
+                    "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "default": "utf8",
+                    "description": "Content encoding; use \"base64\" for binary files",
+                    "enum": [
+                      "utf8",
+                      "base64"
+                    ],
+                    "type": "string"
+                  },
+                  "language": {
+                    "description": "Language hint, e.g. \"typescript\" (optional)",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "File name including extension",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "message": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "seq": {
+              "type": "number"
+            },
+            "snippetId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "files",
+            "message",
+            "seq",
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "snippet:write"
+          ]
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "snippet.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [
+          "search.index"
+        ],
+        "description": "Fired when a snippet gains a revision or is deleted",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "from": [
+          "snippet.delete",
+          "snippet.update"
+        ],
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "action": {
+              "enum": [
+                "updated",
+                "deleted"
+              ],
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "action": {
+              "enum": [
+                "updated",
+                "deleted"
+              ],
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "producers": [
+          "snippet.delete",
+          "snippet.update"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "snippets",
+        "kind": "contour",
+        "surfaces": [],
+        "identity": "id",
+        "schema": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "forkOf": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Snippet id this snippet was forked from, or null"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ownerId": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "visibility": {
+              "description": "Snippet visibility: public, or secret (owner-only)",
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "description",
+            "forkOf",
+            "id",
+            "ownerId",
+            "visibility"
+          ],
+          "type": "object"
+        }
+      },
+      {
+        "exampleCount": 0,
+        "id": "snippets.reconcile",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "snippets",
+            "reconcile"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "snippets",
+                "reconcile"
+              ],
+              "source": "derived",
+              "target": "snippets.reconcile"
+            }
+          ]
+        },
+        "contours": [
+          "snippets"
+        ],
+        "description": "Reconcile a snippet row by versioned upsert (last-write-wins on conflict)",
+        "detours": [
+          {
+            "maxAttempts": 1,
+            "on": "ConflictError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "forkOf": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Snippet id this snippet was forked from, or null"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ownerId": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "visibility": {
+              "description": "Snippet visibility: public, or secret (owner-only)",
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "description",
+            "forkOf",
+            "ownerId",
+            "visibility",
+            "version"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "forkOf": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Snippet id this snippet was forked from, or null"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ownerId": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "visibility": {
+              "description": "Snippet visibility: public, or secret (owner-only)",
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "description",
+            "forkOf",
+            "id",
+            "ownerId",
+            "updatedAt",
+            "visibility",
+            "version"
+          ],
+          "type": "object"
+        },
+        "pattern": "reconcile",
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db",
+        "kind": "resource",
+        "surfaces": [],
+        "description": "SQLite snippet store: snippets, revisions, stars, users, tokens, and the derived search index.",
+        "healthcheck": true
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:revisions.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"revisions\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "files": {
+              "items": {
+                "properties": {
+                  "content": {
+                    "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "default": "utf8",
+                    "description": "Content encoding; use \"base64\" for binary files",
+                    "enum": [
+                      "utf8",
+                      "base64"
+                    ],
+                    "type": "string"
+                  },
+                  "language": {
+                    "description": "Language hint, e.g. \"typescript\" (optional)",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "File name including extension",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "message": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "seq": {
+              "type": "number"
+            },
+            "snippetId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "files",
+            "id",
+            "message",
+            "seq",
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "files": {
+              "items": {
+                "properties": {
+                  "content": {
+                    "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "default": "utf8",
+                    "description": "Content encoding; use \"base64\" for binary files",
+                    "enum": [
+                      "utf8",
+                      "base64"
+                    ],
+                    "type": "string"
+                  },
+                  "language": {
+                    "description": "Language hint, e.g. \"typescript\" (optional)",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "File name including extension",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "message": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "seq": {
+              "type": "number"
+            },
+            "snippetId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "files",
+            "id",
+            "message",
+            "seq",
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:revisions.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"revisions\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "files": {
+              "items": {
+                "properties": {
+                  "content": {
+                    "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "default": "utf8",
+                    "description": "Content encoding; use \"base64\" for binary files",
+                    "enum": [
+                      "utf8",
+                      "base64"
+                    ],
+                    "type": "string"
+                  },
+                  "language": {
+                    "description": "Language hint, e.g. \"typescript\" (optional)",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "File name including extension",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "message": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "seq": {
+              "type": "number"
+            },
+            "snippetId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "files",
+            "id",
+            "message",
+            "seq",
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "files": {
+              "items": {
+                "properties": {
+                  "content": {
+                    "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "default": "utf8",
+                    "description": "Content encoding; use \"base64\" for binary files",
+                    "enum": [
+                      "utf8",
+                      "base64"
+                    ],
+                    "type": "string"
+                  },
+                  "language": {
+                    "description": "Language hint, e.g. \"typescript\" (optional)",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "File name including extension",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "message": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "seq": {
+              "type": "number"
+            },
+            "snippetId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "files",
+            "id",
+            "message",
+            "seq",
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:revisions.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"revisions\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "files": {
+              "items": {
+                "properties": {
+                  "content": {
+                    "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "default": "utf8",
+                    "description": "Content encoding; use \"base64\" for binary files",
+                    "enum": [
+                      "utf8",
+                      "base64"
+                    ],
+                    "type": "string"
+                  },
+                  "language": {
+                    "description": "Language hint, e.g. \"typescript\" (optional)",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "File name including extension",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "message": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "seq": {
+              "type": "number"
+            },
+            "snippetId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "files",
+            "id",
+            "message",
+            "seq",
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "files": {
+              "items": {
+                "properties": {
+                  "content": {
+                    "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                    "type": "string"
+                  },
+                  "encoding": {
+                    "default": "utf8",
+                    "description": "Content encoding; use \"base64\" for binary files",
+                    "enum": [
+                      "utf8",
+                      "base64"
+                    ],
+                    "type": "string"
+                  },
+                  "language": {
+                    "description": "Language hint, e.g. \"typescript\" (optional)",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "File name including extension",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "content",
+                  "name"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "id": {
+              "type": "string"
+            },
+            "message": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "seq": {
+              "type": "number"
+            },
+            "snippetId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "files",
+            "id",
+            "message",
+            "seq",
+            "snippetId"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:searchEntries.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"searchEntries\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "term": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "snippetId",
+            "term"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "term": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "snippetId",
+            "term"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:searchEntries.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"searchEntries\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "term": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "snippetId",
+            "term"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "term": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "snippetId",
+            "term"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:searchEntries.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"searchEntries\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "term": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "snippetId",
+            "term"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "term": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id",
+            "snippetId",
+            "term"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:snippets.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"snippets\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "forkOf": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Snippet id this snippet was forked from, or null"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ownerId": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "visibility": {
+              "description": "Snippet visibility: public, or secret (owner-only)",
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "description",
+            "forkOf",
+            "id",
+            "ownerId",
+            "updatedAt",
+            "visibility",
+            "version"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "forkOf": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Snippet id this snippet was forked from, or null"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ownerId": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "visibility": {
+              "description": "Snippet visibility: public, or secret (owner-only)",
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "description",
+            "forkOf",
+            "id",
+            "ownerId",
+            "updatedAt",
+            "visibility",
+            "version"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:snippets.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"snippets\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "forkOf": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Snippet id this snippet was forked from, or null"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ownerId": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "visibility": {
+              "description": "Snippet visibility: public, or secret (owner-only)",
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "description",
+            "forkOf",
+            "id",
+            "ownerId",
+            "updatedAt",
+            "visibility",
+            "version"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "forkOf": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Snippet id this snippet was forked from, or null"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ownerId": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "visibility": {
+              "description": "Snippet visibility: public, or secret (owner-only)",
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "description",
+            "forkOf",
+            "id",
+            "ownerId",
+            "updatedAt",
+            "visibility",
+            "version"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:snippets.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"snippets\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "forkOf": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Snippet id this snippet was forked from, or null"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ownerId": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "visibility": {
+              "description": "Snippet visibility: public, or secret (owner-only)",
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "description",
+            "forkOf",
+            "id",
+            "ownerId",
+            "updatedAt",
+            "visibility",
+            "version"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "forkOf": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Snippet id this snippet was forked from, or null"
+            },
+            "id": {
+              "type": "string"
+            },
+            "ownerId": {
+              "type": "string"
+            },
+            "updatedAt": {
+              "type": "string"
+            },
+            "version": {
+              "type": "number"
+            },
+            "visibility": {
+              "description": "Snippet visibility: public, or secret (owner-only)",
+              "enum": [
+                "public",
+                "secret"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "description",
+            "forkOf",
+            "id",
+            "ownerId",
+            "updatedAt",
+            "visibility",
+            "version"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:stars.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"stars\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "userId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "snippetId",
+            "userId"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "userId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "snippetId",
+            "userId"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:stars.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"stars\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "userId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "snippetId",
+            "userId"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "userId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "snippetId",
+            "userId"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:stars.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"stars\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "userId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "snippetId",
+            "userId"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "snippetId": {
+              "type": "string"
+            },
+            "userId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "snippetId",
+            "userId"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:tokens.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"tokens\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "revoked": {
+              "default": false,
+              "type": "boolean"
+            },
+            "scopes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "secret": {
+              "type": "string"
+            },
+            "userId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name",
+            "scopes",
+            "secret",
+            "userId"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "revoked": {
+              "default": false,
+              "type": "boolean"
+            },
+            "scopes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "secret": {
+              "type": "string"
+            },
+            "userId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name",
+            "scopes",
+            "secret",
+            "userId"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:tokens.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"tokens\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "revoked": {
+              "default": false,
+              "type": "boolean"
+            },
+            "scopes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "secret": {
+              "type": "string"
+            },
+            "userId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name",
+            "scopes",
+            "secret",
+            "userId"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "revoked": {
+              "default": false,
+              "type": "boolean"
+            },
+            "scopes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "secret": {
+              "type": "string"
+            },
+            "userId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name",
+            "scopes",
+            "secret",
+            "userId"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:tokens.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"tokens\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "revoked": {
+              "default": false,
+              "type": "boolean"
+            },
+            "scopes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "secret": {
+              "type": "string"
+            },
+            "userId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name",
+            "scopes",
+            "secret",
+            "userId"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "revoked": {
+              "default": false,
+              "type": "boolean"
+            },
+            "scopes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "secret": {
+              "type": "string"
+            },
+            "userId": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name",
+            "scopes",
+            "secret",
+            "userId"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:users.created",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"users\" entity is created.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:users.removed",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"users\" entity is removed.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 0,
+        "id": "stash.db:users.updated",
+        "kind": "signal",
+        "surfaces": [],
+        "consumers": [],
+        "description": "Fired after a \"users\" entity is updated.",
+        "diagnostics": {
+          "codes": [
+            "signal.fire.suppressed",
+            "signal.handler.failed",
+            "signal.handler.predicate_failed",
+            "signal.handler.rejected",
+            "signal.invalid",
+            "signal.unknown"
+          ],
+          "strictMode": true
+        },
+        "governance": {
+          "consumers": "trail.on",
+          "payload": "signal.payload",
+          "producers": "trail.fires"
+        },
+        "input": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name"
+          ],
+          "type": "object"
+        },
+        "payload": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name"
+          ],
+          "type": "object"
+        },
+        "producers": []
+      },
+      {
+        "exampleCount": 1,
+        "id": "token.create",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "token",
+            "create"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "token",
+                "create"
+              ],
+              "source": "derived",
+              "target": "token.create"
+            }
+          ]
+        },
+        "description": "Create an API token; the secret is returned once and never again",
+        "examples": [
+          {
+            "input": {
+              "name": "ci-publisher",
+              "scopes": [
+                "snippet:write",
+                "snippet:interact"
+              ]
+            },
+            "kind": "success",
+            "name": "Create a token",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Mint a read-write token"
+          }
+        ],
+        "input": {
+          "properties": {
+            "name": {
+              "description": "Label for this token",
+              "type": "string"
+            },
+            "scopes": {
+              "description": "Scopes to grant: snippet:write, snippet:interact, token:manage, search:admin",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "name",
+            "scopes"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "createdAt": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "revoked": {
+              "type": "boolean"
+            },
+            "scopes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "secret": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "createdAt",
+            "id",
+            "name",
+            "revoked",
+            "scopes",
+            "secret"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "token:manage"
+          ]
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "token.list",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "token",
+            "list"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "token",
+                "list"
+              ],
+              "source": "derived",
+              "target": "token.list"
+            }
+          ]
+        },
+        "description": "List your tokens with secrets redacted",
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "List tokens",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "List tokens for the calling user",
+            "expected": {
+              "tokens": [
+                {
+                  "createdAt": "2026-01-01T00:00:00.000Z",
+                  "id": "tok_alice",
+                  "name": "alice-dev",
+                  "revoked": false,
+                  "scopes": [
+                    "snippet:write",
+                    "snippet:interact",
+                    "token:manage",
+                    "search:admin"
+                  ]
+                },
+                {
+                  "createdAt": "2026-01-01T00:00:00.000Z",
+                  "id": "tok_alice_spare",
+                  "name": "alice-spare",
+                  "revoked": false,
+                  "scopes": [
+                    "snippet:write"
+                  ]
+                }
+              ],
+              "total": 2
+            }
+          }
+        ],
+        "input": {
+          "properties": {},
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "tokens": {
+              "items": {
+                "properties": {
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "revoked": {
+                    "type": "boolean"
+                  },
+                  "scopes": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "required": [
+                  "createdAt",
+                  "id",
+                  "name",
+                  "revoked",
+                  "scopes"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "total": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "tokens",
+            "total"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "token:manage"
+          ]
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 2,
+        "id": "token.revoke",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "token",
+            "revoke"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "token",
+                "revoke"
+              ],
+              "source": "derived",
+              "target": "token.revoke"
+            }
+          ]
+        },
+        "description": "Revoke one of your tokens; revoked tokens stop authenticating",
+        "examples": [
+          {
+            "input": {
+              "id": "tok_alice_spare"
+            },
+            "kind": "success",
+            "name": "Revoke a token",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Revoke a spare token",
+            "expected": {
+              "id": "tok_alice_spare",
+              "revoked": true
+            }
+          },
+          {
+            "input": {
+              "id": "tok_missing"
+            },
+            "kind": "error",
+            "name": "Revoke a missing token",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Unknown ids — and other users’ tokens — return NotFoundError",
+            "error": "NotFoundError"
+          }
+        ],
+        "input": {
+          "properties": {
+            "id": {
+              "description": "Token id to revoke",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        },
+        "output": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "revoked": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "id",
+            "revoked"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": [
+            "token:manage"
+          ]
+        },
+        "resources": [
+          "stash.db"
+        ]
+      },
+      {
+        "exampleCount": 1,
+        "id": "user.me",
+        "kind": "trail",
+        "surfaces": [],
+        "cli": {
+          "path": [
+            "user",
+            "me"
+          ],
+          "routes": [
+            {
+              "kind": "canonical",
+              "path": [
+                "user",
+                "me"
+              ],
+              "source": "derived",
+              "target": "user.me"
+            }
+          ]
+        },
+        "description": "Show the user and scopes behind the calling token",
+        "examples": [
+          {
+            "input": {},
+            "kind": "success",
+            "name": "Who am I",
+            "provenance": {
+              "source": "trail.examples"
+            },
+            "description": "Identify the calling token",
+            "expected": {
+              "id": "usr_alice",
+              "name": "alice",
+              "scopes": [
+                "snippet:write",
+                "snippet:interact",
+                "token:manage",
+                "search:admin"
+              ]
+            }
+          }
+        ],
+        "input": {
+          "properties": {},
+          "type": "object"
+        },
+        "intent": "read",
+        "output": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "scopes": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "id",
+            "name",
+            "scopes"
+          ],
+          "type": "object"
+        },
+        "permit": {
+          "scopes": []
+        },
+        "resources": [
+          "stash.db"
+        ]
+      }
+    ],
+    "library": {
+      "app": "stash",
+      "collisions": [],
+      "excluded": [
+        {
+          "reason": "activation",
+          "trailId": "search.index"
+        }
+      ],
+      "exports": [
+        {
+          "description": "Serve one file of one revision as raw bytes with a content type derived from its extension",
+          "exportName": "fileRaw",
+          "input": {
+            "properties": {
+              "name": {
+                "description": "File name within the revision",
+                "type": "string"
+              },
+              "seq": {
+                "description": "Revision sequence number",
+                "type": "number"
+              },
+              "snippetId": {
+                "description": "Snippet id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "seq",
+              "snippetId"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "kind": {
+                "const": "blob"
+              },
+              "mimeType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "size": {
+                "type": "number"
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "kind",
+              "mimeType",
+              "name",
+              "size",
+              "uri"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "file.raw"
+        },
+        {
+          "description": "Naive line diff between two revisions of a snippet",
+          "exportName": "revisionDiff",
+          "input": {
+            "properties": {
+              "from": {
+                "description": "Base revision seq",
+                "type": "number"
+              },
+              "snippetId": {
+                "description": "Snippet id",
+                "type": "string"
+              },
+              "to": {
+                "description": "Target revision seq",
+                "type": "number"
+              }
+            },
+            "required": [
+              "from",
+              "snippetId",
+              "to"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "files": {
+                "items": {
+                  "properties": {
+                    "addedLines": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "removedLines": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "status": {
+                      "enum": [
+                        "added",
+                        "removed",
+                        "modified",
+                        "unchanged"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "addedLines",
+                    "name",
+                    "removedLines",
+                    "status"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "from": {
+                "type": "number"
+              },
+              "to": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "files",
+              "from",
+              "to"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "revision.diff"
+        },
+        {
+          "description": "Read one revision of a snippet, including full file contents",
+          "exportName": "revisionGet",
+          "input": {
+            "properties": {
+              "seq": {
+                "description": "Revision sequence number",
+                "type": "number"
+              },
+              "snippetId": {
+                "description": "Snippet id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "seq",
+              "snippetId"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "files": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                      "type": "string"
+                    },
+                    "encoding": {
+                      "default": "utf8",
+                      "description": "Content encoding; use \"base64\" for binary files",
+                      "enum": [
+                        "utf8",
+                        "base64"
+                      ],
+                      "type": "string"
+                    },
+                    "language": {
+                      "description": "Language hint, e.g. \"typescript\" (optional)",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "File name including extension",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "content",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "message": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "seq": {
+                "type": "number"
+              },
+              "snippetId": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "createdAt",
+              "files",
+              "message",
+              "seq",
+              "snippetId"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "revision.get"
+        },
+        {
+          "description": "List a snippet’s revisions in seq order",
+          "exportName": "revisionList",
+          "input": {
+            "properties": {
+              "snippetId": {
+                "description": "Snippet id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "snippetId"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "revisions": {
+                "items": {
+                  "properties": {
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "fileNames": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    "message": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "seq": {
+                      "type": "number"
+                    }
+                  },
+                  "required": [
+                    "createdAt",
+                    "fileNames",
+                    "message",
+                    "seq"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "total": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "revisions",
+              "total"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "revision.list"
+        },
+        {
+          "description": "Search public snippets by keyword over the derived index",
+          "exportName": "searchQuery",
+          "input": {
+            "properties": {
+              "limit": {
+                "default": 10,
+                "description": "Maximum results",
+                "type": "number"
+              },
+              "query": {
+                "description": "Search terms (AND across words)",
+                "type": "string"
+              }
+            },
+            "required": [
+              "query"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "query": {
+                "type": "string"
+              },
+              "results": {
+                "items": {
+                  "properties": {
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "forkOf": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "ownerId": {
+                      "type": "string"
+                    },
+                    "starCount": {
+                      "type": "number"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "number"
+                    },
+                    "visibility": {
+                      "enum": [
+                        "public",
+                        "secret"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "createdAt",
+                    "description",
+                    "forkOf",
+                    "id",
+                    "ownerId",
+                    "starCount",
+                    "updatedAt",
+                    "version",
+                    "visibility"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "total": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "query",
+              "results",
+              "total"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "search.query"
+        },
+        {
+          "description": "Rebuild the entire search index from scratch; requires the search:admin scope",
+          "exportName": "searchReindex",
+          "input": {
+            "properties": {},
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "snippets": {
+                "type": "number"
+              },
+              "terms": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "snippets",
+              "terms"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "search.reindex"
+        },
+        {
+          "description": "Create a snippet with its first revision",
+          "exportName": "snippetCreate",
+          "input": {
+            "properties": {
+              "description": {
+                "description": "What this snippet is about",
+                "type": "string"
+              },
+              "files": {
+                "description": "Files for revision 1 (at least one)",
+                "items": {
+                  "properties": {
+                    "content": {
+                      "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                      "type": "string"
+                    },
+                    "encoding": {
+                      "default": "utf8",
+                      "description": "Content encoding; use \"base64\" for binary files",
+                      "enum": [
+                        "utf8",
+                        "base64"
+                      ],
+                      "type": "string"
+                    },
+                    "language": {
+                      "description": "Language hint, e.g. \"typescript\" (optional)",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "File name including extension",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "content",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "message": {
+                "description": "Optional revision message for revision 1",
+                "type": "string"
+              },
+              "visibility": {
+                "default": "public",
+                "description": "Snippet visibility: public, or secret (owner-only)",
+                "enum": [
+                  "public",
+                  "secret"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "description",
+              "files"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "forkOf": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "id": {
+                "type": "string"
+              },
+              "latestRevision": {
+                "properties": {
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "fileNames": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "message": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "seq": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "createdAt",
+                  "fileNames",
+                  "message",
+                  "seq"
+                ],
+                "type": "object"
+              },
+              "ownerId": {
+                "type": "string"
+              },
+              "starCount": {
+                "type": "number"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              },
+              "visibility": {
+                "enum": [
+                  "public",
+                  "secret"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "createdAt",
+              "description",
+              "forkOf",
+              "id",
+              "ownerId",
+              "starCount",
+              "updatedAt",
+              "version",
+              "visibility",
+              "latestRevision"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "snippet.create"
+        },
+        {
+          "description": "Delete a snippet and cascade its revisions, stars, and index entries",
+          "exportName": "snippetDelete",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Snippet id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "destroy",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "deleted": {
+                "type": "boolean"
+              },
+              "id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "deleted",
+              "id"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "snippet.delete"
+        },
+        {
+          "description": "Fork a snippet you can see into your own account, preserving lineage",
+          "exportName": "snippetFork",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Snippet id to fork",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "forkOf": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "id": {
+                "type": "string"
+              },
+              "latestRevision": {
+                "properties": {
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "fileNames": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "message": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "seq": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "createdAt",
+                  "fileNames",
+                  "message",
+                  "seq"
+                ],
+                "type": "object"
+              },
+              "ownerId": {
+                "type": "string"
+              },
+              "starCount": {
+                "type": "number"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              },
+              "visibility": {
+                "enum": [
+                  "public",
+                  "secret"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "createdAt",
+              "description",
+              "forkOf",
+              "id",
+              "ownerId",
+              "starCount",
+              "updatedAt",
+              "version",
+              "visibility",
+              "latestRevision"
+            ],
+            "type": "object"
+          },
+          "resources": [],
+          "trailId": "snippet.fork"
+        },
+        {
+          "description": "Show a snippet with its latest revision; secret snippets are owner-only",
+          "exportName": "snippetGet",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Snippet id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "forkOf": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "id": {
+                "type": "string"
+              },
+              "latestRevision": {
+                "properties": {
+                  "createdAt": {
+                    "type": "string"
+                  },
+                  "fileNames": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "message": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "seq": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "createdAt",
+                  "fileNames",
+                  "message",
+                  "seq"
+                ],
+                "type": "object"
+              },
+              "ownerId": {
+                "type": "string"
+              },
+              "starCount": {
+                "type": "number"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              },
+              "visibility": {
+                "enum": [
+                  "public",
+                  "secret"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "createdAt",
+              "description",
+              "forkOf",
+              "id",
+              "ownerId",
+              "starCount",
+              "updatedAt",
+              "version",
+              "visibility",
+              "latestRevision"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "snippet.get"
+        },
+        {
+          "description": "List snippets with owner and visibility filters; secret snippets appear only for their owner",
+          "exportName": "snippetList",
+          "input": {
+            "properties": {
+              "limit": {
+                "default": 20,
+                "description": "Page size",
+                "type": "number"
+              },
+              "offset": {
+                "default": 0,
+                "description": "Pagination offset",
+                "type": "number"
+              },
+              "owner": {
+                "description": "Filter by owner user id",
+                "type": "string"
+              },
+              "visibility": {
+                "description": "Filter by visibility (secret only matches your own)",
+                "enum": [
+                  "public",
+                  "secret"
+                ],
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "snippets": {
+                "items": {
+                  "properties": {
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "forkOf": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "ownerId": {
+                      "type": "string"
+                    },
+                    "starCount": {
+                      "type": "number"
+                    },
+                    "updatedAt": {
+                      "type": "string"
+                    },
+                    "version": {
+                      "type": "number"
+                    },
+                    "visibility": {
+                      "enum": [
+                        "public",
+                        "secret"
+                      ],
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "createdAt",
+                    "description",
+                    "forkOf",
+                    "id",
+                    "ownerId",
+                    "starCount",
+                    "updatedAt",
+                    "version",
+                    "visibility"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "total": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "snippets",
+              "total"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "snippet.list"
+        },
+        {
+          "description": "Star a snippet (idempotent)",
+          "exportName": "snippetStar",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Snippet id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "snippetId": {
+                "type": "string"
+              },
+              "starCount": {
+                "type": "number"
+              },
+              "starred": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "snippetId",
+              "starCount",
+              "starred"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "snippet.star"
+        },
+        {
+          "description": "Remove your star from a snippet (idempotent)",
+          "exportName": "snippetUnstar",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Snippet id",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "snippetId": {
+                "type": "string"
+              },
+              "starCount": {
+                "type": "number"
+              },
+              "starred": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "snippetId",
+              "starCount",
+              "starred"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "snippet.unstar"
+        },
+        {
+          "description": "Add a new revision to a snippet; earlier revisions are never mutated",
+          "exportName": "snippetUpdate",
+          "input": {
+            "properties": {
+              "files": {
+                "description": "Full file set for the new revision",
+                "items": {
+                  "properties": {
+                    "content": {
+                      "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                      "type": "string"
+                    },
+                    "encoding": {
+                      "default": "utf8",
+                      "description": "Content encoding; use \"base64\" for binary files",
+                      "enum": [
+                        "utf8",
+                        "base64"
+                      ],
+                      "type": "string"
+                    },
+                    "language": {
+                      "description": "Language hint, e.g. \"typescript\" (optional)",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "File name including extension",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "content",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "id": {
+                "description": "Snippet id",
+                "type": "string"
+              },
+              "message": {
+                "description": "Optional revision message",
+                "type": "string"
+              }
+            },
+            "required": [
+              "files",
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "files": {
+                "items": {
+                  "properties": {
+                    "content": {
+                      "description": "File content: UTF-8 text, or base64 when encoding is \"base64\"",
+                      "type": "string"
+                    },
+                    "encoding": {
+                      "default": "utf8",
+                      "description": "Content encoding; use \"base64\" for binary files",
+                      "enum": [
+                        "utf8",
+                        "base64"
+                      ],
+                      "type": "string"
+                    },
+                    "language": {
+                      "description": "Language hint, e.g. \"typescript\" (optional)",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "File name including extension",
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "content",
+                    "name"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "message": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "seq": {
+                "type": "number"
+              },
+              "snippetId": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "createdAt",
+              "files",
+              "message",
+              "seq",
+              "snippetId"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "snippet.update"
+        },
+        {
+          "description": "Reconcile a snippet row by versioned upsert (last-write-wins on conflict)",
+          "exportName": "snippetsReconcile",
+          "input": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "forkOf": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Snippet id this snippet was forked from, or null"
+              },
+              "id": {
+                "type": "string"
+              },
+              "ownerId": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              },
+              "visibility": {
+                "description": "Snippet visibility: public, or secret (owner-only)",
+                "enum": [
+                  "public",
+                  "secret"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "description",
+              "forkOf",
+              "ownerId",
+              "visibility",
+              "version"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "forkOf": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Snippet id this snippet was forked from, or null"
+              },
+              "id": {
+                "type": "string"
+              },
+              "ownerId": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "type": "string"
+              },
+              "version": {
+                "type": "number"
+              },
+              "visibility": {
+                "description": "Snippet visibility: public, or secret (owner-only)",
+                "enum": [
+                  "public",
+                  "secret"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "createdAt",
+              "description",
+              "forkOf",
+              "id",
+              "ownerId",
+              "updatedAt",
+              "visibility",
+              "version"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "snippets.reconcile"
+        },
+        {
+          "description": "Create an API token; the secret is returned once and never again",
+          "exportName": "tokenCreate",
+          "input": {
+            "properties": {
+              "name": {
+                "description": "Label for this token",
+                "type": "string"
+              },
+              "scopes": {
+                "description": "Scopes to grant: snippet:write, snippet:interact, token:manage, search:admin",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "name",
+              "scopes"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "createdAt": {
+                "type": "string"
+              },
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "revoked": {
+                "type": "boolean"
+              },
+              "scopes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "secret": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "createdAt",
+              "id",
+              "name",
+              "revoked",
+              "scopes",
+              "secret"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "token.create"
+        },
+        {
+          "description": "List your tokens with secrets redacted",
+          "exportName": "tokenList",
+          "input": {
+            "properties": {},
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "tokens": {
+                "items": {
+                  "properties": {
+                    "createdAt": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "revoked": {
+                      "type": "boolean"
+                    },
+                    "scopes": {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "required": [
+                    "createdAt",
+                    "id",
+                    "name",
+                    "revoked",
+                    "scopes"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "total": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "tokens",
+              "total"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "token.list"
+        },
+        {
+          "description": "Revoke one of your tokens; revoked tokens stop authenticating",
+          "exportName": "tokenRevoke",
+          "input": {
+            "properties": {
+              "id": {
+                "description": "Token id to revoke",
+                "type": "string"
+              }
+            },
+            "required": [
+              "id"
+            ],
+            "type": "object"
+          },
+          "intent": "write",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "revoked": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "id",
+              "revoked"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "token.revoke"
+        },
+        {
+          "description": "Show the user and scopes behind the calling token",
+          "exportName": "userMe",
+          "input": {
+            "properties": {},
+            "type": "object"
+          },
+          "intent": "read",
+          "nameSource": "derived",
+          "output": {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "scopes": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "id",
+              "name",
+              "scopes"
+            ],
+            "type": "object"
+          },
+          "resources": [
+            "stash.db"
+          ],
+          "trailId": "user.me"
+        }
+      ]
+    },
+    "topoGraphSchemaVersion": 3
+  },
+  "topoGraphHash": "817d29ad50be02ca230b34a9436935421589626b53a740bd886763d8c8f08e6a",
+  "version": 4
+}

--- a/examples/stash/tsconfig.json
+++ b/examples/stash/tsconfig.json
@@ -4,6 +4,6 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["src"],
+  "include": ["src", "bin"],
   "exclude": ["**/__tests__/**", "**/*.test.ts", "dist"]
 }

--- a/examples/stash/tsconfig.tests.json
+++ b/examples/stash/tsconfig.tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["bun"]
+  },
+  "include": ["__tests__/**/*.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
Implements [TRL-1152](https://linear.app/outfitter/issue/TRL-1152/build-stash-per-prd-fable-goal-run-the-mega-app-hard-scope-fence) per the binding PRD: [PRD: stash — self-hosted gists (the mega app)](https://linear.app/outfitter/document/prd-stash-self-hosted-gists-the-mega-app-701510b4539e).

Replaces the `examples/stash` placeholder with the suite's mega app: a self-hosted GitHub-Gists-style snippet service with 20 trails, 2 resources, and 20 signals — snippets with immutable revisions, fork lineage, stars, token permits, a signal-driven search index, raw byte serving, and an MCP-first surface grouped by trailheads. Four commits: entities/CRUD/revisions → permits/fork/stars/tokens → search loop/raw/trailheads/surfaces → README/lock/governance.

## Acceptance evidence (PRD)

- **`testAll` green with mocked db** — `testAllEstablished(graph)` plus focused suites: 81 tests, 0 failures (`bun test` in `examples/stash`). Repo-wide `bun run test`: 48 turbo tasks green.
- **Warden 0 errors** — `warden --root-dir examples/stash --depth all --lock cached --no-lock-mutation`: **PASS, 0 errors** (21 warnings, all advisory: store-table signal coaching from the drizzle resource, the star/unstar duplicate-contract note documented in the README, the singleton `search:admin` scope, and the factory `snippets.reconcile` write-without-permit). Repo `bun run check` fully green, including the repo-level Warden run.
- **Committed lock** — `examples/stash/trails.lock` (first committed lock in the repo). `trails validate` reports `stale: false`; committed hash equals the fresh `deriveTopoGraph` hash. Committing it surfaced [TRL-1191](https://linear.app/outfitter/issue/TRL-1191) (compile-stored graph hashes key-order-differently from fresh derivation); the lock embeds the derivation-order graph via framework derive functions as the workaround.
- **Permit parity across MCP/HTTP/CLI (test)** — `__tests__/permit-parity.test.ts` drives all three surfaces with real bearer tokens through one db-backed auth adapter (HTTP `Authorization` header, MCP authorization, CLI `--token` via `createProgram` + `tokenPreset`).
- **Secret-snippet non-leak proven on every surface** — same file: another user's secret snippet answers `NotFoundError` — same category, code, and message shape as a truly missing id — on MCP, HTTP, and CLI, for reads and writes; owner reads succeed; revoked tokens fall back to anonymous. Non-owner writes to *public* snippets are `PermissionError` (public existence is not a secret). The rule funnels through one helper (`loadVisibleSnippet`) so it cannot drift per trail, and secret snippets are never indexed, so search cannot leak either.
- **Revisions immutable by construction (test)** — `snippet.update` inserts the next `seq`, never mutates. `__tests__/revisions.test.ts` proves revision 1 is byte-identical to its seed after two updates, through the read trails and straight against the store.
- **Raw serving correct for ≥6 types incl. binary** — `__tests__/raw.test.ts` asserts seven content types (ts/js/json/md/txt/png/bin) with byte-exact round-trips over `GET /raw/:snippetId/:seq/:name`, including a binary PNG, plus the non-leak rule over raw HTTP. Verified live with `curl` against `bun run src/http.ts`.
- **Wayfind walks snippet → revisions → forks** — from the committed lock: `wayfind --target snippet.fork --deps` returns `snippet.get` / `revision.get` / `snippet.create` `composed-by` edges; `wayfind --target snippet.updated --impact` returns the `consumed-by search.index` edge that closes the search loop.
- **Trailheads with member identity preserved** — four trailheads (`snippets`, `history`, `search`, `account`) in `src/mcp-options.ts`; `__tests__/trailheads.test.ts` proves grouped tools carry `memberTrailIds`, dispatch `{ trail, input }` → `{ trail, output }`, and reject non-member smuggling (ADR-0050).
- **README quickstart verbatim incl. a real MCP transcript** — README opens with the showcase matrix, leads with the agent story and a captured `stash_snippet_create` → `stash_search_query` transcript (the signal-driven index, no reindex step), contrasts domain revisions with trail versioning, and every quickstart command was executed as written against a fresh seeded app.

## Scope fence

Explicitly deferred per the PRD, not built: web UI, syntax highlighting, markdown rendering, comments, orgs/teams, OAuth, embeds, import-from-gist, and the Cloudflare stretch.

**Deliberate interpretation:** the PRD's permit tiers put fork under "plain authenticated"; because `snippet.fork` composes `snippet.create` (whose `snippet:write` requirement is enforced at the compose site too), fork declares `snippet:write` so the stated contract never understates the runtime requirement. Stars/unstars carry the authenticated-tier `snippet:interact` scope.

## Framework gaps filed (the dogfood payoff)

- [TRL-1191](https://linear.app/outfitter/issue/TRL-1191) — `trails compile` → `trails validate` immediately stale: topoGraph hash is key-order-sensitive across the store round-trip. Workaround: lock embeds the derivation-order graph.
- [TRL-1192](https://linear.app/outfitter/issue/TRL-1192) — HTTP surface has no byte-serving projection for `BlobRef` outputs. Workaround: app-level Hono route in `src/server.ts`.
- [TRL-1193](https://linear.app/outfitter/issue/TRL-1193) — app-authored MCP trailheads have no channel into the compiled lock, so wayfind shows `trailheads: 0`. Workaround: trailheads live in surface options and are proven by tests.

## Release / checks notes

- Example workspace (`private: true`): no changeset required; the release check only tracks publishable `@ontrails/*` workspaces.
- `wayfinder-dogfood` smoke: **not applicable** — this PR is example-only and does not change framework surfaces, operator topo exposure, Topographer export, or Wayfinder queries.
