### PR TITLE
feat(trails): collect app-module overlays on the compile path

### DIFF
--- a/.changeset/trl-1199-compile-collection.md
+++ b/.changeset/trl-1199-compile-collection.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': minor
+---
+
+`trails compile` and `trails validate` now collect adapter overlay overlays from the app module's `trailsOverlays` export and embed the validated facts as `overlays.<namespace>` in `trails.lock`, threading the registrations through every derivation site so compiled and freshly derived graphs stay hash-identical.

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -46,6 +46,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@ontrails/cloudflare": "workspace:^",
     "@ontrails/testing": "workspace:^"
   }
 }

--- a/apps/trails/src/__tests__/lock-overlays-proof.test.ts
+++ b/apps/trails/src/__tests__/lock-overlays-proof.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, relative, resolve } from 'node:path';
+
+import { runLockRoundtripSmoke } from '../release/lock-roundtrip-smoke.js';
+import { compileTrail } from '../trails/compile.js';
+import { validateTrail } from '../trails/validate.js';
+
+const repoRoot = resolve(import.meta.dir, '../../../..');
+const fixtureParent = resolve(import.meta.dir, '../..', '.tmp-tests');
+
+let fixtureDir: string | undefined;
+let testStateHome: string | undefined;
+let originalTrailsStateHome: string | undefined;
+
+beforeEach(() => {
+  originalTrailsStateHome = process.env['TRAILS_STATE_HOME'];
+  testStateHome = mkdtempSync(join(tmpdir(), 'lock-overlays-state-'));
+  process.env['TRAILS_STATE_HOME'] = testStateHome;
+});
+
+afterEach(() => {
+  if (originalTrailsStateHome === undefined) {
+    delete process.env['TRAILS_STATE_HOME'];
+  } else {
+    process.env['TRAILS_STATE_HOME'] = originalTrailsStateHome;
+  }
+  if (testStateHome) {
+    rmSync(testStateHome, { force: true, recursive: true });
+    testStateHome = undefined;
+  }
+  if (fixtureDir) {
+    rmSync(fixtureDir, { force: true, recursive: true });
+    fixtureDir = undefined;
+  }
+});
+
+const writeFixtureApp = (dir: string): void => {
+  mkdirSync(join(dir, 'src'), { recursive: true });
+  writeFileSync(
+    join(dir, 'src', 'app.ts'),
+    `import { Result, topo, trail } from '@ontrails/core';
+import { cloudflareKv } from '@ontrails/cloudflare/kv';
+import { cloudflareOverlay } from '@ontrails/cloudflare';
+import { z } from 'zod';
+
+const flags = cloudflareKv('flags', { binding: 'FLAGS' });
+
+const readFlag = trail('flags.read', {
+  blaze: async () => Result.ok({ value: null }),
+  input: z.object({ key: z.string() }),
+  intent: 'read',
+  output: z.object({ value: z.string().nullable() }),
+  resources: [flags],
+});
+
+export const app = topo('lock-overlays-fixture', { flags, readFlag });
+export const trailsOverlays = [cloudflareOverlay];
+`
+  );
+};
+
+const compileFixture = async (dir: string): Promise<void> => {
+  const compiled = await compileTrail.blaze({ module: './src/app.ts' }, {
+    cwd: dir,
+  } as never);
+  if (compiled.isErr()) {
+    throw compiled.error;
+  }
+};
+
+const newFixtureDir = (): string => {
+  fixtureDir = join(
+    fixtureParent,
+    `lock-overlays-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  return fixtureDir;
+};
+
+const readLockOverlays = (dir: string): unknown => {
+  const lock = JSON.parse(readFileSync(join(dir, 'trails.lock'), 'utf8')) as {
+    readonly topoGraph?: { readonly overlays?: Record<string, unknown> };
+  };
+  return lock.topoGraph?.overlays;
+};
+
+describe('lock overlays proof (TRL-1199 compile-path collection)', () => {
+  test('a cloudflare-adapter app compiles real overlays into trails.lock, round-trips byte-identically, and validates green', async () => {
+    const dir = newFixtureDir();
+    writeFixtureApp(dir);
+
+    // (a) compile succeeds.
+    await compileFixture(dir);
+
+    // (b) the committed lock embeds the validated cloudflare facts.
+    const overlays = readLockOverlays(dir);
+    expect(overlays).toEqual({
+      cloudflare: {
+        bindings: [{ binding: 'FLAGS', resourceId: 'flags' }],
+      },
+    });
+
+    // (c) cold-store recompile is byte-identical.
+    const lockPath = relative(repoRoot, join(dir, 'trails.lock'));
+    const roundtrip = await runLockRoundtripSmoke({
+      lockPaths: [lockPath],
+      repoRoot,
+    });
+    expect(roundtrip.passed).toBe(true);
+    expect(roundtrip.message).toContain('byte-identical');
+
+    // (d) validate re-derives the same graph, overlays included.
+    const validated = await validateTrail.blaze({ module: './src/app.ts' }, {
+      cwd: dir,
+    } as never);
+    if (validated.isErr()) {
+      throw validated.error;
+    }
+    expect(validated.value.stale).toBe(false);
+
+    // (e) a second compile writes the exact same bytes.
+    const firstBytes = readFileSync(join(dir, 'trails.lock'), 'utf8');
+    await compileFixture(dir);
+    const secondBytes = readFileSync(join(dir, 'trails.lock'), 'utf8');
+    expect(secondBytes).toBe(firstBytes);
+  }, 120_000);
+});

--- a/apps/trails/src/trails/compile.ts
+++ b/apps/trails/src/trails/compile.ts
@@ -1,5 +1,6 @@
 import { trail } from '@ontrails/core';
 import type { CliCommandAliasInput, Result, Topo } from '@ontrails/core';
+import type { TopoGraphOverlayRegistration } from '@ontrails/topographer';
 import { z } from 'zod';
 
 import { withFreshOperatorApp } from './operator-context.js';
@@ -18,6 +19,7 @@ export const compileCurrentTopo = async (
       | undefined;
     readonly force?: boolean | undefined;
     readonly rootDir?: string;
+    readonly overlays?: readonly TopoGraphOverlayRegistration[] | undefined;
   }
 ): Promise<Result<TopoExportReport, Error>> => exportCurrentTopo(app, options);
 
@@ -38,6 +40,7 @@ export const compileTrail = trail('compile', {
       compileCurrentTopo(lease.app, {
         cliAliases: lease.cliAliases,
         force: input.force,
+        overlays: lease.overlays,
         rootDir,
       })
     ),

--- a/apps/trails/src/trails/guide.ts
+++ b/apps/trails/src/trails/guide.ts
@@ -55,6 +55,7 @@ export const guideTrail = trail('guide', {
       if (input.trailId) {
         const detail = deriveCurrentTopoDetail(lease.app, input.trailId, {
           cliAliases: lease.cliAliases,
+          overlays: lease.overlays,
           rootDir,
           surfaceLayerNames: readSurfaceLayerNamesFromContext(ctx),
         });

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -25,6 +25,8 @@ import {
   ValidationError,
 } from '@ontrails/core';
 import type { CliCommandAliasInput, Topo } from '@ontrails/core';
+import { isOverlay } from '@ontrails/adapter-kit';
+import type { TopoGraphOverlayRegistration } from '@ontrails/topographer';
 import { findAppModule } from '@ontrails/cli';
 
 import {
@@ -1046,11 +1048,29 @@ const resolveLoadedCliAliases = (
   return aliases as LoadedCliAliases;
 };
 
+const resolveLoadedOverlayRegistrations = (
+  effectivePath: string,
+  mod: Record<string, unknown>
+): readonly TopoGraphOverlayRegistration[] | undefined => {
+  const value = mod['trailsOverlays'];
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value) || !value.every(isOverlay)) {
+    throw new ValidationError(
+      `trailsOverlays export in "${effectivePath}" must be an array of adapter overlay overlays ({ namespace, schema, derive }). Fix the app module export and rerun \`trails compile\`.`
+    );
+  }
+
+  return value;
+};
+
 export interface FreshAppLease {
   readonly app: Topo;
   readonly cliAliases?: LoadedCliAliases | undefined;
   readonly mirrorRoot: string;
   readonly release: () => void;
+  readonly overlays?: readonly TopoGraphOverlayRegistration[] | undefined;
 }
 
 export type LoadAppLeaseOptions = LoadAppTrustOptions;
