### PR TITLE
feat(core): webhook ingress v2 with dynamic paths and resource verify

### DIFF
--- a/.changeset/trl-1194-webhook-ingress-v2.md
+++ b/.changeset/trl-1194-webhook-ingress-v2.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/core": patch
+"@ontrails/http": patch
+"@ontrails/warden": patch
+---
+
+Webhook ingress v2 (TRL-1194, absorbing TRL-1174 and TRL-1175): store-verified, per-endpoint webhook ingress becomes framework-expressible. `webhook()` accepts dynamic path segments (`path: '/hooks/:endpoint'`) whose values are delivered as envelope fields, opt-in `rawBody: true` delivery (a non-JSON body is no longer a surface-level failure — the trail owns payload interpretation), an allowlisted `headers` list delivered lowercased, and `resources` that make `verify` resource-capable: the HTTP surface resolves the declared resources into a context for the verifier and releases them afterwards, so signature checks can reach stores holding per-endpoint secrets. Envelope-mode ingress responds 202 Accepted; classic static webhooks keep their exact-match, JSON-gated, 200 behavior. Core exports `parseWebhookPathParams`, `matchWebhookPath`, `webhookPathPatternsOverlap`, and `createResources`. The `webhook-route-collision` Warden rule now also flags dynamic patterns that overlap other webhook or derived routes, not just exact method/path duplicates.

