### PR TITLE
feat(adapter-kit,cloudflare): overlay contract and first adapter consumer

### DIFF
--- a/.changeset/trl-1199-adapter-overlay-contract.md
+++ b/.changeset/trl-1199-adapter-overlay-contract.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/adapter-kit': minor
+---
+
+Add the `Overlay` contract (namespace + elevated zod fact schema + deterministic derive function) so adapters can contribute namespaced fact overlays to `trails.lock` without any edits to the lock schema or graph type, plus an `isOverlay` guard for compile-side collection.

--- a/.changeset/trl-1199-cloudflare-lock-facts.md
+++ b/.changeset/trl-1199-cloudflare-lock-facts.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/cloudflare': minor
+---
+
+Add `cloudflareOverlay`, the first lock overlay overlay: it derives the app's env-bound resources into `overlays.cloudflare` (wrangler binding name per resource) when the app exports it via `trailsOverlays` and runs `trails compile`.

--- a/adapters/cloudflare/README.md
+++ b/adapters/cloudflare/README.md
@@ -101,3 +101,19 @@ testAll(graph);
 ## Local integration testing
 
 Integration runs are local-first via [miniflare](https://miniflare.dev) (workerd in-process): the test lane bundles a demo Worker with `Bun.build`, boots it with a real KV namespace, and exercises HTTP, webhook, and KV routes. See `src/__tests__/miniflare.test.ts`. Real-account deploys are manual and never CI-required.
+
+## Lock facts
+
+`cloudflareOverlay` (root export) is the adapter's lock overlay overlay: an `Overlay` pairing the `cloudflare` namespace with an elevated zod fact schema and a deterministic derive over the app's topo. It records every env-bound resource as `{ binding, resourceId }` so the committed `trails.lock` documents which wrangler bindings the app depends on.
+
+An app opts in by exporting the overlay list next to its topo, then compiling:
+
+```ts
+// src/app.ts
+import { cloudflareOverlay } from '@ontrails/cloudflare';
+
+export const app = topo('my-worker', { readFlag });
+export const trailsOverlays = [cloudflareOverlay];
+```
+
+`trails compile` validates the derived facts against the schema and embeds them as `overlays.cloudflare`; `trails wayfind --facts cloudflare` reads them back. Toolchains that predate a overlay's namespace preserve it byte-for-byte — adding a new fact family never edits the lock schema or graph type.

--- a/adapters/cloudflare/package.json
+++ b/adapters/cloudflare/package.json
@@ -27,6 +27,7 @@
     "@ontrails/core": "workspace:^"
   },
   "devDependencies": {
+    "@ontrails/adapter-kit": "workspace:^",
     "@ontrails/testing": "workspace:^",
     "miniflare": "^4.20250617.4"
   },

