### PR TITLE
feat(core): type fork version blazes from the entry schemas

### DIFF
--- a/.changeset/trl-1180-fork-version-typing.md
+++ b/.changeset/trl-1180-fork-version-typing.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/core": patch
+---
+
+Add `forkVersion()` so fork version entries get typed blazes (TRL-1180). `TrailVersions` fixes every entry's generics to `unknown`, which left fork blazes with `unknown` input and forced authors to re-parse the already-validated value just to narrow it. `forkVersion({ input, output, blaze, ... })` threads the entry's own schemas into the blaze signature (including merged `composeInput` fields) and enforces the entry's output shape at compile time; the erasure back to `TrailVersionEntry` is sound because the fork pipeline validates raw input against the entry's own schema before dispatch. `TrailVersionForkSpec` is exported alongside it.

--- a/packages/core/src/__tests__/version-execution.test.ts
+++ b/packages/core/src/__tests__/version-execution.test.ts
@@ -14,7 +14,7 @@ import { Result } from '../result';
 import { resource } from '../resource';
 import { run } from '../run';
 import { topo } from '../topo';
-import { trail } from '../trail';
+import { forkVersion, trail } from '../trail';
 import type { TrailContext } from '../types';
 import { deriveTrailVersionMarkers } from '../version-marker';
 
