### PR TITLE
feat(http): stream BlobRef trail outputs as bytes

### DIFF
--- a/.changeset/trl-1192-http-blob-serving.md
+++ b/.changeset/trl-1192-http-blob-serving.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/http": patch
+---
+
+Serve `BlobRef` trail outputs as bytes on HTTP (TRL-1192). When a trail's output schema is `blobRefSchema`, the route handler streams the blob's data with `Content-Type` from its `mimeType` and a `Content-Length` from its `size` — for both `Uint8Array` and `ReadableStream` payloads — instead of wrapping the value in the JSON envelope. Error results keep the JSON error envelope, and non-blob trails are unchanged. Apps no longer need to hand-mount raw-byte routes beside the derived surface.

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -203,6 +203,20 @@ HTTP 200 for all successful responses.
 
 The `code` is the error class name. The `category` matches the error taxonomy. HTTP bodies use the shared public error projection: `TrailsError` messages are redacted before they are returned, internal-category errors are made opaque, and unknown native errors are reported as `InternalError` with `Internal server error`.
 
+### Blob outputs
+
+When a trail declares `output: blobRefSchema`, the derived route streams the returned `BlobRef`'s bytes instead of the JSON envelope: `Content-Type` comes from the blob's `mimeType` and `Content-Length` from its `size`. Both `Uint8Array` and `ReadableStream` payloads stream as-is. Error results from the same trail still use the JSON error envelope, so clients can branch on the response content type.
+
+```ts
+const fileRaw = trail('file.raw', {
+  blaze: async (input, ctx) => Result.ok(createBlobRef({ /* ... */ })),
+  input: z.object({ name: z.string() }),
+  intent: 'read',
+  output: blobRefSchema,
+});
+// GET /file/raw?name=notes.txt → 200 with raw bytes + the blob's mimeType
+```
+
 ## Status Code Mapping
 
 Status codes come directly from the error taxonomy -- the same mapping used across all surfaces:

