### PR TITLE
fix(core,cloudflare): core barrel loads bun:/node: builtins lazily; portability gates (TRL-1198)

### DIFF
--- a/.changeset/core-barrel-runtime-portability.md
+++ b/.changeset/core-barrel-runtime-portability.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/core': patch
+'@ontrails/cloudflare': patch
+---
+
+The core barrel is now execution-portable: no eager `bun:`/`node:` builtin imports remain on its module graph (TRL-1198). `trails-db`, workspace discovery, and path security load `bun:sqlite`, `node:fs`, `node:os`, and `node:path` lazily through `process.getBuiltinModule` at first use, and signal payload summaries plus per-project store keys use a pure SHA-256 (output-identical to `node:crypto`). A Worker bundle no longer needs a `bun:sqlite` stub plugin or the `nodejs_compat` flag to serve trails; the Cloudflare adapter's miniflare lane now bundles without externals and boots workerd without `nodejs_compat` as the structural regression gate, and its README stub instructions are replaced with the portable posture. Tooling helpers throw a clear `InternalError` naming the missing builtin when called on runtimes without it.

--- a/adapters/cloudflare/README.md
+++ b/adapters/cloudflare/README.md
@@ -46,10 +46,8 @@ Missing or mistyped bindings fail the request with a redacted 500 and log full d
 
 ### Runtime notes
 
-These come straight from the runtime-constraint audit that shipped with this subpath (each is also filed as a Trails issue):
-
-- Enable the `nodejs_compat` compatibility flag and use a recent `compatibility_date`: modules on the `@ontrails/core` barrel import `node:fs`, `node:path`, and `node:crypto`, and workerd's `node:fs` support is compatibility-date gated (the integration lane pins `2026-06-01`).
-- Stub `bun:sqlite` in your Worker bundle: the core barrel re-exports `trails-db.js`, whose top-level `import { Database } from 'bun:sqlite'` survives bundling even though the Worker never calls it, and workerd refuses module graphs importing `bun:sqlite`. With wrangler, alias it to a stub module (see the `bunSqliteStub` plugin in `src/__tests__/miniflare.test.ts` for the shape).
+- The core execution path is runtime-portable (TRL-1198): `@ontrails/core` loads `bun:sqlite` and `node:` builtins lazily at first use, so a Worker bundle needs no stub plugin and no `nodejs_compat` flag to serve trails. The integration lane (`src/__tests__/miniflare.test.ts`) bundles the demo Worker with no externals and boots workerd without `nodejs_compat` as the structural regression gate.
+- Tooling helpers on the core barrel (the trails-db store, workspace discovery) still require a Bun or Node runtime when actually called; on workerd they throw a clear `InternalError` naming the missing builtin instead of poisoning the module graph.
 - Explicit `resources` overrides win over env-bound resolution, which is how tests substitute fakes.
 
 ## `/kv` — the key-value resource

--- a/adapters/cloudflare/src/__tests__/miniflare.test.ts
+++ b/adapters/cloudflare/src/__tests__/miniflare.test.ts
@@ -5,7 +5,6 @@
  * resource served through the env bridge.
  */
 
-import type { BunPlugin } from 'bun';
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { Miniflare } from 'miniflare';
 
@@ -13,36 +12,18 @@ const fixtureEntrypoint = new URL('fixtures/demo-worker.ts', import.meta.url)
   .pathname;
 
 /**
- * Runtime-constraint audit workaround (TRL: bun:sqlite in the core barrel):
- * `@ontrails/core` re-exports `trails-db.js`, whose top-level
- * `import { Database } from 'bun:sqlite'` survives bundling even though the
- * Worker never touches it. workerd refuses module graphs that import
- * `bun:sqlite`, so Worker bundles must stub it — the same aliasing a wrangler
- * consumer would configure. Filed as a fix-or-document issue; remove this
- * stub once core stops importing bun:sqlite eagerly on the barrel path.
+ * Portability gate (TRL-1198): the bundle is built with no `bun:sqlite`
+ * stub, no `node:*` externals, and executed without `nodejs_compat`. Core
+ * loads runtime builtins lazily, so the execution-path module graph must
+ * be free of `bun:`/`node:` imports — an eager builtin import regressing
+ * onto the barrel fails this bundle or the workerd boot below,
+ * structurally, without an audit.
  */