--- a/docs/surfaces/http.md
+++ b/docs/surfaces/http.md
@@ -175,7 +175,36 @@ export const stripePaymentSucceeded = webhook(
 );
 ```
 
-Route collision handling is explicit. If two webhook sources claim the same method and path, or a webhook source collides with a derived direct trail route such as `trail('webhooks.payment', ...)`, `deriveHttpRoutes()` returns a `ValidationError` and Warden reports `webhook-route-collision`.
+Route collision handling is explicit. If two webhook sources claim the same method and path, or a webhook source collides with a derived direct trail route such as `trail('webhooks.payment', ...)`, `deriveHttpRoutes()` returns a `ValidationError` and Warden reports `webhook-route-collision`. The rule also flags dynamic patterns that can match the same request path (`/hooks/:endpoint` overlaps `/hooks/github`), not just exact duplicates.
+
+### Ingress envelopes: dynamic paths, raw body, allowlisted headers
+
+Store-verified, per-endpoint ingress is declared on the source. A `webhook()` may use dynamic path segments, opt into raw body delivery, allowlist headers for the trail boundary, and declare resources its `verify` can reach:
+
+```typescript
+const relayIngress = webhook('relay.ingress', {
+  path: '/hooks/:endpointId',
+  rawBody: true,
+  headers: ['content-type', 'x-junction-signature'],
+  parse: z.object({
+    endpointId: z.string(),
+    headers: z.record(z.string(), z.string()),
+    rawBody: z.string(),
+  }),
+  resources: [relayStoreResource],
+  verify: (request, ctx) => {
+    if (ctx === undefined) {
+      return Result.err(new PermissionError('Missing verify context'));
+    }
+    // ctx reaches declared resources — e.g. per-endpoint secrets.
+    const store = relayStoreResource.from(ctx);
+    /* ... */
+    return Result.ok();
+  },
+});
+```
+
+When any of these features is used, the delivered value is an **envelope** instead of the bare JSON body: `{ ...pathParams, body?, headers?, rawBody? }`. Segment values arrive under their segment names, `headers` contains only the lowercased allowlisted entries, `rawBody` is the exact body text (with `rawBody: true`, a non-JSON body is not a surface failure — the trail owns interpretation; `body` is the parsed JSON when parseable). The `parse` schema validates the envelope at the boundary, so the trail input stays schema-declared. Envelope-mode ingress responds `202 Accepted` on success; classic static webhooks keep their `200` and JSON-body gating.
 
 ## Response Format
 

--- a/packages/core/src/__tests__/webhook.test.ts
+++ b/packages/core/src/__tests__/webhook.test.ts
@@ -4,14 +4,19 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
 
 import { z } from 'zod';
 
+import { createTrailContext } from '../context.js';
 import { InternalError, PermissionError, ValidationError } from '../errors.js';
+import { resource } from '../resource.js';
+import { createResources } from '../resource-config.js';
 import { Result } from '../result.js';
 import {
   getWebhookHeader,
   getWebhookHeaders,
+  matchWebhookPath,
   validateWebhookSource,
   verifyWebhookRequest,
   webhook,
+  webhookPathPatternsOverlap,
 } from '../webhook.js';
 
 const signBody = (secret: string, body: string): string =>
@@ -41,6 +46,7 @@ describe('webhook()', () => {
       method: 'POST',
       parse: expect.any(Object),
       path: '/webhooks/payment',
+      pathParams: [],
     });
     expect(Object.isFrozen(source)).toBe(true);
     expect(Object.isFrozen(source.meta)).toBe(true);
@@ -274,5 +280,125 @@ describe('webhook()', () => {
     expect(verified.isErr() ? verified.error : undefined).toBeInstanceOf(
       InternalError
     );
+  });
+});
+
+describe('webhook ingress v2 (TRL-1194)', () => {
+  test('accepts dynamic path segments and derives pathParams', () => {
+    const source = webhook('relay.ingress', {
+      headers: ['Content-Type', 'X-Junction-Signature'],
+      parse: z.object({ endpoint: z.string(), rawBody: z.string() }),
+      path: '/hooks/:endpoint',
+      rawBody: true,
+    });
+
+    expect(source.pathParams).toEqual(['endpoint']);
+    expect(source.rawBody).toBe(true);
+    expect(source.headers).toEqual(['content-type', 'x-junction-signature']);
+  });
+
+  test('rejects malformed and duplicate path segments', () => {
+    expect(() =>
+      webhook('relay.bad-segment', {
+        parse: z.object({}),
+        path: '/hooks/:1endpoint',
+      })
+    ).toThrow(ValidationError);
+    expect(() =>
+      webhook('relay.duplicate-segment', {
+        parse: z.object({}),
+        path: '/hooks/:endpoint/:endpoint',
+      })
+    ).toThrow(ValidationError);
+  });
+
+  test('rejects path segments that shadow reserved envelope fields', () => {
+    for (const reserved of ['body', 'headers', 'rawBody']) {
+      expect(() =>
+        webhook(`relay.reserved-${reserved}`, {
+          parse: z.object({}),
+          path: `/hooks/:${reserved}`,
+        })
+      ).toThrow(ValidationError);
+    }
+  });
+
+  test('matchWebhookPath keeps raw text for malformed percent-encoding', () => {
+    expect(matchWebhookPath('/hooks/:endpoint', '/hooks/%E0%A4%A')).toEqual({
+      endpoint: '%E0%A4%A',
+    });
+    expect(matchWebhookPath('/hooks/:endpoint', '/hooks/gh%20hub')).toEqual({
+      endpoint: 'gh hub',
+    });
+  });
+
+  test('matchWebhookPath captures segment values and rejects mismatches', () => {
+    expect(matchWebhookPath('/hooks/:endpoint', '/hooks/github')).toEqual({
+      endpoint: 'github',
+    });
+    expect(
+      matchWebhookPath('/hooks/:endpoint/:event', '/hooks/github/push')
+    ).toEqual({ endpoint: 'github', event: 'push' });
+    expect(matchWebhookPath('/hooks/:endpoint', '/hooks')).toBeUndefined();
+    expect(
+      matchWebhookPath('/hooks/:endpoint', '/other/github')
+    ).toBeUndefined();
+    expect(matchWebhookPath('/hooks/payment', '/hooks/payment')).toEqual({});
+    expect(matchWebhookPath('/hooks/:endpoint', '/hooks/')).toBeUndefined();
+  });
+
+  test('webhookPathPatternsOverlap detects overlapping patterns', () => {
+    expect(
+      webhookPathPatternsOverlap('/hooks/:endpoint', '/hooks/github')
+    ).toBe(true);
+    expect(webhookPathPatternsOverlap('/hooks/:a', '/hooks/:b')).toBe(true);
+    expect(webhookPathPatternsOverlap('/hooks/:a', '/api/:b')).toBe(false);
+    expect(webhookPathPatternsOverlap('/hooks/:a', '/hooks/:a/extra')).toBe(
+      false
+    );
+  });
+
+  test('verifyWebhookRequest forwards a context to resource-capable verifiers', async () => {
+    let seenSecret: string | undefined;
+    const secrets = resource('webhook.secrets', {
+      create: () => Result.ok({ github: 'shh' }),
+    });
+    const source = webhook('relay.verified', {
+      parse: z.object({}),
+      path: '/hooks/:endpoint',
+      resources: [secrets],
+      verify: (request, ctx) => {
+        if (ctx === undefined) {
+          return Result.err(new PermissionError('No context provided'));
+        }
+        seenSecret = (secrets.from(ctx) as Record<string, string>)['github'];
+        return getWebhookHeader(request, 'x-signature') === seenSecret
+          ? Result.ok()
+          : Result.err(new PermissionError('Bad signature'));
+      },
+    });
+
+    const scope = await createResources(
+      { resources: [secrets] },
+      createTrailContext()
+    );
+    expect(scope.isOk()).toBe(true);
+    if (!scope.isOk()) {
+      return;
+    }
+
+    const accepted = await verifyWebhookRequest(
+      source,
+      {
+        body: '{}',
+        headers: { 'x-signature': 'shh' },
+        method: 'POST',
+        path: '/hooks/github',
+      },
+      scope.value.ctx
+    );
+    expect(accepted.isOk()).toBe(true);
+    expect(seenSecret).toBe('shh');
+    scope.value.release();
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -143,8 +143,13 @@ export {
   isResource,
   resource,
 } from './resource.js';
-export { drainResources, resolveResourceConfig } from './resource-config.js';
+export {
+  createResources,
+  drainResources,
+  resolveResourceConfig,
+} from './resource-config.js';
 export type {
+  ResolvedResourceScope,
   ResourceConfigValues,
   ResourceDrainReport,
 } from './resource-config.js';
@@ -304,10 +309,13 @@ export type {
 export {
   getWebhookHeader,
   getWebhookHeaders,
+  matchWebhookPath,
+  parseWebhookPathParams,
   validateWebhookSource,
   verifyWebhookRequest,
   webhook,
   webhookMethods,
+  webhookPathPatternsOverlap,
 } from './webhook.js';
 export type {
   WebhookMethod,

--- a/packages/core/src/resource-config.ts
+++ b/packages/core/src/resource-config.ts
@@ -585,7 +585,7 @@ const withResolvedResources = (
 /**
  * Resolved trail context plus lease release for resources used by the run.
  */
-interface ResolvedResourceScope {
+export interface ResolvedResourceScope {
   readonly ctx: TrailContext;
   release(): void;
 }
@@ -593,14 +593,26 @@ interface ResolvedResourceScope {
 const releaseNoResources = (): undefined => undefined;
 
 /**
- * Resolve all declared resources for a trail.
+ * Resolve all declared resources for a resource-bearing declaration.
  *
  * Validates per-resource config, checks overrides and caches, and creates
  * new instances as needed. Returns an enriched context with all resource
- * instances injected into extensions.
+ * instances injected into extensions. Callers own the returned `release`.
+ *
+ * @example
+ * ```ts
+ * const scope = await createResources(
+ *   { resources: [secretsStore] },
+ *   createTrailContext()
+ * );
+ * if (scope.isOk()) {
+ *   const secrets = secretsStore.from(scope.value.ctx);
+ *   scope.value.release();
+ * }
+ * ```
  */
 export const createResources = async (
-  trail: AnyTrail,
+  trail: Pick<AnyTrail, 'resources'>,
   ctx: TrailContext,
   overrides?: ResourceOverrideMap,
   configValues?: ConfigValues

--- a/packages/core/src/webhook.ts
+++ b/packages/core/src/webhook.ts
@@ -4,7 +4,9 @@ import type {
   ActivationSourceParse,
 } from './activation-source.js';
 import { InternalError, ValidationError } from './errors.js';
+import type { AnyResource } from './resource.js';
 import { Result } from './result.js';
+import type { TrailContext } from './types.js';
 
 export const webhookMethods = Object.freeze([
   'DELETE',
@@ -28,16 +30,46 @@ export interface WebhookVerifyRequest {
   readonly path: string;
 }
 
+/**
+ * Verification callback for inbound webhook requests.
+ *
+ * When the source declares `resources`, surfaces call `verify` with a
+ * resource-capable context so signature checks can reach declared
+ * resources (e.g. a store holding per-endpoint secrets). Verifiers that
+ * only need the request may ignore the second parameter.
+ */
 export type WebhookVerify = (
-  request: WebhookVerifyRequest
+  request: WebhookVerifyRequest,
+  ctx?: TrailContext
 ) => Promise<Result<void, Error>> | Result<void, Error>;
 
 export interface WebhookSpec<TOutput = unknown> {
+  /**
+   * Allowlist of header names delivered to the consumer trail. When set,
+   * the webhook envelope includes a `headers` map with the matching
+   * headers, lowercased. Headers outside the allowlist never reach the
+   * trail boundary.
+   */
+  readonly headers?: readonly string[] | undefined;
   readonly meta?: ActivationSourceMeta | undefined;
   readonly method?: WebhookMethodInput | undefined;
   readonly parse: ActivationSourceParse<TOutput>;
+  /**
+   * Absolute path, optionally with dynamic segments (`/hooks/:endpoint`).
+   * Segment values are delivered as fields of the webhook envelope under
+   * their segment names.
+   */
   readonly path: string;
   readonly payload?: ActivationSource['payload'] | undefined;
+  /**
+   * Deliver the raw request body text to the consumer trail as a
+   * `rawBody` envelope field. With `rawBody`, a non-JSON body no longer
+   * fails at the surface — the trail owns payload interpretation (e.g.
+   * HMAC verification over exact bytes).
+   */
+  readonly rawBody?: boolean | undefined;
+  /** Resources the `verify` callback may access through its context. */
+  readonly resources?: readonly AnyResource[] | undefined;
   readonly verify?: WebhookVerify | undefined;
   /** Reserved for future webhook-specific design; trail versioning is trail-only. */
   readonly version?: never;
@@ -45,11 +77,16 @@ export interface WebhookSpec<TOutput = unknown> {
 
 export interface WebhookSource<TOutput = unknown> extends ActivationSource {
   readonly kind: 'webhook';
+  readonly headers?: readonly string[] | undefined;
   readonly meta?: ActivationSourceMeta | undefined;
   readonly method: WebhookMethod;
   readonly parse: ActivationSourceParse<TOutput>;
   readonly path: string;
+  /** Dynamic segment names parsed from `path`, in order. Empty for static paths. */
+  readonly pathParams: readonly string[];
   readonly payload?: ActivationSource['payload'] | undefined;
+  readonly rawBody?: boolean | undefined;
+  readonly resources?: readonly AnyResource[] | undefined;
   readonly verify?: WebhookVerify | undefined;
 }
 
@@ -65,6 +102,111 @@ const normalizeMethod = (
 ): string => (method ?? DEFAULT_WEBHOOK_METHOD).trim().toUpperCase();
 
 const normalizePath = (path: string): string => path.trim();
+
+const WEBHOOK_PATH_PARAM_PATTERN = /^:[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Envelope field names a path segment must not shadow. */
+const RESERVED_ENVELOPE_FIELDS = new Set(['body', 'headers', 'rawBody']);
+
+const pathSegments = (path: string): readonly string[] =>
+  normalizePath(path).split('/').slice(1);
+
+const isParamSegment = (segment: string): boolean => segment.startsWith(':');
+
+/** Decode a path segment, keeping the raw text when the encoding is malformed. */
+const decodeSegment = (segment: string): string => {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+};
+
+/**
+ * Parse the dynamic segment names out of a webhook path pattern.
+ *
+ * @example
+ * ```ts
+ * parseWebhookPathParams('/hooks/:endpoint'); // ['endpoint']
+ * parseWebhookPathParams('/webhooks/payment'); // []
+ * ```
+ */
+export const parseWebhookPathParams = (path: string): readonly string[] =>
+  pathSegments(path)
+    .filter((segment) => isParamSegment(segment))
+    .map((segment) => segment.slice(1));
+
+/**
+ * Match a concrete request path against a webhook path pattern.
+ *
+ * Returns the captured segment values keyed by segment name, or
+ * `undefined` when the path does not match. Static patterns match only
+ * themselves and capture nothing.
+ *
+ * @example
+ * ```ts
+ * matchWebhookPath('/hooks/:endpoint', '/hooks/github');
+ * // { endpoint: 'github' }
+ * ```
+ */
+export const matchWebhookPath = (
+  pattern: string,
+  path: string
+): Readonly<Record<string, string>> | undefined => {
+  const patternSegments = pathSegments(pattern);
+  const actualSegments = path.split('/').slice(1);
+  if (patternSegments.length !== actualSegments.length) {
+    return undefined;
+  }
+
+  const params: Record<string, string> = {};
+  for (const [index, patternSegment] of patternSegments.entries()) {
+    const actual = actualSegments[index] ?? '';
+    if (isParamSegment(patternSegment)) {
+      if (actual.length === 0) {
+        return undefined;
+      }
+      params[patternSegment.slice(1)] = decodeSegment(actual);
+      continue;
+    }
+    if (patternSegment !== actual) {
+      return undefined;
+    }
+  }
+  return params;
+};
+
+/**
+ * True when two webhook path patterns can both match one concrete path.
+ *
+ * Segment-wise: two literals overlap only when equal; a dynamic segment
+ * overlaps anything. Used by governance to extend route-collision
+ * detection past exact-path equality.
+ *
+ * @example
+ * ```ts
+ * webhookPathPatternsOverlap('/hooks/:a', '/hooks/github'); // true
+ * webhookPathPatternsOverlap('/hooks/:a', '/api/:b'); // false
+ * ```
+ */
+export const webhookPathPatternsOverlap = (
+  left: string,
+  right: string
+): boolean => {
+  const leftSegments = pathSegments(left);
+  const rightSegments = pathSegments(right);
+  if (leftSegments.length !== rightSegments.length) {
+    return false;
+  }
+  return leftSegments.every((leftSegment, index) => {
+    const rightSegment = rightSegments[index] ?? '';
+    return (
+      isParamSegment(leftSegment) ||
+      isParamSegment(rightSegment) ||
+      leftSegment === rightSegment
+    );
+  });
+};
 
 const isWebhookMethod = (method: string): method is WebhookMethod =>
   (webhookMethods as readonly string[]).includes(method);
@@ -100,14 +242,42 @@ const validatePath = (path: unknown): WebhookValidationIssue[] => {
   }
 
   const normalized = normalizePath(path);
-  return normalized.startsWith('/')
-    ? []
-    : [
-        {
-          field: 'path',
-          message: 'Webhook path must start with "/"',
-        },
-      ];
+  if (!normalized.startsWith('/')) {
+    return [
+      {
+        field: 'path',
+        message: 'Webhook path must start with "/"',
+      },
+    ];
+  }
+
+  const issues: WebhookValidationIssue[] = [];
+  for (const segment of pathSegments(normalized)) {
+    if (isParamSegment(segment) && !WEBHOOK_PATH_PARAM_PATTERN.test(segment)) {
+      issues.push({
+        field: 'path',
+        message: `Webhook path segment "${segment}" must match :name with a letter or underscore first`,
+      });
+    }
+  }
+
+  const params = parseWebhookPathParams(normalized);
+  if (new Set(params).size !== params.length) {
+    issues.push({
+      field: 'path',
+      message: 'Webhook path segments must use unique names',
+    });
+  }
+  for (const param of params) {
+    if (RESERVED_ENVELOPE_FIELDS.has(param)) {
+      issues.push({
+        field: 'path',
+        message: `Webhook path segment ":${param}" collides with the reserved envelope field "${param}"`,
+      });
+    }
+  }
+
+  return issues;
 };
 
 const validateRequiredParse = (parse: unknown): WebhookValidationIssue[] =>
@@ -229,14 +399,15 @@ export const getWebhookHeader = (
 
 export const verifyWebhookRequest = async (
   source: Pick<WebhookSource, 'id' | 'verify'>,
-  request: WebhookVerifyRequest
+  request: WebhookVerifyRequest,
+  ctx?: TrailContext
 ): Promise<Result<void, Error>> => {
   if (source.verify === undefined) {
     return Result.ok();
   }
 
   try {
-    return await source.verify(request);
+    return await source.verify(request, ctx);
   } catch (error) {
     const cause = errorFromUnknown(error);
     return Result.err(
@@ -269,10 +440,22 @@ export function webhook<TOutput>(
     method: normalized.method,
     parse: spec.parse,
     path: normalized.path,
+    pathParams: Object.freeze([...parseWebhookPathParams(normalized.path)]),
+    ...(spec.headers === undefined
+      ? {}
+      : {
+          headers: Object.freeze(
+            spec.headers.map((name) => name.toLowerCase())
+          ),
+        }),
     ...(spec.meta === undefined
       ? {}
       : { meta: Object.freeze({ ...spec.meta }) }),
     ...(spec.payload === undefined ? {} : { payload: spec.payload }),
+    ...(spec.rawBody === undefined ? {} : { rawBody: spec.rawBody }),
+    ...(spec.resources === undefined
+      ? {}
+      : { resources: Object.freeze([...spec.resources]) }),
     ...(spec.verify === undefined ? {} : { verify: spec.verify }),
   });
 }

--- a/packages/http/src/__tests__/fetch.test.ts
+++ b/packages/http/src/__tests__/fetch.test.ts
@@ -7,6 +7,7 @@ import {
   blobRefSchema,
   createBlobRef,
   getWebhookHeader,
+  resource,
   trail,
   topo,
   webhook,
@@ -531,5 +532,170 @@ describe('BlobRef byte serving (TRL-1192)', () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ data: { reply: 'json' } });
+  });
+});
+
+describe('webhook ingress v2 (TRL-1194)', () => {
+  const ingressWebhook = webhook('relay.ingress', {
+    headers: ['content-type', 'x-junction-signature'],
+    parse: z.object({
+      endpoint: z.string(),
+      headers: z.record(z.string(), z.string()),
+      rawBody: z.string(),
+    }),
+    path: '/hooks/:endpoint',
+    rawBody: true,
+  });
+
+  const receiveTrail = trail('ingress.receive', {
+    blaze: (input) =>
+      Result.ok({
+        endpoint: input.endpoint,
+        headerNames: Object.keys(input.headers).toSorted(),
+        rawBody: input.rawBody,
+      }),
+    input: z.object({
+      endpoint: z.string(),
+      headers: z.record(z.string(), z.string()),
+      rawBody: z.string(),
+    }),
+    on: [ingressWebhook],
+    output: z.object({
+      endpoint: z.string(),
+      headerNames: z.array(z.string()),
+      rawBody: z.string(),
+    }),
+  });
+
+  test('delivers path params, raw body, and allowlisted headers to the trail', async () => {
+    const handler = createFetchHandler(topo('ingress-api', { receiveTrail }));
+
+    const response = await handler(
+      buildRequest('/hooks/github', {
+        body: '{"payload":true}',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Junction-Signature': 'sig-1',
+          'X-Secret-Internal': 'never-delivered',
+        },
+        method: 'POST',
+      })
+    );
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      data: {
+        endpoint: 'github',
+        headerNames: ['content-type', 'x-junction-signature'],
+        rawBody: '{"payload":true}',
+      },
+    });
+  });
+
+  test('rawBody webhooks accept non-JSON bodies — the trail owns interpretation', async () => {
+    const handler = createFetchHandler(topo('ingress-api', { receiveTrail }));
+
+    const response = await handler(
+      buildRequest('/hooks/stripe', {
+        body: 'not json at all',
+        headers: { 'Content-Type': 'text/plain' },
+        method: 'POST',
+      })
+    );
+
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      data: {
+        endpoint: 'stripe',
+        headerNames: ['content-type'],
+        rawBody: 'not json at all',
+      },
+    });
+  });
+
+  test('unmatched dynamic paths fall through to not-found', async () => {
+    const handler = createFetchHandler(topo('ingress-api', { receiveTrail }));
+
+    const response = await handler(
+      buildRequest('/hooks/github/extra', { method: 'POST' })
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  test('classic static webhooks keep their exact-match behavior and 200 status', async () => {
+    const handler = createFetchHandler(
+      topo('ingress-api', { paymentWebhookTrail })
+    );
+
+    const response = await handler(
+      buildRequest('/webhooks/payment', {
+        body: JSON.stringify({ paymentId: 'pay_1' }),
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Secret': webhookSecret,
+        },
+        method: 'POST',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      data: { paymentId: 'pay_1' },
+    });
+  });
+
+  test('verify reaches declared resources through its context', async () => {
+    const secrets = resource('ingress.secrets', {
+      create: () => Result.ok({ github: 'store-held-secret' }),
+    });
+    const verifiedWebhook = webhook('relay.verified', {
+      parse: z.object({ endpoint: z.string(), rawBody: z.string() }),
+      path: '/verified/:endpoint',
+      rawBody: true,
+      resources: [secrets],
+      verify: (request, ctx) => {
+        if (ctx === undefined) {
+          return Result.err(new PermissionError('No verify context'));
+        }
+        const expected = (secrets.from(ctx) as Record<string, string>)[
+          'github'
+        ];
+        return getWebhookHeader(request, 'x-signature') === expected
+          ? Result.ok()
+          : Result.err(new PermissionError('Invalid signature'));
+      },
+    });
+    const verifiedTrail = trail('verified.receive', {
+      blaze: (input) => Result.ok({ endpoint: input.endpoint }),
+      input: z.object({ endpoint: z.string(), rawBody: z.string() }),
+      on: [verifiedWebhook],
+      output: z.object({ endpoint: z.string() }),
+    });
+    const handler = createFetchHandler(topo('ingress-api', { verifiedTrail }));
+
+    const accepted = await handler(
+      buildRequest('/verified/github', {
+        body: '{}',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Signature': 'store-held-secret',
+        },
+        method: 'POST',
+      })
+    );
+    expect(accepted.status).toBe(202);
+
+    const rejected = await handler(
+      buildRequest('/verified/github', {
+        body: '{}',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Signature': 'wrong',
+        },
+        method: 'POST',
+      })
+    );
+    expect(rejected.status).toBe(403);
   });
 });

--- a/packages/http/src/build.ts
+++ b/packages/http/src/build.ts
@@ -12,6 +12,8 @@ import {
   ValidationError,
   buildActivationProvenanceTraceAttrs,
   collectAttachedTypedLayers,
+  createResources,
+  createTrailContext,
   deriveSurfaceTrailVersionProjections,
   executeTrail,
   filterSurfaceTrails,
@@ -1038,6 +1040,44 @@ type MergeableWebhookRoute = HttpRouteDefinition & {
   readonly [WEBHOOK_INVALID_RECORDERS]?: readonly WebhookInvalidConsumerRecorder[];
 };
 
+/**
+ * Wrap a webhook source's `verify` for the route boundary.
+ *
+ * Sources that declare `resources` get a resource-capable context: the
+ * declared resources are resolved (honoring surface overrides and config
+ * values) for the duration of the verification and released afterwards,
+ * so signature checks can reach stores holding per-endpoint secrets.
+ */
+const createWebhookVerifier =
+  (
+    source: WebhookSource,
+    options: DeriveHttpRoutesOptions
+  ): ((request: WebhookVerifyRequest) => Promise<Result<void, Error>>) =>
+  async (request) => {
+    const declared = source.resources ?? [];
+    if (source.verify === undefined || declared.length === 0) {
+      return await verifyWebhookRequest(source, request);
+    }
+
+    const seed = options.createContext
+      ? await options.createContext()
+      : undefined;
+    const scope = await createResources(
+      { resources: declared },
+      createTrailContext(seed),
+      options.resources,
+      options.configValues
+    );
+    if (scope.isErr()) {
+      return scope;
+    }
+    try {
+      return await verifyWebhookRequest(source, request, scope.value.ctx);
+    } finally {
+      scope.value.release();
+    }
+  };
+
 const buildWebhookRoute = (
   graph: Topo,
   trail: Trail<unknown, unknown, unknown>,
@@ -1089,7 +1129,7 @@ const buildWebhookRoute = (
     ),
     trail,
     trailId: trail.id,
-    verifyWebhook: (request) => verifyWebhookRequest(source.value, request),
+    verifyWebhook: createWebhookVerifier(source.value, options),
     ...(versions === undefined ? {} : { versions }),
     webhookSource: source.value,
   };
@@ -1142,6 +1182,20 @@ const hasMatchingWebhookParse = (
   right: HttpRouteDefinition
 ): boolean => left.webhookSource?.parse === right.webhookSource?.parse;
 
+/**
+ * Envelope facts must agree before merging: the merged route delivers one
+ * envelope shape, so diverging `rawBody`/`headers` declarations would
+ * silently drop a consumer's declared fields.
+ */
+const hasMatchingWebhookEnvelope = (
+  left: HttpRouteDefinition,
+  right: HttpRouteDefinition
+): boolean =>
+  (left.webhookSource?.rawBody === true) ===
+    (right.webhookSource?.rawBody === true) &&
+  JSON.stringify(left.webhookSource?.headers ?? null) ===
+    JSON.stringify(right.webhookSource?.headers ?? null);
+
 const webhookConsumers = (
   route: MergeableWebhookRoute
 ): readonly WebhookConsumerExecute[] | undefined => route[WEBHOOK_CONSUMERS];
@@ -1176,6 +1230,14 @@ const mergeWebhookRoutes = (
     return {
       error: new ValidationError(
         `HTTP route collision: trails "${existing.trailId}" and "${route.trailId}" share webhook source "${existing.webhookSource?.id}" on ${route.method} ${route.path} but declare a mismatched webhook parse contract. Reuse the same WebhookSource object so both consumers parse payloads under one contract.`
+      ),
+      kind: 'parse-mismatch',
+    };
+  }
+  if (!hasMatchingWebhookEnvelope(existing, route)) {
+    return {
+      error: new ValidationError(
+        `HTTP route collision: trails "${existing.trailId}" and "${route.trailId}" share webhook source "${existing.webhookSource?.id}" on ${route.method} ${route.path} but declare mismatched rawBody/headers envelope facts. Reuse the same WebhookSource object so both consumers receive one envelope shape.`
       ),
       kind: 'parse-mismatch',
     };

--- a/packages/http/src/fetch.ts
+++ b/packages/http/src/fetch.ts
@@ -3,7 +3,9 @@ import {
   CancelledError,
   isBlobRef,
   isTrailsError,
+  matchWebhookPath,
   NotFoundError,
+  parseWebhookPathParams,
   projectErrorDiagnostics,
   projectPublicSurfaceError,
   ValidationError,
@@ -475,11 +477,76 @@ const recordInvalidWebhook = async (
 const errorCategoryForWebhookFailure = (error: Error | undefined): string =>
   error !== undefined && isTrailsError(error) ? error.category : 'internal';
 
+/**
+ * True when the route's webhook source opts into ingress-envelope
+ * delivery: dynamic path segments, raw body, or allowlisted headers.
+ */
+const usesWebhookEnvelope = (route: HttpRouteDefinition): boolean => {
+  const source = route.webhookSource;
+  return (
+    source !== undefined &&
+    (source.rawBody === true ||
+      source.headers !== undefined ||
+      parseWebhookPathParams(source.path).length > 0)
+  );
+};
+
+const pickAllowlistedHeaders = (
+  headers: Headers,
+  allowlist: readonly string[]
+): Record<string, string> => {
+  const allowed = new Set(allowlist.map((name) => name.toLowerCase()));
+  const kept: Record<string, string> = {};
+  for (const [name, value] of headers) {
+    const normalized = name.toLowerCase();
+    if (allowed.has(normalized)) {
+      kept[normalized] = value;
+    }
+  }
+  return kept;
+};
+
+/**
+ * Assemble the delivered webhook value.
+ *
+ * Classic webhooks deliver the parsed JSON body directly. Envelope-mode
+ * webhooks deliver `{ ...pathParams, body?, headers?, rawBody? }` — the
+ * schema-declared boundary shape TRL-1194 lifts from the hand-mounted
+ * ingress routes.
+ */
+const buildWebhookDeliveredValue = (
+  route: HttpRouteDefinition,
+  request: Request,
+  rawBody: string,
+  jsonBody: unknown,
+  pathParams: Readonly<Record<string, string>> | undefined
+): unknown => {
+  const source = route.webhookSource;
+  if (source === undefined || !usesWebhookEnvelope(route)) {
+    return jsonBody;
+  }
+  return {
+    ...(jsonBody === undefined ? {} : { body: jsonBody }),
+    ...(source.headers === undefined
+      ? {}
+      : { headers: pickAllowlistedHeaders(request.headers, source.headers) }),
+    ...(source.rawBody === true ? { rawBody } : {}),
+    ...pathParams,
+  };
+};
+
 const handleWebhookRoute = async (
   route: HttpRouteDefinition,
   options: RuntimeOptions,
   request: Request
 ): Promise<Response> => {
+  const envelope = usesWebhookEnvelope(route);
+  // Self-derive dynamic segment values from the route's own pattern so
+  // every adapter (fetch dispatcher, Bun routes, Hono) gets pattern
+  // support without threading params through handler signatures.
+  const pathParams = envelope
+    ? matchWebhookPath(route.path, new URL(request.url).pathname)
+    : undefined;
   const rawBody = await readWebhookBodyText(request, options.maxJsonBodyBytes);
 
   if (rawBody === JSON_BODY_INVALID_CONTENT_LENGTH) {
@@ -504,12 +571,22 @@ const handleWebhookRoute = async (
   }
 
   const jsonBody = parseWebhookBodyText(request, rawBody);
-  if (jsonBody === JSON_PARSE_ERROR) {
+  // With rawBody delivery the trail owns payload interpretation, so a
+  // non-JSON body is not a surface-level failure.
+  if (jsonBody === JSON_PARSE_ERROR && route.webhookSource?.rawBody !== true) {
     await recordInvalidWebhook(route);
     return invalidJsonResponse();
   }
 
-  const parsed = route.parseWebhookInput?.(jsonBody);
+  const delivered = buildWebhookDeliveredValue(
+    route,
+    request,
+    rawBody,
+    jsonBody === JSON_PARSE_ERROR ? undefined : jsonBody,
+    pathParams
+  );
+
+  const parsed = route.parseWebhookInput?.(delivered);
   if (parsed === undefined) {
     await recordInvalidWebhook(route, 'internal');
     return mapResultToResponse(
@@ -529,6 +606,11 @@ const handleWebhookRoute = async (
   const result = await route.execute(parsed.value, requestId, request.signal, {
     headers: request.headers,
   });
+  // Envelope-mode ingress acknowledges accepted work with 202, matching
+  // the accepted-for-processing semantics of webhook receivers.
+  if (envelope && result.isOk()) {
+    return json({ data: result.value }, 202);
+  }
   return mapResultToResponse(result, request);
 };
 
@@ -628,22 +710,45 @@ export const createFetchHandler = (
     throw routesResult.error;
   }
 
-  const routeHandlers = new Map<
-    string,
-    (request: Request) => Promise<Response>
-  >();
+  type BoundRouteHandler = (request: Request) => Promise<Response>;
+
+  const routeHandlers = new Map<string, BoundRouteHandler>();
+  const patternRoutes: {
+    readonly handler: BoundRouteHandler;
+    readonly method: string;
+    readonly pattern: string;
+  }[] = [];
   for (const route of routesResult.value) {
-    routeHandlers.set(
-      routeKey(route.method, route.path),
-      createRouteHandler(route, {
-        maxJsonBodyBytes: options.maxJsonBodyBytes,
-      })
-    );
+    const handler = createRouteHandler(route, {
+      maxJsonBodyBytes: options.maxJsonBodyBytes,
+    });
+    if (parseWebhookPathParams(route.path).length > 0) {
+      patternRoutes.push({
+        handler,
+        method: route.method.toUpperCase(),
+        pattern: route.path,
+      });
+      continue;
+    }
+    routeHandlers.set(routeKey(route.method, route.path), handler);
   }
 
   return async (request) => {
     const path = new URL(request.url).pathname;
     const handler = routeHandlers.get(routeKey(request.method, path));
-    return handler === undefined ? notFoundResponse(request) : handler(request);
+    if (handler !== undefined) {
+      return handler(request);
+    }
+    // Exact routes win; dynamic-segment routes match in registration order.
+    const method = request.method.toUpperCase();
+    for (const candidate of patternRoutes) {
+      if (candidate.method !== method) {
+        continue;
+      }
+      if (matchWebhookPath(candidate.pattern, path) !== undefined) {
+        return candidate.handler(request);
+      }
+    }
+    return notFoundResponse(request);
   };
 };

--- a/packages/warden/src/__tests__/webhook-route-collision.test.ts
+++ b/packages/warden/src/__tests__/webhook-route-collision.test.ts
@@ -334,4 +334,54 @@ describe('webhook-route-collision', () => {
       rmSync(rootDir, { force: true, recursive: true });
     }
   });
+
+  test('errors when a dynamic-segment pattern overlaps a static webhook path', async () => {
+    const dynamicIngress = webhook('webhook.relay.ingress', {
+      parse: z.object({ endpoint: z.string() }),
+      path: '/webhooks/:endpoint',
+    });
+    const dynamicReceiver = trail('relay.receive', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ endpoint: z.string() }),
+      on: [dynamicIngress],
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const diagnostics = await webhookRouteCollision.checkTopo(
+      topo('webhook-routes-pattern-overlap', {
+        dynamicReceiver,
+        paymentReceiver,
+      })
+    );
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('pattern overlap'),
+        rule: 'webhook-route-collision',
+        severity: 'error',
+      }),
+    ]);
+  });
+
+  test('stays quiet for dynamic patterns that cannot match the same path', async () => {
+    const hooksIngress = webhook('webhook.relay.hooks', {
+      parse: z.object({ endpoint: z.string() }),
+      path: '/hooks/:endpoint',
+    });
+    const hooksReceiver = trail('relay.hooks.receive', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ endpoint: z.string() }),
+      on: [hooksIngress],
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    const diagnostics = await webhookRouteCollision.checkTopo(
+      topo('webhook-routes-pattern-disjoint', {
+        hooksReceiver,
+        paymentReceiver,
+      })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
 });

--- a/packages/warden/src/rules/webhook-route-collision.ts
+++ b/packages/warden/src/rules/webhook-route-collision.ts
@@ -1,4 +1,7 @@
-import { shouldIncludeTrailForSurface } from '@ontrails/core';
+import {
+  shouldIncludeTrailForSurface,
+  webhookPathPatternsOverlap,
+} from '@ontrails/core';
 import type { Topo, Trail } from '@ontrails/core';
 
 import type { TopoAwareWardenRule, WardenDiagnostic } from './types.js';
@@ -200,6 +203,65 @@ const collectPolicyMismatchDiagnostics = (
   return diagnostics;
 };
 
+const hasDynamicSegment = (path: string): boolean => path.includes('/:');
+
+/**
+ * Flag distinct route keys whose path patterns can both match one concrete
+ * request. Exact-key collisions are handled by the grouping pass; this pass
+ * extends detection to dynamic-segment patterns (`/hooks/:endpoint` vs
+ * `/hooks/github`), where at least one webhook claim participates.
+ */
+const collectPatternOverlapDiagnostics = (
+  claimsByRoute: ReadonlyMap<string, readonly RouteClaim[]>
+): WardenDiagnostic[] => {
+  const diagnostics: WardenDiagnostic[] = [];
+  const keys = [...claimsByRoute.keys()].toSorted();
+
+  for (const [index, leftKey] of keys.entries()) {
+    for (const rightKey of keys.slice(index + 1)) {
+      const leftClaims = claimsByRoute.get(leftKey) ?? [];
+      const rightClaims = claimsByRoute.get(rightKey) ?? [];
+      const [leftFirst] = leftClaims;
+      const [rightFirst] = rightClaims;
+      if (leftFirst === undefined || rightFirst === undefined) {
+        continue;
+      }
+      if (leftFirst.method !== rightFirst.method) {
+        continue;
+      }
+      if (
+        !(
+          hasDynamicSegment(leftFirst.path) ||
+          hasDynamicSegment(rightFirst.path)
+        )
+      ) {
+        continue;
+      }
+      const participants = [...leftClaims, ...rightClaims];
+      if (!participants.some((claim) => claim.type === 'webhook')) {
+        continue;
+      }
+      if (!webhookPathPatternsOverlap(leftFirst.path, rightFirst.path)) {
+        continue;
+      }
+      diagnostics.push({
+        filePath: TOPO_FILE,
+        line: 1,
+        message: `HTTP webhook route pattern overlap between ${leftKey} and ${rightKey}: ${sortedClaims(
+          participants
+        )
+          .map(claimLabel)
+          .join(
+            ', '
+          )}. Both patterns can match one request path; make the patterns disjoint or merge the sources.`,
+        rule: RULE_NAME,
+        severity: 'error',
+      });
+    }
+  }
+  return diagnostics;
+};
+
 const buildDiagnostics = (claims: readonly RouteClaim[]) => {
   const claimsByRoute = new Map<string, RouteClaim[]>();
   for (const claim of claims) {
@@ -227,6 +289,7 @@ const buildDiagnostics = (claims: readonly RouteClaim[]) => {
     }
     diagnostics.push(...collectPolicyMismatchDiagnostics(key, webhookClaims));
   }
+  diagnostics.push(...collectPatternOverlapDiagnostics(claimsByRoute));
   return diagnostics;
 };
 


### PR DESCRIPTION
Store-verified, per-endpoint webhook ingress becomes framework-
expressible (TRL-1194, absorbing TRL-1174 and TRL-1175), lifting the
shape of junction's hand-mounted /hooks/:endpoint route.

- webhook() accepts dynamic path segments (path: /hooks/:endpoint)
  validated at authoring time (grammar, duplicates, reserved envelope
  names); segment values arrive as envelope fields and the HTTP
  dispatcher matches patterns after exact routes
- opt-in rawBody: true delivers the exact body text and stops gating
  non-JSON bodies at the surface — the trail owns interpretation
- headers: [...] allowlists which lowercased headers reach the trail
  boundary; nothing outside the allowlist is delivered
- WebhookSpec.resources + verify(request, ctx) give verifiers a
  resource-capable context: the HTTP surface resolves declared
  resources (honoring overrides/config) around verification and
  releases them afterwards
- envelope-mode ingress responds 202 Accepted; classic static webhooks
  keep exact-match dispatch, JSON gating, and 200
- webhook-route-collision learns pattern overlap, not just exact pairs
- merged webhook routes refuse mismatched rawBody/headers facts

Core exports parseWebhookPathParams, matchWebhookPath,
webhookPathPatternsOverlap, and createResources.

Refs TRL-1194