### PR TITLE
docs(adr): promote overlays ADR to accepted as ADR-0052 (TRL-1197)

### DIFF
--- a/docs/adr/0050-surface-accommodations-preserve-trail-identity.md
+++ b/docs/adr/0050-surface-accommodations-preserve-trail-identity.md
@@ -4,12 +4,14 @@ slug: surface-accommodations-preserve-trail-identity
 title: Surface Accommodations Preserve Trail Identity
 status: accepted
 created: 2026-06-14
-updated: 2026-06-14
+updated: 2026-07-07
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [0, 1, 8, 19, 27, 35, 46]
 ---
 
 # ADR-0050: Surface Accommodations Preserve Trail Identity
+
+> **Status update (2026-07-07):** Amended by [ADR-0052: Overlays Are the Lock's One Extension Mechanism](0052-overlays-one-extension-mechanism.md). The accommodation doctrine here stands — converge without lying, gather without merging, the trail fork test. The implementation carrier moved: `alias` and `trailhead` are no longer API identifiers; both dissolve into surface-overlay binding shapes (scalar = synonym, list = grouped entry), and the protections re-key onto those shapes.
 
 ## Context
 

--- a/docs/adr/0052-overlays-one-extension-mechanism.md
+++ b/docs/adr/0052-overlays-one-extension-mechanism.md
@@ -1,14 +1,15 @@
 ---
+id: 52
 slug: overlays-one-extension-mechanism
 title: Overlays Are the Lock's One Extension Mechanism
-status: draft
+status: accepted
 created: 2026-07-05
-updated: 2026-07-05
+updated: 2026-07-07
 owners: ['[galligan](https://github.com/galligan)']
 depends_on: [17, 46, 50, 51]
 ---
 
-# ADR: Overlays Are the Lock's One Extension Mechanism
+# ADR-0052: Overlays Are the Lock's One Extension Mechanism
 
 ## Context
 
@@ -18,7 +19,7 @@ The lock accumulated three separate ways for information that is not core graph 
 
 - **CLI aliases** rode an ad-hoc export convention (`cliAliases` / `trailsCliAliases`) that compile lifted into `deriveTopoGraph` through a dedicated option. Warden's drift check derived a fresh graph *without* that lift, so every alias-exporting app compared dirty against its own committed lock — permanently "stale" the moment it compiled ([TRL-1179](https://linear.app/outfitter/issue/TRL-1179/warden-drift-check-ignores-clialiases-so-alias-exporting-app-modules)).
 - **MCP trailheads** never reached the lock in practice. The map passed at the `surface()` call is runtime-correct — the ADR-0050 identity tests pass — but lock-blind: invisible to Wayfinder, invisible to drift detection, un-inspectable by agents reading the committed story ([TRL-1193](https://linear.app/outfitter/issue/TRL-1193/app-authored-mcp-trailheads-have-no-channel-into-the-compiled-lock)). Topographer grew a `DeriveTopoGraphOptions.trailheads` declaration option, but nothing on the compile path ever wires it.
-- **Adapter facts** (the Cloudflare adapter's deployment metadata) landed as the right shape on the first try: a named, schema-registered, namespace-keyed sheet collected on the compile path, round-tripped byte-preserved when unrecognized, covered by the canonical hash, and readable generically through `trails wayfind --overlay <namespace>` ([#900](https://github.com/outfitter-dev/trails/pull/900)–[#903](https://github.com/outfitter-dev/trails/pull/903)). One gap remains: the shipped channel is compile-path-only — Warden's fresh drift derivation does not collect it yet, which is exactly the asymmetry the drift-symmetry decision below closes.
+- **Adapter facts** (the Cloudflare adapter's deployment metadata) landed as the right shape on the first try: a named, schema-registered, namespace-keyed sheet collected on the compile path, round-tripped byte-preserved when unrecognized, covered by the canonical hash, and readable generically through `trails wayfind --overlay <namespace>` ([#900](https://github.com/outfitter-dev/trails/pull/900)–[#903](https://github.com/outfitter-dev/trails/pull/903)). One gap remained at drafting time: the shipped channel was compile-path-only — Warden's fresh drift derivation did not collect it, exactly the asymmetry the drift-symmetry decision below closes. Wave 2 closed it before acceptance ([TRL-1209](https://linear.app/outfitter/issue/TRL-1209/wave-2-drift-symmetry-compile-and-warden-derive-collect-overlays)): compile and Warden fresh derivation now read `trailsOverlays` through one shared collection function.
 
 The third channel is the tell. It shipped without per-kind plumbing because it is a *mechanism*, not a feature: register a schema, collect through one path, preserve tolerantly, hash canonically. The first two channels are the same shape wearing bespoke plumbing — and the bespoke plumbing is exactly where the bugs live. [TRL-1179](https://linear.app/outfitter/issue/TRL-1179/warden-drift-check-ignores-clialiases-so-alias-exporting-app-modules) is not an alias bug; it is an asymmetric-lifting bug. Any per-kind lift can drift from any fresh derivation that forgets it.
 
@@ -68,7 +69,7 @@ Per-surface keys (`cli`, `mcp`, future `ws`/`http`) map names to `TrailRef | Tra
 - A **list** value is a grouped entry — the old "trailhead." One derived surface entry over the members, member identity preserved at invocation and response.
 - **A singleton list stays a group.** Cardinality is not the discriminator; value shape is. A group of one keeps its grouped invocation envelope and does not change contract when member two arrives.
 
-ADR-0050's protections re-key onto the shapes rather than the retired nouns: [converge-without-lying](../0050-surface-accommodations-preserve-trail-identity.md#two-axes) governs scalar bindings; [gather-without-merging](../0050-surface-accommodations-preserve-trail-identity.md#two-axes) identity preservation governs list bindings. The doctrine is unchanged; only the carrier moved.
+ADR-0050's protections re-key onto the shapes rather than the retired nouns: [converge-without-lying](0050-surface-accommodations-preserve-trail-identity.md#two-axes) governs scalar bindings; [gather-without-merging](0050-surface-accommodations-preserve-trail-identity.md#two-axes) identity preservation governs list bindings. The doctrine is unchanged; only the carrier moved.
 
 The subsumption also makes both capabilities symmetric across surfaces for free: list bindings on CLI are command groups (`app gear list`); scalar bindings on MCP are tool synonyms. The trailhead concept was never MCP-specific — the bespoke plumbing just made it look that way.
 
@@ -84,7 +85,7 @@ Compile and every fresh derivation (Warden drift, `trails validate`, Wayfinder l
 
 ### The call-site option survives as override-in-context
 
-The MCP surface's call-site map is not deleted; it is re-classed under the [authored-defaults-overridable pattern](../../tenets.md#authored-defaults-overridable-in-context). The module overlay is the authored, lockable default; a map passed at `surface()` still works and wins at runtime — and is *visible as an override*: Warden warns when the runtime override diverges from the authored overlay. This is a permanent feature of the model, not a compatibility bridge.
+The MCP surface's call-site map is not deleted; it is re-classed under the [authored-defaults-overridable pattern](../tenets.md#authored-defaults-overridable-in-context). The module overlay is the authored, lockable default; a map passed at `surface()` still works and wins at runtime — and is *visible as an override*: Warden warns when the runtime override diverges from the authored overlay. This is a permanent feature of the model, not a compatibility bridge.
 
 ### Vocabulary rulings
 
@@ -94,7 +95,7 @@ The MCP surface's call-site map is not deleted; it is re-classed under the [auth
 
 ### Natural altitude extends to vocabulary
 
-[ADR-0051](../0051-package-ownership-follows-natural-altitude.md) says a reusable capability lives in the lowest package where it is coherent. This ADR extends the doctrine from code to *concepts*: a vocabulary item belongs to the package that acts on it. `@ontrails/cli` owns what a `cli` binding means; the MCP projection owns what an `mcp` binding means; core and topographer know only the overlay envelope — determinism, tolerant preservation, provenance, hash coverage. Adding accommodation kind N+1 is a schema plus a consumer; core diffs zero lines.
+[ADR-0051](0051-package-ownership-follows-natural-altitude.md) says a reusable capability lives in the lowest package where it is coherent. This ADR extends the doctrine from code to *concepts*: a vocabulary item belongs to the package that acts on it. `@ontrails/cli` owns what a `cli` binding means; the MCP projection owns what an `mcp` binding means; core and topographer know only the overlay envelope — determinism, tolerant preservation, provenance, hash coverage. Adding accommodation kind N+1 is a schema plus a consumer; core diffs zero lines.
 
 ### Hard cutover
 
@@ -144,10 +145,10 @@ Two adjacent pressures, answered in advance so they do not grow channels:
 ## References
 
 - [Design: overlays — one extension mechanism, and the migration semantics for cliAliases + MCP trailheads](https://linear.app/outfitter/document/design-overlays-one-extension-mechanism-and-the-migration-semantics-be1578213cd9) — the ratified binding spec this ADR records
-- [ADR-0050: Surface Accommodations Preserve Trail Identity](../0050-surface-accommodations-preserve-trail-identity.md) — amended: the accommodation doctrine stands; its implementation story re-keys from named machinery (alias maps, trailhead maps) onto binding shapes
-- [ADR-0051: Package Ownership Follows Natural Altitude](../0051-package-ownership-follows-natural-altitude.md) — extended: natural altitude now governs vocabulary, not just code
-- [ADR-0017: Serialized Topo Graph](../0017-serialized-topo-graph.md) — the lock promise overlays extend
-- [ADR-0046: Lock v3 Artifact Family](../0046-lock-v3-artifact-family.md) — the artifact family the `overlays` field lives in
+- [ADR-0050: Surface Accommodations Preserve Trail Identity](0050-surface-accommodations-preserve-trail-identity.md) — amended: the accommodation doctrine stands; its implementation story re-keys from named machinery (alias maps, trailhead maps) onto binding shapes
+- [ADR-0051: Package Ownership Follows Natural Altitude](0051-package-ownership-follows-natural-altitude.md) — extended: natural altitude now governs vocabulary, not just code
+- [ADR-0017: Serialized Topo Graph](0017-serialized-topo-graph.md) — the lock promise overlays extend
+- [ADR-0046: Lock v3 Artifact Family](0046-lock-v3-artifact-family.md) — the artifact family the `overlays` field lives in
 - Shipped mechanism evidence: [#900](https://github.com/outfitter-dev/trails/pull/900), [#901](https://github.com/outfitter-dev/trails/pull/901), [#902](https://github.com/outfitter-dev/trails/pull/902), [#903](https://github.com/outfitter-dev/trails/pull/903) (generic namespaced overlays: registration, compile-path collection, tolerant reader, canonical hash, generic wayfind read)
 - [TRL-1179](https://linear.app/outfitter/issue/TRL-1179/warden-drift-check-ignores-clialiases-so-alias-exporting-app-modules) — the asymmetric-lift drift bug this design retires as a class
 - [TRL-1193](https://linear.app/outfitter/issue/TRL-1193/app-authored-mcp-trailheads-have-no-channel-into-the-compiled-lock) — the lock-blind trailheads gap this design closes

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,3 +58,4 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0049](0049-composition-is-compose-not-cross.md) | Composition is `compose`, not `cross` | Accepted |
 | [0050](0050-surface-accommodations-preserve-trail-identity.md) | Surface Accommodations Preserve Trail Identity | Accepted |
 | [0051](0051-package-ownership-follows-natural-altitude.md) | Package Ownership Follows Natural Altitude | Accepted |
+| [0052](0052-overlays-one-extension-mechanism.md) | Overlays Are the Lock's One Extension Mechanism | Accepted |

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -1453,6 +1453,11 @@
           "fromPath": "docs/adr/0048-trail-versioning-v3.md"
         },
         {
+          "context": "- [ADR-0017: Serialized Topo Graph](0017-serialized-topo-graph.md) — the lock promise overlays extend",
+          "from": "0052",
+          "fromPath": "docs/adr/0052-overlays-one-extension-mechanism.md"
+        },
+        {
           "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) -- rig state captured in the lockfile graph; rig lock state occupies a section in `trails.lock`",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-external-trailheads-as-trails.md"
@@ -1476,11 +1481,6 @@
           "context": "- [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md) — established the resolved graph as a serialized artifact.",
           "from": "20260622",
           "fromPath": "docs/adr/drafts/20260622-project-substrate-names-its-truth.md"
-        },
-        {
-          "context": "- [ADR-0017: Serialized Topo Graph](../0017-serialized-topo-graph.md) — the lock promise overlays extend",
-          "from": "20260705",
-          "fromPath": "docs/adr/drafts/20260705-overlays-one-extension-mechanism.md"
         },
         {
           "context": "- **[ADR-0017: The Serialized Topo Graph](./adr/0017-serialized-topo-graph.md)** — Lockfile as resolved graph",
@@ -2718,6 +2718,11 @@
           "fromPath": "docs/adr/0050-surface-accommodations-preserve-trail-identity.md"
         },
         {
+          "context": "- [ADR-0046: Lock v3 Artifact Family](0046-lock-v3-artifact-family.md) — the artifact family the `overlays` field lives in",
+          "from": "0052",
+          "fromPath": "docs/adr/0052-overlays-one-extension-mechanism.md"
+        },
+        {
           "context": "- [ADR-0046: Lock v3 Artifact Family](../0046-lock-v3-artifact-family.md) - `.trails/topo.lock` as the inspectable topo content artifact",
           "from": "20260603",
           "fromPath": "docs/adr/drafts/20260603-surface-trailheads-shape-dense-topos.md"
@@ -2736,11 +2741,6 @@
           "context": "- [ADR-0046: Lock v3 Artifact Family](../0046-lock-v3-artifact-family.md) — the artifact family this ADR collapses into one root lock.",
           "from": "20260622",
           "fromPath": "docs/adr/drafts/20260622-project-substrate-names-its-truth.md"
-        },
-        {
-          "context": "- [ADR-0046: Lock v3 Artifact Family](../0046-lock-v3-artifact-family.md) — the artifact family the `overlays` field lives in",
-          "from": "20260705",
-          "fromPath": "docs/adr/drafts/20260705-overlays-one-extension-mechanism.md"
         },
         {
           "context": "Typed view over the saved `TopoGraph` content artifact for a snapshot. This is the `topo_graph` member of the lock v3 artifact family defined in [ADR-0046](./adr/0046-lock-v3-artifact-family.md):",
@@ -2881,6 +2881,11 @@
           "fromPath": "AGENTS.md"
         },
         {
+          "context": "ADR-0050's protections re-key onto the shapes rather than the retired nouns: [converge-without-lying](0050-surface-accommodations-preserve-trail-identity.md#two-axes) governs scalar bindings; [gather-",
+          "from": "0052",
+          "fromPath": "docs/adr/0052-overlays-one-extension-mechanism.md"
+        },
+        {
           "context": "- [ADR-0050: Surface Accommodations Preserve Trail Identity](../0050-surface-accommodations-preserve-trail-identity.md) - surface accommodation vocabulary and fork test",
           "from": "20260603",
           "fromPath": "docs/adr/drafts/20260603-surface-trailheads-shape-dense-topos.md"
@@ -2894,11 +2899,6 @@
           "context": "- [ADR-0050: Surface Accommodations Preserve Trail Identity](../0050-surface-accommodations-preserve-trail-identity.md) — preserve authored contract identity.",
           "from": "20260622",
           "fromPath": "docs/adr/drafts/20260622-project-substrate-names-its-truth.md"
-        },
-        {
-          "context": "ADR-0050's protections re-key onto the shapes rather than the retired nouns: [converge-without-lying](../0050-surface-accommodations-preserve-trail-identity.md#two-axes) governs scalar bindings; [gath",
-          "from": "20260705",
-          "fromPath": "docs/adr/drafts/20260705-overlays-one-extension-mechanism.md"
         },
         {
           "context": "CLI routes are a surface accommodation. In CLI terms, the surface entry is the command, the command path is the path for an approach, and an alias is an alternate approach to the same command. See [AD",
@@ -2933,16 +2933,16 @@
       "status": "accepted",
       "superseded_by": null,
       "title": "Surface Accommodations Preserve Trail Identity",
-      "updated": "2026-06-14"
+      "updated": "2026-07-07"
     },
     {
       "created": "2026-07-01",
       "depends_on": ["1", "9", "41"],
       "inbound": [
         {
-          "context": "[ADR-0051](../0051-package-ownership-follows-natural-altitude.md) says a reusable capability lives in the lowest package where it is coherent. This ADR extends the doctrine from code to *concepts*: a ",
-          "from": "20260705",
-          "fromPath": "docs/adr/drafts/20260705-overlays-one-extension-mechanism.md"
+          "context": "[ADR-0051](0051-package-ownership-follows-natural-altitude.md) says a reusable capability lives in the lowest package where it is coherent. This ADR extends the doctrine from code to *concepts*: a voc",
+          "from": "0052",
+          "fromPath": "docs/adr/0052-overlays-one-extension-mechanism.md"
         }
       ],
       "number": "0051",
@@ -2953,6 +2953,25 @@
       "superseded_by": null,
       "title": "Package Ownership Follows Natural Altitude",
       "updated": "2026-07-01"
+    },
+    {
+      "created": "2026-07-05",
+      "depends_on": ["17", "46", "50", "51"],
+      "inbound": [
+        {
+          "context": "> **Status update (2026-07-07):** Amended by [ADR-0052: Overlays Are the Lock's One Extension Mechanism](0052-overlays-one-extension-mechanism.md). The accommodation doctrine here stands — converge wi",
+          "from": "0050",
+          "fromPath": "docs/adr/0050-surface-accommodations-preserve-trail-identity.md"
+        }
+      ],
+      "number": "0052",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0052-overlays-one-extension-mechanism.md",
+      "slug": "overlays-one-extension-mechanism",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Overlays Are the Lock's One Extension Mechanism",
+      "updated": "2026-07-07"
     }
   ],
   "version": 1

--- a/docs/adr/drafts/README.md
+++ b/docs/adr/drafts/README.md
@@ -56,8 +56,3 @@ Draft map: `docs/adr/drafts/decision-map.json`; numbered map: `docs/adr/decision
   - depends on [ADR-0008: Deterministic Surface Derivation](../0008-deterministic-trailhead-derivation.md), [ADR-0019: Hierarchical Command Trees from Trail IDs](../0019-hierarchical-command-trees-from-trail-ids.md), [ADR-0035: Surface APIs Render the Graph](../0035-surface-apis-render-the-graph.md), [ADR-0047: Stable Release Line Discipline](../0047-stable-release-line-discipline.md), [ADR-0050: Surface Accommodations Preserve Trail Identity](../0050-surface-accommodations-preserve-trail-identity.md)
 - [Project Substrate Names Its Truth](20260622-project-substrate-names-its-truth.md)
   - depends on [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md), [ADR-0042: Core/Topographer Boundary Doctrine](../0042-core-topographer-boundary-doctrine.md), [ADR-0046: Lock v3 Artifact Family](../0046-lock-v3-artifact-family.md), [ADR-0050: Surface Accommodations Preserve Trail Identity](../0050-surface-accommodations-preserve-trail-identity.md)
-
-## 2026-07
-
-- [Overlays Are the Lock's One Extension Mechanism](20260705-overlays-one-extension-mechanism.md)
-  - depends on [ADR-0017: The Serialized Topo Graph](../0017-serialized-topo-graph.md), [ADR-0046: Lock v3 Artifact Family](../0046-lock-v3-artifact-family.md), [ADR-0050: Surface Accommodations Preserve Trail Identity](../0050-surface-accommodations-preserve-trail-identity.md), [ADR-0051: Package Ownership Follows Natural Altitude](../0051-package-ownership-follows-natural-altitude.md)

--- a/docs/adr/drafts/decision-map.json
+++ b/docs/adr/drafts/decision-map.json
@@ -325,19 +325,6 @@
       "superseded_by": null,
       "title": "Project Substrate Names Its Truth",
       "updated": "2026-06-22"
-    },
-    {
-      "created": "2026-07-05",
-      "depends_on": ["17", "46", "50", "51"],
-      "inbound": [],
-      "number": null,
-      "owners": ["[galligan](https://github.com/galligan)"],
-      "path": "docs/adr/drafts/20260705-overlays-one-extension-mechanism.md",
-      "slug": "overlays-one-extension-mechanism",
-      "status": "draft",
-      "superseded_by": null,
-      "title": "Overlays Are the Lock's One Extension Mechanism",
-      "updated": "2026-07-05"
     }
   ],
   "version": 1


### PR DESCRIPTION
Closes [TRL-1197](https://linear.app/outfitter/issue/TRL-1197/adr-overlays-the-locks-one-extension-mechanism-subsumes-aliases).

## What

Promotes the overlays ADR from draft to **accepted ADR-0052** via the trails-adrs workflow:

- `docs/adr/drafts/20260705-overlays-one-extension-mechanism.md` → `docs/adr/0052-overlays-one-extension-mechanism.md` (status `accepted`), with draft-relative links rewritten for the new location.
- ADR-0050 gets a status-update blockquote (the ADR-0044 pattern): the accommodation doctrine stands; the implementation carrier re-keyed from alias/trailhead machinery onto surface-overlay binding shapes. `updated` bumped.
- ADR index and both decision maps regenerated by the script; `adr.ts check` passes with 0 errors, 0 warnings.

## Why now

The draft gated acceptance on Wave 2 proving the semantics. That gate is satisfied:

- Wave 2 consumer cutovers (TRL-1207 CLI, TRL-1208 MCP) are merged on main and green.
- beta.39 published on the `beta` tag including the first `@ontrails/cloudflare` package; registry checks and a fresh temp-project install verified (see issue comments).

## Not applicable

- Changeset: docs-only; no publishable package content changes.
- Migration/docs surfaces: the mechanism itself shipped and was documented in Waves 0–2 (#900–#903, TRL-1207/1208); this PR only records the decision as accepted.

https://claude.ai/code/session_01NPU7jAWhAaCyGgDRv6my1J