-const bunSqliteStub: BunPlugin = {
-  name: 'stub-bun-sqlite',
-  setup(build) {
-    build.onResolve({ filter: /^bun:sqlite$/ }, () => ({
-      namespace: 'bun-sqlite-stub',
-      path: 'bun:sqlite',
-    }));
-    build.onLoad({ filter: /.*/, namespace: 'bun-sqlite-stub' }, () => ({
-      contents:
-        'export class Database { constructor() { throw new Error("bun:sqlite is unavailable on Cloudflare Workers"); } }',
-      loader: 'js',
-    }));
-  },
-};
-
 const bundleWorkerScript = async (): Promise<string> => {
   const build = await Bun.build({
     entrypoints: [fixtureEntrypoint],
-    external: ['node:*'],
     format: 'esm',
     minify: false,
-    plugins: [bunSqliteStub],
     target: 'browser',
   });
   if (!build.success) {
@@ -64,7 +45,6 @@ describe('demo worker under miniflare', () => {
     const script = await bundleWorkerScript();
     mf = new Miniflare({
       compatibilityDate: '2026-06-01',
-      compatibilityFlags: ['nodejs_compat'],
       kvNamespaces: ['FLAGS'],
       modules: true,
       script,

--- a/packages/core/src/__tests__/runtime-builtins.test.ts
+++ b/packages/core/src/__tests__/runtime-builtins.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+
+import { loadRuntimeBuiltin } from '../runtime-builtins.js';
+
+describe('loadRuntimeBuiltin', () => {
+  test('loads node builtins lazily and returns the live module', () => {
+    const fs = loadRuntimeBuiltin('node:fs');
+    expect(typeof fs.existsSync).toBe('function');
+    const nodePath = loadRuntimeBuiltin('node:path');
+    expect(nodePath.join('a', 'b')).toBe('a/b');
+  });
+
+  test('loads bun:sqlite through the same loader', () => {
+    const sqlite = loadRuntimeBuiltin('bun:sqlite');
+    expect(typeof sqlite.Database).toBe('function');
+  });
+
+  test('caches loaded modules by name', () => {
+    expect(loadRuntimeBuiltin('node:fs')).toBe(loadRuntimeBuiltin('node:fs'));
+  });
+});

--- a/packages/core/src/__tests__/runtime-portability.test.ts
+++ b/packages/core/src/__tests__/runtime-portability.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/**
+ * Structural portability gate (TRL-1198): the core barrel must carry no
+ * eager `bun:`/`node:` builtin value imports. The Cloudflare adapter's
+ * miniflare lane proves the bundled execution path boots under workerd,
+ * but Bun's browser-target bundler silently shims `node:` imports to
+ * empty objects, so a regressed eager `node:` import would sail through
+ * it — this source-level scan is the airtight half of the gate.
+ */
+
+const SRC_DIR = new URL('..', import.meta.url).pathname;
+
+const listSourceFiles = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    if (entry.name === '__tests__') {
+      return [];
+    }
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return listSourceFiles(path);
+    }
+    return entry.name.endsWith('.ts') ? [path] : [];
+  });
+
+// Matches `import ... from 'bun:x'` / `import 'node:x'` value imports and
+// `export ... from` re-exports, but not `import type` (erased at runtime).
+const EAGER_BUILTIN_IMPORT =
+  /^(?:import|export)\s+(?!type\b)[^;]*?from\s+['"](?:bun|node):/m;
+const BARE_BUILTIN_IMPORT = /^import\s+['"](?:bun|node):/m;
+
+describe('core barrel runtime portability', () => {
+  test('no source module eagerly imports a bun:/node: builtin', () => {
+    const offenders = listSourceFiles(SRC_DIR)
+      .filter((path) => {
+        const source = readFileSync(path, 'utf8');
+        return (
+          EAGER_BUILTIN_IMPORT.test(source) || BARE_BUILTIN_IMPORT.test(source)
+        );
+      })
+      .map((path) => relative(SRC_DIR, path));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/core/src/__tests__/sha256.test.ts
+++ b/packages/core/src/__tests__/sha256.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+
+import { sha256Hex } from '../sha256.js';
+
+describe('sha256Hex', () => {
+  test('matches FIPS 180-4 known-answer vectors', () => {
+    expect(sha256Hex('')).toBe(
+      'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+    );
+    expect(sha256Hex('abc')).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    );
+    expect(
+      sha256Hex('abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq')
+    ).toBe('248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1');
+  });
+
+  test('is output-identical to node:crypto across padding boundaries', () => {
+    // Lengths 0..129 cross both the 56-byte and 64-byte block boundaries
+    // where padding bugs hide; the unicode suffix exercises multi-byte
+    // UTF-8 encoding.
+    for (let length = 0; length <= 129; length += 1) {
+      const text = `${'x'.repeat(length)}${length % 3 === 0 ? '✨日本語' : ''}`;
+      expect(sha256Hex(text)).toBe(
+        createHash('sha256').update(text).digest('hex')
+      );
+    }
+  });
+});

--- a/packages/core/src/path-security.ts
+++ b/packages/core/src/path-security.ts
@@ -4,10 +4,14 @@
  * All functions are runtime-agnostic (Node / Bun compatible).
  */
 
-import { resolve, relative, normalize, isAbsolute } from 'node:path';
-
 import { PermissionError } from './errors.js';
 import { Result } from './result.js';
+// Path security guards filesystem access on tooling paths: node:path
+// loads lazily at first use so the core barrel's module graph stays
+// execution-portable on runtimes without node: builtins (TRL-1198).
+import { loadRuntimeBuiltin } from './runtime-builtins.js';
+
+const nodePath = () => loadRuntimeBuiltin('node:path');
 
 // ---------------------------------------------------------------------------
 // Internal
@@ -15,6 +19,7 @@ import { Result } from './result.js';
 
 /** Returns true when `target` is equal to or a descendant of `base`. */
 const isWithin = (base: string, target: string): boolean => {
+  const { isAbsolute, relative } = nodePath();
   const rel = relative(base, target);
   // Empty string means they are the same directory.
   // A relative path starting with ".." means it escapes.
@@ -39,6 +44,7 @@ export const securePath = (
   basePath: string,
   userPath: string
 ): Result<string, PermissionError> => {
+  const { resolve } = nodePath();
   const base = resolve(basePath);
   const resolved = resolve(base, userPath);
 
@@ -61,6 +67,7 @@ export const securePath = (
  * `basePath`.
  */
 export const isPathSafe = (basePath: string, userPath: string): boolean => {
+  const { resolve } = nodePath();
   const base = resolve(basePath);
   const resolved = resolve(base, userPath);
   return isWithin(base, resolved);
@@ -74,6 +81,7 @@ export const deriveSafePath = (
   basePath: string,
   ...segments: string[]
 ): Result<string, PermissionError> => {
+  const { normalize, resolve } = nodePath();
   const base = resolve(basePath);
   const joined = resolve(base, ...segments.map((s) => normalize(s)));
 

--- a/packages/core/src/runtime-builtins.ts
+++ b/packages/core/src/runtime-builtins.ts
@@ -1,0 +1,69 @@
+/**
+ * Lazy runtime-builtin loading for the execution-portable core barrel.
+ *
+ * Core tooling modules that need Bun or Node capabilities (`bun:sqlite`,
+ * `node:fs`, `node:os`, `node:path`) must not import them eagerly: the
+ * core barrel sits on the execution path of every surface, and edge
+ * runtimes such as workerd refuse module graphs that import `bun:`
+ * builtins and gate `node:` builtins behind compatibility flags
+ * (TRL-1198). Loading through `process.getBuiltinModule` keeps the
+ * specifier out of bundler module graphs entirely and defers the
+ * capability requirement to first use, so runtimes that never call a
+ * tooling helper never pay for it.
+ */
+
+import type * as BunSqlite from 'bun:sqlite';
+import type * as NodeFs from 'node:fs';
+import type * as NodeOs from 'node:os';
+import type * as NodePath from 'node:path';
+
+import { InternalError } from './errors.js';
+
+interface BuiltinModules {
+  readonly 'bun:sqlite': typeof BunSqlite;
+  readonly 'node:fs': typeof NodeFs;
+  readonly 'node:os': typeof NodeOs;
+  readonly 'node:path': typeof NodePath;
+}
+
+const loadedBuiltins = new Map<keyof BuiltinModules, unknown>();
+
+/**
+ * Load a Bun/Node builtin module at first use.
+ *
+ * @throws {InternalError} When the runtime does not expose the builtin
+ * (for example workerd without `nodejs_compat`). Trail execution never
+ * reaches this loader; only tooling helpers (trails-db, workspace
+ * discovery) do.
+ */
+export const loadRuntimeBuiltin = <TName extends keyof BuiltinModules>(
+  name: TName
+): BuiltinModules[TName] => {
+  const cached = loadedBuiltins.get(name);
+  if (cached !== undefined) {
+    return cached as BuiltinModules[TName];
+  }
+
+  const proc = (
+    globalThis as {
+      readonly process?: {
+        readonly getBuiltinModule?: (id: string) => unknown;
+      };
+    }
+  ).process;
+  if (typeof proc?.getBuiltinModule !== 'function') {
+    throw new InternalError(
+      `Runtime builtin "${name}" is unavailable: this runtime does not expose process.getBuiltinModule. Trails tooling helpers need a Bun or Node runtime; the trail execution path never loads them.`
+    );
+  }
+
+  const loaded = proc.getBuiltinModule(name);
+  if (loaded === undefined || loaded === null) {
+    throw new InternalError(
+      `Runtime builtin "${name}" is unavailable on this runtime.`
+    );
+  }
+
+  loadedBuiltins.set(name, loaded);
+  return loaded as BuiltinModules[TName];
+};

--- a/packages/core/src/sha256.ts
+++ b/packages/core/src/sha256.ts
@@ -1,0 +1,136 @@
+/**
+ * Pure synchronous SHA-256 for runtime-portable fingerprints.
+ *
+ * `node:crypto`'s `createHash` is unavailable on edge runtimes without
+ * compatibility flags, and Web Crypto's `subtle.digest` is asynchronous,
+ * which does not fit the synchronous summary paths that need a digest
+ * (signal payload summaries, per-project store keys). This implementation
+ * follows FIPS 180-4 and produces output identical to
+ * `createHash('sha256').update(text).digest('hex')`.
+ */
+
+/* oxlint-disable no-bitwise, unicorn/prefer-math-trunc, unicorn/number-literal-case -- SHA-256 is defined over 32-bit words: rotations, xor, and `>>> 0` unsigned wrapping are the specified operations, and `Math.trunc()` is not equivalent to `>>> 0` (it neither wraps to 32 bits nor coerces to unsigned). number-literal-case is disabled because oxfmt normalizes hex digits to lowercase, which the rule rejects — the formatter wins. */
+
+// FIPS 180-4 §4.2.2: first 32 bits of the fractional parts of the cube
+// roots of the first 64 primes.
+const K = Uint32Array.from([
+  0x42_8a_2f_98, 0x71_37_44_91, 0xb5_c0_fb_cf, 0xe9_b5_db_a5, 0x39_56_c2_5b,
+  0x59_f1_11_f1, 0x92_3f_82_a4, 0xab_1c_5e_d5, 0xd8_07_aa_98, 0x12_83_5b_01,
+  0x24_31_85_be, 0x55_0c_7d_c3, 0x72_be_5d_74, 0x80_de_b1_fe, 0x9b_dc_06_a7,
+  0xc1_9b_f1_74, 0xe4_9b_69_c1, 0xef_be_47_86, 0x0f_c1_9d_c6, 0x24_0c_a1_cc,
+  0x2d_e9_2c_6f, 0x4a_74_84_aa, 0x5c_b0_a9_dc, 0x76_f9_88_da, 0x98_3e_51_52,
+  0xa8_31_c6_6d, 0xb0_03_27_c8, 0xbf_59_7f_c7, 0xc6_e0_0b_f3, 0xd5_a7_91_47,
+  0x06_ca_63_51, 0x14_29_29_67, 0x27_b7_0a_85, 0x2e_1b_21_38, 0x4d_2c_6d_fc,
+  0x53_38_0d_13, 0x65_0a_73_54, 0x76_6a_0a_bb, 0x81_c2_c9_2e, 0x92_72_2c_85,
+  0xa2_bf_e8_a1, 0xa8_1a_66_4b, 0xc2_4b_8b_70, 0xc7_6c_51_a3, 0xd1_92_e8_19,
+  0xd6_99_06_24, 0xf4_0e_35_85, 0x10_6a_a0_70, 0x19_a4_c1_16, 0x1e_37_6c_08,
+  0x27_48_77_4c, 0x34_b0_bc_b5, 0x39_1c_0c_b3, 0x4e_d8_aa_4a, 0x5b_9c_ca_4f,
+  0x68_2e_6f_f3, 0x74_8f_82_ee, 0x78_a5_63_6f, 0x84_c8_78_14, 0x8c_c7_02_08,
+  0x90_be_ff_fa, 0xa4_50_6c_eb, 0xbe_f9_a3_f7, 0xc6_71_78_f2,
+]);
+
+const rotr = (value: number, bits: number): number =>
+  (value >>> bits) | (value << (32 - bits));
+
+/**
+ * Total array accessor: every read in the compression loop is provably in
+ * range, so the fallback never fires — it only satisfies
+ * `noUncheckedIndexedAccess` without an assertion.
+ */
+const wordAt = (words: Uint32Array, index: number): number => words[index] ?? 0;
+
+const padMessage = (bytes: Uint8Array): Uint8Array => {
+  const bitLength = bytes.length * 8;
+  // Message + 0x80 marker, padded to 56 mod 64, then a 64-bit big-endian
+  // bit length. Message sizes here are far below 2^32 bits, so the high
+  // word of the length is derived from the float division.
+  const paddedLength = (Math.floor((bytes.length + 8) / 64) + 1) * 64;
+  const padded = new Uint8Array(paddedLength);
+  padded.set(bytes);
+  padded[bytes.length] = 0x80;
+  const view = new DataView(padded.buffer);
+  view.setUint32(paddedLength - 8, Math.floor(bitLength / 0x1_00_00_00_00));
+  view.setUint32(paddedLength - 4, bitLength >>> 0);
+  return padded;
+};
+
+const fillSchedule = (w: Uint32Array, view: DataView, offset: number): void => {
+  for (let i = 0; i < 16; i += 1) {
+    w[i] = view.getUint32(offset + i * 4);
+  }
+  for (let i = 16; i < 64; i += 1) {
+    const w15 = wordAt(w, i - 15);
+    const w2 = wordAt(w, i - 2);
+    const s0 = rotr(w15, 7) ^ rotr(w15, 18) ^ (w15 >>> 3);
+    const s1 = rotr(w2, 17) ^ rotr(w2, 19) ^ (w2 >>> 10);
+    w[i] = (wordAt(w, i - 16) + s0 + wordAt(w, i - 7) + s1) >>> 0;
+  }
+};
+
+// oxlint-disable-next-line max-statements -- the FIPS 180-4 compression loop reads more clearly as one block than split across helpers
+const digestHex = (padded: Uint8Array): string => {
+  // FIPS 180-4 §5.3.3 initial hash value.
+  let h0 = 0x6a_09_e6_67;
+  let h1 = 0xbb_67_ae_85;
+  let h2 = 0x3c_6e_f3_72;
+  let h3 = 0xa5_4f_f5_3a;
+  let h4 = 0x51_0e_52_7f;
+  let h5 = 0x9b_05_68_8c;
+  let h6 = 0x1f_83_d9_ab;
+  let h7 = 0x5b_e0_cd_19;
+
+  const view = new DataView(padded.buffer);
+  const w = new Uint32Array(64);
+
+  for (let offset = 0; offset < padded.length; offset += 64) {
+    fillSchedule(w, view, offset);
+
+    let a = h0;
+    let b = h1;
+    let c = h2;
+    let d = h3;
+    let e = h4;
+    let f = h5;
+    let g = h6;
+    let h = h7;
+
+    for (let i = 0; i < 64; i += 1) {
+      const s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+      const ch = (e & f) ^ (~e & g);
+      const temp1 = (h + s1 + ch + wordAt(K, i) + wordAt(w, i)) >>> 0;
+      const s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+      const maj = (a & b) ^ (a & c) ^ (b & c);
+      const temp2 = (s0 + maj) >>> 0;
+
+      h = g;
+      g = f;
+      f = e;
+      e = (d + temp1) >>> 0;
+      d = c;
+      c = b;
+      b = a;
+      a = (temp1 + temp2) >>> 0;
+    }
+
+    h0 = (h0 + a) >>> 0;
+    h1 = (h1 + b) >>> 0;
+    h2 = (h2 + c) >>> 0;
+    h3 = (h3 + d) >>> 0;
+    h4 = (h4 + e) >>> 0;
+    h5 = (h5 + f) >>> 0;
+    h6 = (h6 + g) >>> 0;
+    h7 = (h7 + h) >>> 0;
+  }
+
+  return [h0, h1, h2, h3, h4, h5, h6, h7]
+    .map((word) => word.toString(16).padStart(8, '0'))
+    .join('');
+};
+
+/**
+ * SHA-256 of the UTF-8 encoding of `text`, as lowercase hex.
+ *
+ * Output-identical to `createHash('sha256').update(text).digest('hex')`.
+ */
+export const sha256Hex = (text: string): string =>
+  digestHex(padMessage(new TextEncoder().encode(text)));

--- a/packages/core/src/signal-diagnostics.ts
+++ b/packages/core/src/signal-diagnostics.ts
@@ -5,11 +5,10 @@
  * observable without changing the best-effort producer API.
  */
 
-import { createHash } from 'node:crypto';
-
 import type { z } from 'zod';
 
 import type { ActivationProvenance } from './activation-provenance.js';
+import { sha256Hex } from './sha256.js';
 import type { Logger } from './types.js';
 
 export const SIGNAL_DIAGNOSTICS_SINK_KEY =
@@ -349,8 +348,9 @@ const stableJson = (value: unknown): string => {
   }
 };
 
-const hashText = (text: string): string =>
-  createHash('sha256').update(text).digest('hex');
+// Pure sha256 keeps payload summarization on the execution path portable:
+// node:crypto is unavailable on edge runtimes without compat flags.
+const hashText = (text: string): string => sha256Hex(text);
 
 export const summarizeSignalPayload = (
   payload: unknown

--- a/packages/core/src/trails-db.ts
+++ b/packages/core/src/trails-db.ts
@@ -1,10 +1,19 @@
-import { Database } from 'bun:sqlite';
-import { createHash } from 'node:crypto';
-import { existsSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { basename, dirname, join, resolve } from 'node:path';
+import type { Database } from 'bun:sqlite';
 
 import { NotFoundError } from './errors.js';
+import { loadRuntimeBuiltin } from './runtime-builtins.js';
+import { sha256Hex } from './sha256.js';
+
+// Altitude ruling (TRL-1198, ADR-0051 lens): trails-db stays core-owned
+// shared framework infrastructure (ADR-0014) and stays on the barrel —
+// topographer, tracing, warden, wayfinder, and the operator app all
+// consume it from `@ontrails/core`. What it may NOT do is assume runtime
+// capabilities eagerly: `bun:sqlite` and the node builtins load lazily at
+// first use so the barrel's module graph stays execution-portable.
+const sqlite = () => loadRuntimeBuiltin('bun:sqlite');
+const fs = () => loadRuntimeBuiltin('node:fs');
+const os = () => loadRuntimeBuiltin('node:os');
+const nodePath = () => loadRuntimeBuiltin('node:path');
 
 const TRAILS_DIR = '.trails';
 const TRAILS_DB_FILE = 'trails.db';
@@ -46,7 +55,7 @@ interface SchemaVersionRow {
 }
 
 const deriveRootDir = (rootDir?: string): string =>
-  resolve(rootDir ?? process.cwd());
+  nodePath().resolve(rootDir ?? process.cwd());
 
 const sanitizeProjectKeyName = (name: string): string => {
   const normalized = name.replaceAll(/[^a-zA-Z0-9._-]+/g, '-');
@@ -54,33 +63,30 @@ const sanitizeProjectKeyName = (name: string): string => {
 };
 
 const projectHash = (rootDir: string): string =>
-  createHash('sha256')
-    .update(rootDir)
-    .digest('hex')
-    .slice(0, PROJECT_KEY_HASH_LENGTH);
+  sha256Hex(rootDir).slice(0, PROJECT_KEY_HASH_LENGTH);
 
 export const deriveTrailsProjectKey = (
   options?: TrailsDbLocationOptions
 ): string => {
   const rootDir = deriveRootDir(options?.rootDir);
-  return `${sanitizeProjectKeyName(basename(rootDir))}-${projectHash(rootDir)}`;
+  return `${sanitizeProjectKeyName(nodePath().basename(rootDir))}-${projectHash(rootDir)}`;
 };
 
 export const deriveTrailsStateHome = (
   options?: TrailsDbLocationOptions
 ): string => {
   const env = options?.env ?? process.env;
-  return resolve(
+  return nodePath().resolve(
     env['TRAILS_STATE_HOME'] ??
       env['XDG_STATE_HOME'] ??
-      join(homedir(), '.local', 'state')
+      nodePath().join(os().homedir(), '.local', 'state')
   );
 };
 
 export const deriveTrailsStateDir = (
   options?: TrailsDbLocationOptions
 ): string =>
-  join(
+  nodePath().join(
     deriveTrailsStateHome(options),
     TRAILS_STORE_DIR,
     TRAILS_PROJECTS_DIR,
@@ -88,15 +94,15 @@ export const deriveTrailsStateDir = (
   );
 
 export const deriveTrailsDir = (options?: TrailsDbLocationOptions): string =>
-  join(deriveRootDir(options?.rootDir), TRAILS_DIR);
+  nodePath().join(deriveRootDir(options?.rootDir), TRAILS_DIR);
 
 export const deriveTrailsDbPath = (options?: TrailsDbLocationOptions): string =>
   options?.path
-    ? resolve(options.path)
-    : join(deriveTrailsStateDir(options), TRAILS_DB_FILE);
+    ? nodePath().resolve(options.path)
+    : nodePath().join(deriveTrailsStateDir(options), TRAILS_DB_FILE);
 
 const ensureDbParentDir = (dbPath: string): void => {
-  mkdirSync(dirname(dbPath), { recursive: true });
+  fs().mkdirSync(nodePath().dirname(dbPath), { recursive: true });
 };
 
 /**
@@ -108,7 +114,7 @@ const ensureDbParentDir = (dbPath: string): void => {
  */
 export const ensureTrailsWorkspace = (rootDir: string): void => {
   const trailsDir = deriveTrailsDir({ rootDir });
-  mkdirSync(trailsDir, { recursive: true });
+  fs().mkdirSync(trailsDir, { recursive: true });
 };
 
 const initializeWritePragmas = (db: Database): void => {
@@ -168,7 +174,7 @@ export const openWriteTrailsDb = (
 
   ensureDbParentDir(dbPath);
 
-  const db = new Database(dbPath, { create: true });
+  const db = new (sqlite().Database)(dbPath, { create: true });
   initializeWritePragmas(db);
   ensureSchemaVersionTable(db);
   return db;
@@ -178,12 +184,12 @@ export const openReadTrailsDb = (
   options?: TrailsDbLocationOptions
 ): Database => {
   const dbPath = deriveTrailsDbPath(options);
-  if (!existsSync(dbPath)) {
+  if (!fs().existsSync(dbPath)) {
     throw new NotFoundError(
       `Trails database not found at "${dbPath}". Run a write operation first to initialize it.`
     );
   }
-  const db = new Database(dbPath, { readonly: true });
+  const db = new (sqlite().Database)(dbPath, { readonly: true });
   initializeReadPragmas(db);
   return db;
 };

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -5,11 +5,15 @@
  * helpers for working with paths relative to a workspace.
  */
 
-import { existsSync, readFileSync, readdirSync, realpathSync } from 'node:fs';
-import { resolve, relative, dirname, join, isAbsolute } from 'node:path';
-
 import { NotFoundError } from './errors.js';
 import { Result } from './result.js';
+// Workspace discovery is a tooling path: the node builtins load lazily at
+// first use so the core barrel's module graph stays execution-portable on
+// runtimes without node: builtins (TRL-1198).
+import { loadRuntimeBuiltin } from './runtime-builtins.js';
+
+const fs = () => loadRuntimeBuiltin('node:fs');
+const nodePath = () => loadRuntimeBuiltin('node:path');
 
 export interface WorkspaceRootManifest {
   readonly workspaces?: unknown;
@@ -31,33 +35,24 @@ const normalizePath = (path: string): string => path.replaceAll('\\', '/');
 
 const normalizeRealPath = (path: string): string => {
   try {
-    return normalizePath(realpathSync(path));
+    return normalizePath(fs().realpathSync(path));
   } catch {
-    return normalizePath(resolve(path));
+    return normalizePath(nodePath().resolve(path));
   }
 };
 
 const readJsonSync = <T>(path: string): T | undefined => {
   try {
-    return JSON.parse(readFileSync(path, 'utf8')) as T;
+    return JSON.parse(fs().readFileSync(path, 'utf8')) as T;
   } catch {
     return undefined;
   }
 };
 
 /** Check if a directory has a package.json with a `workspaces` field. */
-const hasWorkspacesField = async (dir: string): Promise<boolean> => {
-  const pkgPath = join(dir, 'package.json');
-  const file = Bun.file(pkgPath);
-  if (!(await file.exists())) {
-    return false;
-  }
-  try {
-    const pkg: unknown = await file.json();
-    return typeof pkg === 'object' && pkg !== null && 'workspaces' in pkg;
-  } catch {
-    return false;
-  }
+const hasWorkspacesField = (dir: string): boolean => {
+  const pkg = readJsonSync<unknown>(nodePath().join(dir, 'package.json'));
+  return typeof pkg === 'object' && pkg !== null && 'workspaces' in pkg;
 };
 
 /**
@@ -93,19 +88,24 @@ const workspaceDirsForPattern = (
   pattern: string
 ): readonly string[] => {
   if (!pattern.endsWith('/*')) {
-    const workspaceDir = join(rootDir, pattern);
-    return existsSync(join(workspaceDir, 'package.json')) ? [workspaceDir] : [];
+    const workspaceDir = nodePath().join(rootDir, pattern);
+    return fs().existsSync(nodePath().join(workspaceDir, 'package.json'))
+      ? [workspaceDir]
+      : [];
   }
 
-  const groupDir = join(rootDir, pattern.slice(0, -2));
-  if (!existsSync(groupDir)) {
+  const groupDir = nodePath().join(rootDir, pattern.slice(0, -2));
+  if (!fs().existsSync(groupDir)) {
     return [];
   }
 
-  return readdirSync(groupDir, { withFileTypes: true })
+  return fs()
+    .readdirSync(groupDir, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
-    .map((entry) => join(groupDir, entry.name))
-    .filter((workspaceDir) => existsSync(join(workspaceDir, 'package.json')))
+    .map((entry) => nodePath().join(groupDir, entry.name))
+    .filter((workspaceDir) =>
+      fs().existsSync(nodePath().join(workspaceDir, 'package.json'))
+    )
     .toSorted();
 };
 
@@ -140,7 +140,7 @@ export const listWorkspacePackages = <
 ): readonly WorkspacePackage<Manifest>[] => {
   const normalizedRoot = normalizeRealPath(rootDir);
   const rootManifest = readJsonSync<WorkspaceRootManifest>(
-    join(normalizedRoot, 'package.json')
+    nodePath().join(normalizedRoot, 'package.json')
   );
   const packages: WorkspacePackage<Manifest>[] = [];
 
@@ -148,18 +148,20 @@ export const listWorkspacePackages = <
     normalizedRoot,
     listWorkspacePatterns(rootManifest)
   )) {
-    const packageJsonPath = join(workspaceDir, 'package.json');
+    const packageJsonPath = nodePath().join(workspaceDir, 'package.json');
     const manifest = readJsonSync<Manifest>(packageJsonPath);
     if (!manifest || typeof manifest.name !== 'string') {
       continue;
     }
 
-    const packageRoot = normalizeRealPath(dirname(packageJsonPath));
+    const packageRoot = normalizeRealPath(nodePath().dirname(packageJsonPath));
     packages.push({
       manifest,
       packageJsonPath: normalizeRealPath(packageJsonPath),
       packageRoot,
-      workspacePath: normalizePath(relative(normalizedRoot, packageRoot)),
+      workspacePath: normalizePath(
+        nodePath().relative(normalizedRoot, packageRoot)
+      ),
     });
   }
 
@@ -196,15 +198,15 @@ export const findWorkspacePackage = <
 export const findWorkspaceRoot = async (
   startDir?: string
 ): Promise<Result<string, NotFoundError>> => {
-  let current = resolve(startDir ?? process.cwd());
+  let current = nodePath().resolve(startDir ?? process.cwd());
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    if (await hasWorkspacesField(current)) {
+    if (hasWorkspacesField(current)) {
       return Result.ok(current);
     }
 
-    const parent = dirname(current);
+    const parent = nodePath().dirname(current);
 
     if (parent === current) {
       return Result.err(
@@ -225,6 +227,7 @@ export const isInsideWorkspace = (
   filePath: string,
   workspaceRoot: string
 ): boolean => {
+  const { isAbsolute, relative, resolve } = nodePath();
   const rel = relative(resolve(workspaceRoot), resolve(filePath));
   return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel);
 };
@@ -235,4 +238,7 @@ export const isInsideWorkspace = (
 export const deriveRelativePath = (
   filePath: string,
   workspaceRoot: string
-): string => relative(resolve(workspaceRoot), resolve(filePath));
+): string => {
+  const { relative, resolve } = nodePath();
+  return relative(resolve(workspaceRoot), resolve(filePath));
+};


### PR DESCRIPTION
Closes [TRL-1198](https://linear.app/outfitter/issue/TRL-1198/core-barrel-runtime-portability-no-eager-bunnode-imports-on-the).

The `@ontrails/core` barrel eagerly imported `bun:sqlite` (trails-db) and `node:crypto`/`node:fs`/`node:os`/`node:path` (signal diagnostics, workspace discovery, path security), so every Worker bundle needed a `bun:sqlite` stub plugin and the `nodejs_compat` flag just to serve trails.

## What changed

- New internal `loadRuntimeBuiltin` loads `bun:sqlite` and node builtins through `process.getBuiltinModule` at first use — the specifiers never enter bundler module graphs, and runtimes without a builtin get a clear `InternalError` only if a tooling helper is actually called.
- `trails-db`, `workspace`, and `path-security` route every builtin call site through the lazy loader; `trails-db` keeps only a type-only `Database` import. Public signatures unchanged, so barrel consumers (topographer, tracing, warden, wayfinder, operator app) need no edits.
- New pure FIPS 180-4 `sha256Hex` replaces `node:crypto.createHash` in signal payload summaries (execution path) and `deriveTrailsProjectKey` — output-identical to node:crypto, proven by known-answer vectors plus a 0–129 length parity sweep, so existing per-user store keys are byte-identical (no store orphaning).
- Workspace discovery drops its `Bun.file` dependency (now `readFileSync` via the lazy loader), so it fails with the same clear `InternalError` posture instead of `ReferenceError: Bun is not defined`.
- **Altitude ruling (recorded in trails-db.ts):** trails-db stays core-owned shared infrastructure (ADR-0014) and stays on the barrel — warden, topographer, tracing, and wayfinder consume it there — but it may not assume runtime capabilities eagerly (ADR-0051 lens).

## Portability gates

- The Cloudflare miniflare lane now bundles the demo Worker with **no stub plugin, no `node:*` externals**, and boots workerd **without `nodejs_compat`** — an eager `bun:` import fails the bundle structurally.
- Because Bun's browser-target bundler silently shims `node:` imports (found by the pre-submit review subagent), a source-level structural test in core additionally asserts no eager `bun:`/`node:` value import exists anywhere in `packages/core/src`.

The cloudflare README's stub instructions are deleted and replaced with the portable posture.

## Verification

`bun run check` and `bun run test` green at repo root; package suites green for core (1239), topographer (184), tracing (143), wayfinder (67), warden (1246, read-only run), apps/trails (606), cloudflare (36, incl. the 4-test miniflare gate). Changeset: `@ontrails/core` + `@ontrails/cloudflare` patch.

Review subagent outcome: its P2 (node-shim gate porosity) is fixed by the structural test in this diff; its workspace-discovery P3 is fixed by dropping `Bun.file`; its `engines` P3 is intentionally skipped — Bun-first posture, and the loader's error message already names the requirement.