### PR TITLE
fix(testing): forward full McpExtra through createMcpHarness

### DIFF
--- a/.changeset/trl-1176-mcp-harness-extra.md
+++ b/.changeset/trl-1176-mcp-harness-extra.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/testing": patch
+---
+
+`createMcpHarness` now forwards the full `McpExtra` from `options.extra` — `authorization`, `permit`, and `sessionId` in addition to the already-forwarded `abortSignal`, `progressToken`, and `sendProgress` — so bearer-token permit enforcement can be exercised through the harness instead of invoking `deriveMcpTools` handlers directly (TRL-1176).

--- a/packages/testing/src/__tests__/harness-mcp.test.ts
+++ b/packages/testing/src/__tests__/harness-mcp.test.ts
@@ -34,4 +34,68 @@ describe('createMcpHarness', () => {
     expect(result.isError).toBe(false);
     expect(JSON.stringify(result.content)).toContain('override');
   });
+
+  test('forwards authorization through the harness so bearer-token permits enforce', async () => {
+    // Regression for TRL-1176: the harness used to drop authorization,
+    // permit, and sessionId from options.extra, so permit-guarded tools
+    // always failed with "No permit provided" even for valid tokens.
+    const protectedTrail = trail('permit.guarded', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      permit: { scopes: ['thing:read'] },
+    });
+    const graph = topo('test-app', { protectedTrail });
+    let seenSession: string | undefined;
+    const buildHarness = (authorization: string) =>
+      createMcpHarness({
+        extra: { authorization, sessionId: 'session-1' },
+        graph,
+        resolvePermit: ({ bearerToken, sessionId }) => {
+          seenSession = sessionId;
+          return Result.ok(
+            bearerToken === 'admin-token'
+              ? { id: 'admin', scopes: ['thing:read'] }
+              : { id: 'guest', scopes: [] }
+          );
+        },
+      });
+    const toolName = deriveToolName(graph.name, protectedTrail.id);
+
+    const accepted = await buildHarness('Bearer admin-token').callTool(
+      toolName,
+      {}
+    );
+    expect(accepted.isError).toBe(false);
+    expect(JSON.stringify(accepted.content)).toContain('true');
+    expect(seenSession).toBe('session-1');
+
+    const rejected = await buildHarness('Bearer guest-token').callTool(
+      toolName,
+      {}
+    );
+    expect(rejected.isError).toBe(true);
+    expect(JSON.stringify(rejected.content)).toContain('Missing scopes');
+  });
+
+  test('forwards an explicit permit from options.extra', async () => {
+    const protectedTrail = trail('permit.direct', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({}),
+      output: z.object({ ok: z.boolean() }),
+      permit: { scopes: ['thing:read'] },
+    });
+    const graph = topo('test-app', { protectedTrail });
+    const harness = createMcpHarness({
+      extra: { permit: { id: 'direct', scopes: ['thing:read'] } },
+      graph,
+    });
+
+    const result = await harness.callTool(
+      deriveToolName(graph.name, protectedTrail.id),
+      {}
+    );
+
+    expect(result.isError).toBe(false);
+  });
 });

--- a/packages/testing/src/harness-mcp.ts
+++ b/packages/testing/src/harness-mcp.ts
@@ -80,8 +80,11 @@ export const createMcpHarness = (options: McpHarnessOptions): McpHarness => {
 
       const result = await tool.handler(args, {
         abortSignal: extra?.abortSignal,
+        authorization: extra?.authorization,
+        permit: extra?.permit,
         progressToken: extra?.progressToken,
         sendProgress: extra?.sendProgress,
+        sessionId: extra?.sessionId,
       });
 
       return {

--- a/packages/topographer/src/__tests__/source-fingerprint.test.ts
+++ b/packages/topographer/src/__tests__/source-fingerprint.test.ts
@@ -5,10 +5,10 @@ import { join } from 'node:path';
 
 import { deriveSourceFingerprint } from '../source-fingerprint.js';
 
-const withFixtureDir = (run: (dir: string) => void): void => {
+const withFixtureDir = (probe: (dir: string) => void): void => {
   const dir = mkdtempSync(join(tmpdir(), 'source-fingerprint-'));
   try {
-    run(dir);
+    probe(dir);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/scripts/vocab-cutover-map.ts
+++ b/scripts/vocab-cutover-map.ts
@@ -195,39 +195,27 @@ const topographArtifactFamilyRetiredMatches = [
   { line: 228, path: 'apps/trails/src/__tests__/create.test.ts' },
   // The topo-store migration and fixture must name pre-v12 columns exactly.
   {
-    line: 345,
+    line: 361,
     path: 'packages/topographer/src/internal/topo-snapshots.ts',
   },
   {
-    line: 355,
+    line: 371,
     path: 'packages/topographer/src/internal/topo-snapshots.ts',
   },
   {
-    line: 1423,
+    line: 1525,
     path: 'packages/topographer/src/__tests__/topo-store.test.ts',
   },
   {
-    line: 1425,
+    line: 1527,
     path: 'packages/topographer/src/__tests__/topo-store.test.ts',
   },
   {
-    line: 1439,
+    line: 1541,
     path: 'packages/topographer/src/__tests__/topo-store.test.ts',
   },
   {
-    line: 1441,
-    path: 'packages/topographer/src/__tests__/topo-store.test.ts',
-  },
-  {
-    line: 1443,
-    path: 'packages/topographer/src/__tests__/topo-store.test.ts',
-  },
-  {
-    line: 1457,
-    path: 'packages/topographer/src/__tests__/topo-store.test.ts',
-  },
-  {
-    line: 1459,
+    line: 1543,
     path: 'packages/topographer/src/__tests__/topo-store.test.ts',
   },
 ] as const;


### PR DESCRIPTION
fix(testing): forward full McpExtra through createMcpHarness

McpHarnessOptions.extra is typed Partial<McpExtra>, but callTool only
forwarded abortSignal, progressToken, and sendProgress — authorization,
permit, and sessionId were silently dropped, so bearer-token permit
enforcement could not be exercised through the harness (a permit-parity
test saw PermitError: No permit provided for a valid token).

Forward all six McpExtra fields and prove permit accept/reject through
the harness: a guarded tool accepts a resolving bearer token, rejects a
scope-less one, and honors an explicit permit from options.extra.

Refs TRL-1176

chore(vocab): repair audit allowlist after #893 line shifts

Opportunistic main-health fix: bun run vocab:audit was red on main —
PR #893 shifted the line-keyed allowMatches for the retired-term rule in
topo-snapshots.ts and topo-store.test.ts, and its new
source-fingerprint.test.ts used a parameter named run that trips the
run-field rule. Refresh the allowlist lines to current reality (7 stale
test-file entries collapse to the 4 real matches) and rename the test
parameter. No behavior change.