### PR TITLE
feat(store): sync() gains permit and per-endpoint contour options (TRL-1201)

### DIFF
--- a/.changeset/sync-permit-contour-parity.md
+++ b/.changeset/sync-permit-contour-parity.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/store': patch
+---
+
+`sync()` gains the factory-contract options `crud()` and `reconcile()` received in TRL-1195: a `permit` option declared on the produced trail, and per-endpoint `contour` options on `SyncEndpoint` so a `crud()` bundle's table contour can be shared instead of colliding as a duplicate registration at `topo()`.

--- a/packages/store/src/__tests__/factory-contracts.test.ts
+++ b/packages/store/src/__tests__/factory-contracts.test.ts
@@ -1,16 +1,21 @@
 /**
- * Factory contract completeness (TRL-1195): crud()/reconcile() declare
- * permits and share one table contour instead of forcing consuming apps
- * to post-process the produced trails.
+ * Factory contract completeness (TRL-1195, TRL-1201): crud()/reconcile()/
+ * sync() declare permits and share table contours instead of forcing
+ * consuming apps to post-process the produced trails.
  */
 
 import { describe, expect, test } from 'bun:test';
 import { Result, resource, topo } from '@ontrails/core';
 import { z } from 'zod';
 
-import type { EntityOf, StoreAccessor } from '../index.js';
+import type {
+  EntityOf,
+  ReadOnlyStoreTableAccessor,
+  StoreAccessor,
+} from '../index.js';
 import { store } from '../index.js';
