### PR TITLE
fix(http): OpenAPI documents BlobRef routes as binary responses (TRL-1202)

### DIFF
--- a/.changeset/openapi-blob-binary-response.md
+++ b/.changeset/openapi-blob-binary-response.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/http': patch
+---
+
+The OpenAPI projection now documents BlobRef routes as binary responses (`content: { '*/*': { schema: { type: 'string', format: 'binary' } } }`) instead of a JSON data envelope, matching the raw bytes the runtime serves with the blob's declared mimeType. Error responses keep the JSON error envelope. Both the fetch handler and the OpenAPI projection now share one BlobRef output recognition helper.

--- a/packages/http/src/__tests__/openapi.test.ts
+++ b/packages/http/src/__tests__/openapi.test.ts
@@ -1,9 +1,18 @@
 import { describe, expect, test } from 'bun:test';
 
-import { Result, ValidationError, signal, topo, trail } from '@ontrails/core';
+import {
+  Result,
+  ValidationError,
+  blobRefSchema,
+  createBlobRef,
+  signal,
+  topo,
+  trail,
+} from '@ontrails/core';
 import type { Topo } from '@ontrails/core';
 import { z } from 'zod';
 
+import { createFetchHandler } from '../fetch.js';
 import { deriveOpenApiSpec } from '../openapi.js';
 
 // ---------------------------------------------------------------------------
@@ -750,6 +759,98 @@ const registerMetadataAndStructureTests = () => {
   });
 };
 
