### PR TITLE
fix(warden): signal-graph-coaching treats store-derived table signals as advertised capability, not unconsumed reactive intent (TRL-1183)

### DIFF
--- a/.changeset/trl-1183-signal-graph-coaching-store-derived.md
+++ b/.changeset/trl-1183-signal-graph-coaching-store-derived.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/warden': patch
+---
+
+`signal-graph-coaching` no longer flags store-derived table signals (`created`/`updated`/`removed`) that have no consumers. Store resources advertise those signals as available capability, so leaving them unconsumed is a legitimate steady state for store-backed apps. Non-store produced signals without consumers still warn, and dead-signal coaching (no producer and no consumer) is unchanged.

--- a/packages/warden/src/__tests__/signal-graph-coaching.test.ts
+++ b/packages/warden/src/__tests__/signal-graph-coaching.test.ts
@@ -3,7 +3,14 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { Result, resource, signal, topo, trail } from '@ontrails/core';
+import {
+  attachLateBoundSignalRef,
+  Result,
+  resource,
+  signal,
+  topo,
+  trail,
+} from '@ontrails/core';
 import { z } from 'zod';
 
 import { runWarden } from '../cli.js';
@@ -115,6 +122,42 @@ describe('signal-graph-coaching', () => {
         severity: 'warn',
       },
     ]);
+  });
+
+  test('stays quiet for store-derived producer signals without consumers', async () => {
+    const packCreated = attachLateBoundSignalRef(
+      signal('store:pack.created', {
+        payload: z.object({ id: z.string() }),
+      }),
+      { kind: 'store-derived', token: 'test-token-pack-created' }
+    );
+    const store = resource('store', {
+      create: () => Result.ok({ ok: true }),
+      signals: [packCreated],
+    });
+
+    const diagnostics = await signalGraphCoaching.checkTopo(
+      topo('signal-graph-store-derived', { store })
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('still warns for non-store resource-produced signals without consumers', async () => {
+    const emitted = signal('queue:job.enqueued', {
+      payload: z.object({ jobId: z.string() }),
+    });
+    const queue = resource('queue', {
+      create: () => Result.ok({ ok: true }),
+      signals: [emitted],
+    });
+
+    const diagnostics = await signalGraphCoaching.checkTopo(
+      topo('signal-graph-non-store-resource', { queue })
+    );
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('"queue:job.enqueued"');
   });
 
   test('leaves consumed-without-producer coaching to activation-orphan', async () => {

--- a/packages/warden/src/rules/signal-graph-coaching.ts
+++ b/packages/warden/src/rules/signal-graph-coaching.ts
@@ -1,3 +1,4 @@
+import { getLateBoundSignalRef } from '@ontrails/core';
 import type { Topo } from '@ontrails/core';
 
 import type { TopoAwareWardenRule, WardenDiagnostic } from './types.js';
@@ -69,6 +70,25 @@ const collectProducerResources = (
     ])
   );
 };
+
+/**
+ * Signal ids whose contracts are store-derived advertisements.
+ *
+ * @remarks
+ * Store resources advertise `created`/`updated`/`removed` signals for every
+ * table as available capability. Leaving them unconsumed is a legitimate
+ * steady state, so produced-without-consumer coaching would be pure noise for
+ * store-backed apps.
+ */
+const collectStoreDerivedSignalIds = (topo: Topo): ReadonlySet<string> =>
+  new Set(
+    topo
+      .listSignals()
+      .filter(
+        (signal) => getLateBoundSignalRef(signal)?.kind === 'store-derived'
+      )
+      .map((signal) => signal.id)
+  );
 
 const collectConsumers = (
   topo: Topo
@@ -162,7 +182,8 @@ const hasConsumer = ({ consumers }: SignalRelations): boolean =>
   consumers.length > 0;
 
 const buildDiagnostics = (
-  relationsBySignal: ReadonlyMap<string, SignalRelations>
+  relationsBySignal: ReadonlyMap<string, SignalRelations>,
+  storeDerivedSignalIds: ReadonlySet<string>
 ): readonly WardenDiagnostic[] => {
   const diagnostics: WardenDiagnostic[] = [];
 
@@ -172,7 +193,11 @@ const buildDiagnostics = (
       continue;
     }
 
-    if (hasProducer(relations) && !hasConsumer(relations)) {
+    if (
+      hasProducer(relations) &&
+      !hasConsumer(relations) &&
+      !storeDerivedSignalIds.has(signalId)
+    ) {
       diagnostics.push(
         buildProducedWithoutConsumerDiagnostic(signalId, relations)
       );
@@ -183,7 +208,11 @@ const buildDiagnostics = (
 };
 
 export const signalGraphCoaching: TopoAwareWardenRule = {
-  checkTopo: (topo) => buildDiagnostics(collectRelations(topo)),
+  checkTopo: (topo) =>
+    buildDiagnostics(
+      collectRelations(topo),
+      collectStoreDerivedSignalIds(topo)
+    ),
   description:
     'Warn when typed signal contracts are declared or produced without reactive consumers.',
   name: RULE_NAME,


### PR DESCRIPTION
Fixes [TRL-1183](https://linear.app/outfitter/issue/TRL-1183/signal-graph-coaching-flags-every-store-derived-signal-without-a).

## Problem

A store resource advertises three derived signals per table (`created`/`updated`/`removed`). `signal-graph-coaching` warned for each one without an `on:` consumer, so a three-table app started with nine warnings before writing any code (found building `examples/packlist`; `trails-demo` showed the same three for its single table). Consuming every store signal just to quiet the warden would be artificial.

## Fix

Store-derived signals are treated as advertised capability rather than unconsumed reactive intent: produced-without-consumer coaching skips signals whose late-bound ref is `kind: 'store-derived'` (the marker `createStoreTableSignals` attaches and `cloneSignalWithId` preserves through scoped binding). Non-store produced signals without consumers still warn; dead-signal coaching (no producer and no consumer) is unchanged.

## Tests

- New: `stays quiet for store-derived producer signals without consumers`.
- New: `still warns for non-store resource-produced signals without consumers`.
- Warden package suite: 1250 pass / 0 fail. Repo `bun run check` green — and the three `demo.entity-store:entities.*` warnings that previously appeared in every `bun run check` are gone from the output. `bun run test` 51/51 turbo tasks.

## Release intent

`.changeset/trl-1183-signal-graph-coaching-store-derived.md` — `@ontrails/warden` patch.

## Review

Fresh-context review subagent: no P1/P2; verdict ship. It traced the late-bound ref end-to-end (store → resource → topo.listSignals(), no serialization strips the symbol) and confirmed the dead-signal branch is untouched. Accepted P3 nits: the test attaches the ref directly rather than through a real store (integration covered in packages/store tests); the one-line rule description stays broad; the rule's trail example uses a resource named `store` with a plain signal (still exercises the warning path).
