### PR TITLE
fix(trails): fresh app load resolves extensionless relative imports like the runtime and names unresolvable specifiers instead of an opaque internal error (TRL-1184)

### DIFF
--- a/.changeset/trl-1184-fresh-load-extensionless-imports.md
+++ b/.changeset/trl-1184-fresh-load-extensionless-imports.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': patch
+---
+
+Fresh app loading now resolves extensionless relative imports the way Bun does at runtime, so runtime-valid apps stay operator-loadable (`trails compile`, `trails warden`, and every other fresh-load path). When a relative import cannot be resolved at all, the failure is an actionable `ValidationError` naming the importer file and specifier instead of an opaque redacted "Internal server error".

--- a/apps/trails/src/__tests__/load-app.test.ts
+++ b/apps/trails/src/__tests__/load-app.test.ts
@@ -93,6 +93,39 @@ const assertLoadAppDependencyCaching = async (cwd: string): Promise<void> => {
   expect(fresh.name).toBe('second');
 };
 
+const writeExtensionlessSpecifierLoadAppFixture = (
+  cwd: string,
+  name: string
+): void => {
+  writeFileSync(resolve(cwd, 'src/name.ts'), `export const name = '${name}';`);
+  writeFileSync(
+    resolve(cwd, 'src/app.ts'),
+    `import { name } from './name';
+
+export const app = {
+  name,
+  trails: new Map(),
+  signals: new Map(),
+  resources: new Map()
+};`
+  );
+};
+
+const assertLoadAppExtensionlessSpecifierCaching = async (
+  cwd: string
+): Promise<void> => {
+  writeExtensionlessSpecifierLoadAppFixture(cwd, 'first');
+
+  const first = await loadApp('./src/app.ts', cwd);
+
+  writeExtensionlessSpecifierLoadAppFixture(cwd, 'second');
+
+  const fresh = await loadApp('./src/app.ts', cwd, { fresh: true });
+
+  expect(first.name).toBe('first');
+  expect(fresh.name).toBe('second');
+};
+
 const assertLoadAppJsSpecifierCaching = async (cwd: string): Promise<void> => {
   writeJsSpecifierLoadAppFixture(cwd, 'first');
 
@@ -450,6 +483,59 @@ describe('loadApp', () => {
     try {
       mkdirSync(resolve(cwd, 'src'), { recursive: true });
       await assertLoadAppJsSpecifierCaching(cwd);
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test('fresh loading resolves extensionless relative specifiers like the runtime', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-extensionless-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      await assertLoadAppExtensionlessSpecifierCaching(cwd);
+    } finally {
+      rmSync(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test('fresh loading names unresolvable relative imports instead of failing opaquely', async () => {
+    const cwd = resolve(
+      tmpdir(),
+      `trails-load-app-unresolvable-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+
+    try {
+      mkdirSync(resolve(cwd, 'src'), { recursive: true });
+      writeFileSync(
+        resolve(cwd, 'src/app.ts'),
+        `import { missing } from './missing';
+
+export const app = {
+  name: missing,
+  trails: new Map(),
+  signals: new Map(),
+  resources: new Map()
+};`
+      );
+
+      const result = await tryLoadFreshAppLease('./src/app.ts', cwd);
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ValidationError);
+        expect(result.error.message).toContain('Cannot resolve import');
+        expect(result.error.message).toContain('"./missing"');
+        expect(result.error.message).toContain('src/app.ts');
+        expect(result.error.message).not.toBe('Internal server error');
+      }
     } finally {
       rmSync(cwd, { force: true, recursive: true });
     }

--- a/apps/trails/src/trails/load-app.ts
+++ b/apps/trails/src/trails/load-app.ts
@@ -358,10 +358,33 @@ const resolveImportedModulePath = (
     importPath,
     pathToFileURL(importerPath).href
   );
-  return resolveFilesystemModulePath(
+  const literalPath = resolveFilesystemModulePath(
     fileURLToPath(resolved),
     dirname(importerPath)
   );
+  if (safeStat(literalPath)?.isFile()) {
+    return literalPath;
+  }
+
+  // `import.meta.resolve` joins relative specifiers without probing the
+  // filesystem, so extensionless imports point at paths that do not exist even
+  // though Bun resolves them at runtime. Fall back to the runtime resolver so
+  // runtime-valid apps stay fresh-loadable.
+  try {
+    return resolveFilesystemModulePath(
+      Bun.resolveSync(importPath, dirname(importerPath)),
+      dirname(importerPath)
+    );
+  } catch (error) {
+    const extensionlessHint =
+      extname(importPath) === ''
+        ? ' Extensionless relative imports must match a .ts/.tsx/.js module or a directory index.'
+        : '';
+    throw new ValidationError(
+      `Cannot resolve import "${importPath}" from "${importerPath}" while mirroring the app for fresh loading: "${literalPath}" does not exist and runtime resolution found no match. Fix the specifier or add the missing file.${extensionlessHint}`,
+      { cause: asError(error), context: { importPath, importerPath } }
+    );
+  }
 };
 
 interface WorkspacePackage {


### PR DESCRIPTION
Fixes [TRL-1184](https://linear.app/outfitter/issue/TRL-1184/fresh-app-load-fails-with-opaque-internal-server-error-when-app).

## Problem

An app whose sources use extensionless relative imports (`import { flagSchema } from '../model'`) runs fine under `bun` and `bun test` but could not be fresh-loaded by the operator CLI: `trails compile --root-dir <app>` failed with only `Error: Internal server error` (found building `examples/switchback`). Root cause: the fresh-load mirror resolved relative specifiers with `import.meta.resolve`, which joins URLs without filesystem probing, so the extensionless path reached `Bun.file(...).bytes()`, ENOENT'd into an `InternalError`, and the internal category is redacted to the generic public message.

## Fix

Both asks from the issue:

1. **Runtime-accurate resolution.** When the literally-resolved path is not an existing file, `resolveImportedModulePath` falls back to `Bun.resolveSync(importPath, dirname(importerPath))` — the same resolver the runtime uses — so extensionless specifiers (and directory-index imports) mirror correctly and runtime-valid apps stay operator-loadable.
2. **Actionable diagnostic.** When nothing resolves, the failure is a `ValidationError` (validation category is not redacted) naming the specifier and importer file, with an extensionless hint only when the specifier actually lacks an extension.

## Tests

- New: `fresh loading resolves extensionless relative specifiers like the runtime` (fresh load through the mirror with `import { name } from './name'`).
- New: `fresh loading names unresolvable relative imports instead of failing opaquely` (asserts `ValidationError` with specifier + importer path, not the redacted message).
- apps/trails suite: 621 pass / 0 fail; repo `bun run check` and `bun run test` (51/51 turbo tasks) green.

## Release intent

`.changeset/trl-1184-fresh-load-extensionless-imports.md` — `@ontrails/trails` patch.

## Review

Fresh-context review subagent: no P1/P2. It verified the `.js`→`.ts` remap, `file:` specifiers, and `#imports` behave identically to before (isFile gate returns the literal path whenever it exists), that the `ValidationError` passes `toLoadAppError` un-redacted, and that the fallback applies at every graph depth. Its P3 on the error message assuming the extensionless case was fixed (hint is now conditional). Noted behavior tightening: a statically-analyzable but never-executed import of a missing module now fails the fresh load deterministically with a named diagnostic, instead of passing or failing depending on mirror walk order.
