### PR TITLE
fix(warden): duplicate-public-contract fingerprints contour anchoring so factory CRUD deletes across tables stop false-positiving (TRL-1181)

### DIFF
--- a/.changeset/trl-1181-duplicate-public-contract-contours.md
+++ b/.changeset/trl-1181-duplicate-public-contract-contours.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/warden': patch
+---
+
+`duplicate-public-contract` now includes contour anchoring in the normalized contract fingerprint, so factory CRUD trails derived against different contours (for example two tables' `delete` trails that both normalize to `{ id } → void` with the same intent) are no longer flagged as duplicates. Genuine duplicates — identical facts with the same or no contour anchoring — still warn, and the diagnostic message names contours among the shared facts.

--- a/packages/warden/src/__tests__/duplicate-public-contract.test.ts
+++ b/packages/warden/src/__tests__/duplicate-public-contract.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'bun:test';
 
-import { Result, topo, trail } from '@ontrails/core';
+import {
+  contour,
+  deriveTrail,
+  resource,
+  Result,
+  topo,
+  trail,
+} from '@ontrails/core';
 import { deriveTopoGraph } from '@ontrails/topographer';
 import { z } from 'zod';
 
@@ -31,7 +38,7 @@ describe('duplicate-public-contract', () => {
         filePath: '<topo>',
         line: 1,
         message:
-          'Likely duplicate public trail contracts "diff", "survey.diff" share the same input, output, intent, permits, resources, composes, signals, and detours. Keep one contract with aliases/input mappings, compose a distinct wrapper, or document why these public contracts are separate.',
+          'Likely duplicate public trail contracts "diff", "survey.diff" share the same input, output, intent, permits, resources, contours, composes, signals, and detours. Keep one contract with aliases/input mappings, compose a distinct wrapper, or document why these public contracts are separate.',
         rule: 'duplicate-public-contract',
         severity: 'warn',
       },
@@ -70,6 +77,63 @@ describe('duplicate-public-contract', () => {
     );
 
     expect(diagnostics).toEqual([]);
+  });
+
+  test('stays quiet for factory CRUD deletes anchored to different contours', async () => {
+    const pack = contour(
+      'pack',
+      { id: z.string(), name: z.string() },
+      { identity: 'id' }
+    );
+    const trip = contour(
+      'trip',
+      { id: z.string(), name: z.string() },
+      { identity: 'id' }
+    );
+    const db = resource('db.main', {
+      create: () => Result.ok({}),
+      mock: () => ({}),
+    });
+    const packDelete = deriveTrail(pack, 'delete', {
+      blaze: () => Result.ok(),
+      resource: db,
+    });
+    const tripDelete = deriveTrail(trip, 'delete', {
+      blaze: () => Result.ok(),
+      resource: db,
+    });
+
+    const diagnostics = await duplicatePublicContract.checkTopo(
+      topo('factory-crud-tables', { db, packDelete, tripDelete })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('still warns for identical contracts anchored to the same contour', async () => {
+    const pack = contour(
+      'pack',
+      { id: z.string(), name: z.string() },
+      { identity: 'id' }
+    );
+    const canonical = trail('pack.remove', {
+      blaze: () => Result.ok({ ok: true }),
+      contours: [pack],
+      input,
+      output,
+    });
+    const duplicate = trail('pack.destroy', {
+      blaze: () => Result.ok({ ok: true }),
+      contours: [pack],
+      input,
+      output,
+    });
+
+    const diagnostics = await duplicatePublicContract.checkTopo(
+      topo('same-contour-duplicates', { canonical, duplicate })
+    );
+
+    expect(diagnostics).toHaveLength(1);
   });
 
   test('uses provided graph facts when available', async () => {

--- a/packages/warden/src/rules/duplicate-public-contract.ts
+++ b/packages/warden/src/rules/duplicate-public-contract.ts
@@ -30,6 +30,7 @@ const contractFingerprint = (entry: TopoGraphEntry): string =>
   JSON.stringify(
     canonicalize({
       composes: entry.composes,
+      contours: entry.contours,
       detours: entry.detours,
       dryRunCapable: entry.dryRunCapable,
       fires: entry.fires,
@@ -62,7 +63,7 @@ const renderTrailIds = (trailIds: readonly string[]): string =>
 const buildDiagnostic = (trailIds: readonly string[]): WardenDiagnostic => ({
   filePath: TOPO_FILE,
   line: 1,
-  message: `Likely duplicate public trail contracts ${renderTrailIds(trailIds)} share the same input, output, intent, permits, resources, composes, signals, and detours. Keep one contract with aliases/input mappings, compose a distinct wrapper, or document why these public contracts are separate.`,
+  message: `Likely duplicate public trail contracts ${renderTrailIds(trailIds)} share the same input, output, intent, permits, resources, contours, composes, signals, and detours. Keep one contract with aliases/input mappings, compose a distinct wrapper, or document why these public contracts are separate.`,
   rule: RULE_NAME,
   severity: 'warn',
 });

--- a/packages/warden/src/trails/duplicate-public-contract.trail.ts
+++ b/packages/warden/src/trails/duplicate-public-contract.trail.ts
@@ -28,7 +28,7 @@ export const duplicatePublicContractTrail = wrapTopoRule({
             filePath: '<topo>',
             line: 1,
             message:
-              'Likely duplicate public trail contracts "diff", "survey.diff" share the same input, output, intent, permits, resources, composes, signals, and detours. Keep one contract with aliases/input mappings, compose a distinct wrapper, or document why these public contracts are separate.',
+              'Likely duplicate public trail contracts "diff", "survey.diff" share the same input, output, intent, permits, resources, contours, composes, signals, and detours. Keep one contract with aliases/input mappings, compose a distinct wrapper, or document why these public contracts are separate.',
             rule: 'duplicate-public-contract',
             severity: 'warn',
           },


### PR DESCRIPTION
Fixes [TRL-1181](https://linear.app/outfitter/issue/TRL-1181/duplicate-public-contract-false-positives-on-factory-crud-deletes).

## Problem

With factory CRUD for two tables in one topo, every `deriveTrail(contour, 'delete')` produces `{ id } → void` with the same intent, so `duplicate-public-contract` flagged deletes on *different* tables as duplicates. Any app with two or more factory-CRUD tables shipped this warning (found building `examples/packlist`).

## Fix

The normalized contract fingerprint now includes contour anchoring (`entry.contours`). `deriveTrail` already sets `contours: [contour]` on every derived trail and Topographer projects the contour names onto the graph entry, so deletes anchored to different tables fingerprint differently. Trails with identical facts and the same (or no) contour anchoring still collide, and the diagnostic message now names contours among the shared facts.

## Tests

- New: `stays quiet for factory CRUD deletes anchored to different contours` (was red before the fix — the two deletes collided).
- New: `still warns for identical contracts anchored to the same contour`.
- Pre-existing no-contour duplicate case still warns (message updated).
- Warden package suite: 1248 pass / 0 fail. Repo `bun run check` and `bun run test` (51/51 turbo tasks) green.

## Release intent

`.changeset/trl-1181-duplicate-public-contract-contours.md` — `@ontrails/warden` patch.

## Review

Fresh-context review subagent: no P1/P2 findings; confirmed old message wording appears nowhere else in the repo and generated warden guides embed only the (unchanged) invariant/summary.