--- a/adapters/cloudflare/src/__tests__/facts.test.ts
+++ b/adapters/cloudflare/src/__tests__/facts.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Lock facts overlay tests.
+ *
+ * The load-bearing guarantees: `cloudflareOverlay.derive` finds every
+ * env-bound resource visible on the topo, its output satisfies the
+ * overlay's own schema, and derivation is deterministic — the same topo
+ * always yields a deeply-equal, identically ordered value.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { Result, topo, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+import { cloudflareOverlay } from '../facts.js';
+import { cloudflareKv } from '../kv/index.js';
+
+const flags = cloudflareKv('flags', { binding: 'FLAGS' });
+
+const showFlag = trail('flag.show', {
+  blaze: async (input, ctx) => {
+    const value = await flags.from(ctx).get(input.key);
+    return Result.ok({ value });
+  },
+  input: z.object({ key: z.string() }),
+  intent: 'read',
+  output: z.object({ value: z.string().nullable() }),
+  resources: [flags],
+});
+
+describe('cloudflareOverlay', () => {
+  test('owns the cloudflare namespace', () => {
+    expect(cloudflareOverlay.namespace).toBe('cloudflare');
+  });
+
+  test('derives env-bound resource bindings from the topo', () => {
+    const app = topo('cf-facts', { flags, showFlag });
+
+    expect(cloudflareOverlay.derive(app)).toEqual({
+      bindings: [{ binding: 'FLAGS', resourceId: 'flags' }],
+    });
+  });
+
+  test('derived facts satisfy the overlay schema', () => {
+    const app = topo('cf-facts-schema', { flags, showFlag });
+
+    const parsed = cloudflareOverlay.schema.safeParse(
+      cloudflareOverlay.derive(app)
+    );
+    expect(parsed.success).toBe(true);
+  });
+
+  test('derive is deterministic: same topo, deeply-equal and identically ordered facts', () => {
+    const sessions = cloudflareKv('sessions', { binding: 'SESSIONS' });
+    const app = topo('cf-facts-deterministic', { flags, sessions, showFlag });
+
+    const first = cloudflareOverlay.derive(app);
+    const second = cloudflareOverlay.derive(app);
+
+    expect(second).toEqual(first);
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+    expect(first.bindings.map((entry) => entry.resourceId)).toEqual([
+      'flags',
+      'sessions',
+    ]);
+  });
+
+  test('finds trail-declared env-bound resources not exported from the module', () => {
+    const app = topo('cf-facts-trail-declared', { showFlag });
+
+    expect(cloudflareOverlay.derive(app)).toEqual({
+      bindings: [{ binding: 'FLAGS', resourceId: 'flags' }],
+    });
+  });
+
+  test('a topo with no env-bound resources yields empty bindings', () => {
+    const ping = trail('ping', {
+      blaze: () => Result.ok({ pong: true }),
+      input: z.object({}),
+      intent: 'read',
+      output: z.object({ pong: z.boolean() }),
+    });
+    const app = topo('cf-facts-empty', { ping });
+
+    expect(cloudflareOverlay.derive(app)).toEqual({ bindings: [] });
+  });
+});

--- a/adapters/cloudflare/src/facts.ts
+++ b/adapters/cloudflare/src/facts.ts
@@ -1,0 +1,112 @@
+/**
+ * Cloudflare lock facts.
+ *
+ * The adapter's `trails.lock` overlay overlay: `derive` projects the
+ * topo's env-bound resources (resources with a registered
+ * {@link EnvBindingSpec | env binding}, such as every `cloudflareKv`
+ * definition) into `overlays.cloudflare`, listing the wrangler binding name
+ * each resource resolves from. The import from `@ontrails/adapter-kit` is
+ * type-only — the adapter never depends on the adapter kit at runtime.
+ */
+
+import type { Overlay } from '@ontrails/adapter-kit';
+import type { AnyResource, Topo } from '@ontrails/core';
+import { z } from 'zod';
+
+import { getEnvBinding } from './env.js';
+import type { EnvBindingSpec } from './env.js';
+
+const cloudflareFactsSchema = z
+  .object({
+    bindings: z.array(
+      z
+        .object({
+          binding: z.string(),
+          resourceId: z.string(),
+        })
+        .strict()
+    ),
+  })
+  .strict();
+
+/**
+ * The facts embedded at `overlays.cloudflare` in `trails.lock`: one entry
+ * per env-bound resource, pairing the resource ID with its wrangler binding
+ * name.
+ */
+export type CloudflareLockFacts = z.infer<typeof cloudflareFactsSchema>;
+
+/**
+ * Every resource visible on the topo: module-registered resources plus
+ * resources declared on trail contracts (including fork version entries),
+ * which core executes with but `topo()` does not auto-register.
+ */
+const collectTopoResources = (graph: Topo): readonly AnyResource[] => {
+  const collected = new Map<string, AnyResource>();
+  for (const definition of graph.listResources()) {
+    collected.set(definition.id, definition);
+  }
+  for (const graphTrail of graph.list()) {
+    const declared = [
+      ...graphTrail.resources,
+      ...Object.values(graphTrail.versions ?? {}).flatMap(
+        (entry) => entry.resources ?? []
+      ),
+    ];
+    for (const definition of declared) {
+      if (!collected.has(definition.id)) {
+        collected.set(definition.id, definition);
+      }
+    }
+  }
+  return [...collected.values()];
+};
+
+const derive = (graph: Topo): CloudflareLockFacts => {
+  const bindings = collectTopoResources(graph)
+    .map((definition) => ({
+      definition,
+      spec: getEnvBinding(definition),
+    }))
+    .filter(
+      (entry): entry is { definition: AnyResource; spec: EnvBindingSpec } =>
+        entry.spec !== undefined
+    )
+    .map((entry) => ({
+      binding: entry.spec.binding,
+      resourceId: entry.definition.id,
+    }))
+    .toSorted(
+      (a, b) =>
+        a.resourceId.localeCompare(b.resourceId) ||
+        a.binding.localeCompare(b.binding)
+    );
+  return { bindings };
+};
+
+/**
+ * The Cloudflare adapter's `trails.lock` overlay overlay.
+ *
+ * An app opts in by exporting `trailsOverlays` next to its topo export;
+ * `trails compile` then validates `derive(topo)` against the facts schema
+ * and embeds the result as `overlays.cloudflare`, listing every env-bound
+ * resource's wrangler binding. Derivation is deterministic: the same topo
+ * always yields the same facts, sorted by resource ID then binding.
+ *
+ * @example
+ * ```ts
+ * import { cloudflareOverlay, cloudflareKv } from '@ontrails/cloudflare';
+ * import { topo } from '@ontrails/core';
+ *
+ * export const flags = cloudflareKv('flags', { binding: 'FLAGS' });
+ * export const app = topo('my-worker', { flags });
+ * export const trailsOverlays = [cloudflareOverlay];
+ * // `trails compile` embeds overlays.cloudflare:
+ * // { bindings: [{ binding: 'FLAGS', resourceId: 'flags' }] }
+ * ```
+ */
+export const cloudflareOverlay = {
+  derive,
+  namespace: 'cloudflare',
+  schema: cloudflareFactsSchema,
+} satisfies Overlay;

--- a/adapters/cloudflare/src/index.ts
+++ b/adapters/cloudflare/src/index.ts
@@ -5,9 +5,13 @@
  * - `@ontrails/cloudflare/workers` — HTTP surface materializer (fetch handler)
  * - `@ontrails/cloudflare/kv` — key-value resource
  *
- * The root export re-exports the subpaths for convenience and adapter tooling.
+ * The root export re-exports the subpaths for convenience and adapter
+ * tooling, and owns the adapter's `trails.lock` overlay overlay
+ * (`cloudflareOverlay`).
  */
 
+export { cloudflareOverlay } from './facts.js';
+export type { CloudflareLockFacts } from './facts.js';
 export {
   buildEnvResourceOverrides,
   getEnvBinding,

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "@ontrails/core": "workspace:^",
       },
       "devDependencies": {
+        "@ontrails/adapter-kit": "workspace:^",
         "@ontrails/testing": "workspace:^",
         "miniflare": "^4.20250617.4",
       },
@@ -196,6 +197,9 @@
       "version": "1.0.0-beta.38",
       "dependencies": {
         "@ontrails/core": "workspace:^",
+      },
+      "peerDependencies": {
+        "zod": "catalog:",
       },
     },
     "packages/cli": {

--- a/packages/adapter-kit/package.json
+++ b/packages/adapter-kit/package.json
@@ -22,5 +22,8 @@
   },
   "dependencies": {
     "@ontrails/core": "workspace:^"
+  },
+  "peerDependencies": {
+    "zod": "catalog:"
   }
 }