@@ -444,5 +444,41 @@ describe('trail version execution', () => {
 
     expect(result.isOk()).toBe(true);
     expect(result.unwrap()).toEqual({ ok: true });
+  });
+
+  test('executes a forkVersion-authored entry with schema-validated typed input', async () => {
+    // TRL-1180: forkVersion threads the entry schemas into the blaze, so the
+    // v1 blaze below reads typed fields without re-parsing.
+    const gearTrail = trail('version.runtime.fork-helper', {
+      blaze: (input) =>
+        Result.ok({ id: input.name, weightGrams: input.weightGrams }),
+      input: z.object({ name: z.string(), weightGrams: z.number() }),
+      output: z.object({ id: z.string(), weightGrams: z.number() }),
+      version: 2,
+      versions: {
+        1: forkVersion({
+          blaze: (input) =>
+            Result.ok({ id: input.name, weightOz: input.weightOz * 2 }),
+          input: z.object({ name: z.string(), weightOz: z.number() }),
+          output: z.object({ id: z.string(), weightOz: z.number() }),
+        }),
+      },
+    });
+
+    const forked = await executeTrail(
+      gearTrail,
+      { name: 'tarp', weightOz: 8 },
+      { version: 1 }
+    );
+    expect(forked.isOk()).toBe(true);
+    expect(forked.unwrap()).toEqual({ id: 'tarp', weightOz: 16 });
+
+    const invalid = await executeTrail(
+      gearTrail,
+      { name: 'tarp' },
+      { version: 1 }
+    );
+    expect(invalid.isErr()).toBe(true);
+    expect(invalid.error).toBeInstanceOf(ValidationError);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -186,6 +186,7 @@ export {
 export type { ActivationSourceProjection } from './activation-source-projection.js';
 export {
   deriveSupportedTrailVersions,
+  forkVersion,
   getTrailVersionEntryKind,
   hasDeprecatedTrailVersionGuidance,
   intentValues,
@@ -224,6 +225,7 @@ export type {
   TrailVersionArchivedStatus,
   TrailVersionDeprecatedStatus,
   TrailVersionForkEntry,
+  TrailVersionForkSpec,
   TrailVersionRevisionEntry,
   TrailVersions,
   TrailVersionStatus,

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -315,6 +315,84 @@ export type TrailVersions<
   >
 >;
 
+/**
+ * Spec for {@link forkVersion}: a fork entry whose blaze signature is owned
+ * by the entry's own schemas instead of falling back to `unknown`.
+ */
+export interface TrailVersionForkSpec<
+  TInputSchema extends z.ZodType,
+  TOutputSchema extends z.ZodType,
+  TComposeInputSchema extends z.ZodType | undefined = undefined,
+> {
+  /** The historical blaze, typed by this entry's schemas. */
+  readonly blaze: Implementation<
+    BlazeInput<
+      z.output<TInputSchema>,
+      ComposeSchemaOutput<TComposeInputSchema>
+    >,
+    z.output<TOutputSchema>
+  >;
+  readonly composeInput?: TComposeInputSchema | undefined;
+  readonly composes?: readonly (string | AnyTrail)[] | undefined;
+  readonly detours?:
+    | readonly Detour<
+        z.output<TInputSchema>,
+        z.output<TOutputSchema>,
+        TrailsError
+      >[]
+    | undefined;
+  readonly examples?:
+    | readonly TrailExample<z.input<TInputSchema>, z.output<TOutputSchema>>[]
+    | undefined;
+  readonly input: TInputSchema;
+  readonly output: TOutputSchema;
+  readonly resources?: readonly AnyResource[] | undefined;
+  readonly status?: TrailVersionStatus | undefined;
+}
+
+/**
+ * Author a fork version entry with a blaze typed by the entry's own schemas.
+ *
+ * `TrailVersions` fixes every entry's generics to `unknown`, so a fork blaze
+ * written inline receives `unknown` input and authors end up re-parsing the
+ * already-validated value just to narrow it. This helper threads the entry's
+ * `input`/`output` schemas into the blaze signature and erases the generics
+ * on the way out. The erasure is sound because the fork pipeline validates
+ * raw input against this entry's own `input` schema before dispatching to
+ * the entry blaze (see `createForkTrailVersion` in execute.ts).
+ *
+ * @example
+ * ```ts
+ * const gearV1Input = z.object({ name: z.string(), weightOz: z.number() });
+ * const gearV1Output = z.object({ id: z.string(), weightOz: z.number() });
+ *
+ * const gearCreate = trail('gear.create', {
+ *   // ... current v2 contract ...
+ *   version: 2,
+ *   versions: {
+ *     1: forkVersion({
+ *       blaze: (input) =>
+ *         // input is { name: string; weightOz: number } — no re-parse
+ *         Result.ok({ id: input.name, weightOz: input.weightOz }),
+ *       input: gearV1Input,
+ *       output: gearV1Output,
+ *     }),
+ *   },
+ * });
+ * ```
+ */
+export const forkVersion = <
+  TInputSchema extends z.ZodType,
+  TOutputSchema extends z.ZodType,
+  TComposeInputSchema extends z.ZodType | undefined = undefined,
+>(
+  spec: TrailVersionForkSpec<TInputSchema, TOutputSchema, TComposeInputSchema>
+): TrailVersionForkEntry =>
+  // Erasing the per-entry generics narrows function parameters, which TS
+  // cannot express without a conversion. Safe: the fork pipeline re-validates
+  // input against `spec.input` before the blaze runs.
+  spec as unknown as TrailVersionForkEntry;
+
 export const getTrailVersionEntryKind = (
   entry: TrailVersionEntry
 ): TrailVersionEntryKind => {

--- a/packages/core/src/type-checks.test-d.ts
+++ b/packages/core/src/type-checks.test-d.ts
@@ -11,7 +11,7 @@
  */
 
 import type { Signal, SignalSpec } from './signal.js';
-import { trail } from './trail.js';
+import { forkVersion, trail } from './trail.js';
 import type { Trail, TrailSpec, TrailVersionRevisionEntry } from './trail.js';
 import type { ExecuteTrailOptions } from './execute.js';
 import { resource } from './resource.js';
@@ -530,6 +530,64 @@ export type RevisionRuntimeFieldContract = [
 ] extends [true]
   ? 'pass'
   : never;
+
+// ---------------------------------------------------------------------------
+// forkVersion threads the entry's own schemas into the fork blaze (TRL-1180)
+// ---------------------------------------------------------------------------
+
+const forkV1Input = z.object({ name: z.string(), weightOz: z.number() });
+const forkV1Output = z.object({ id: z.string(), weightOz: z.number() });
+
+const _typedForkEntry = forkVersion({
+  blaze: (input) => {
+    type AssertForkBlazeInputTyped = Assert<
+      IsExact<typeof input, { name: string; weightOz: number }>
+    >;
+    const _forkBlazeInputTyped: AssertForkBlazeInputTyped = true;
+    void _forkBlazeInputTyped;
+    return Result.ok({ id: input.name, weightOz: input.weightOz });
+  },
+  input: forkV1Input,
+  output: forkV1Output,
+});
+type AssertForkEntryAssignable = Assert<
+  IsAssignable<
+    typeof _typedForkEntry,
+    NonNullable<TrailSpec<{ ok: boolean }, string>['versions']>[number]
+  >
+>;
+export type ForkVersionEntryContract = [AssertForkEntryAssignable] extends [
+  true,
+]
+  ? 'pass'
+  : never;
+
+const _typedForkEntryOutputChecked = forkVersion({
+  // @ts-expect-error — blaze must return the entry output shape, not extras
+  blaze: (input) => Result.ok({ unexpected: input.name }),
+  input: forkV1Input,
+  output: forkV1Output,
+});
+export type ForkVersionOutputEnforced = typeof _typedForkEntryOutputChecked;
+
+const _typedForkEntryComposeInput = forkVersion({
+  blaze: (input) => {
+    type AssertForkComposeMerged = Assert<
+      IsExact<
+        typeof input,
+        { name: string; weightOz: number } & { source: string }
+      >
+    >;
+    const _forkComposeMerged: AssertForkComposeMerged = true;
+    void _forkComposeMerged;
+    return Result.ok({ id: input.source, weightOz: input.weightOz });
+  },
+  composeInput: z.object({ source: z.string() }),
+  input: forkV1Input,
+  output: forkV1Output,
+});
+export type ForkVersionComposeInputContract =
+  typeof _typedForkEntryComposeInput;
 
 // ---------------------------------------------------------------------------
 // ExecuteTrailOptions keeps compose-validation internals out of the public API


### PR DESCRIPTION
TrailVersions fixes every entry's generics to unknown, so a fork
entry's blaze was contextually typed as Implementation<BlazeInput<
unknown, never>, unknown> and authors re-parsed the already-validated
input just to narrow it (packlist's v1 gear entry marked this with a
trails-gap TODO).

Add forkVersion(): a helper that threads the entry's own input/output
schemas into the blaze signature, merges declared composeInput fields,
and enforces the entry output shape at compile time. The erasure back
to TrailVersionEntry is sound because the fork pipeline validates raw
input against the entry's own schema before dispatch
(createForkTrailVersion). TrailVersionForkSpec is exported alongside.

Type-level assertions live in type-checks.test-d.ts (exact blaze input,
@ts-expect-error on wrong return, assignability into TrailSpec
versions); a runtime test executes a forkVersion-authored entry and its
validation-failure path.

Refs TRL-1180