### PR TITLE
feat(topographer): namespaced overlay extension point on the topo graph

### DIFF
--- a/.agents/memory/decisions.md
+++ b/.agents/memory/decisions.md
@@ -256,3 +256,57 @@ Merit aside: a *gate* is a point (binary allow/deny on a path); the job is a *br
 **Other same-class gaps found:** v1-workflow docs/agent-guidance (no issue at all); the `reviewDeclarationTypes` public-API auto-rename-vs-review policy (confirm it's inside TRL-1123's "review gates" or capture it).
 
 **Basis (tenets):** "ship the whole developer experience" / done-means-usable-teachable-releasable — applied to substrate, not just features; natural-altitude (seams live at shared altitude). **Confidence:** High. Fourth run-exposed gap in the loop (structured-preserve, md-code-shield, `--input-json`, now TRL-1125) — the pattern is that *running* finds seams that *reading/planning* cannot.
+
+### 2026-07-02 Package taxonomy rulings (from the 2026-07-01 hot-take note)
+
+**Question:** The package-taxonomy note proposed (a) teaching package families instead of consolidating, (b) "longer term" moving tracing dev-state into `@ontrails/observe/dev`/`observe/otel` subpaths, (c) treating logtape/pino as adapters, (d) a post-reset re-audit of `detour`/`fires`/`transpose`/`survey`.
+
+**Decisions:**
+
+1. **Families: teach, derive, don't consolidate.** Family is authored metadata per package (one write); docs render it (many reads). A hand-maintained docs table is a parallel ledger. → TRL-1127.
+2. **Observe-subpath consolidation of tracing dev-state: REJECTED, not deferred.** It would reopen the ADR-0041 boundary closed in #870 the day after closing it, with no new evidence — and it inverts natural altitude (ADR-0051): observe is a low-altitude contracts/sinks package; tracing dev-state is high-altitude tooling (query/status *trails*, SQLite store, OTel bridge). Subpaths hide coupling from the docs page, not from the dependency graph. Re-open only with new evidence.
+3. **The line that distinguishes ruling 2 from the logtape/pino fold (TRL-1126):** subpath-on-primitive is for **zero-dep structural bridges shaped entirely around the owner's contracts** (logtape/pino over observe's `LogSink`; precedent `tracing/otel`). It is NOT for dependency-heavy tooling that would raise the owner's altitude. Same word ("subpath"), opposite altitude direction — don't conflate.
+4. **logtape/pino violate the adapter dependency test** (verified: zero foreign deps, structural typing, only peer = observe). Recommended fold into `@ontrails/observe/logtape|pino`; explicit alternative move-to-`adapters/` requires a recorded discoverability carve-out to the dependency test. Matt decides in TRL-1126.
+5. **Post-reset re-audit is evidence-gated and the bar goes UP** now that governed renames are cheap (deferral is nearly free, so "while we're at it" batching loses its justification). Candidates never enter `lexicon-pending.md` before ratification. → TRL-1128.
+
+**Basis (tenets):** one-write-many-reads (families as authored metadata); natural altitude / ADR-0051 (rulings 2–3); add-with-intent + evidence-over-aesthetics (ruling 5). **Confidence:** High on 1–3 and 5; ruling 4 is a recommendation pending Matt's call.
+
+### 2026-07-02 Regrade scope & file-rename rulings (from the facet tracer #880 review)
+
+**Question:** The facet tracer left three capability gaps: file renames done by hand outside the transition contract; registry path *excludes* that silently unscan everything they match; and docs updates that can fall through via quiet scope holes. Matt: filenames should be in the mix, with recursion to catch references; directories should be lockable off-limits — but some catches should be *flagged into the judgment workflow*, not vanish.
+
+**Decisions:**
+
+1. **File renames become governed transition facts** (TRL-1130): authored `fileRenames` in the typed registry; in-scope *references* to renamed files are **derived** from the declaration (nobody authors the reference list). Recursion is bounded by design: apply all renames first, then ONE reference pass against the final rename map — chains resolve without fixpoint iteration; genuinely recursive residue routes to review.
+2. **Scope is three tiers, not one exclude bucket** (TRL-1131). Tier 1 hard-exclude (never scanned): mechanical noise only. Tier 2 policy-classified: historical surfaces (CHANGELOGs, .changeset/, ADR history) are *scanned*, auto-disposed (`historical-by-policy`, extending the TRL-1122 disposition set), **counted in the report**, never rewritten by default, overridable through normal judgment. Tier 3 in-scope — **docs are tier 3 by default** and can only leave via recorded registry policy, never a quiet glob omission. "Off limits" and "caught and flagged" are different tiers, not a contradiction.
+3. **Docs-skipping made structural:** the family report carries a docs-coverage line (teaching surfaces touched vs census-expected); a miss is a gate failure, not a post-merge discovery.
+4. **Process rule — packet-acceptance diff:** the TRL-1119 teaching doc escaped a *third* time because the goal packet never carried it; the packet is the executor's operative contract and issue→packet transcription is lossy. Every acceptance line is carried into the packet DoD or explicitly waived with a reason, checked before execution starts.
+
+**Basis (tenets):** derive-what's-known (reference closure from rename declarations); the-contract-is-queryable + gate honesty (tier-2 visibility over silent exclusion); ship-the-whole-DX (docs-coverage as gate); regressions-harden-the-trail (three run-exposed substrate fixes landed in-stack in #880 — the loop is working). **Confidence:** High. Note: `.agents/notes/2026-07-02-trl-1119-review-and-regrade-scope-followup.md`.
+
+### 2026-07-02 Regrade transition records — the change carries its own memory (ratified)
+
+**Question:** Matt: we're stacking assumptions (well-authored acceptance criteria → pre-work done → diligent executor → criteria met) — probabilistic outcomes layered on probabilistic outcomes. Adopters won't have our discipline. How does Regrade carry the burden itself, and what artifact survives?
+
+**Decision (Matt + Clark, basis for a future ADR — full note `.agents/notes/2026-07-02-regrade-transition-records.md`):**
+
+1. **Principle: checkpoint probabilistic steps through deterministic artifacts.** Every meaningful run writes a **transition record** (resolved plan snapshot + occurrence ledger with dispositions + gate state + environment incl. topo lock graph hash). The record is the story of the change, as the lock is the story of the system.
+2. **Committed, at `.trails/regrade/history/<from>-to-<target>-<lockhash7>.json`** (Matt's naming: kebab transition name + short lock hash; commit-SHA fallback until root trails.lock is universal). Name collision = same transition on same graph state = idempotency signal. Extends `.trails/`'s existing committed-beside-local pattern. → TRL-1132 (Urgent).
+3. **The record is load-bearing:** apply consumes a confirmed plan record (Terraform contract; no blind apply; stale lock-hash → re-plan), and `--check` computes the gate as machine acceptance so adopters' vague issues stop mattering for the checkable half. → TRL-1133 (Urgent). Both **block blaze (TRL-1018)**.
+4. **Stance reversal ratified:** enforcement can retire when a transition completes; **evidence never should.** History enables Warden reintroduction + unknown-permutation watch (stem-match not in form set/ledger = legible "missed permutation" finding). → TRL-1135.
+5. **Seed → derived plan** for the naive path: `from`/`to` is a seed; morphology, filename candidates, census tiers, and topo-derived live-API preserves (ON by default) are derived into a proposed plan; derived candidates start review-routed. → TRL-1134. Posture: **aggressive discovery, conservative application, total visibility.**
+
+**Basis (tenets):** regressions-harden-the-trail's move-left ladder applied to the workflow itself (we built the engine contract-first but left the workflow discipline-first — operator memory must move into the contract); derive-by-default; the-contract-is-queryable. **Confidence:** High. Open questions (record weight, dry-run commit policy, morphology derivation mode, lifecycle home) recorded in the note for the ADR.
+
+### 2026-07-05 Overlay: the lock's one extension noun; alias/trailhead subsumed; layer kept
+
+**Question (Matt's first-principles push, three rounds):** (1) Do cliAliases and trailheads need to exist as framework concepts, or does the new lock-extension mechanism subsume them? (2) What is the unifying noun — section, segment, or overlay? (3) Is `layer` still the right word alongside it?
+
+**Decisions:**
+
+1. **Subsume, fully.** Aliases and trailheads are duals (N→1 / 1→N) of one construct: named bindings from a surface's namespace onto trails. One shared schema: scalar value = transparent synonym, list value = grouped entry, **singleton list stays a group** (the typing rule that keeps it honest — cardinality is NOT the discriminator; value shape is). ADR-0050 protections re-key onto shapes (normalize-without-lying → scalar; identity-preservation → list). Both behaviors become available on all surfaces automatically. `alias`/`trailhead` survive as prose/teaching words only.
+2. **The noun is `overlay`** (section → segment → overlay across three rounds, each fixing the last's flaw): section named the storage slot, not the concept; segment implies *partition-of-a-route* (parts the whole depends on) but the mechanism is *additive* — and **the lock is a map, not a route**. Overlay scores perfectly: never alters the base, tolerant reader IS the defining GIS-overlay property (the metaphor self-explains the hardest guarantee), themed/namespaced, provenance-cited. Grammar: `Overlay` type, `trailsOverlays` export (sole channel), lock field `overlays`, `wayfind overlay <ns>`, `surfaceOverlay` helper. Bonus: kills the "trail segments/trails segments" homophone.
+3. **`layer` keeps its name.** Middleware-standard, tenets chose it deliberately, no better successor (wrapper flavorless; stage linear-not-wrapping; gate saturated). Contrast pair for the lexicon: **"layers wrap what runs; overlays enrich the map."** Layer↔overlay adjacency goes on TRL-1128's evidence-gated watch list — act on demonstrated confusion only.
+4. **Anticipation recorded:** if layer declarations ever need lock visibility, they ride an overlay — never a fourth lift channel.
+
+**Basis (tenets):** natural altitude applied to vocabulary (a concept belongs to the package that acts on it; core knows only the envelope); brand test (overlay self-explains via common map knowledge); evidence-over-adjacency for renames (Regrade makes them cheap, which RAISES the bar for speculative ones). **Sequencing:** rename folds into the unmerged #900–903 restack (free — nothing shipped); TRL-1197 becomes the subsumption ADR. **Confidence:** High; Matt ratified all three explicitly.

--- a/.changeset/trl-1199-overlays-surface.md
+++ b/.changeset/trl-1199-overlays-surface.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/topographer': minor
+---
+
+Add the namespaced-overlays extension point to the topo graph: `deriveTopoGraph` accepts overlay registrations (namespace + zod schema + derive function), embeds validated facts as `overlays.<namespace>`, covers them with the canonical graph hash, and preserves unknown namespaces byte-for-byte so older toolchains never drop or reject newer overlays.

--- a/packages/topographer/src/__tests__/overlays.test.ts
+++ b/packages/topographer/src/__tests__/overlays.test.ts
@@ -1,0 +1,342 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  Result,
+  ValidationError,
+  openWriteTrailsDb,
+  topo,
+  trail,
+} from '@ontrails/core';
+import type { Topo } from '@ontrails/core';
+import { z } from 'zod';
+
+import {
+  createStoredTopoSnapshot,
+  getStoredTopoExport,
+} from '../backend-support.js';
+import { deriveTopoGraph } from '../derive.js';
+import { deriveTopoGraphHash } from '../hash.js';
+import { collectTopoGraphOverlays } from '../overlays.js';
+import {
+  TRAILS_LOCK_SCHEMA_VERSION,
+  topoGraphSchema,
+  trailsLockSchema,
+} from '../types.js';
+import type {
+  TopoGraph,
+  TopoGraphOverlayRegistration,
+  TrailsLock,
+} from '../types.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const noop = () => Result.ok({ ok: true });
+
+const buildApp = (): Topo =>
+  topo('overlays-app', {
+    entityAdd: trail('entity.add', {
+      blaze: noop,
+      input: z.object({ name: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+    }),
+  });
+
+/** Insert keys in deliberately unsorted order to prove canonicalization. */
+const unsortedWorker = (): Record<string, unknown> =>
+  Object.fromEntries([
+    ['routes', ['b-route', 'a-route']],
+    ['name', 'edge'],
+  ]);
+
+const cloudflareOverlay: TopoGraphOverlayRegistration = {
+  derive: () => ({
+    workers: [unsortedWorker()],
+  }),
+  namespace: 'cloudflare',
+  schema: z.object({
+    workers: z.array(
+      z.object({ name: z.string(), routes: z.array(z.string()) })
+    ),
+  }),
+};
+
+const zetaOverlay: TopoGraphOverlayRegistration = {
+  derive: (tp) => ({ trailCount: tp.trails.size }),
+  namespace: 'zeta.family',
+  schema: z.object({ trailCount: z.number().int() }),
+};
+
+const graphWithoutGeneratedAt = (
+  graph: ReturnType<typeof deriveTopoGraph>
+): TopoGraph => {
+  const { generatedAt: _unused, ...rest } = graph;
+  return rest;
+};
+
+const lockFor = (graph: TopoGraph): TrailsLock =>
+  trailsLockSchema.parse({
+    scope: { app: 'overlays-app' },
+    summary: { contours: 0, resources: 0, signals: 0, trails: 1 },
+    topoGraph: graph,
+    topoGraphHash: deriveTopoGraphHash(graph),
+    version: TRAILS_LOCK_SCHEMA_VERSION,
+  });
+
+const captureValidationError = (attempt: () => unknown): ValidationError => {
+  try {
+    attempt();
+  } catch (error) {
+    expect(error).toBeInstanceOf(ValidationError);
+    return error as ValidationError;
+  }
+  throw new Error('Expected a ValidationError');
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('topo graph overlays', () => {
+  describe('back-compat', () => {
+    test('deriveTopoGraph without registrations omits the overlays key', () => {
+      const graph = deriveTopoGraph(buildApp());
+      expect(Object.hasOwn(graph, 'overlays')).toBe(false);
+    });
+
+    test('collectTopoGraphOverlays returns undefined for missing or empty registrations', () => {
+      const app = buildApp();
+      // oxlint-disable-next-line no-useless-undefined -- exercising the explicit-undefined registrations path
+      expect(collectTopoGraphOverlays(app, undefined)).toBeUndefined();
+      expect(collectTopoGraphOverlays(app, [])).toBeUndefined();
+    });
+
+    test('a serialized graph without overlays still parses via topoGraphSchema and trailsLockSchema', () => {
+      const graph = graphWithoutGeneratedAt(deriveTopoGraph(buildApp()));
+      const graphBytes = JSON.stringify(graph);
+
+      const graphResult = topoGraphSchema.safeParse(JSON.parse(graphBytes));
+      expect(graphResult.success).toBe(true);
+
+      const lockBytes = JSON.stringify(lockFor(graph));
+      const lockResult = trailsLockSchema.safeParse(JSON.parse(lockBytes));
+      expect(lockResult.success).toBe(true);
+    });
+  });
+
+  describe('registration', () => {
+    test('embeds schema-parsed, deep-key-sorted facts under the namespace', () => {
+      const graph = deriveTopoGraph(buildApp(), {
+        overlays: [cloudflareOverlay],
+      });
+
+      expect(graph.overlays).toEqual({
+        cloudflare: {
+          workers: [{ name: 'edge', routes: ['b-route', 'a-route'] }],
+        },
+      });
+      // Deep key-sort: object keys serialize sorted, array order is preserved.
+      expect(JSON.stringify(graph.overlays?.['cloudflare'])).toBe(
+        '{"workers":[{"name":"edge","routes":["b-route","a-route"]}]}'
+      );
+    });
+
+    test('assembles namespaces sorted lexicographically regardless of registration order', () => {
+      const graph = deriveTopoGraph(buildApp(), {
+        overlays: [zetaOverlay, cloudflareOverlay],
+      });
+
+      expect(Object.keys(graph.overlays ?? {})).toEqual([
+        'cloudflare',
+        'zeta.family',
+      ]);
+      expect(graph.overlays?.['zeta.family']).toEqual({ trailCount: 1 });
+    });
+  });
+
+  describe('determinism', () => {
+    test('consecutive derivations produce equal hashes', () => {
+      const first = deriveTopoGraph(buildApp(), {
+        overlays: [cloudflareOverlay],
+      });
+      const second = deriveTopoGraph(buildApp(), {
+        overlays: [cloudflareOverlay],
+      });
+      expect(deriveTopoGraphHash(first)).toBe(deriveTopoGraphHash(second));
+    });
+
+    test('the canonical hash covers overlays', () => {
+      const without = deriveTopoGraph(buildApp());
+      const withOverlays = deriveTopoGraph(buildApp(), {
+        overlays: [cloudflareOverlay],
+      });
+      expect(deriveTopoGraphHash(withOverlays)).not.toBe(
+        deriveTopoGraphHash(without)
+      );
+    });
+
+    test('the hash is stable across a JSON round-trip', () => {
+      const graph = deriveTopoGraph(buildApp(), {
+        overlays: [cloudflareOverlay],
+      });
+      const graphBytes = JSON.stringify(graph);
+      const roundTripped = JSON.parse(graphBytes) as TopoGraph;
+      expect(deriveTopoGraphHash(roundTripped)).toBe(
+        deriveTopoGraphHash(graph)
+      );
+    });
+  });
+
+  describe('tolerant reader', () => {
+    test('an unregistered namespace round-trips byte-preserved and hash-stable through trailsLockSchema', () => {
+      const graphWithUnknown: TopoGraph = {
+        ...graphWithoutGeneratedAt(deriveTopoGraph(buildApp())),
+        overlays: { 'future.family': { anything: [1, 2, 3] } },
+      };
+
+      // Parse once to obtain canonical bytes in zod's shape order, then
+      // assert parse(stringify(parse(x))) is byte-stable.
+      const first = lockFor(graphWithUnknown);
+      const canonicalBytes = JSON.stringify(first);
+      const second = trailsLockSchema.parse(JSON.parse(canonicalBytes));
+
+      expect(JSON.stringify(second)).toBe(canonicalBytes);
+      expect(second.topoGraph.overlays).toEqual({
+        'future.family': { anything: [1, 2, 3] },
+      });
+      expect(deriveTopoGraphHash(second.topoGraph as TopoGraph)).toBe(
+        deriveTopoGraphHash(graphWithUnknown)
+      );
+    });
+  });
+
+  describe('failure modes', () => {
+    test('a namespace outside the dotted-kebab grammar throws with compile guidance', () => {
+      const error = captureValidationError(() =>
+        deriveTopoGraph(buildApp(), {
+          overlays: [{ ...cloudflareOverlay, namespace: 'Bad.Namespace' }],
+        })
+      );
+      expect(error.message).toContain('Bad.Namespace');
+      expect(error.message).toContain('trails compile');
+      expect(error.message).not.toMatch(/lock/i);
+    });
+
+    test('duplicate namespaces throw with compile guidance', () => {
+      const error = captureValidationError(() =>
+        deriveTopoGraph(buildApp(), {
+          overlays: [cloudflareOverlay, cloudflareOverlay],
+        })
+      );
+      expect(error.message).toContain('Duplicate overlay namespace');
+      expect(error.message).toContain('"cloudflare"');
+      expect(error.message).toContain('trails compile');
+      expect(error.message).not.toMatch(/lock/i);
+    });
+
+    test('derive output that fails the registered schema throws with the issue summary', () => {
+      const error = captureValidationError(() =>
+        deriveTopoGraph(buildApp(), {
+          overlays: [
+            {
+              derive: () => ({ trailCount: 'not-a-number' }),
+              namespace: 'zeta.family',
+              schema: z.object({ trailCount: z.number() }),
+            },
+          ],
+        })
+      );
+      expect(error.message).toContain('zeta.family');
+      expect(error.message).toContain('trailCount');
+      expect(error.message).toContain('trails compile');
+      expect(error.message).not.toMatch(/lock/i);
+    });
+
+    test('non-JSON-serializable derive output throws with compile guidance', () => {
+      const circular: Record<string, unknown> = {};
+      circular['self'] = circular;
+      const error = captureValidationError(() =>
+        deriveTopoGraph(buildApp(), {
+          overlays: [
+            {
+              derive: () => circular,
+              namespace: 'circular-ns',
+              schema: z.unknown(),
+            },
+          ],
+        })
+      );
+      expect(error.message).toContain('circular-ns');
+      expect(error.message).toContain('trails compile');
+      expect(error.message).not.toMatch(/lock/i);
+    });
+  });
+
+  describe('store parity', () => {
+    let tmpRoot: string | undefined;
+    let testStateHome: string | undefined;
+    let originalTrailsStateHome: string | undefined;
+
+    beforeEach(() => {
+      originalTrailsStateHome = process.env['TRAILS_STATE_HOME'];
+      testStateHome = mkdtempSync(join(tmpdir(), 'overlays-store-state-'));
+      process.env['TRAILS_STATE_HOME'] = testStateHome;
+    });
+
+    afterEach(() => {
+      if (originalTrailsStateHome === undefined) {
+        delete process.env['TRAILS_STATE_HOME'];
+      } else {
+        process.env['TRAILS_STATE_HOME'] = originalTrailsStateHome;
+      }
+      if (tmpRoot) {
+        rmSync(tmpRoot, { force: true, recursive: true });
+        tmpRoot = undefined;
+      }
+      if (testStateHome) {
+        rmSync(testStateHome, { force: true, recursive: true });
+        testStateHome = undefined;
+      }
+    });
+
+    test('the stored export embeds the same overlays and hash as a fresh derivation', () => {
+      tmpRoot = mkdtempSync(join(tmpdir(), 'overlays-store-'));
+      const db = openWriteTrailsDb({ rootDir: tmpRoot });
+      try {
+        const created = createStoredTopoSnapshot(db, buildApp(), {
+          createdAt: '2026-07-05T00:00:00.000Z',
+          overlays: [zetaOverlay, cloudflareOverlay],
+        });
+        if (created.isErr()) {
+          throw created.error;
+        }
+
+        const stored = getStoredTopoExport(db, created.value.id);
+        if (stored === undefined) {
+          throw new Error('Expected a stored topo export');
+        }
+
+        const storedGraph = JSON.parse(stored.topoGraphJson) as TopoGraph;
+        const derived = deriveTopoGraph(buildApp(), {
+          overlays: [zetaOverlay, cloudflareOverlay],
+        });
+
+        expect(storedGraph.overlays).toEqual({
+          cloudflare: {
+            workers: [{ name: 'edge', routes: ['b-route', 'a-route'] }],
+          },
+          'zeta.family': { trailCount: 1 },
+        });
+        expect(storedGraph.overlays).toEqual(derived.overlays ?? {});
+        expect(stored.topoGraphHash).toBe(deriveTopoGraphHash(storedGraph));
+        expect(stored.topoGraphHash).toBe(deriveTopoGraphHash(derived));
+      } finally {
+        db.close();
+      }
+    });
+  });
+});

--- a/packages/topographer/src/__tests__/source-fingerprint.test.ts
+++ b/packages/topographer/src/__tests__/source-fingerprint.test.ts
@@ -5,10 +5,10 @@ import { join } from 'node:path';
 
 import { deriveSourceFingerprint } from '../source-fingerprint.js';
 
-const withFixtureDir = (probe: (dir: string) => void): void => {
+const withFixtureDir = (exercise: (dir: string) => void): void => {
   const dir = mkdtempSync(join(tmpdir(), 'source-fingerprint-'));
   try {
-    probe(dir);
+    exercise(dir);
   } finally {
     rmSync(dir, { force: true, recursive: true });
   }

--- a/packages/topographer/src/derive.ts
+++ b/packages/topographer/src/derive.ts
@@ -31,6 +31,7 @@ import type {
 import { addPermitRequirement } from './permit.js';
 import { deriveStableHash } from './hash.js';
 import { collectLibraryProjection } from './library-projection.js';
+import { collectTopoGraphOverlays } from './overlays.js';
 import { TOPO_GRAPH_SCHEMA_VERSION } from './types.js';
 import { projectTrailVersions } from './versioning.js';
 import type {
@@ -734,6 +735,7 @@ export const deriveTopoGraph = (
   const activationSources = collectActivationSourceCatalog(topo);
   const activationEdges = collectActivationGraphEdges(topo);
   const trailheads = collectTrailheads(topo, options);
+  const overlays = collectTopoGraphOverlays(topo, options?.overlays);
   const library = collectLibraryProjection(topo);
 
   return {
@@ -743,6 +745,7 @@ export const deriveTopoGraph = (
     ),
     entries: sorted,
     ...(trailheads === undefined ? {} : { trailheads }),
+    ...(overlays === undefined ? {} : { overlays }),
     generatedAt: new Date().toISOString(),
     library,
     topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,

--- a/packages/topographer/src/index.ts
+++ b/packages/topographer/src/index.ts
@@ -19,6 +19,7 @@ export type {
   TrailActivationReport,
 } from './activation-report.js';
 export { deriveTopoGraphHash } from './hash.js';
+export { collectTopoGraphOverlays } from './overlays.js';
 export { deriveSourceFingerprint } from './source-fingerprint.js';
 export { deriveTopoGraphDiff } from './diff.js';
 export {
@@ -100,6 +101,8 @@ export type {
   TopoGraphLibraryExportSource,
   TopoGraphLibraryProjection,
   TopoGraphLayerReference,
+  TopoGraphOverlayRegistration,
+  TopoGraphOverlays,
   DeriveTopoGraphOptions,
   TopoGraphVersionDetour,
   TopoGraphVersionEntry,

--- a/packages/topographer/src/internal/topo-snapshots.ts
+++ b/packages/topographer/src/internal/topo-snapshots.ts
@@ -3,6 +3,8 @@ import type { Database, SQLQueryBindings } from 'bun:sqlite';
 import { ensureSubsystemSchema } from '@ontrails/core';
 import type { CliCommandAliasInput } from '@ontrails/core';
 
+import type { TopoGraphOverlayRegistration } from '../types.js';
+
 const TOPO_SUBSYSTEM = 'topo';
 const TOPO_TABLE_STATEMENTS = [
   `CREATE TABLE IF NOT EXISTS topo_snapshots (
@@ -211,6 +213,7 @@ export interface CreateTopoSnapshotInput {
   readonly gitSha?: string;
   readonly id?: string;
   readonly resourceCount?: number;
+  readonly overlays?: readonly TopoGraphOverlayRegistration[] | undefined;
   readonly signalCount?: number;
   readonly sourceFingerprint?: string;
   readonly trailCount?: number;

--- a/packages/topographer/src/internal/topo-store.ts
+++ b/packages/topographer/src/internal/topo-store.ts
@@ -29,6 +29,7 @@ import type {
 
 import { addPermitRequirement } from '../permit.js';
 import { collectLibraryProjection } from '../library-projection.js';
+import { collectTopoGraphOverlays } from '../overlays.js';
 import { deriveStableHash } from '../hash.js';
 import { TOPO_GRAPH_SCHEMA_VERSION } from '../types.js';
 import { projectTrailVersions } from '../versioning.js';
@@ -37,6 +38,7 @@ import type {
   TopoGraphFieldOverride,
   TopoGraphFieldOverrideKey,
   TopoGraphLibraryProjection,
+  TopoGraphOverlays,
 } from '../types.js';
 import type {
   CreateTopoSnapshotInput,
@@ -60,6 +62,7 @@ type TopoGraphRecord = Readonly<{
   readonly entries: readonly TopoGraphEntryRecord[];
   readonly generatedAt: string;
   readonly library: TopoGraphLibraryProjection;
+  readonly overlays?: TopoGraphOverlays | undefined;
   readonly topoGraphSchemaVersion: typeof TOPO_GRAPH_SCHEMA_VERSION;
 }>;
 
@@ -1248,8 +1251,9 @@ const buildTopoGraph = (
     }>
   >,
   trails: readonly AnyTrail[],
-  options?: Pick<CreateTopoSnapshotInput, 'cliAliases'> | undefined
+  options?: Pick<CreateTopoSnapshotInput, 'cliAliases' | 'overlays'> | undefined
 ): TopoGraphRecord => {
+  const overlays = collectTopoGraphOverlays(topo, options?.overlays);
   const signalRelations = collectSignalGraphRelations(signals, trails);
   const activationSources = collectActivationSourceCatalog(trails);
   const activationEdges = collectActivationGraphEdges(trails);
@@ -1284,6 +1288,7 @@ const buildTopoGraph = (
     entries,
     generatedAt,
     library: collectLibraryProjection(topo),
+    ...(overlays === undefined ? {} : { overlays }),
     topoGraphSchemaVersion: TOPO_GRAPH_SCHEMA_VERSION,
   };
 };
@@ -1321,7 +1326,7 @@ const buildStoredTopoExport = (
   db: Database,
   snapshot: TopoSnapshot,
   topo: Topo,
-  options?: Pick<CreateTopoSnapshotInput, 'cliAliases'> | undefined
+  options?: Pick<CreateTopoSnapshotInput, 'cliAliases' | 'overlays'> | undefined
 ): MaterializedTopoArtifacts => {
   const contours = topo
     .listContours()

--- a/packages/topographer/src/overlays.ts
+++ b/packages/topographer/src/overlays.ts
@@ -1,0 +1,136 @@
+/**
+ * Namespaced overlay collection for topo graphs.
+ *
+ * Both derivation pipelines — `deriveTopoGraph` and the store-side
+ * `buildTopoGraph` — consume overlay registrations through this single
+ * collection path so compiled locks and fresh derivations cannot diverge.
+ */
+
+import { ValidationError } from '@ontrails/core';
+import type { Topo } from '@ontrails/core';
+
+import type {
+  TopoGraphOverlayRegistration,
+  TopoGraphOverlays,
+} from './types.js';
+
+const OVERLAY_NAMESPACE_PATTERN = /^[a-z][a-z0-9-]*(\.[a-z0-9-]+)*$/u;
+
+const DERIVE_REMEDIATION =
+  "Fix the contribution's derive output and rerun `trails compile`.";
+
+/** Sort object keys recursively for deterministic overlay serialization. */
+const deepSortKeys = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(deepSortKeys);
+  }
+  if (value !== null && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).toSorted()) {
+      sorted[key] = deepSortKeys((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+};
+
+const summarizeIssuePath = (path: readonly PropertyKey[]): string =>
+  path.length === 0 ? '(root)' : path.map(String).join('.');
+
+/**
+ * Canonicalize schema-parsed facts into JSON-plain, deterministically ordered
+ * data: a JSON round-trip strips non-JSON residue, then a deep key-sort makes
+ * serialization order stable.
+ */
+const canonicalizeOverlayFacts = (
+  namespace: string,
+  parsed: unknown
+): unknown => {
+  let serialized: string | undefined;
+  try {
+    serialized = JSON.stringify(parsed);
+  } catch {
+    serialized = undefined;
+  }
+  if (serialized === undefined) {
+    throw new ValidationError(
+      `Overlay namespace "${namespace}" derived facts are not JSON-serializable. ${DERIVE_REMEDIATION}`
+    );
+  }
+  return deepSortKeys(JSON.parse(serialized));
+};
+
+const assertValidNamespace = (namespace: string): void => {
+  if (!OVERLAY_NAMESPACE_PATTERN.test(namespace)) {
+    throw new ValidationError(
+      `Overlay namespace "${namespace}" must be dotted kebab-case (matching ${OVERLAY_NAMESPACE_PATTERN.source}). Fix the contribution's namespace and rerun \`trails compile\`.`
+    );
+  }
+};
+
+const deriveOverlayFacts = (
+  topo: Topo,
+  registration: TopoGraphOverlayRegistration
+): unknown => {
+  const derived = registration.derive(topo);
+  const parsed = registration.schema.safeParse(derived);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((issue) => `${summarizeIssuePath(issue.path)}: ${issue.message}`)
+      .join('; ');
+    throw new ValidationError(
+      `Overlay namespace "${registration.namespace}" derived facts failed schema validation (${issues}). ${DERIVE_REMEDIATION}`
+    );
+  }
+  return canonicalizeOverlayFacts(registration.namespace, parsed.data);
+};
+
+/**
+ * Collect namespaced fact overlays from overlay registrations.
+ *
+ * Each registration owns one dotted-kebab namespace; its derived facts are
+ * validated against the registration's schema, canonicalized into JSON-plain
+ * deep-key-sorted data, and assembled with namespaces sorted
+ * lexicographically. Returns `undefined` when no registrations are supplied
+ * so graphs without overlays stay byte-identical to pre-overlays locks.
+ *
+ * @example
+ * ```ts
+ * const overlays = collectTopoGraphOverlays(app, [
+ *   {
+ *     derive: (topo) => ({ trailCount: topo.trails.size }),
+ *     namespace: 'cloudflare',
+ *     schema: z.object({ trailCount: z.number() }),
+ *   },
+ * ]);
+ * // => { cloudflare: { trailCount: 3 } }
+ * ```
+ */
+export const collectTopoGraphOverlays = (
+  topo: Topo,
+  registrations: readonly TopoGraphOverlayRegistration[] | undefined
+): TopoGraphOverlays | undefined => {
+  if (registrations === undefined || registrations.length === 0) {
+    return undefined;
+  }
+
+  const collected = new Map<string, unknown>();
+  for (const registration of registrations) {
+    assertValidNamespace(registration.namespace);
+    if (collected.has(registration.namespace)) {
+      throw new ValidationError(
+        `Duplicate overlay namespace "${registration.namespace}". Each contribution owns one namespace; remove the duplicate registration and rerun \`trails compile\`.`
+      );
+    }
+    collected.set(
+      registration.namespace,
+      deriveOverlayFacts(topo, registration)
+    );
+  }
+
+  const overlays: Record<string, unknown> = {};
+  for (const namespace of [...collected.keys()].toSorted()) {
+    overlays[namespace] = collected.get(namespace);
+  }
+  return overlays;
+};

--- a/packages/topographer/src/types.ts
+++ b/packages/topographer/src/types.ts
@@ -7,6 +7,7 @@ import type {
   CliCommandRoute,
   StructuredSignalExample,
   StructuredTrailExample,
+  Topo,
   TrailVersionStatus,
 } from '@ontrails/core';
 import { z } from 'zod';
@@ -193,6 +194,27 @@ export interface TopoGraphLibraryProjection {
 // TopoGraph
 // ---------------------------------------------------------------------------
 
+/**
+ * Namespaced fact overlays embedded on a topo graph, keyed by contribution
+ * namespace. Values are overlay-owned JSON-plain facts; readers that do not
+ * recognize a namespace preserve it verbatim.
+ */
+export type TopoGraphOverlays = Readonly<Record<string, unknown>>;
+
+/**
+ * A namespaced overlay contribution consumed by the topo graph derivers as
+ * data. Each registration owns one namespace and supplies the schema its
+ * derived facts must satisfy before they enter the graph.
+ */
+export interface TopoGraphOverlayRegistration {
+  /** Unique dotted-kebab namespace, e.g. "cloudflare" or "cloudflare.workers". */
+  readonly namespace: string;
+  /** Zod schema the derived facts must satisfy before they enter the graph. */
+  readonly schema: z.ZodType;
+  /** Derive the namespace's facts from the topo. Must be deterministic. */
+  readonly derive: (topo: Topo) => unknown;
+}
+
 export interface TopoGraphEntry {
   readonly id: string;
   readonly kind: 'contour' | 'trail' | 'signal' | 'resource';
@@ -262,6 +284,12 @@ export interface TopoGraph {
   readonly trailheads?: readonly TopoGraphTrailheadEntry[] | undefined;
   readonly forces?: readonly TopoGraphForceEntry[] | undefined;
   readonly library?: TopoGraphLibraryProjection | undefined;
+  /**
+   * Namespaced fact overlays contributed by registered overlay contributions
+   * (adapters). Unknown namespaces are preserved verbatim by every reader
+   * (tolerant reader) and covered by the canonical graph hash.
+   */
+  readonly overlays?: TopoGraphOverlays | undefined;
   readonly workspace?: WorkspaceTopoMetadata | undefined;
 }
 
@@ -269,6 +297,7 @@ export interface DeriveTopoGraphOptions {
   readonly cliAliases?:
     | Readonly<Record<string, readonly CliCommandAliasInput[]>>
     | undefined;
+  readonly overlays?: readonly TopoGraphOverlayRegistration[] | undefined;
   readonly trailheads?: readonly TopoGraphTrailheadDeclaration[] | undefined;
 }
 
@@ -420,6 +449,7 @@ export const topoGraphSchema = z
     forces: z.array(topoGraphForceEntrySchema).optional(),
     generatedAt: z.string().optional(),
     library: topoGraphLibraryProjectionSchema.optional(),
+    overlays: z.record(z.string(), z.unknown()).optional(),
     topoGraphSchemaVersion: z.literal(TOPO_GRAPH_SCHEMA_VERSION),
     trailheads: z.array(topoGraphTrailheadEntrySchema).optional(),
     workspace: workspaceTopoMetadataSchema.optional(),

--- a/scripts/vocab-cutover-map.ts
+++ b/scripts/vocab-cutover-map.ts
@@ -195,11 +195,11 @@ const topographArtifactFamilyRetiredMatches = [
   { line: 228, path: 'apps/trails/src/__tests__/create.test.ts' },
   // The topo-store migration and fixture must name pre-v12 columns exactly.
   {
-    line: 361,
+    line: 364,
     path: 'packages/topographer/src/internal/topo-snapshots.ts',
   },
   {
-    line: 371,
+    line: 374,
     path: 'packages/topographer/src/internal/topo-snapshots.ts',
   },
   {


### PR DESCRIPTION
Part 1/4 of the TRL-1199 lock-extensibility stack ([TRL-1199](https://linear.app/outfitter/issue/TRL-1199/lock-extensibility-namespaced-fact-sections-with-elevated-schemas), milestones 1–3).

The topo graph gains ONE namespaced-sections extension point: `DeriveTopoGraphOptions.sections` accepts registrations (namespace + zod schema + derive function) as data; `collectTopoGraphSections` validates derive output against the elevated schema, canonicalizes it (JSON round-trip + deep key sort), and embeds it as `sections.<namespace>`. Both derivation pipelines (fresh `deriveTopoGraph` and the store's `buildTopoGraph`) share the one collector, so compiled and freshly derived graphs cannot hash-diverge.

- **Determinism inherited:** the canonical hash covers sections generically (no sections-specific hash code); the `sections` key is omitted when empty so pre-sections locks recompile byte-identical.
- **Tolerant reader:** `sections` parses as `z.record(z.string(), z.unknown())` inside the still-strict graph schema — unknown namespaces round-trip byte-preserved and hash-stable (test injects an unregistered `future.family` section: parse succeeds, bytes preserved, hash stable).
- **Diagnostics doctrine:** every new failure mode (bad namespace grammar, duplicate namespace, schema-mismatch, non-JSON facts) names the fix and `trails compile`; hand-editing the lock is never a remediation.
- Second commit is a clearly-labeled mechanical fix: the vocab audit's line-pinned allowances had drifted on main (audit was failing there); repinned and renamed two stray `run:` callback params.

13 new tests in `sections.test.ts` incl. store/fresh hash parity and the unknown-namespace round-trip. Changeset: `@ontrails/topographer` minor.