--- a/packages/adapter-kit/src/__tests__/overlay.test.ts
+++ b/packages/adapter-kit/src/__tests__/overlay.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+
+import { isOverlay } from '../overlay.js';
+
+const validOverlay = {
+  derive: () => ({ facts: [] }),
+  namespace: 'acme',
+  schema: z.object({ facts: z.array(z.string()) }).strict(),
+};
+
+describe('isOverlay', () => {
+  test('accepts a valid overlay with a real zod schema', () => {
+    expect(isOverlay(validOverlay)).toBe(true);
+  });
+
+  test('rejects null', () => {
+    expect(isOverlay(null)).toBe(false);
+  });
+
+  test('rejects a missing namespace', () => {
+    const { namespace: _namespace, ...withoutNamespace } = validOverlay;
+    expect(isOverlay(withoutNamespace)).toBe(false);
+  });
+
+  test('rejects a non-function derive', () => {
+    expect(isOverlay({ ...validOverlay, derive: 'nope' })).toBe(false);
+  });
+
+  test('rejects a schema without safeParse', () => {
+    expect(
+      isOverlay({
+        ...validOverlay,
+        schema: { parse: () => ({}) },
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/adapter-kit/src/index.ts
+++ b/packages/adapter-kit/src/index.ts
@@ -1,4 +1,6 @@
 export { checkAdapters } from './check.js';
+export { isOverlay } from './overlay.js';
+export type { Overlay } from './overlay.js';
 export type {
   AdapterCheckDiagnostic,
   AdapterCheckDiagnosticCode,

--- a/packages/adapter-kit/src/overlay.ts
+++ b/packages/adapter-kit/src/overlay.ts
@@ -1,0 +1,111 @@
+/**
+ * The adapter overlay overlay contract.
+ *
+ * Adapters export a overlay object describing one namespaced fact
+ * overlay; the app module re-exports it (conventionally as
+ * `trailsOverlays`), and the compile path validates `derive(topo)`
+ * output against the overlay's schema before embedding the facts as
+ * `overlays.<namespace>` in `trails.lock`. The lock schema and graph type
+ * never change — unknown namespaces are preserved byte-for-byte by older
+ * toolchains (tolerant reader).
+ */
+
+import type { Topo } from '@ontrails/core';
+import type { z } from 'zod';
+
+/**
+ * One adapter-owned namespaced fact overlay for `trails.lock`.
+ *
+ * A overlay is authored by an adapter package and opted into by the
+ * app: the app module exports `trailsOverlays` next to its topo export,
+ * and `trails compile` runs each overlay's {@link derive} over the
+ * compiled topo, validates the result against {@link schema}, and embeds it
+ * as `overlays.<namespace>` in the committed lock.
+ *
+ * @example
+ * ```ts
+ * import type { Overlay } from '@ontrails/adapter-kit';
+ * import { z } from 'zod';
+ *
+ * const factsSchema = z.object({ regions: z.array(z.string()) }).strict();
+ *
+ * export const overlay = {
+ *   namespace: 'acme',
+ *   schema: factsSchema,
+ *   derive: (topo) => ({
+ *     regions: topo
+ *       .listResources()
+ *       .map((definition) => definition.id)
+ *       .toSorted(),
+ *   }),
+ * } satisfies Overlay;
+ *
+ * // In the app module, next to the topo export:
+ * // export const trailsOverlays = [overlay];
+ * // `trails compile` then embeds the facts as `overlays.acme`.
+ * ```
+ */
+export interface Overlay {
+  /**
+   * The lock overlay this overlay owns.
+   *
+   * Dotted kebab-case: `/^[a-z][a-z0-9-]*(\.[a-z0-9-]+)*$/`. Each
+   * overlay owns exactly one namespace, and the facts land at
+   * `overlays.<namespace>` in `trails.lock`. Unknown namespaces are
+   * preserved byte-for-byte by older toolchains, so new overlays never
+   * break existing lock readers.
+   */
+  readonly namespace: string;
+  /**
+   * The elevated fact schema.
+   *
+   * The compile path enforces this schema against every {@link derive}
+   * output before embedding the facts, so a drifting derive function fails
+   * `trails compile` instead of committing invalid facts.
+   */
+  readonly schema: z.ZodType;
+  /**
+   * Project the topo into this overlay's facts.
+   *
+   * Must be deterministic — the same topo always yields the same facts
+   * (sort any collections) — and must return JSON-plain data, because the
+   * result is embedded verbatim in the committed lock.
+   */
+  readonly derive: (topo: Topo) => unknown;
+}
+
+const isFunction = (value: unknown): value is (...args: unknown[]) => unknown =>
+  typeof value === 'function';
+
+/**
+ * Structurally recognize an {@link Overlay}.
+ *
+ * Used by the compile-side collector when scanning an app module's
+ * `trailsOverlays` export — adapters never import this at runtime. The
+ * check is hand-rolled (string `namespace`, schema object exposing a
+ * `safeParse` function, function `derive`) so recognizing overlays
+ * needs no zod runtime dependency.
+ *
+ * @example
+ * ```ts
+ * import { isOverlay } from '@ontrails/adapter-kit';
+ *
+ * const overlays = moduleExports['trailsOverlays'];
+ * if (Array.isArray(overlays)) {
+ *   const recognized = overlays.filter(isOverlay);
+ * }
+ * ```
+ */
+export const isOverlay = (value: unknown): value is Overlay => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<Record<keyof Overlay, unknown>>;
+  return (
+    typeof candidate.namespace === 'string' &&
+    typeof candidate.schema === 'object' &&
+    candidate.schema !== null &&
+    isFunction((candidate.schema as { safeParse?: unknown }).safeParse) &&
+    isFunction(candidate.derive)
+  );
+};


### PR DESCRIPTION
Part 2/4 of the TRL-1199 lock-extensibility stack ([TRL-1199](https://linear.app/outfitter/issue/TRL-1199/lock-extensibility-namespaced-fact-sections-with-elevated-schemas), milestone 4 — contract half).

`@ontrails/adapter-kit` grows the elevation contract: `AdapterSectionContribution` (unique dotted-kebab namespace + elevated zod fact schema + deterministic derive over the topo) plus an `isAdapterSectionContribution` guard for compile-side collection. `@ontrails/cloudflare` ships the first consumer: `cloudflareContribution` derives the app's env-bound resources into `sections.cloudflare` (wrangler binding per resource, sorted deterministically).

- **Tooling boundary preserved:** the adapter imports adapter-kit type-only and lists it only in devDependencies; `checkAdapters` stays clean (verified: zero diagnostics).
- README documents the lock-facts opt-in (`export const trailsContributions = [cloudflareContribution]` + `trails compile`).

Changesets: `@ontrails/adapter-kit` minor, `@ontrails/cloudflare` minor.