### PR TITLE
chore(check): give examples/* apps first-class Warden coverage in the repo check via root warden.apps (TRL-1182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,9 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Warden
-        run: bun packages/warden/bin/warden.ts --ci --apps trails,trails-demo
+        # App selection comes from warden.apps in root trails.config.ts so the
+        # framework apps and examples/* stay covered from one source of truth.
+        run: bun packages/warden/bin/warden.ts --ci
 
       - name: ADR check
         run: bun scripts/adr.ts check

--- a/docs/warden.md
+++ b/docs/warden.md
@@ -46,10 +46,10 @@ bun trails warden
 bun trails warden --pre-push
 ```
 
-CI can use the direct Warden bin:
+CI can use the direct Warden bin. When `warden.apps` is set in `trails.config.ts`, the config governs app selection; pass `--apps` only to override it for a single run:
 
 ```bash
-bunx @ontrails/warden --ci --apps trails,trails-demo
+bunx @ontrails/warden --ci
 ```
 
 `--ci` is a preset on the Warden bin. It runs all depths, emits GitHub annotations by default, fails on errors, and suppresses lockfile mutation. Use `--fail-on warning` or `--strict` when warnings should block the run.

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,3 +37,5 @@ Because app builds cannot touch framework surfaces, the wayfinder-dogfood smoke 
 ## CI
 
 Example workspaces run in the normal gates: turbo picks up `build`, `test`, `typecheck`, and `lint` from each example's package scripts, and `bun run check` covers the repo-wide checks. An example app never needs a changeset; the release check only tracks publishable `@ontrails/*` workspaces.
+
+Example topos also get first-class Warden coverage: root `trails.config.ts` lists each example's app module in `warden.apps`, so `bun run check` → `bun trails warden` loads the example topos and runs topo-aware rules against them. Because app build runs cannot touch root config, adding a new example to `warden.apps` happens in a separate framework-side branch, like any other framework change.

--- a/trails.config.ts
+++ b/trails.config.ts
@@ -6,7 +6,15 @@ import { z } from 'zod';
 export default defineConfig({
   base: {
     warden: {
-      apps: ['trails', 'trails-demo'],
+      apps: [
+        'trails',
+        'trails-demo',
+        'examples/junction/src/app.ts',
+        'examples/lookout/src/app.ts',
+        'examples/packlist/src/app.ts',
+        'examples/stash/src/app.ts',
+        'examples/switchback/src/app.ts',
+      ],
     },
   },
   schema: z.object({


### PR DESCRIPTION
Fixes [TRL-1182](https://linear.app/outfitter/issue/TRL-1182/give-examples-apps-first-class-warden-coverage-in-the-repo-check).

Stacked on #917/#918 deliberately: without those fixes the examples would surface the factory-CRUD duplicate and store-signal coaching false positives this run just removed.

## Problem

Root `trails.config.ts` pinned `warden.apps: ['trails', 'trails-demo']`, so the repo Warden run never loaded example topos. Every public trail an example exports was flagged `dead-public-trail` (pure false positives), and the examples' own topo-aware acceptance ran out-of-band with nothing in CI executing it.

## Fix

- Root `warden.apps` now lists all five example app modules by repo-root-relative path (the spelling the named-app resolver requires — it falls through `findAppModuleCandidates`, which only scans `apps/*`, to explicit-path resolution).
- CI's Governance Warden step drops its hardcoded `--apps trails,trails-demo` override (CLI flags beat file config, so the old flag would have kept CI blind to the examples). App selection now has one source of truth: the config.
- `docs/warden.md` CI snippet updated to match; `examples/README.md` CI section documents that new examples get added to `warden.apps` in a framework-side branch (app-build runs may not touch root config).

## Verification

`bun run trails:check` and the exact CI invocation (`bun packages/warden/bin/warden.ts --ci`) both load all seven topos: **PASS, 0 errors, 25 warnings**, zero warnings referencing `examples/*` files as dead-public-trail (previously 86 warnings with the old app set, dozens of them example false positives — reproduced via `TRAILS_APPS=trails,trails-demo` env override). Remaining warnings are pre-existing framework-package `dead-public-trail` entries plus genuine example-topo findings (permit coaching, three enable/disable-style toggle pairs — filed as [TRL-1218](https://linear.app/outfitter/issue/TRL-1218/duplicate-public-contract-still-collides-enabledisable-style-toggle)). Repo `bun run check` and `bun run test` (51/51 turbo tasks) green.

## Release intent

No changeset: this touches only root config, CI workflow, and docs — no publishable `@ontrails/*` package content (`git show --stat`: trails.config.ts, .github/workflows/ci.yml, docs/warden.md, examples/README.md).

## Review

Fresh-context review subagent caught the CI `--apps` override as a P1 (config would never have reached the Governance job) — fixed in this PR along with its P3 on the stale docs snippet.