+const registerBlobResponseTests = () => {
+  describe('BlobRef responses', () => {
+    const fileBytes = new TextEncoder().encode('raw file bytes');
+    const blobTrail = trail('file.raw', {
+      blaze: (input: { name: string }) =>
+        Result.ok(
+          createBlobRef({
+            data: fileBytes,
+            mimeType: 'text/plain; charset=utf-8',
+            name: input.name,
+            size: fileBytes.byteLength,
+          })
+        ),
+      input: z.object({ name: z.string() }),
+      intent: 'read',
+      output: blobRefSchema,
+    });
+
+    const blobSuccessResponse = (): Record<string, unknown> => {
+      const spec = deriveOpenApiSpec(topoFrom({ blobTrail }));
+      const responses = getOperation(spec, '/file/raw', 'get')[
+        'responses'
+      ] as Record<string, unknown>;
+      return responses['200'] as Record<string, unknown>;
+    };
+
+    test('blob output → 200 documents a binary body, not a JSON descriptor envelope', () => {
+      const success = blobSuccessResponse();
+      const content = success['content'] as Record<string, unknown>;
+
+      expect(content['application/json']).toBeUndefined();
+      const binary = content['*/*'] as Record<string, unknown>;
+      expect(binary['schema']).toEqual({ format: 'binary', type: 'string' });
+      expect(success['description']).toContain('mimeType');
+    });
+
+    test('blob route error responses keep the JSON error envelope', () => {
+      const failingBlobTrail = trail('file.raw', {
+        blaze: blobTrail.blaze,
+        examples: [
+          {
+            error: 'NotFoundError',
+            input: { name: 'missing.txt' },
+            name: 'missing file',
+          },
+        ],
+        input: z.object({ name: z.string() }),
+        intent: 'read',
+        output: blobRefSchema,
+      });
+      const spec = deriveOpenApiSpec(topoFrom({ failingBlobTrail }));
+      const responses = getOperation(spec, '/file/raw', 'get')[
+        'responses'
+      ] as Record<string, unknown>;
+
+      const validation = responses['400'] as Record<string, unknown>;
+      const validationContent = validation['content'] as Record<
+        string,
+        unknown
+      >;
+      expect(validationContent['application/json']).toBeDefined();
+      expect(validationContent['*/*']).toBeUndefined();
+
+      // Example-derived error statuses are documented without a content
+      // entry (description only, for every trail shape) — the binary body
+      // must not leak onto them.
+      const notFound = responses['404'] as Record<string, unknown>;
+      expect(notFound['description']).toBeDefined();
+      expect(notFound['content']).toBeUndefined();
+    });
+
+    test('the documented binary response matches what the runtime serves', async () => {
+      const app = topo('blob-api', { blobTrail });
+      const success = blobSuccessResponse();
+      const handler = createFetchHandler(app);
+
+      const response = await handler(
+        new Request('http://localhost/file/raw?name=notes.txt')
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe(
+        'text/plain; charset=utf-8'
+      );
+      expect(new Uint8Array(await response.arrayBuffer())).toEqual(fileBytes);
+      // The spec's only 200 content entry is the binary body — the JSON
+      // descriptor envelope the runtime never serves is not documented.
+      expect(Object.keys(success['content'] as object)).toEqual(['*/*']);
+    });
+  });
+};
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -759,5 +860,6 @@ describe('deriveOpenApiSpec', () => [
   registerGetQueryParameterTests(),
   registerRequestBodyTests(),
   registerResponseTests(),
+  registerBlobResponseTests(),
   registerMetadataAndStructureTests(),
 ]);

--- a/packages/http/src/blob-output.ts
+++ b/packages/http/src/blob-output.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared recognition for BlobRef trail output schemas.
+ *
+ * The runtime handler (`fetch.ts`) and the OpenAPI projection
+ * (`openapi.ts`) must agree on which routes serve raw bytes, so both
+ * read the same authored fact: the BlobRef marker meta on the trail's
+ * output schema.
+ */
+
+import { BLOB_REF_SCHEMA_META_KEY } from '@ontrails/core';
+
+/**
+ * True when a trail output schema carries the BlobRef marker meta — the
+ * authored fact that selects byte streaming over the JSON envelope on
+ * the HTTP surface and a binary response body in the OpenAPI projection.
+ */
+export const isBlobOutputSchema = (output: unknown): boolean => {
+  if (typeof output !== 'object' || output === null) {
+    return false;
+  }
+  const maybeMeta = (output as { meta?: () => unknown }).meta;
+  if (typeof maybeMeta !== 'function') {
+    return false;
+  }
+  const meta = maybeMeta.call(output);
+  return (
+    typeof meta === 'object' &&
+    meta !== null &&
+    (meta as Record<string, unknown>)[BLOB_REF_SCHEMA_META_KEY] === true
+  );
+};

--- a/packages/http/src/fetch.ts
+++ b/packages/http/src/fetch.ts
@@ -1,5 +1,4 @@
 import {
-  BLOB_REF_SCHEMA_META_KEY,
   CancelledError,
   isBlobRef,
   isTrailsError,
@@ -12,6 +11,7 @@ import {
 } from '@ontrails/core';
 import type { BlobRef, Topo } from '@ontrails/core';
 
+import { isBlobOutputSchema } from './blob-output.js';
 import { deriveHttpRoutes } from './build.js';
 import type { DeriveHttpRoutesOptions, HttpRouteDefinition } from './build.js';
 
@@ -345,22 +345,8 @@ interface ResultLike {
  * True when the route's trail declares a BlobRef output schema — the
  * authored fact that selects byte streaming over the JSON envelope.
  */
-const rendersBlobOutput = (route: HttpRouteDefinition): boolean => {
-  const { output } = route.trail;
-  if (output === undefined) {
-    return false;
-  }
-  const maybeMeta = (output as { meta?: () => unknown }).meta;
-  if (typeof maybeMeta !== 'function') {
-    return false;
-  }
-  const meta = maybeMeta.call(output);
-  return (
-    typeof meta === 'object' &&
-    meta !== null &&
-    (meta as Record<string, unknown>)[BLOB_REF_SCHEMA_META_KEY] === true
-  );
-};
+const rendersBlobOutput = (route: HttpRouteDefinition): boolean =>
+  isBlobOutputSchema(route.trail.output);
 
 /**
  * Narrow blob bytes for `Response`. `BlobRef.data` is typed `Uint8Array`

--- a/packages/http/src/openapi.ts
+++ b/packages/http/src/openapi.ts
@@ -19,6 +19,7 @@ import type {
   Trail,
 } from '@ontrails/core';
 
+import { isBlobOutputSchema } from './blob-output.js';
 import { deriveHttpOperationMethod } from './method.js';
 
 type JsonSchema = Readonly<Record<string, unknown>>;
@@ -213,6 +214,21 @@ const buildSuccessResponse = (
 ): Record<string, unknown> => {
   if (!t.output) {
     return { '200': { description: 'Success' } };
+  }
+  if (isBlobOutputSchema(t.output)) {
+    // BlobRef routes stream raw bytes at runtime (`fetch.ts` serves the
+    // blob's declared mimeType and Content-Length), so the spec documents
+    // a binary body instead of the JSON data envelope. The concrete
+    // Content-Type is per-blob runtime data, hence the `*/*` range.
+    return {
+      '200': {
+        content: {
+          '*/*': { schema: { format: 'binary', type: 'string' } },
+        },
+        description:
+          "Binary content: raw blob bytes served with the blob's declared mimeType",
+      },
+    };
   }
   const outputSchema = toJsonSchema(t.output);
   return {


### PR DESCRIPTION
Closes [TRL-1202](https://linear.app/outfitter/issue/TRL-1202/openapi-documents-blobref-routes-as-json-descriptors-while-the-runtime).

With TRL-1192's byte-serving in place (#898), the OpenAPI projection still documented BlobRef routes as a JSON `{ data: <blob descriptor> }` envelope while the runtime streams raw bytes with the blob's declared mimeType and Content-Length.

## What changed

- New internal `packages/http/src/blob-output.ts` exposes `isBlobOutputSchema` — one shared recognition of the `BLOB_REF_SCHEMA_META_KEY` marker, so the fetch handler and the OpenAPI projection cannot drift on which routes serve bytes. `rendersBlobOutput` in fetch.ts now delegates to it.
- `buildSuccessResponse` in openapi.ts emits `content: { '*/*': { schema: { type: 'string', format: 'binary' } } }` for blob outputs instead of the JSON data envelope. The concrete Content-Type is per-blob runtime data, hence the wildcard range. Error responses keep the JSON error envelope.

## Tests

New `BlobRef responses` suite in openapi.test.ts: binary 200 body with no `application/json` entry; 400 validation stays a JSON envelope and example-derived error statuses gain no binary content; and a spec-vs-runtime coherence test that serves the same topo through `createFetchHandler` and asserts the bytes/mimeType the runtime produces against the spec's sole `*/*` entry.

`bun run check` and `bun run test` green at repo root. Changeset: `@ontrails/http` patch.

Reviewed pre-submit by a fresh-context subagent against the issue acceptance: no P1/P2; its error-example P3 is covered in this diff; two remaining P3s intentionally skipped (function-typed schema recognition is speculative — no callable schema carries the marker today; Content-Length assertion already lives in fetch.test.ts).