@@ -1073,6 +1093,7 @@ const createUrlSchemeLease = async (
     app: resolveLoadedTopo(effectivePath, mod),
     cliAliases: resolveLoadedCliAliases(effectivePath, mod),
     mirrorRoot: absolutePath,
+    overlays: resolveLoadedOverlayRegistrations(effectivePath, mod),
     release: noopRelease,
   };
 };
@@ -1095,6 +1116,7 @@ const createFilesystemLease = async (
       app: resolveLoadedTopo(effectivePath, mod),
       cliAliases: resolveLoadedCliAliases(effectivePath, mod),
       mirrorRoot,
+      overlays: resolveLoadedOverlayRegistrations(effectivePath, mod),
       release,
     };
   } catch (error) {

--- a/apps/trails/src/trails/survey.ts
+++ b/apps/trails/src/trails/survey.ts
@@ -15,7 +15,12 @@ import {
   trail,
   ValidationError,
 } from '@ontrails/core';
-import type { DiffEntry, DiffResult, TopoGraph } from '@ontrails/topographer';
+import type {
+  DiffEntry,
+  DiffResult,
+  TopoGraph,
+  TopoGraphOverlayRegistration,
+} from '@ontrails/topographer';
 import {
   createTopoStore,
   deriveTopoGraphDiff,
@@ -509,10 +514,12 @@ const buildSurveyLookup = (
   cliAliases:
     | Readonly<Record<string, readonly CliCommandAliasInput[]>>
     | undefined,
+  overlays: readonly TopoGraphOverlayRegistration[] | undefined,
   surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ): Result<object, Error> => {
   const matches = deriveCurrentTopoMatches(app, entityId, {
     cliAliases,
+    overlays,
     rootDir,
     surfaceLayerNames,
   });
@@ -526,10 +533,12 @@ const buildSurveyTrailDetail = (
   cliAliases:
     | Readonly<Record<string, readonly CliCommandAliasInput[]>>
     | undefined,
+  overlays: readonly TopoGraphOverlayRegistration[] | undefined,
   surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ): Result<object, Error> => {
   const detail = deriveCurrentTrailDetail(app, id, {
     cliAliases,
+    overlays,
     rootDir,
     surfaceLayerNames,
   });
@@ -584,12 +593,13 @@ type SurveyHandler = (
   cliAliases:
     | Readonly<Record<string, readonly CliCommandAliasInput[]>>
     | undefined,
+  overlays: readonly TopoGraphOverlayRegistration[] | undefined,
   surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ) => Result<object, Error> | Promise<Result<object, Error>>;
 
 /** Handlers keyed by survey mode. */
 const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
-  lookup: (app, input, rootDir, cliAliases, surfaceLayerNames) =>
+  lookup: (app, input, rootDir, cliAliases, overlays, surfaceLayerNames) =>
     input.id === undefined || input.id === ''
       ? Result.err(new ValidationError('Survey lookup requires an id'))
       : buildSurveyLookup(
@@ -597,6 +607,7 @@ const surveyHandlers: Record<SurveyMode, SurveyHandler> = {
           input.id,
           rootDir,
           cliAliases,
+          overlays,
           surfaceLayerNames
         ),
   overview: (app, _input, rootDir) =>
@@ -616,6 +627,7 @@ const dispatchSurvey = async (
   cliAliases:
     | Readonly<Record<string, readonly CliCommandAliasInput[]>>
     | undefined,
+  overlays: readonly TopoGraphOverlayRegistration[] | undefined,
   surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined
 ): Promise<Result<SurveyEnvelope, Error>> => {
   const mode = deriveSurveyMode(input);
@@ -625,6 +637,7 @@ const dispatchSurvey = async (
     input,
     rootDir,
     cliAliases,
+    overlays,
     surfaceLayerNames
   );
   if (result.isErr()) {
@@ -646,11 +659,12 @@ const withFreshSurveyApp = async <T>(
     app: Topo,
     cliAliases:
       | Readonly<Record<string, readonly CliCommandAliasInput[]>>
-      | undefined
+      | undefined,
+    overlays: readonly TopoGraphOverlayRegistration[] | undefined
   ) => Promise<Result<T, Error>> | Result<T, Error>
 ): Promise<Result<T, Error>> =>
   withFreshAppLease(input.module, rootDir, (lease) =>
-    consume(lease.app, lease.cliAliases)
+    consume(lease.app, lease.cliAliases, lease.overlays)
   );
 
 const withResolvedSurveyApp = async <T>(
@@ -664,12 +678,13 @@ const withResolvedSurveyApp = async <T>(
     rootDir: string,
     cliAliases:
       | Readonly<Record<string, readonly CliCommandAliasInput[]>>
-      | undefined
+      | undefined,
+    overlays: readonly TopoGraphOverlayRegistration[] | undefined
   ) => Promise<Result<T, Error>> | Result<T, Error>
 ): Promise<Result<T, Error>> =>
   withOperatorRootDir(input, { cwd }, (rootDir) =>
-    withFreshSurveyApp(input, rootDir, (app, cliAliases) =>
-      consume(app, rootDir, cliAliases)
+    withFreshSurveyApp(input, rootDir, (app, cliAliases, overlays) =>
+      consume(app, rootDir, cliAliases, overlays)
     )
   );
 
@@ -743,14 +758,18 @@ const surveyMatchOutput = z.discriminatedUnion('kind', [
 export const surveyTrail = trail('survey', {
   args: ['id'],
   blaze: async (input, ctx) =>
-    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir, cliAliases) =>
-      dispatchSurvey(
-        app,
-        input,
-        rootDir,
-        cliAliases,
-        readSurfaceLayerNamesFromContext(ctx)
-      )
+    withResolvedSurveyApp(
+      input,
+      ctx.cwd,
+      (app, rootDir, cliAliases, overlays) =>
+        dispatchSurvey(
+          app,
+          input,
+          rootDir,
+          cliAliases,
+          overlays,
+          readSurfaceLayerNamesFromContext(ctx)
+        )
     ),
   description: 'Full topo introspection',
   examples: [
@@ -904,14 +923,18 @@ export const surveyDiffTrail = trail('survey.diff', {
 export const surveyTrailDetailTrail = trail('survey.trail', {
   args: ['id'],
   blaze: async (input, ctx) =>
-    withResolvedSurveyApp(input, ctx.cwd, (app, rootDir, cliAliases) =>
-      buildSurveyTrailDetail(
-        app,
-        input.id,
-        rootDir,
-        cliAliases,
-        readSurfaceLayerNamesFromContext(ctx)
-      )
+    withResolvedSurveyApp(
+      input,
+      ctx.cwd,
+      (app, rootDir, cliAliases, overlays) =>
+        buildSurveyTrailDetail(
+          app,
+          input.id,
+          rootDir,
+          cliAliases,
+          overlays,
+          readSurfaceLayerNamesFromContext(ctx)
+        )
     ),
   description: 'Inspect one trail by ID',
   examples: [

--- a/apps/trails/src/trails/topo-read-support.ts
+++ b/apps/trails/src/trails/topo-read-support.ts
@@ -27,7 +27,11 @@ import {
   readTrailsLock,
   stripTopoGraphForces,
 } from '@ontrails/topographer';
-import type { LockManifest, TopoGraph } from '@ontrails/topographer';
+import type {
+  LockManifest,
+  TopoGraph,
+  TopoGraphOverlayRegistration,
+} from '@ontrails/topographer';
 
 import type {
   BriefReport,
@@ -76,6 +80,7 @@ export interface CurrentTopoReadOptions {
     | Readonly<Record<string, readonly CliCommandAliasInput[]>>
     | undefined;
   readonly rootDir?: string | undefined;
+  readonly overlays?: readonly TopoGraphOverlayRegistration[] | undefined;
   readonly surfaceLayerNames?: Partial<SurfaceLayerNames> | undefined;
 }
 
@@ -199,7 +204,10 @@ export const deriveCurrentTrailDetail = (
     ? undefined
     : deriveTrailDetail(trail, app, undefined, {
         surfaceLayerNames: options?.surfaceLayerNames,
-        topoGraph: deriveTopoGraph(app, { cliAliases: options?.cliAliases }),
+        topoGraph: deriveTopoGraph(app, {
+          cliAliases: options?.cliAliases,
+          overlays: options?.overlays,
+        }),
       });
 };
 
@@ -238,7 +246,10 @@ export const deriveCurrentTopoMatches = (
     (activationGraph ??= deriveActivationGraph(app));
   let topoGraph: ReturnType<typeof deriveTopoGraph> | undefined;
   const getTopoGraph = (): ReturnType<typeof deriveTopoGraph> =>
-    (topoGraph ??= deriveTopoGraph(app, { cliAliases: options?.cliAliases }));
+    (topoGraph ??= deriveTopoGraph(app, {
+      cliAliases: options?.cliAliases,
+      overlays: options?.overlays,
+    }));
 
   const trail = app.get(id);
   if (trail !== undefined) {
@@ -271,6 +282,7 @@ export const validateCurrentTopo = async (
       | Readonly<Record<string, readonly CliCommandAliasInput[]>>
       | undefined;
     readonly rootDir?: string;
+    readonly overlays?: readonly TopoGraphOverlayRegistration[] | undefined;
   }
 ): Promise<Result<TopoValidateReport, Error>> => {
   const rootDir = deriveRootDir(options?.rootDir);
@@ -299,6 +311,7 @@ export const validateCurrentTopo = async (
 
   const currentExport = deriveCurrentTopoExport(app, {
     cliAliases: options?.cliAliases,
+    overlays: options?.overlays,
     rootDir,
   });
   if (currentExport.isErr()) {

--- a/apps/trails/src/trails/topo-store-support.ts
+++ b/apps/trails/src/trails/topo-store-support.ts
@@ -19,6 +19,7 @@ import {
 import type {
   LockManifest,
   TopoGraph,
+  TopoGraphOverlayRegistration,
   TopoSnapshot,
   TrailsLock,
 } from '@ontrails/topographer';
@@ -50,17 +51,25 @@ type CliAliasesOption = Readonly<
   Record<string, readonly CliCommandAliasInput[]>
 >;
 
+type OverlaysOption = readonly TopoGraphOverlayRegistration[];
+
 const persistAndReadStoredExport = (
   app: Topo,
   db: ReturnType<typeof openWriteTrailsDb>,
   rootDir: string,
-  options?: { readonly cliAliases?: CliAliasesOption | undefined } | undefined
+  options?:
+    | {
+        readonly cliAliases?: CliAliasesOption | undefined;
+        readonly overlays?: OverlaysOption | undefined;
+      }
+    | undefined
 ): Result<
   { snapshot: TopoSnapshot; storedExport: StoredTopoExport },
   Error
 > => {
   const snapshotResult = createStoredTopoSnapshot(db, app, {
     cliAliases: options?.cliAliases,
+    overlays: options?.overlays,
     sourceFingerprint: deriveSourceFingerprint(rootDir),
     ...readGitState(rootDir),
     ...deriveTopoCounts(app),
@@ -129,6 +138,7 @@ export const deriveCurrentTopoExport = (
   options?: {
     readonly cliAliases?: CliAliasesOption | undefined;
     readonly rootDir?: string;
+    readonly overlays?: OverlaysOption | undefined;
   }
 ): Result<StoredTopoExport, Error> => {
   const rootDir = deriveRootDir(options?.rootDir);
@@ -137,6 +147,7 @@ export const deriveCurrentTopoExport = (
   try {
     const projected = persistAndReadStoredExport(app, db, rootDir, {
       cliAliases: options?.cliAliases,
+      overlays: options?.overlays,
     });
     return projected.isErr()
       ? projected
@@ -265,6 +276,7 @@ export const exportCurrentTopo = async (
     readonly cliAliases?: CliAliasesOption | undefined;
     readonly force?: boolean | undefined;
     readonly rootDir?: string;
+    readonly overlays?: OverlaysOption | undefined;
   }
 ): Promise<Result<TopoExportReport, Error>> => {
   const rootDir = deriveRootDir(options?.rootDir);
@@ -273,6 +285,7 @@ export const exportCurrentTopo = async (
   try {
     const candidate = deriveCurrentTopoExport(app, {
       cliAliases: options?.cliAliases,
+      overlays: options?.overlays,
       rootDir,
     });
     if (candidate.isErr()) {
@@ -290,6 +303,7 @@ export const exportCurrentTopo = async (
     db = openWriteTrailsDb({ rootDir });
     const persisted = persistAndReadStoredExport(app, db, rootDir, {
       cliAliases: options?.cliAliases,
+      overlays: options?.overlays,
     });
     if (persisted.isErr()) {
       return persisted;

--- a/apps/trails/src/trails/validate.ts
+++ b/apps/trails/src/trails/validate.ts
@@ -9,6 +9,7 @@ export const validateTrail = trail('validate', {
     withFreshOperatorApp(input, ctx, ({ lease, rootDir }) =>
       validateCurrentTopo(lease.app, {
         cliAliases: lease.cliAliases,
+        overlays: lease.overlays,
         rootDir,
       })
     ),

--- a/bun.lock
+++ b/bun.lock
@@ -113,6 +113,7 @@
         "zod": "catalog:",
       },
       "devDependencies": {
+        "@ontrails/cloudflare": "workspace:^",
         "@ontrails/testing": "workspace:^",
       },
     },

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -91,6 +91,18 @@ if (testingWorkspaceEntry) {
   };
 }
 
+// The lock-overlays proof test writes a fixture app whose source string
+// imports `@ontrails/cloudflare`; the devDependency exists so that fixture
+// resolves at runtime, but knip cannot see imports inside string literals.
+const trailsAppWorkspace = 'apps/trails';
+const trailsAppWorkspaceEntry = workspaceMap[trailsAppWorkspace];
+if (trailsAppWorkspaceEntry) {
+  workspaceMap[trailsAppWorkspace] = {
+    ...trailsAppWorkspaceEntry,
+    ignoreDependencies: ['@ontrails/cloudflare'],
+  };
+}
+
 const config: KnipConfig = {
   ignoreExportsUsedInFile: true,
   treatConfigHintsAsErrors: true,


### PR DESCRIPTION
Part 3/4 of the TRL-1199 lock-extensibility stack ([TRL-1199](https://linear.app/outfitter/issue/TRL-1199/lock-extensibility-namespaced-fact-sections-with-elevated-schemas), milestone 4 — collection half).

The app module's `trailsContributions` export is lifted into the fresh-app lease exactly like `cliAliases` and threaded through every derivation site — compile, validate, guide, survey, and the stored-export pipeline — so compiled and freshly derived graphs stay hash-identical (the TRL-1191 doctrine applied to the new surface).

**Zero-edit proof:** the proof test compiles a fixture demo app using the real cloudflare adapter (`cloudflareKv` + `cloudflareContribution`); the lock lands `sections.cloudflare.bindings = [{ binding: 'FLAGS', resourceId: 'flags' }]`, recompiles cold byte-identically via `runLockRoundtripSmoke` (subprocess, temp `TRAILS_STATE_HOME`), validates `stale: false`, and a second compile is byte-identical — with zero edits to `TopoGraph`'s core type, the lock schema module, or wayfinder per-family code (`git diff` for those files in this PR: empty).

- Invalid `trailsContributions` shapes throw a `ValidationError` naming the export, the fix, and `trails compile`.
- knip carve-out: the fixture references `@ontrails/cloudflare` from inside a source string, so the devDependency is registered in `knip.config.ts` with a comment.

Changeset: `@ontrails/trails` minor.