-import { crud, reconcile } from '../trails/index.js';
+import type { TableContour } from '../trails/index.js';
+import { crud, reconcile, sync } from '../trails/index.js';
 
 const noteSchema = z.object({
   body: z.string(),
@@ -155,5 +160,188 @@ describe('shared table contours', () => {
     });
     expect(second.contour).toBe(first.contour);
     expect(second[0].contours[0]).toBe(first.contour);
+  });
+});
+
+const externalNoteSchema = z.object({
+  bodyText: z.string(),
+  createdAt: z.string(),
+  heading: z.string(),
+  id: z.string(),
+});
+
+const externalDefinition = store({
+  externalNotes: {
+    fixtures: [
+      {
+        bodyText: 'Copied body',
+        createdAt: '2026-04-10T12:00:00.000Z',
+        heading: 'Copied title',
+        id: 'external-1',
+      },
+    ],
+    identity: 'id',
+    schema: externalNoteSchema,
+  },
+});
+
+type ExternalTable = typeof externalDefinition.tables.externalNotes;
+type ExternalConnection = Readonly<
+  Record<'externalNotes', ReadOnlyStoreTableAccessor<ExternalTable>>
+>;
+
+const createExternalAccessor =
+  (): ReadOnlyStoreTableAccessor<ExternalTable> => {
+    const records = new Map<string, EntityOf<ExternalTable>>();
+    return {
+      get(id) {
+        const entity = records.get(id);
+        return Promise.resolve(
+          entity === undefined ? null : structuredClone(entity)
+        );
+      },
+      list() {
+        return Promise.resolve(
+          [...records.values()].map((entity) => structuredClone(entity))
+        );
+      },
+    };
+  };
+
+const externalResource = resource<ExternalConnection>('db.external.factory', {
+  create: () => Result.ok({ externalNotes: createExternalAccessor() }),
+});
+
+type WritableExternalConnection = Readonly<
+  Record<'externalNotes', StoreAccessor<ExternalTable>>
+>;
+
+const createWritableExternalAccessor = (): StoreAccessor<ExternalTable> => {
+  const records = new Map<string, EntityOf<ExternalTable>>();
+  return {
+    get(id) {
+      const entity = records.get(id);
+      return Promise.resolve(
+        entity === undefined ? null : structuredClone(entity)
+      );
+    },
+    list() {
+      return Promise.resolve(
+        [...records.values()].map((entity) => structuredClone(entity))
+      );
+    },
+    remove(id) {
+      return Promise.resolve({ deleted: records.delete(id) });
+    },
+    upsert(entity) {
+      const stored = structuredClone(entity) as EntityOf<ExternalTable>;
+      records.set(String(stored.id), stored);
+      return Promise.resolve(structuredClone(stored));
+    },
+  };
+};
+
+const writableExternalResource = resource<WritableExternalConnection>(
+  'db.external.crud.factory',
+  {
+    create: () =>
+      Result.ok({ externalNotes: createWritableExternalAccessor() }),
+  }
+);
+
+const syncNotes = (options?: {
+  readonly fromContour?: TableContour<ExternalTable>;
+  readonly permit?: Parameters<typeof sync>[0]['permit'];
+  readonly toContour?: TableContour<typeof noteDefinition.tables.notes>;
+}) =>
+  sync({
+    from: {
+      ...(options?.fromContour === undefined
+        ? {}
+        : { contour: options.fromContour }),
+      resource: externalResource,
+      table: externalDefinition.tables.externalNotes,
+    },
+    ...(options?.permit === undefined ? {} : { permit: options.permit }),
+    to: {
+      ...(options?.toContour === undefined
+        ? {}
+        : { contour: options.toContour }),
+      resource: notesResource,
+      table: noteDefinition.tables.notes,
+    },
+    transform: (entity) => ({
+      body: entity.bodyText,
+      id: entity.id,
+      title: entity.heading,
+    }),
+  });
+
+describe('sync() permits', () => {
+  test('permit is declared on the produced trail', () => {
+    const syncTrail = syncNotes({ permit: { scopes: ['notes:write'] } });
+    expect(syncTrail.permit).toEqual({ scopes: ['notes:write'] });
+  });
+
+  test('trail carries no permit when none is declared', () => {
+    expect(syncNotes().permit).toBeUndefined();
+  });
+});
+
+describe('sync() shared contours', () => {
+  test('sync reuses a crud bundle contour so topo sees one instance', () => {
+    const crudTrails = crud(noteDefinition.tables.notes, notesResource);
+    const syncTrail = syncNotes({ toContour: crudTrails.contour });
+    expect(syncTrail.contours[1]).toBe(crudTrails.contour);
+
+    const [create, read, update, remove, list] = crudTrails;
+    expect(() =>
+      topo('factory-sync-shared-app', {
+        create,
+        list,
+        read,
+        remove,
+        syncTrail,
+        update,
+      })
+    ).not.toThrow();
+  });
+
+  test('unshared contours still collide at topo() so the sharing is load-bearing', () => {
+    const crudTrails = crud(noteDefinition.tables.notes, notesResource);
+    const syncTrail = syncNotes();
+
+    const [create, read, update, remove, list] = crudTrails;
+    expect(() =>
+      topo('factory-sync-collision-app', {
+        create,
+        list,
+        read,
+        remove,
+        syncTrail,
+        update,
+      })
+    ).toThrow(/[Dd]uplicate contour/);
+  });
+
+  test('sync reuses a source-side crud contour so topo sees one instance', () => {
+    const externalCrud = crud(
+      externalDefinition.tables.externalNotes,
+      writableExternalResource
+    );
+    const syncTrail = syncNotes({ fromContour: externalCrud.contour });
+    expect(syncTrail.contours[0]).toBe(externalCrud.contour);
+
+    const [create, read, update, remove, list] = externalCrud;
+    expect(() =>
+      topo('factory-sync-source-shared-app', {
+        create,
+        list,
+        read,
+        remove,
+        syncTrail,
+        update,
+      })
+    ).not.toThrow();
   });
 });

