### PR TITLE
fix(warden): allow inverse toggle contracts

### DIFF
--- a/.changeset/trl-1218-inverse-toggle-contracts.md
+++ b/.changeset/trl-1218-inverse-toggle-contracts.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/warden": patch
+---
+
+Treat same-scope inverse operation pairs such as enable/disable, pause/resume,
+star/unstar, and archive/restore as intentional distinct public contracts in
+the `duplicate-public-contract` rule.

--- a/packages/warden/src/__tests__/duplicate-public-contract.test.ts
+++ b/packages/warden/src/__tests__/duplicate-public-contract.test.ts
@@ -136,6 +136,96 @@ describe('duplicate-public-contract', () => {
     expect(diagnostics).toHaveLength(1);
   });
 
+  test('stays quiet for inverse operation pairs on the same scope', async () => {
+    const pairs = [
+      ['route.disable', 'route.enable'],
+      ['check.pause', 'check.resume'],
+      ['snippet.star', 'snippet.unstar'],
+      ['document.archive', 'document.restore'],
+    ] as const;
+
+    for (const [disabled, enabled] of pairs) {
+      const left = trail(disabled, {
+        implementation: () => Result.ok({ ok: true }),
+        input,
+        output,
+      });
+      const right = trail(enabled, {
+        implementation: () => Result.ok({ ok: true }),
+        input,
+        output,
+      });
+
+      const diagnostics = await duplicatePublicContract.checkTopo(
+        topo(`inverse-${disabled}`, { left, right })
+      );
+
+      expect(diagnostics).toEqual([]);
+    }
+  });
+
+  test('still warns when matching facts do not form an inverse operation pair', async () => {
+    const first = trail('route.enable', {
+      implementation: () => Result.ok({ ok: true }),
+      input,
+      output,
+    });
+    const second = trail('route.activate', {
+      implementation: () => Result.ok({ ok: true }),
+      input,
+      output,
+    });
+
+    const diagnostics = await duplicatePublicContract.checkTopo(
+      topo('non-inverse-duplicates', { first, second })
+    );
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('still warns for inverse operation names on different scopes', async () => {
+    const disable = trail('route.disable', {
+      implementation: () => Result.ok({ ok: true }),
+      input,
+      output,
+    });
+    const enable = trail('feature.enable', {
+      implementation: () => Result.ok({ ok: true }),
+      input,
+      output,
+    });
+
+    const diagnostics = await duplicatePublicContract.checkTopo(
+      topo('different-scope-inverses', { disable, enable })
+    );
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
+  test('still warns when an inverse pair shares its contract with a third trail', async () => {
+    const disable = trail('route.disable', {
+      implementation: () => Result.ok({ ok: true }),
+      input,
+      output,
+    });
+    const enable = trail('route.enable', {
+      implementation: () => Result.ok({ ok: true }),
+      input,
+      output,
+    });
+    const reset = trail('route.reset', {
+      implementation: () => Result.ok({ ok: true }),
+      input,
+      output,
+    });
+
+    const diagnostics = await duplicatePublicContract.checkTopo(
+      topo('crowded-inverse-contract', { disable, enable, reset })
+    );
+
+    expect(diagnostics).toHaveLength(1);
+  });
+
   test('uses provided graph facts when available', async () => {
     const canonical = trail('survey.diff', {
       implementation: () => Result.ok({ ok: true }),

--- a/packages/warden/src/rules/duplicate-public-contract.ts
+++ b/packages/warden/src/rules/duplicate-public-contract.ts
@@ -5,6 +5,12 @@ import type { TopoAwareWardenRule, WardenDiagnostic } from './types.js';
 
 const RULE_NAME = 'duplicate-public-contract';
 const TOPO_FILE = '<topo>';
+const INVERSE_OPERATION_PAIRS = new Map([
+  ['archive', 'restore'],
+  ['disable', 'enable'],
+  ['pause', 'resume'],
+  ['star', 'unstar'],
+]);
 
 const resolveGraph = (
   topo: Parameters<TopoAwareWardenRule['checkTopo']>[0],
@@ -60,6 +66,42 @@ const renderTrailIds = (trailIds: readonly string[]): string =>
     .map((trailId) => `"${trailId}"`)
     .join(', ');
 
+const splitOperation = (
+  trailId: string
+): { readonly scope: string; readonly operation: string } | undefined => {
+  const separatorIndex = trailId.lastIndexOf('.');
+
+  if (separatorIndex <= 0 || separatorIndex === trailId.length - 1) {
+    return undefined;
+  }
+
+  return {
+    operation: trailId.slice(separatorIndex + 1),
+    scope: trailId.slice(0, separatorIndex),
+  };
+};
+
+const areInverseOperations = (left: string, right: string): boolean =>
+  INVERSE_OPERATION_PAIRS.get(left) === right ||
+  INVERSE_OPERATION_PAIRS.get(right) === left;
+
+const isAcceptedInverseOperationPair = (
+  trailIds: readonly string[]
+): boolean => {
+  if (trailIds.length !== 2) {
+    return false;
+  }
+
+  const [left, right] = trailIds.map(splitOperation);
+
+  return Boolean(
+    left &&
+    right &&
+    left.scope === right.scope &&
+    areInverseOperations(left.operation, right.operation)
+  );
+};
+
 const buildDiagnostic = (trailIds: readonly string[]): WardenDiagnostic => ({
   filePath: TOPO_FILE,
   line: 1,
@@ -82,7 +124,10 @@ export const duplicatePublicContract: TopoAwareWardenRule = {
     }
 
     return [...groups.values()]
-      .filter((trailIds) => trailIds.length > 1)
+      .filter(
+        (trailIds) =>
+          trailIds.length > 1 && !isAcceptedInverseOperationPair(trailIds)
+      )
       .map(buildDiagnostic);
   },
   description:


### PR DESCRIPTION
## Context

Fixes TRL-1218. The `duplicate-public-contract` Warden rule treated deliberate inverse toggle pairs like `route.disable` / `route.enable`, `check.pause` / `check.resume`, and `snippet.star` / `snippet.unstar` as duplicate public contracts because their normalized contract facts match.

## What Changed

- Added a narrow same-scope inverse operation-pair exception to `duplicate-public-contract`.
- Kept genuine duplicate detection intact by requiring exactly two trail ids, the same dotted scope, and a known inverse operation pair.
- Added focused tests for quiet inverse pairs and a non-inverse same-scope pair that still warns.
- Added a patch changeset for `@ontrails/warden`.

## Verification

- `bun test packages/warden/src/__tests__/duplicate-public-contract.test.ts`
- `bun run trails:check` -> PASS, 0 errors / 22 warnings; the three TRL-1218 duplicate-public-contract warnings are gone from the recorded 25-warning baseline.
- `bun run format:check`
- `bun run lint`
- `bun run --cwd packages/warden typecheck`
- `bun run changeset:check` -> passed for `@ontrails/warden` after commit.
- Graphite pre-push stable checks passed: warden pre-push, ADR check, turbo tests, typecheck, lint, ast-grep, format, release-pack, and dead-code.

## Risks / Notes

- Full `bun run check` currently fails before this branch's relevant gates on an unrelated `vocab:audit` hit in `packages/regrade/CHANGELOG.md` for the existing `layers-term` rule. I left that untouched and kept this PR draft until CI settles.
