### PR TITLE
feat(store): declare permits and share table contours in crud/reconcile

### DIFF
--- a/.changeset/trl-1195-factory-contracts.md
+++ b/.changeset/trl-1195-factory-contracts.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/store": patch
+---
+
+Complete the store factory trail contracts (TRL-1195, absorbing TRL-1177 and TRL-1178). `crud()` gains `permit` (applied to every produced trail) and `permits` (per-operation overrides, so destroy trails satisfy permit governance) plus a `contour` option, and the returned tuple now exposes the table contour it registered as a `contour` property. `reconcile()` gains `permit` and accepts a shared `contour` instance, so crud + reconcile on one table register cleanly in a single `topo()` instead of colliding on a duplicate contour name. `TableContour` is exported from `@ontrails/store/trails`. Consuming apps no longer need to post-process factory trails to attach permits or strip contours.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -356,7 +356,14 @@ CrudTrails<T>, CrudOptions<T>, CrudBlazeOverrides<T>
 SyncEndpoint<T, C>, SyncOptions<TSource, TTarget, TSourceConnection, TTargetConnection>
 SyncTransform<TSource, TTarget>
 ReconcileConflict<T>, ReconcileOptions<T, C>, ReconcileStrategy<T>
-CrudOperation, CrudAccessorExpectation
+CrudOperation, CrudAccessorExpectation, TableContour<T>
+
+// crud() options: `permit` declares a permit on every produced trail;
+// `permits: { delete: {...} }` overrides per operation (destroy trails need
+// one for permit governance); `contour` accepts an existing table contour.
+// The returned tuple exposes the contour it registered as `.contour` —
+// pass it to reconcile({ contour }) so one table registers one contour.
+// reconcile() likewise accepts `permit` to declare its trail's requirement.
 ```
 
 ### `@ontrails/store/adapter-support`

--- a/packages/store/src/__tests__/factory-contracts.test.ts
+++ b/packages/store/src/__tests__/factory-contracts.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Factory contract completeness (TRL-1195): crud()/reconcile() declare
+ * permits and share one table contour instead of forcing consuming apps
+ * to post-process the produced trails.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Result, resource, topo } from '@ontrails/core';
+import { z } from 'zod';
+
+import type { EntityOf, StoreAccessor } from '../index.js';
+import { store } from '../index.js';
+import { crud, reconcile } from '../trails/index.js';
+
+const noteSchema = z.object({
+  body: z.string(),
+  createdAt: z.string(),
+  id: z.string(),
+  title: z.string(),
+});
+
+const noteDefinition = store({
+  notes: {
+    fixtures: [
+      {
+        body: 'Seed body',
+        createdAt: '2026-04-10T12:00:00.000Z',
+        id: 'note-1',
+        title: 'Seed title',
+        version: 1,
+      },
+    ],
+    generated: ['createdAt'],
+    identity: 'id',
+    schema: noteSchema,
+    versioned: true,
+  },
+});
+
+type NotesTable = typeof noteDefinition.tables.notes;
+type NotesConnection = Readonly<Record<'notes', StoreAccessor<NotesTable>>>;
+
+const createNotesAccessor = (): StoreAccessor<NotesTable> => {
+  const records = new Map<string, EntityOf<NotesTable>>();
+  return {
+    get(id) {
+      const entity = records.get(id);
+      return Promise.resolve(
+        entity === undefined ? null : structuredClone(entity)
+      );
+    },
+    list() {
+      return Promise.resolve(
+        [...records.values()].map((entity) => structuredClone(entity))
+      );
+    },
+    remove(id) {
+      return Promise.resolve({ deleted: records.delete(id) });
+    },
+    upsert(entity) {
+      const stored = {
+        createdAt: '2026-04-10T12:00:00.000Z',
+        ...structuredClone(entity),
+      } as EntityOf<NotesTable>;
+      records.set(String(stored.id), stored);
+      return Promise.resolve(structuredClone(stored));
+    },
+  };
+};
+
+const notesResource = resource<NotesConnection>('db.notes.factory', {
+  create: () => Result.ok({ notes: createNotesAccessor() }),
+});
+
+describe('crud() permits', () => {
+  test('permit applies to every produced trail and permits override per op', () => {
+    const [create, read, update, remove, list] = crud(
+      noteDefinition.tables.notes,
+      notesResource,
+      {
+        permit: { scopes: ['notes:write'] },
+        permits: {
+          delete: { scopes: ['notes:destroy'] },
+          read: 'public',
+        },
+      }
+    );
+
+    expect(create.permit).toEqual({ scopes: ['notes:write'] });
+    expect(update.permit).toEqual({ scopes: ['notes:write'] });
+    expect(list.permit).toEqual({ scopes: ['notes:write'] });
+    expect(read.permit).toBe('public');
+    expect(remove.permit).toEqual({ scopes: ['notes:destroy'] });
+    expect(remove.intent).toBe('destroy');
+  });
+
+  test('trails carry no permit when none is declared', () => {
+    const [create] = crud(noteDefinition.tables.notes, notesResource);
+    expect(create.permit).toBeUndefined();
+  });
+});
+
+describe('shared table contours', () => {
+  test('crud exposes its contour and reconcile reuses the instance', () => {
+    const crudTrails = crud(noteDefinition.tables.notes, notesResource);
+    expect(crudTrails.contour).toBeDefined();
+    expect(crudTrails[0].contours[0]).toBe(crudTrails.contour);
+
+    const reconcileNotes = reconcile({
+      contour: crudTrails.contour,
+      permit: { scopes: ['notes:write'] },
+      resource: notesResource,
+      table: noteDefinition.tables.notes,
+    });
+    expect(reconcileNotes.contours[0]).toBe(crudTrails.contour);
+    expect(reconcileNotes.permit).toEqual({ scopes: ['notes:write'] });
+
+    const [create, read, update, remove, list] = crudTrails;
+    expect(() =>
+      topo('factory-contract-app', {
+        create,
+        list,
+        read,
+        reconcileNotes,
+        remove,
+        update,
+      })
+    ).not.toThrow();
+  });
+
+  test('unshared contours still collide at topo() so the sharing is load-bearing', () => {
+    const crudTrails = crud(noteDefinition.tables.notes, notesResource);
+    const reconcileNotes = reconcile({
+      resource: notesResource,
+      table: noteDefinition.tables.notes,
+    });
+
+    const [create, read, update, remove, list] = crudTrails;
+    expect(() =>
+      topo('factory-contract-collision-app', {
+        create,
+        list,
+        read,
+        reconcileNotes,
+        remove,
+        update,
+      })
+    ).toThrow(/[Dd]uplicate contour/);
+  });
+
+  test('crud accepts an existing contour instance', () => {
+    const first = crud(noteDefinition.tables.notes, notesResource);
+    const second = crud(noteDefinition.tables.notes, notesResource, {
+      contour: first.contour,
+    });
+    expect(second.contour).toBe(first.contour);
+    expect(second[0].contours[0]).toBe(first.contour);
+  });
+});

--- a/packages/store/src/trails/crud.ts
+++ b/packages/store/src/trails/crud.ts
@@ -1,4 +1,9 @@
-import type { Implementation, Resource, Trail } from '@ontrails/core';
+import type {
+  Implementation,
+  PermitRequirement,
+  Resource,
+  Trail,
+} from '@ontrails/core';
 import { deriveTrail } from '@ontrails/core/trails';
 import type {
   DeriveTrailInput,
@@ -137,7 +142,15 @@ export type CrudTrails<TTable extends AnyStoreTable> = readonly [
   update: UpdateTrailOf<TTable>,
   remove: DeleteTrailOf<TTable>,
   list: ListTrailOf<TTable>,
-];
+] & {
+  /**
+   * The table contour the factory registered on its trails. Pass it to
+   * `reconcile({ contour })` (or other factories over the same table) so
+   * the topo sees one shared contour instance instead of rejecting two
+   * same-named rebuilds as duplicates.
+   */
+  readonly contour: TableContour<TTable>;
+};
 
 export interface CrudBlazeOverrides<TTable extends AnyStoreTable> {
   readonly create?: Implementation<InsertOf<TTable>, EntityOf<TTable>>;
@@ -152,6 +165,24 @@ export interface CrudBlazeOverrides<TTable extends AnyStoreTable> {
 
 export interface CrudOptions<TTable extends AnyStoreTable> {
   readonly blaze?: CrudBlazeOverrides<TTable>;
+  /**
+   * Existing table contour to register on the produced trails. When
+   * omitted, the factory builds one from the table. Pass a shared
+   * instance when another factory (e.g. `reconcile()`) covers the same
+   * table so `topo()` sees a single contour registration.
+   */
+  readonly contour?: TableContour<TTable>;
+  /**
+   * Permit requirement declared on every produced trail. Factory trails
+   * carry authored defaults like any hand-written trail; per-operation
+   * entries in `permits` override this baseline.
+   */
+  readonly permit?: PermitRequirement;
+  /**
+   * Per-operation permit overrides. At minimum, destroy-intent trails
+   * (`delete`) need a declaration to satisfy permit governance.
+   */
+  readonly permits?: Partial<Record<CrudOperation, PermitRequirement>>;
 }
 
 interface InternalCrudBlazeOverrides<TTable extends AnyStoreTable> {
@@ -179,6 +210,9 @@ interface InternalCrudBlazeOverrides<TTable extends AnyStoreTable> {
 
 interface InternalCrudOptions<TTable extends AnyStoreTable> {
   readonly blaze?: InternalCrudBlazeOverrides<TTable>;
+  readonly contour?: TableContour<TTable>;
+  readonly permit?: PermitRequirement;
+  readonly permits?: Partial<Record<CrudOperation, PermitRequirement>>;
 }
 
 const normalizeExampleForOutput = <TInput, TOutput>(
@@ -225,6 +259,7 @@ const finalizeTrail = <TInput, TOutput>(
     readonly blaze?: Implementation<TInput, TOutput> | undefined;
     readonly output?: z.ZodType<TOutput> | undefined;
     readonly pattern?: string | undefined;
+    readonly permit?: PermitRequirement | undefined;
   } = {}
 ): Trail<TInput, TOutput> =>
   Object.freeze({
@@ -237,6 +272,7 @@ const finalizeTrail = <TInput, TOutput>(
           output: options.output,
         }),
     ...(options.pattern === undefined ? {} : { pattern: options.pattern }),
+    ...(options.permit === undefined ? {} : { permit: options.permit }),
   }) as Trail<TInput, TOutput>;
 
 const deriveCrudBaseTrails = <
@@ -244,9 +280,9 @@ const deriveCrudBaseTrails = <
   TConnection extends CrudConnection<TTable>,
 >(
   table: TTable,
-  resource: Resource<TConnection>
+  resource: Resource<TConnection>,
+  entityContour: TableContour<TTable>
 ): InternalCrudBaseTrails<TTable> => {
-  const entityContour = createTableContour(table);
   // Narrow the store's `readonly string[]` to the contour's typed field-key
   // array so `deriveTrail`'s `TGenerated` generic picks up the precise
   // key-of shape that `CreateInputOf<Contour, TGenerated>` expects. The
@@ -282,38 +318,51 @@ const deriveCrudBaseTrails = <
 
 const buildCrudTrails = <TTable extends AnyStoreTable>(
   baseTrails: InternalCrudBaseTrails<TTable>,
-  overrides: InternalCrudBlazeOverrides<TTable>,
+  options: InternalCrudOptions<TTable>,
   entityOutput: z.ZodType<DerivedOutput<TTable, 'create'>>,
   listOutput: z.ZodType<DerivedOutput<TTable, 'list'>>
-): InternalCrudTrails<TTable> =>
-  Object.freeze([
+): InternalCrudTrails<TTable> => {
+  const overrides = options.blaze ?? {};
+  const permitFor = (operation: CrudOperation): PermitRequirement | undefined =>
+    options.permits?.[operation] ?? options.permit;
+
+  return Object.freeze([
     finalizeTrail(baseTrails.createBase, {
       ...(overrides.create === undefined ? {} : { blaze: overrides.create }),
       output: entityOutput,
       pattern: 'crud',
+      permit: permitFor('create'),
     }),
     finalizeTrail(baseTrails.readBase, {
       ...(overrides.read === undefined ? {} : { blaze: overrides.read }),
       output: entityOutput,
       pattern: 'crud',
+      permit: permitFor('read'),
     }),
     finalizeTrail(baseTrails.updateBase, {
       ...(overrides.update === undefined ? {} : { blaze: overrides.update }),
       output: entityOutput,
       pattern: 'crud',
+      permit: permitFor('update'),
     }),
     overrides.delete === undefined
-      ? finalizeTrail(baseTrails.deleteBase, { pattern: 'crud' })
+      ? finalizeTrail(baseTrails.deleteBase, {
+          pattern: 'crud',
+          permit: permitFor('delete'),
+        })
       : finalizeTrail(baseTrails.deleteBase, {
           blaze: overrides.delete,
           pattern: 'crud',
+          permit: permitFor('delete'),
         }),
     finalizeTrail(baseTrails.listBase, {
       ...(overrides.list === undefined ? {} : { blaze: overrides.list }),
       output: listOutput,
       pattern: 'crud',
+      permit: permitFor('list'),
     }),
   ]) as InternalCrudTrails<TTable>;
+};
 
 /**
  * Produce the standard CRUD trail tuple for one normalized store table.
@@ -340,8 +389,8 @@ export function crud<
   resource: Resource<TConnection>,
   options: InternalCrudOptions<TTable> = {}
 ) {
-  const overrides = options.blaze ?? {};
-  const baseTrails = deriveCrudBaseTrails(table, resource);
+  const entityContour = options.contour ?? createTableContour(table);
+  const baseTrails = deriveCrudBaseTrails(table, resource, entityContour);
   // Narrow `table.schema` (typed `StoreObjectSchema`, which is
   // `z.ZodObject<Record<string, z.ZodType>>`) to a ZodObject keyed by the
   // concrete shape so its `z.output` unifies with the contour-derived
@@ -352,5 +401,12 @@ export function crud<
   const listOutput: z.ZodType<DerivedOutput<TTable, 'list'>> =
     entitySchema.array();
 
-  return buildCrudTrails(baseTrails, overrides, entityOutput, listOutput);
+  const trails = buildCrudTrails(baseTrails, options, entityOutput, listOutput);
+  // Expose the registered contour so other factories over the same table
+  // (reconcile, sync) can share the instance instead of rebuilding it.
+  return Object.freeze(
+    Object.assign([...trails], { contour: entityContour })
+  ) as unknown as InternalCrudTrails<TTable> & {
+    readonly contour: TableContour<TTable>;
+  };
 }

--- a/packages/store/src/trails/index.ts
+++ b/packages/store/src/trails/index.ts
@@ -13,3 +13,4 @@ export type {
 } from './reconcile.js';
 export { sync } from './sync.js';
 export type { SyncEndpoint, SyncOptions, SyncTransform } from './sync.js';
+export type { TableContour } from './utils.js';

--- a/packages/store/src/trails/reconcile.ts
+++ b/packages/store/src/trails/reconcile.ts
@@ -2,6 +2,7 @@ import { ConflictError, Result, ValidationError, trail } from '@ontrails/core';
 import type {
   AnySignal,
   Detour,
+  PermitRequirement,
   Resource,
   Trail,
   TrailContext,
@@ -18,6 +19,7 @@ import type {
 } from '../types.js';
 import { versionFieldName } from '../store.js';
 import { createTableContour, mapStoreTrailError } from './utils.js';
+import type { TableContour } from './utils.js';
 
 type ReconcileConnection<TTable extends AnyStoreTable> = Readonly<
   Record<TTable['name'], StoreAccessor<TTable>>
@@ -39,9 +41,19 @@ export interface ReconcileOptions<
   TTable extends AnyStoreTable,
   TConnection extends ReconcileConnection<TTable>,
 > {
+  /**
+   * Existing table contour to register on the reconcile trail. Pass the
+   * contour a `crud()` call over the same table exposes (its `contour`
+   * property) so `topo()` sees one shared instance instead of rejecting
+   * two same-named rebuilds as duplicates. When omitted, the factory
+   * builds its own.
+   */
+  readonly contour?: TableContour<TTable>;
   readonly description?: string;
   readonly id?: string;
   readonly on?: readonly (AnySignal | string)[];
+  /** Permit requirement declared on the reconcile trail. */
+  readonly permit?: PermitRequirement;
   readonly resource: Resource<TConnection>;
   readonly strategy?: ReconcileStrategy<TTable>;
   readonly table: TTable;
@@ -260,7 +272,7 @@ export const reconcile = <
   }
 
   const id = options.id ?? `${options.table.name}.reconcile`;
-  const entityContour = createTableContour(options.table);
+  const entityContour = options.contour ?? createTableContour(options.table);
   const strategy = options.strategy ?? 'last-write-wins';
 
   return trail(id, {
@@ -276,6 +288,7 @@ export const reconcile = <
     on: options.on,
     output: options.table.schema as unknown as z.ZodType<EntityOf<TTable>>,
     pattern: 'reconcile',
+    ...(options.permit === undefined ? {} : { permit: options.permit }),
     resources: [options.resource],
   });
 };


### PR DESCRIPTION
Store factories under-expressed the trail contract (TRL-1195, absorbing
TRL-1177 and TRL-1178): they accepted no permit declaration, so factory
destroy trails failed permit governance, and crud() + reconcile() on one
table each rebuilt the contour, so topo() rejected the duplicate name.
Packlist worked around both with spread-and-freeze helpers
(withOperatorPermit, withoutTableContour) that this change makes
deletable.

- CrudOptions gains permit (baseline for all five trails) and permits
  (per-operation overrides); reconcile() gains permit
- crud() accepts an existing contour and exposes the contour it
  registered as a .contour property on the returned tuple; reconcile()
  accepts that instance, so one table registers one contour
- TableContour is exported from @ontrails/store/trails
- tests prove the delete trail carries a declared permit with destroy
  intent, contour identity flows end to end, shared registration
  passes topo(), and unshared registration still collides

Known sibling gap filed as TRL-1201: sync() still lacks permit/contour
options.

Refs TRL-1195