--- a/packages/store/src/trails/sync.ts
+++ b/packages/store/src/trails/sync.ts
@@ -1,6 +1,7 @@
 import { InternalError, NotFoundError, Result, trail } from '@ontrails/core';
 import type {
   AnySignal,
+  PermitRequirement,
   Resource,
   Trail,
   TrailContext,
@@ -17,6 +18,7 @@ import type {
   UpsertOf,
 } from '../types.js';
 import { createTableContour, mapStoreTrailError } from './utils.js';
+import type { TableContour } from './utils.js';
 
 type IdentityInputOf<TTable extends AnyStoreTable> = Readonly<
   Record<Extract<TTable['identity'], string>, StoreIdentifierOf<TTable>>
@@ -34,6 +36,14 @@ export interface SyncEndpoint<
   TTable extends AnyStoreTable,
   TConnection extends SourceConnection<TTable> | TargetConnection<TTable>,
 > {
+  /**
+   * Existing table contour to register on the produced trail for this
+   * endpoint. Pass the contour a `crud()` bundle over the same table
+   * exposes (its `contour` property) so `topo()` sees one shared
+   * instance instead of rejecting two same-named rebuilds as
+   * duplicates. When omitted, the factory builds one from the table.
+   */
+  readonly contour?: TableContour<TTable>;
   readonly resource: Resource<TConnection>;
   readonly table: TTable;
 }
@@ -56,6 +66,11 @@ export interface SyncOptions<
   readonly from: SyncEndpoint<TSourceTable, TSourceConnection>;
   readonly id?: string;
   readonly on?: readonly (AnySignal | string)[];
+  /**
+   * Permit requirement declared on the produced trail. Factory trails
+   * carry authored defaults like any hand-written trail.
+   */
+  readonly permit?: PermitRequirement;
   readonly to: SyncEndpoint<TTargetTable, TTargetConnection>;
   readonly transform?: SyncTransform<TSourceTable, TTargetTable>;
 }
@@ -175,8 +190,10 @@ export const sync = <
   >
 ): Trail<IdentityInputOf<TSourceTable>, EntityOf<TTargetTable>> => {
   const id = options.id ?? `${options.to.table.name}.sync`;
-  const sourceContour = createTableContour(options.from.table);
-  const targetContour = createTableContour(options.to.table);
+  const sourceContour =
+    options.from.contour ?? createTableContour(options.from.table);
+  const targetContour =
+    options.to.contour ?? createTableContour(options.to.table);
 
   return trail(id, {
     // oxlint-disable-next-line max-statements -- sync blaze reads more clearly as one try/catch with schema validation, transform, and accessor call inline
@@ -246,6 +263,7 @@ export const sync = <
       EntityOf<TTargetTable>
     >,
     pattern: 'sync',
+    ...(options.permit === undefined ? {} : { permit: options.permit }),
     resources: [options.from.resource, options.to.resource],
   });
 };


### PR DESCRIPTION
Closes [TRL-1201](https://linear.app/outfitter/issue/TRL-1201/sync-lacks-permitcontour-options-the-trl-1195-factory-contract-fix).

The TRL-1195 factory-contract fix (#897) gave `crud()` and `reconcile()` permit declarations and shared table contours, but left `sync()` behind: it had no `permit` option and always rebuilt both endpoint contours, so `crud()` + `sync()` over one table still hit the duplicate-contour collision at `topo()`.

## What changed

- `SyncOptions` gains `permit?: PermitRequirement`, applied to the produced trail with the same spread idiom as `reconcile()`.
- `SyncEndpoint` gains `contour?: TableContour<TTable>` on both `from` and `to`, falling back to `createTableContour(table)` when omitted — pass the contour a `crud()` bundle exposes so `topo()` sees one shared instance.

## Tests

New coverage in `factory-contracts.test.ts`: permit declared / absent on sync-produced trails; target-side shared contour registers cleanly at `topo()` while unshared still collides (proving the sharing is load-bearing); source-side shared contour with a `crud()` bundle over the source table.

`bun run check` and `bun run test` green at repo root. Changeset: `@ontrails/store` patch (matches the TRL-1195 precedent).

Reviewed pre-submit by a fresh-context subagent against the issue acceptance; its one finding (missing source-side contour test) is fixed in this diff.