--- a/packages/http/src/__tests__/fetch.test.ts
+++ b/packages/http/src/__tests__/fetch.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 import {
+  NotFoundError,
   PermissionError,
   Result,
+  blobRefSchema,
+  createBlobRef,
   getWebhookHeader,
   trail,
   topo,
@@ -441,5 +444,92 @@ describe('@ontrails/http/fetch', () => {
     });
     expect(invalidWebhookCategories).toEqual(['internal']);
     expect(loggedErrors).toHaveLength(1);
+  });
+});
+
+describe('BlobRef byte serving (TRL-1192)', () => {
+  const fileBytes = new TextEncoder().encode('raw file bytes');
+
+  const fileRawTrail = trail('file.raw', {
+    blaze: (input) =>
+      input.name === 'missing.txt'
+        ? Result.err(new NotFoundError('No such file'))
+        : Result.ok(
+            createBlobRef({
+              data: fileBytes,
+              mimeType: 'text/plain; charset=utf-8',
+              name: input.name,
+              size: fileBytes.byteLength,
+            })
+          ),
+    input: z.object({ name: z.string() }),
+    intent: 'read',
+    output: blobRefSchema,
+  });
+
+  test('streams Uint8Array blob bytes with mimeType and Content-Length', async () => {
+    const handler = createFetchHandler(topo('blob-api', { fileRawTrail }));
+
+    const response = await handler(buildRequest('/file/raw?name=notes.txt'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe(
+      'text/plain; charset=utf-8'
+    );
+    expect(response.headers.get('Content-Length')).toBe(
+      String(fileBytes.byteLength)
+    );
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(fileBytes);
+  });
+
+  test('streams ReadableStream blob data', async () => {
+    const streamTrail = trail('file.stream', {
+      blaze: () =>
+        Result.ok(
+          createBlobRef({
+            data: new Response(fileBytes).body ?? new ReadableStream(),
+            mimeType: 'application/octet-stream',
+            name: 'stream.bin',
+            size: fileBytes.byteLength,
+          })
+        ),
+      input: z.object({}),
+      intent: 'read',
+      output: blobRefSchema,
+    });
+    const handler = createFetchHandler(topo('blob-api', { streamTrail }));
+
+    const response = await handler(buildRequest('/file/stream'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe(
+      'application/octet-stream'
+    );
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(fileBytes);
+  });
+
+  test('error results from blob trails stay JSON error envelopes', async () => {
+    const handler = createFetchHandler(topo('blob-api', { fileRawTrail }));
+
+    const response = await handler(buildRequest('/file/raw?name=missing.txt'));
+
+    expect(response.status).toBe(404);
+    expect(response.headers.get('Content-Type')).toContain('application/json');
+    expect(await response.json()).toEqual({
+      error: {
+        category: 'not_found',
+        code: 'NotFoundError',
+        message: 'No such file',
+      },
+    });
+  });
+
+  test('non-blob trails keep the JSON data envelope', async () => {
+    const handler = createFetchHandler(topo('blob-api', { echoTrail }));
+
+    const response = await handler(buildRequest('/echo?message=json'));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: { reply: 'json' } });
   });
 });

--- a/packages/http/src/fetch.ts
+++ b/packages/http/src/fetch.ts
@@ -1,12 +1,14 @@
 import {
+  BLOB_REF_SCHEMA_META_KEY,
   CancelledError,
+  isBlobRef,
   isTrailsError,
   NotFoundError,
   projectErrorDiagnostics,
   projectPublicSurfaceError,
   ValidationError,
 } from '@ontrails/core';
-import type { Topo } from '@ontrails/core';
+import type { BlobRef, Topo } from '@ontrails/core';
 
 import { deriveHttpRoutes } from './build.js';
 import type { DeriveHttpRoutesOptions, HttpRouteDefinition } from './build.js';
@@ -337,11 +339,55 @@ interface ResultLike {
   readonly value?: unknown;
 }
 
+/**
+ * True when the route's trail declares a BlobRef output schema — the
+ * authored fact that selects byte streaming over the JSON envelope.
+ */
+const rendersBlobOutput = (route: HttpRouteDefinition): boolean => {
+  const { output } = route.trail;
+  if (output === undefined) {
+    return false;
+  }
+  const maybeMeta = (output as { meta?: () => unknown }).meta;
+  if (typeof maybeMeta !== 'function') {
+    return false;
+  }
+  const meta = maybeMeta.call(output);
+  return (
+    typeof meta === 'object' &&
+    meta !== null &&
+    (meta as Record<string, unknown>)[BLOB_REF_SCHEMA_META_KEY] === true
+  );
+};
+
+/**
+ * Narrow blob bytes for `Response`. `BlobRef.data` is typed `Uint8Array`
+ * (ArrayBufferLike backing) while `BodyInit` wants a plain-ArrayBuffer
+ * view; blob producers construct views over plain buffers, so narrowing
+ * here avoids copying the bytes.
+ */
+const blobBody = (data: BlobRef['data']): BodyInit =>
+  data instanceof ReadableStream ? data : (data as Uint8Array<ArrayBuffer>);
+
+/** Stream a BlobRef's bytes with its declared content type and length. */
+const blobResponse = (blob: BlobRef): Response =>
+  new Response(blobBody(blob.data), {
+    headers: {
+      'Content-Length': String(blob.size),
+      'Content-Type': blob.mimeType,
+    },
+    status: 200,
+  });
+
 const mapResultToResponse = (
   result: ResultLike,
-  request: Request
+  request: Request,
+  options?: { readonly rendersBlob?: boolean }
 ): Response => {
   if (result.isOk()) {
+    if (options?.rendersBlob === true && isBlobRef(result.value)) {
+      return blobResponse(result.value);
+    }
     return json({ data: result.value }, 200);
   }
   const error = result.error ?? new Error('Unknown error');
@@ -511,6 +557,7 @@ export const createRouteHandler = (
   const runtimeOptions = {
     maxJsonBodyBytes: resolveMaxJsonBodyBytes(options.maxJsonBodyBytes),
   };
+  const rendersBlob = rendersBlobOutput(route);
 
   return async (request) => {
     try {
@@ -540,7 +587,7 @@ export const createRouteHandler = (
       const result = await route.execute(rawInput, requestId, request.signal, {
         headers: request.headers,
       });
-      return mapResultToResponse(result, request);
+      return mapResultToResponse(result, request, { rendersBlob });
     } catch (error: unknown) {
       return handleCaughtError(error, request);
     }


### PR DESCRIPTION
HTTP projected blobRefSchema outputs as JSON only, so every app serving
real bytes hand-mounted the same boundary route (stash's raw route).
When a route's trail declares output: blobRefSchema (recognized by the
BLOB_REF_SCHEMA_META_KEY zod meta, the same recognition the JSON Schema
projection uses), the handler now streams the blob's bytes with
Content-Type from mimeType and Content-Length from size, for both
Uint8Array and ReadableStream data. Error results keep the JSON error
envelope; non-blob trails are unchanged. Rendering happens after
route.execute, so permits and output validation still apply; wired at
createRouteHandler so the Bun and Hono adapters inherit it.

Path-param route shapes stay a separate accommodation per the issue.
OpenAPI blob response projection is filed as TRL-1202.

Refs TRL-1192