### PR TITLE
chore(adapter-kit): share adapter source scanning

### DIFF
--- a/.changeset/adapter-source-scanning-owner.md
+++ b/.changeset/adapter-source-scanning-owner.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/adapter-kit": patch
+"@ontrails/trails": patch
+---
+
+Move adapter source export scanning into adapter-kit and have `create.adapter`
+consume the shared helper.

--- a/apps/trails/src/__tests__/create-adapter.test.ts
+++ b/apps/trails/src/__tests__/create-adapter.test.ts
@@ -270,6 +270,68 @@ describe('trails create adapter', () => {
     expect(result.diagnostics).toEqual([]);
   });
 
+  test('accepts HTTP options that share type and value declarations', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      [
+        'export interface CreateFetchHandlerOptions {}',
+        'export const CreateFetchHandlerOptions = {};',
+        'export const createFetchHandler = () => undefined;',
+        '',
+      ].join('\n')
+    );
+
+    const result = expectOk(
+      await createAdapterTrail.implementation(
+        {
+          dryRun: false,
+          name: 'merged-options',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(result.created).toContain('adapters/merged-options/src/index.ts');
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  test('accepts HTTP option type aliases that share a value name', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      [
+        'export type CreateFetchHandlerOptions = { enabled?: boolean };',
+        'export const CreateFetchHandlerOptions = { enabled: true };',
+        'export const createFetchHandler = () => undefined;',
+        '',
+      ].join('\n')
+    );
+
+    const result = expectOk(
+      await createAdapterTrail.implementation(
+        {
+          dryRun: false,
+          name: 'aliased-options',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(result.created).toContain('adapters/aliased-options/src/index.ts');
+    expect(result.diagnostics).toEqual([]);
+  });
+
   test('fails before writing when same-file HTTP support type exports resolve only to values', async () => {
     const root = makeRoot();
     writeHttpOwner(root);
@@ -301,6 +363,36 @@ describe('trails create adapter', () => {
     expect(existsSync(join(root, 'adapters/value-only-type-support'))).toBe(
       false
     );
+  });
+
+  test('fails before writing when HTTP options are exported as an enum', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      [
+        'export enum CreateFetchHandlerOptions {}',
+        'export const createFetchHandler = () => undefined;',
+        '',
+      ].join('\n')
+    );
+
+    const error = expectValidationError(
+      await createAdapterTrail.implementation(
+        {
+          dryRun: false,
+          name: 'enum-options',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('CreateFetchHandlerOptions');
+    expect(existsSync(join(root, 'adapters/enum-options'))).toBe(false);
   });
 
   test('accepts HTTP scaffold support through owner root import-export barrels', async () => {
@@ -368,6 +460,49 @@ describe('trails create adapter', () => {
       'adapters/hono-type-import-barrel/src/index.ts'
     );
     expect(result.diagnostics).toEqual([]);
+  });
+
+  test('rejects enum options hidden behind a type-only import-export barrel', async () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeFile(
+      root,
+      'packages/http/src/fetch.ts',
+      [
+        'export enum CreateFetchHandlerOptions {}',
+        'export const createFetchHandler = () => undefined;',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/index.ts',
+      [
+        'import { createFetchHandler } from "./fetch.js";',
+        'import type { CreateFetchHandlerOptions } from "./fetch.js";',
+        'export type { CreateFetchHandlerOptions };',
+        'export { createFetchHandler };',
+        '',
+      ].join('\n')
+    );
+
+    const error = expectValidationError(
+      await createAdapterTrail.implementation(
+        {
+          dryRun: false,
+          name: 'enum-type-import-barrel',
+          placement: 'extracted',
+          rootDir: root,
+          target: 'http',
+        },
+        { cwd: root } as never
+      )
+    );
+
+    expect(error.message).toContain('CreateFetchHandlerOptions');
+    expect(existsSync(join(root, 'adapters/enum-type-import-barrel'))).toBe(
+      false
+    );
   });
 
   test('fails before writing when HTTP support value re-exports resolve only to types', async () => {

--- a/apps/trails/src/trails/create-adapter.ts
+++ b/apps/trails/src/trails/create-adapter.ts
@@ -3,6 +3,8 @@
  */
 
 import {
+  adapterSourceExportKind,
+  adapterSourceExports,
   adapterTargetPlacements,
   checkAdapters,
   deriveAdapterTargetCatalog,
@@ -22,7 +24,7 @@ import {
 } from '@ontrails/core';
 import type { WorkspaceRootManifest } from '@ontrails/core';
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { join, resolve } from 'node:path';
 import { z } from 'zod';
 
 import {
@@ -79,18 +81,6 @@ interface AdapterOperationPlan {
 interface WorkspacePackageManifest {
   readonly exports?: unknown;
   readonly name?: unknown;
-}
-
-interface LocalNamedReexport {
-  readonly local: string;
-  readonly specifier: string;
-  readonly typeOnly: boolean;
-}
-
-interface LocalNamedImport {
-  readonly imported: string;
-  readonly specifier: string;
-  readonly typeOnly: boolean;
 }
 
 const literal = (value: string): string => JSON.stringify(value);
@@ -208,392 +198,6 @@ const packageRootExportTarget = (
   return resolve(target.packageRoot, exportTarget);
 };
 
-const maskSource = (source: string, options: { strings: boolean }): string => {
-  const output = [...source];
-  let index = 0;
-
-  const maskRange = (start: number, end: number): void => {
-    for (let cursor = start; cursor < end; cursor += 1) {
-      if (output[cursor] !== '\n') {
-        output[cursor] = ' ';
-      }
-    }
-  };
-
-  const skipQuoted = (quote: '"' | "'" | '`'): void => {
-    const start = index;
-    index += 1;
-    while (index < source.length) {
-      if (source[index] === '\\') {
-        index += 2;
-        continue;
-      }
-      if (source[index] === quote) {
-        index += 1;
-        break;
-      }
-      index += 1;
-    }
-    if (options.strings) {
-      maskRange(start, index);
-    }
-  };
-
-  while (index < source.length) {
-    if (source.startsWith('//', index)) {
-      const end = source.indexOf('\n', index + 2);
-      const stop = end === -1 ? source.length : end;
-      maskRange(index, stop);
-      index = stop;
-      continue;
-    }
-    if (source.startsWith('/*', index)) {
-      const end = source.indexOf('*/', index + 2);
-      const stop = end === -1 ? source.length : end + 2;
-      maskRange(index, stop);
-      index = stop;
-      continue;
-    }
-    const char = source[index];
-    if (char === '"' || char === "'" || char === '`') {
-      skipQuoted(char);
-      continue;
-    }
-    index += 1;
-  }
-
-  return output.join('');
-};
-
-const sameFileExportListLocalForIdentifier = (
-  source: string,
-  identifier: string,
-  expected: 'type' | 'value'
-): string | undefined => {
-  const exportCode = maskSource(source, { strings: false });
-  const stringsMaskedCode = maskSource(source, { strings: true });
-  const exportListPattern =
-    /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}(?<from>\s+from\s+['"][^'"]+['"])?/gu;
-  for (const match of exportCode.matchAll(exportListPattern)) {
-    if (!stringsMaskedCode.startsWith('export', match.index ?? 0)) {
-      continue;
-    }
-
-    if (match.groups?.['from']) {
-      continue;
-    }
-
-    const namedExports = match.groups?.['exports'] ?? '';
-    for (const item of namedExports.split(',')) {
-      const trimmedItem = item.trim();
-      const specifierTypeOnly =
-        Boolean(match.groups?.['typeOnly']) || trimmedItem.startsWith('type ');
-      const specifierText = trimmedItem.replace(/^type\s+/u, '');
-      const exported =
-        /^(?<local>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<name>[A-Za-z_$][\w$]*))?$/u.exec(
-          specifierText
-        )?.groups;
-      if (
-        !exported?.['local'] ||
-        (exported['name'] ?? exported['local']) !== identifier
-      ) {
-        continue;
-      }
-      if (expected === 'type') {
-        return exported['local'];
-      }
-      if (!specifierTypeOnly) {
-        return exported['local'];
-      }
-    }
-  }
-
-  return undefined;
-};
-
-const declaresTypeBinding = (source: string, identifier: string): boolean => {
-  const code = maskSource(source, { strings: true });
-  const escapedIdentifier = identifier.replaceAll(
-    /[.*+?^${}()|[\]\\]/gu,
-    '\\$&'
-  );
-  return new RegExp(
-    `(?:^|[;\\n\\r])\\s*(?:export\\s+)?(?:declare\\s+)?(?:interface|type)\\s+${escapedIdentifier}\\b`,
-    'u'
-  ).test(code);
-};
-
-const declaresValueBinding = (source: string, identifier: string): boolean => {
-  const code = maskSource(source, { strings: true });
-  const escapedIdentifier = identifier.replaceAll(
-    /[.*+?^${}()|[\]\\]/gu,
-    '\\$&'
-  );
-  return new RegExp(
-    `(?:^|[;\\n\\r])\\s*(?:export\\s+)?(?:(?:async\\s+)?function|const|let|var|class|enum)\\s+${escapedIdentifier}\\b`,
-    'u'
-  ).test(code);
-};
-
-const sourceExportsIdentifier = (
-  source: string,
-  identifier: string,
-  expected: 'type' | 'value'
-): boolean => {
-  const code = maskSource(source, { strings: true });
-  const escapedIdentifier = identifier.replaceAll(
-    /[.*+?^${}()|[\]\\]/gu,
-    '\\$&'
-  );
-  const valueDeclarationPattern = new RegExp(
-    `\\bexport\\s+(?:(?:async\\s+)?function|const|let|var|class|enum)\\s+${escapedIdentifier}\\b`,
-    'u'
-  );
-  if (expected === 'value' && valueDeclarationPattern.test(code)) {
-    return true;
-  }
-
-  const typeDeclarationPattern = new RegExp(
-    `\\bexport\\s+(?:declare\\s+)?(?:interface|type)\\s+${escapedIdentifier}\\b`,
-    'u'
-  );
-  const sameFileLocal = sameFileExportListLocalForIdentifier(
-    source,
-    identifier,
-    expected
-  );
-  return (
-    (expected === 'type' &&
-      (typeDeclarationPattern.test(code) ||
-        (sameFileLocal !== undefined &&
-          declaresTypeBinding(source, sameFileLocal)))) ||
-    (expected === 'value' &&
-      sameFileLocal !== undefined &&
-      declaresValueBinding(source, sameFileLocal))
-  );
-};
-
-const localNamedImports = (
-  source: string,
-  identifier: string
-): readonly LocalNamedImport[] => {
-  const code = maskSource(source, { strings: false });
-  const stringsMaskedCode = maskSource(source, { strings: true });
-  const imports: LocalNamedImport[] = [];
-  const pattern =
-    /\bimport\s+(?<typeOnly>type\s+)?\{(?<imports>[\s\S]*?)\}\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
-
-  for (const match of code.matchAll(pattern)) {
-    if (!stringsMaskedCode.startsWith('import', match.index ?? 0)) {
-      continue;
-    }
-
-    const specifier = match.groups?.['specifier'];
-    if (!specifier?.startsWith('.')) {
-      continue;
-    }
-
-    const namedImports = match.groups?.['imports'] ?? '';
-    for (const item of namedImports.split(',')) {
-      const trimmedItem = item.trim();
-      if (!trimmedItem) {
-        continue;
-      }
-
-      const specifierTypeOnly =
-        Boolean(match.groups?.['typeOnly']) || trimmedItem.startsWith('type ');
-      const specifierText = trimmedItem.replace(/^type\s+/u, '');
-      const imported =
-        /^(?<imported>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<local>[A-Za-z_$][\w$]*))?$/u.exec(
-          specifierText
-        )?.groups;
-      if (
-        !imported?.['imported'] ||
-        (imported['local'] ?? imported['imported']) !== identifier
-      ) {
-        continue;
-      }
-
-      imports.push({
-        imported: imported['imported'],
-        specifier,
-        typeOnly: specifierTypeOnly,
-      });
-    }
-  }
-
-  return imports;
-};
-
-const localNamedReexports = (
-  source: string,
-  identifier: string
-): readonly LocalNamedReexport[] => {
-  const code = maskSource(source, { strings: false });
-  const stringsMaskedCode = maskSource(source, { strings: true });
-  const exports: LocalNamedReexport[] = [];
-  const pattern =
-    /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
-
-  for (const match of code.matchAll(pattern)) {
-    if (!stringsMaskedCode.startsWith('export', match.index ?? 0)) {
-      continue;
-    }
-
-    const specifier = match.groups?.['specifier'];
-    if (!specifier?.startsWith('.')) {
-      continue;
-    }
-
-    const namedExports = match.groups?.['exports'] ?? '';
-    for (const item of namedExports.split(',')) {
-      const trimmedItem = item.trim();
-      if (!trimmedItem) {
-        continue;
-      }
-
-      const specifierTypeOnly =
-        Boolean(match.groups?.['typeOnly']) || trimmedItem.startsWith('type ');
-      const specifierText = trimmedItem.replace(/^type\s+/u, '');
-      const exported =
-        /^(?<local>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<name>[A-Za-z_$][\w$]*))?$/u.exec(
-          specifierText
-        )?.groups;
-      if (
-        !exported?.['local'] ||
-        (exported['name'] ?? exported['local']) !== identifier
-      ) {
-        continue;
-      }
-
-      exports.push({
-        local: exported['local'],
-        specifier,
-        typeOnly: specifierTypeOnly,
-      });
-    }
-  }
-
-  return exports;
-};
-
-const localStarReexports = (
-  source: string
-): readonly { readonly specifier: string; readonly typeOnly: boolean }[] => {
-  const code = maskSource(source, { strings: false });
-  const stringsMaskedCode = maskSource(source, { strings: true });
-  return [
-    ...code.matchAll(
-      /\bexport\s+(?<typeOnly>type\s+)?\*\s+from\s+['"](?<specifier>[^'"]+)['"]/gu
-    ),
-  ]
-    .filter((match) => stringsMaskedCode.startsWith('export', match.index ?? 0))
-    .map((match) => ({
-      specifier: match.groups?.['specifier'] ?? '',
-      typeOnly: Boolean(match.groups?.['typeOnly']),
-    }))
-    .filter((entry) => entry.specifier.startsWith('.'));
-};
-
-const resolveLocalModuleSpecifier = (
-  sourcePath: string,
-  specifier: string
-): string | undefined => {
-  const basePath = resolve(dirname(sourcePath), specifier);
-  const candidates = [
-    basePath,
-    basePath.endsWith('.js') ? `${basePath.slice(0, -3)}.ts` : undefined,
-    basePath.endsWith('.js') ? `${basePath.slice(0, -3)}.tsx` : undefined,
-    `${basePath}.ts`,
-    `${basePath}.tsx`,
-    join(basePath, 'index.ts'),
-    join(basePath, 'index.tsx'),
-  ].filter((candidate): candidate is string => candidate !== undefined);
-
-  return candidates.find((candidate) => existsSync(candidate));
-};
-
-const sourcePathExportsIdentifier = (
-  sourcePath: string,
-  identifier: string,
-  expected: 'type' | 'value',
-  visited = new Set<string>()
-): boolean => {
-  const normalizedSourcePath = realpathSync(sourcePath);
-  const visitKey = `${normalizedSourcePath}:${identifier}:${expected}`;
-  if (visited.has(visitKey)) {
-    return false;
-  }
-  visited.add(visitKey);
-
-  const source = readFileSync(normalizedSourcePath, 'utf8');
-  if (sourceExportsIdentifier(source, identifier, expected)) {
-    return true;
-  }
-
-  const sameFileLocal = sameFileExportListLocalForIdentifier(
-    source,
-    identifier,
-    expected
-  );
-  if (sameFileLocal) {
-    for (const localImport of localNamedImports(source, sameFileLocal)) {
-      if (expected === 'value' && localImport.typeOnly) {
-        continue;
-      }
-      const targetPath = resolveLocalModuleSpecifier(
-        normalizedSourcePath,
-        localImport.specifier
-      );
-      if (
-        targetPath &&
-        sourcePathExportsIdentifier(
-          targetPath,
-          localImport.imported,
-          expected,
-          visited
-        )
-      ) {
-        return true;
-      }
-    }
-  }
-
-  for (const reexport of localNamedReexports(source, identifier)) {
-    if (expected === 'value' && reexport.typeOnly) {
-      continue;
-    }
-    const targetPath = resolveLocalModuleSpecifier(
-      normalizedSourcePath,
-      reexport.specifier
-    );
-    if (
-      targetPath &&
-      sourcePathExportsIdentifier(targetPath, reexport.local, expected, visited)
-    ) {
-      return true;
-    }
-  }
-
-  for (const reexport of localStarReexports(source)) {
-    if (expected === 'value' && reexport.typeOnly) {
-      continue;
-    }
-    const targetPath = resolveLocalModuleSpecifier(
-      normalizedSourcePath,
-      reexport.specifier
-    );
-    if (
-      targetPath &&
-      sourcePathExportsIdentifier(targetPath, identifier, expected, visited)
-    ) {
-      return true;
-    }
-  }
-
-  return false;
-};
-
 const assertHttpOwnerSupport = (
   target: AdapterTargetCatalogEntry
 ): Result<void, ValidationError> => {
@@ -605,13 +209,22 @@ const assertHttpOwnerSupport = (
   }
 
   const requiredExports = [
-    ['createFetchHandler', 'value'],
-    ['CreateFetchHandlerOptions', 'type'],
+    ['createFetchHandler', 'value', false],
+    ['CreateFetchHandlerOptions', 'type', true],
   ] as const;
-  const missing = requiredExports.filter(
-    ([identifier, expected]) =>
-      !sourcePathExportsIdentifier(rootExportTarget, identifier, expected)
-  );
+  const missing = requiredExports.filter(([identifier, expected, typeOnly]) => {
+    if (typeOnly) {
+      const exportKind = adapterSourceExportKind(rootExportTarget, identifier);
+      return (
+        exportKind !== 'type' &&
+        exportKind !== 'interface-value' &&
+        exportKind !== 'interface-value-erased' &&
+        exportKind !== 'type-alias-value' &&
+        exportKind !== 'type-alias-value-erased'
+      );
+    }
+    return !adapterSourceExports(rootExportTarget, identifier, expected);
+  });
   if (missing.length === 0) {
     return Result.ok();
   }

--- a/docs/contributing/package-ownership.md
+++ b/docs/contributing/package-ownership.md
@@ -49,7 +49,7 @@ The review question:
 | OpenTelemetry trace adapter | `@ontrails/tracing/otel` for v1 | users exporting traces | `owned` | ADR-0041 keeps the v1 OTel adapter at the current `@ontrails/tracing/otel` subpath. It is an adapter boundary, not an observe memory-sink contract. |
 | Activation graph derived facts | `@ontrails/topography` | Trails app topo reports | `owned` | Prior cleanup moved activation-derived facts to Topography so app reports do not re-project the activation graph. |
 | Stable topo hashing | `@ontrails/topography` | watch mode, topo artifacts | `proposal` | `apps/trails/src/run-watch.ts` has carried stable JSON hashing parallel to `packages/topography/src/hash.ts`. Proposed extraction: expose the Topography-owned stable hash needed by watch mode. |
-| Adapter source scanning | `@ontrails/adapter-kit` | adapter generator, adapter checks/catalog | `proposal` | `apps/trails/src/trails/create-adapter.ts` duplicates source masking and import/export scans from adapter-kit. Proposed extraction: adapter-kit owns reusable scanning helpers; CLI consumes them. |
+| Adapter source scanning | `@ontrails/adapter-kit` | adapter generator, adapter checks/catalog | `owned` | `packages/adapter-kit/src/source.ts` owns reusable source export scanning; `create.adapter` and adapter catalog conformance checks consume that shared contract. |
 | Public/internal export-map boundary checks | `@ontrails/warden` plus source facts from packages | repo governance | `proposal` | Warden should encode the durable rule, but packages own their export maps. Do not move package export truth into Warden. |
 | Topo summary facts for read/report trails | likely Trails app or Topography, depending on fact | Trails CLI reports, Wayfinder | `unknown` | `buildCurrentTopo*` naming drift was identified, but the ownership split still needs a focused pass: pure graph facts belong lower; presentation-specific summaries may remain app-owned. |
 | Serialization and lock IO | Topography and Trails app split | compile, validate, Wayfinder | `unknown` | Not audited in this first pass. Future map update should separate lock schema ownership from CLI file IO. |
@@ -71,7 +71,6 @@ These are open findings from the map. They are not newly created Linear issues i
 | Finding | Proposed extraction | Why it belongs there |
 | --- | --- | --- |
 | Stable topo hash duplicate | Expose or consume the Topography-owned stable hash from watch mode. | Topography owns topo artifact identity. |
-| Adapter source scan duplicate | Move reusable source masking and import/export scans to adapter-kit; let `create-adapter` consume it. | Adapter-kit owns adapter authoring conformance. |
 
 ## Tracked Unknowns
 

--- a/packages/adapter-kit/src/__tests__/source.test.ts
+++ b/packages/adapter-kit/src/__tests__/source.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { adapterSourceExportKind, adapterSourceExports } from '../source.js';
+
+const roots: string[] = [];
+
+const writeFile = (root: string, path: string, value: string): void => {
+  const filePath = join(root, path);
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, value);
+};
+
+const makeRoot = (): string => {
+  const root = mkdtempSync(join(tmpdir(), 'trails-adapter-source-'));
+  roots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+describe('adapter source export scanning', () => {
+  test('classifies direct source exports by type and value position', () => {
+    const root = makeRoot();
+    writeFile(
+      root,
+      'src/index.ts',
+      [
+        'export interface AdapterOptions {}',
+        'export const createAdapter = () => undefined;',
+        'export class AdapterRuntime {}',
+        '',
+      ].join('\n')
+    );
+    const sourcePath = join(root, 'src/index.ts');
+
+    expect(adapterSourceExportKind(sourcePath, 'AdapterOptions')).toBe('type');
+    expect(adapterSourceExportKind(sourcePath, 'createAdapter')).toBe('value');
+    expect(adapterSourceExportKind(sourcePath, 'AdapterRuntime')).toBe(
+      'type-value'
+    );
+    expect(adapterSourceExports(sourcePath, 'AdapterRuntime', 'type')).toBe(
+      true
+    );
+    expect(adapterSourceExports(sourcePath, 'AdapterRuntime', 'value')).toBe(
+      true
+    );
+    expect(adapterSourceExports(sourcePath, 'createAdapter', 'type')).toBe(
+      false
+    );
+  });
+
+  test('preserves shared type and value names through type-only barrels', () => {
+    const root = makeRoot();
+    writeFile(
+      root,
+      'src/fetch.ts',
+      [
+        'export interface CreateFetchHandlerOptions { enabled: boolean }',
+        'export const CreateFetchHandlerOptions = { enabled: true };',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'src/index.ts',
+      ['export type { CreateFetchHandlerOptions } from "./fetch.js";', ''].join(
+        '\n'
+      )
+    );
+
+    expect(
+      adapterSourceExportKind(
+        join(root, 'src/fetch.ts'),
+        'CreateFetchHandlerOptions'
+      )
+    ).toBe('interface-value');
+    expect(
+      adapterSourceExports(
+        join(root, 'src/index.ts'),
+        'CreateFetchHandlerOptions',
+        'type'
+      )
+    ).toBe(true);
+    expect(
+      adapterSourceExports(
+        join(root, 'src/index.ts'),
+        'CreateFetchHandlerOptions',
+        'value'
+      )
+    ).toBe(false);
+  });
+
+  test('preserves shared type-alias and value names through type-only barrels', () => {
+    const root = makeRoot();
+    writeFile(
+      root,
+      'src/fetch.ts',
+      [
+        'export type CreateFetchHandlerOptions = { enabled?: boolean };',
+        'export const CreateFetchHandlerOptions = { enabled: true };',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'src/index.ts',
+      ['export type { CreateFetchHandlerOptions } from "./fetch.js";', ''].join(
+        '\n'
+      )
+    );
+
+    expect(
+      adapterSourceExportKind(
+        join(root, 'src/fetch.ts'),
+        'CreateFetchHandlerOptions'
+      )
+    ).toBe('type-alias-value');
+    expect(
+      adapterSourceExportKind(
+        join(root, 'src/index.ts'),
+        'CreateFetchHandlerOptions'
+      )
+    ).toBe('type-alias-value-erased');
+  });
+
+  test('combines direct type and re-exported value evidence', () => {
+    const root = makeRoot();
+    writeFile(
+      root,
+      'src/fetch.ts',
+      'export const createFetchHandler = () => undefined;\n'
+    );
+    writeFile(
+      root,
+      'src/index.ts',
+      [
+        'export type createFetchHandler = () => unknown;',
+        'export { createFetchHandler } from "./fetch.js";',
+        '',
+      ].join('\n')
+    );
+    const sourcePath = join(root, 'src/index.ts');
+
+    expect(adapterSourceExportKind(sourcePath, 'createFetchHandler')).toBe(
+      'type-value'
+    );
+    expect(
+      adapterSourceExports(sourcePath, 'createFetchHandler', 'value')
+    ).toBe(true);
+  });
+
+  test('follows same-file export lists backed by local imports', () => {
+    const root = makeRoot();
+    writeFile(
+      root,
+      'src/fetch.ts',
+      [
+        'export interface CreateFetchHandlerOptions {}',
+        'export const createFetchHandler = () => undefined;',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'src/index.ts',
+      [
+        'import { createFetchHandler } from "./fetch.js";',
+        'import type { CreateFetchHandlerOptions } from "./fetch.js";',
+        'export { createFetchHandler, type CreateFetchHandlerOptions };',
+        '',
+      ].join('\n')
+    );
+    const sourcePath = join(root, 'src/index.ts');
+
+    expect(
+      adapterSourceExports(sourcePath, 'createFetchHandler', 'value')
+    ).toBe(true);
+    expect(
+      adapterSourceExports(sourcePath, 'CreateFetchHandlerOptions', 'type')
+    ).toBe(true);
+    expect(adapterSourceExports(sourcePath, 'createFetchHandler', 'type')).toBe(
+      false
+    );
+  });
+
+  test('preserves erased type-value provenance through type-only barrels', () => {
+    const root = makeRoot();
+    writeFile(
+      root,
+      'src/fetch.ts',
+      [
+        'export enum CreateFetchHandlerOptions { Default }',
+        'export class CreateFetchHandlerClass {}',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'src/index.ts',
+      [
+        'import type { CreateFetchHandlerClass, CreateFetchHandlerOptions } from "./fetch.js";',
+        'export type { CreateFetchHandlerClass, CreateFetchHandlerOptions };',
+        '',
+      ].join('\n')
+    );
+    const sourcePath = join(root, 'src/index.ts');
+
+    expect(
+      adapterSourceExportKind(sourcePath, 'CreateFetchHandlerOptions')
+    ).toBe('type-value-erased');
+    expect(adapterSourceExportKind(sourcePath, 'CreateFetchHandlerClass')).toBe(
+      'type-value-erased'
+    );
+    expect(
+      adapterSourceExports(sourcePath, 'CreateFetchHandlerOptions', 'type')
+    ).toBe(true);
+    expect(
+      adapterSourceExports(sourcePath, 'CreateFetchHandlerOptions', 'value')
+    ).toBe(false);
+  });
+
+  test('does not treat declare-only same-file export lists as values', () => {
+    const root = makeRoot();
+    writeFile(
+      root,
+      'src/index.ts',
+      [
+        'declare const createFetchHandler: () => unknown;',
+        'export interface CreateFetchHandlerOptions {}',
+        'export { createFetchHandler };',
+        '',
+      ].join('\n')
+    );
+    const sourcePath = join(root, 'src/index.ts');
+
+    expect(
+      adapterSourceExports(sourcePath, 'createFetchHandler', 'value')
+    ).toBe(false);
+    expect(
+      adapterSourceExports(sourcePath, 'CreateFetchHandlerOptions', 'type')
+    ).toBe(true);
+  });
+
+  test('follows named and star re-exports while preserving type-only erasure', () => {
+    const root = makeRoot();
+    writeFile(
+      root,
+      'src/fetch.ts',
+      [
+        'export interface CreateFetchHandlerOptions {}',
+        'export const createFetchHandler = () => undefined;',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'src/barrel.ts',
+      [
+        'export { createFetchHandler as aliasedFetch } from "./fetch.js";',
+        'export type { CreateFetchHandlerOptions } from "./fetch.js";',
+        'export type { createFetchHandler as erasedFetch } from "./fetch.js";',
+        '',
+      ].join('\n')
+    );
+    writeFile(root, 'src/index.ts', 'export * from "./barrel.js";\n');
+    const sourcePath = join(root, 'src/index.ts');
+
+    expect(adapterSourceExports(sourcePath, 'aliasedFetch', 'value')).toBe(
+      true
+    );
+    expect(
+      adapterSourceExports(sourcePath, 'CreateFetchHandlerOptions', 'type')
+    ).toBe(true);
+    expect(adapterSourceExports(sourcePath, 'erasedFetch', 'value')).toBe(
+      false
+    );
+  });
+
+  test('gives explicit exports precedence over same-name star exports', () => {
+    const root = makeRoot();
+    writeFile(root, 'src/value.ts', 'export const Subject = true;\n');
+    writeFile(root, 'src/types.ts', 'export interface Subject {}\n');
+    writeFile(
+      root,
+      'src/index.ts',
+      [
+        'export { Subject } from "./value.js";',
+        'export * from "./types.js";',
+        '',
+      ].join('\n')
+    );
+
+    expect(adapterSourceExportKind(join(root, 'src/index.ts'), 'Subject')).toBe(
+      'value'
+    );
+  });
+
+  test('ignores comments and strings while resolving local mts targets', () => {
+    const root = makeRoot();
+    writeFile(
+      root,
+      'src/index.ts',
+      [
+        '// export const Ghost = true;',
+        'const docs = "export const Phantom = true";',
+        'export { actual } from "./runtime.mjs";',
+        '',
+      ].join('\n')
+    );
+    writeFile(root, 'src/runtime.mts', 'export const actual = true;\n');
+    const sourcePath = join(root, 'src/index.ts');
+
+    expect(adapterSourceExports(sourcePath, 'Ghost', 'value')).toBe(false);
+    expect(adapterSourceExports(sourcePath, 'Phantom', 'value')).toBe(false);
+    expect(adapterSourceExports(sourcePath, 'actual', 'value')).toBe(true);
+  });
+
+  test('returns no export kind for unreadable source paths', () => {
+    const root = makeRoot();
+    const sourcePath = join(root, 'src/missing.ts');
+
+    expect(adapterSourceExportKind(sourcePath, 'missing')).toBeUndefined();
+    expect(adapterSourceExports(sourcePath, 'missing', 'value')).toBe(false);
+  });
+});

--- a/packages/adapter-kit/src/catalog.ts
+++ b/packages/adapter-kit/src/catalog.ts
@@ -6,10 +6,16 @@
  * internal tooling package.
  */
 
-import { existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { existsSync, realpathSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 
 import { listWorkspacePackages } from '@ontrails/core';
+
+import {
+  adapterSourceExportKind,
+  adapterSourceExportKindHasType,
+  adapterSourceExportKindHasValue,
+} from './source.js';
 
 export const adapterTargetPlacements = ['extracted', 'subpath'] as const;
 
@@ -85,46 +91,11 @@ interface ParsedCatalogTarget {
   readonly targetEntry?: AdapterTargetCatalogEntry | undefined;
 }
 
-type ExportKind = 'type' | 'type-value' | 'value';
-
-interface StarExportSpecifier {
-  readonly specifier: string;
-  readonly typeOnly: boolean;
-}
-
-interface NamedExportSpecifier {
-  readonly identifier: string;
-  readonly specifier: string;
-  readonly typeOnly: boolean;
-}
-
-interface NamedImportSpecifier {
-  readonly identifier: string;
-  readonly specifier: string;
-  readonly typeOnly: boolean;
-}
-
-interface ExportListSpecifier {
-  readonly exported: string;
-  readonly local: string;
-  readonly typeOnly: boolean;
-}
-
-type ImportKindResolver = (
-  importSpecifier: NamedImportSpecifier
-) => ExportKind | undefined;
-
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === 'object' && !Array.isArray(value));
 
 const targetIdPattern = /^[a-z][a-z0-9-]*$/u;
 const exportIdentifierPattern = /^[A-Za-z_$][\w$]*$/u;
-
-const exportKindHasType = (kind: ExportKind | undefined): boolean =>
-  kind === 'type' || kind === 'type-value';
-
-const exportKindHasValue = (kind: ExportKind | undefined): boolean =>
-  kind === 'value' || kind === 'type-value';
 
 const normalizePath = (path: string): string => path.replaceAll('\\', '/');
 
@@ -142,264 +113,6 @@ const pathIsFile = (path: string): boolean => {
   } catch {
     return false;
   }
-};
-
-const localDeclarationKind = (
-  code: string,
-  identifier: string,
-  exportedOnly = false
-): ExportKind | undefined => {
-  const escapedIdentifier = identifier.replaceAll(
-    /[.*+?^${}()|[\]\\]/gu,
-    '\\$&'
-  );
-  const exportPrefix = exportedOnly ? '\\bexport\\s+' : '\\b(?:export\\s+)?';
-  const valueDeclarationPattern = new RegExp(
-    `${exportPrefix}(?!declare\\s+)(?:(?:async\\s+)?function|const|let|var)\\s+${escapedIdentifier}\\b`,
-    'u'
-  );
-  if (valueDeclarationPattern.test(code)) {
-    return 'value';
-  }
-
-  const typeValueDeclarationPattern = new RegExp(
-    `${exportPrefix}(?!declare\\s+)(?:abstract\\s+)?(?:class|enum)\\s+${escapedIdentifier}\\b`,
-    'u'
-  );
-  if (typeValueDeclarationPattern.test(code)) {
-    return 'type-value';
-  }
-
-  const typeDeclarationPattern = new RegExp(
-    `${exportPrefix}(?:declare\\s+)?(?:interface|type)\\s+${escapedIdentifier}\\b`,
-    'u'
-  );
-  return typeDeclarationPattern.test(code) ? 'type' : undefined;
-};
-
-const maskDeadSourceText = (
-  source: string,
-  options: { strings: boolean }
-): string => {
-  const output = [...source];
-  let index = 0;
-
-  const maskRange = (start: number, end: number): void => {
-    for (let cursor = start; cursor < end; cursor += 1) {
-      if (output[cursor] !== '\n') {
-        output[cursor] = ' ';
-      }
-    }
-  };
-
-  const skipQuoted = (quote: '"' | "'" | '`'): void => {
-    const start = index;
-    index += 1;
-    while (index < source.length) {
-      if (source[index] === '\\') {
-        index += 2;
-        continue;
-      }
-      if (source[index] === quote) {
-        index += 1;
-        break;
-      }
-      index += 1;
-    }
-    if (options.strings) {
-      maskRange(start, index);
-    }
-  };
-
-  while (index < source.length) {
-    if (source.startsWith('//', index)) {
-      const end = source.indexOf('\n', index + 2);
-      const stop = end === -1 ? source.length : end;
-      maskRange(index, stop);
-      index = stop;
-      continue;
-    }
-    if (source.startsWith('/*', index)) {
-      const end = source.indexOf('*/', index + 2);
-      const stop = end === -1 ? source.length : end + 2;
-      maskRange(index, stop);
-      index = stop;
-      continue;
-    }
-    const char = source[index];
-    if (char === '"' || char === "'" || char === '`') {
-      skipQuoted(char);
-      continue;
-    }
-    index += 1;
-  }
-
-  return output.join('');
-};
-
-const defaultExportKind = (source: string): ExportKind | undefined => {
-  const code = maskDeadSourceText(source, { strings: true });
-  if (/\bexport\s+default\s+(?:async\s+)?function\*?\b/u.test(code)) {
-    return 'value';
-  }
-  if (/\bexport\s+default\s+(?:abstract\s+)?(?:class|enum)\b/u.test(code)) {
-    return 'type-value';
-  }
-  if (/\bexport\s+default\s+(?:interface|type)\b/u.test(code)) {
-    return 'type';
-  }
-
-  const expressionIdentifier =
-    /\bexport\s+default\s+(?<identifier>[A-Za-z_$][\w$]*)\b/u.exec(code)
-      ?.groups?.['identifier'];
-  if (expressionIdentifier) {
-    return localDeclarationKind(code, expressionIdentifier) ?? 'value';
-  }
-
-  return /\bexport\s+default\b/u.test(code) ? 'value' : undefined;
-};
-
-const localDefaultImportSpecifier = (
-  code: string,
-  stringsMaskedCode: string,
-  identifier: string
-): NamedImportSpecifier | undefined => {
-  const pattern =
-    /\bimport\s+(?<importTypeOnly>type\s+)?(?<local>[A-Za-z_$][\w$]*)(?:\s*,\s*(?:\{[\s\S]*?\}|\*\s+as\s+[A-Za-z_$][\w$]*))?\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
-
-  for (const match of code.matchAll(pattern)) {
-    if (!stringsMaskedCode.startsWith('import', match.index ?? 0)) {
-      continue;
-    }
-    if (match.groups?.['local'] !== identifier) {
-      continue;
-    }
-
-    return {
-      identifier: 'default',
-      specifier: match.groups?.['specifier'] ?? '',
-      typeOnly: Boolean(match.groups?.['importTypeOnly']),
-    };
-  }
-
-  return undefined;
-};
-
-const parseNamedImportSpecifier = (
-  item: string,
-  declarationTypeOnly: boolean,
-  specifier: string,
-  identifier: string
-): NamedImportSpecifier | undefined => {
-  const trimmedItem = item.trim();
-  if (!trimmedItem) {
-    return undefined;
-  }
-
-  const itemTypeOnly = declarationTypeOnly || trimmedItem.startsWith('type ');
-  const specifierText = trimmedItem.replace(/^type\s+/u, '');
-  const imported =
-    /^(?<imported>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<local>[A-Za-z_$][\w$]*))?$/u.exec(
-      specifierText
-    )?.groups;
-  const local = imported?.['local'] ?? imported?.['imported'];
-  const importedName = imported?.['imported'];
-  if (local !== identifier || !importedName) {
-    return undefined;
-  }
-
-  return {
-    identifier: importedName,
-    specifier,
-    typeOnly: itemTypeOnly,
-  };
-};
-
-const localNamedImportSpecifier = (
-  source: string,
-  identifier: string
-): NamedImportSpecifier | undefined => {
-  const code = maskDeadSourceText(source, { strings: false });
-  const stringsMaskedCode = maskDeadSourceText(source, { strings: true });
-  const defaultSpecifier = localDefaultImportSpecifier(
-    code,
-    stringsMaskedCode,
-    identifier
-  );
-  if (defaultSpecifier) {
-    return defaultSpecifier;
-  }
-
-  const pattern =
-    /\bimport\s+(?<importTypeOnly>type\s+)?\{(?<imports>[\s\S]*?)\}\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
-
-  for (const match of code.matchAll(pattern)) {
-    if (!stringsMaskedCode.startsWith('import', match.index ?? 0)) {
-      continue;
-    }
-
-    const declarationTypeOnly = Boolean(match.groups?.['importTypeOnly']);
-    const namedImports = match.groups?.['imports'] ?? '';
-    const specifier = match.groups?.['specifier'] ?? '';
-    for (const item of namedImports.split(',')) {
-      const namedSpecifier = parseNamedImportSpecifier(
-        item,
-        declarationTypeOnly,
-        specifier,
-        identifier
-      );
-      if (namedSpecifier) {
-        return namedSpecifier;
-      }
-    }
-  }
-
-  return undefined;
-};
-
-const parseExportListSpecifier = (
-  item: string,
-  declarationTypeOnly: boolean
-): ExportListSpecifier | undefined => {
-  const trimmedItem = item.trim();
-  if (!trimmedItem) {
-    return undefined;
-  }
-
-  const typeOnly = declarationTypeOnly || trimmedItem.startsWith('type ');
-  const specifierText = trimmedItem.replace(/^type\s+/u, '');
-  const exported =
-    /^(?<local>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<name>[A-Za-z_$][\w$]*))?$/u.exec(
-      specifierText
-    )?.groups;
-  const local = exported?.['local'];
-  if (!local) {
-    return undefined;
-  }
-
-  return {
-    exported: exported?.['name'] ?? local,
-    local,
-    typeOnly,
-  };
-};
-
-const exportedLocalBindingKind = (
-  source: string,
-  code: string,
-  local: string,
-  resolveImportKind: ImportKindResolver
-): ExportKind | undefined => {
-  const localKind = localDeclarationKind(code, local);
-  if (localKind) {
-    return localKind;
-  }
-
-  const importSpecifier = localNamedImportSpecifier(source, local);
-  if (importSpecifier?.typeOnly) {
-    return 'type';
-  }
-  return importSpecifier ? resolveImportKind(importSpecifier) : undefined;
 };
 
 const exportConditions = new Set([
@@ -870,228 +583,6 @@ const normalizeConformance = (
   };
 };
 
-const namedExportKind = (
-  source: string,
-  identifier: string,
-  resolveImportKind: ImportKindResolver
-): ExportKind | undefined => {
-  if (identifier === 'default') {
-    const defaultKind = defaultExportKind(source);
-    if (defaultKind) {
-      return defaultKind;
-    }
-  }
-
-  const code = maskDeadSourceText(source, { strings: true });
-  const directKind = localDeclarationKind(code, identifier, true);
-  if (directKind) {
-    return directKind;
-  }
-
-  const exportListPattern =
-    /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}(?!\s+from\b)/gu;
-
-  for (const match of code.matchAll(exportListPattern)) {
-    const declarationTypeOnly = Boolean(match.groups?.['typeOnly']);
-    const namedExports = match.groups?.['exports'] ?? '';
-    for (const item of namedExports.split(',')) {
-      const exported = parseExportListSpecifier(item, declarationTypeOnly);
-      if (exported?.exported !== identifier) {
-        continue;
-      }
-
-      const localKind = exportedLocalBindingKind(
-        source,
-        code,
-        exported.local,
-        resolveImportKind
-      );
-      if (!localKind) {
-        return undefined;
-      }
-      return exported.typeOnly ? 'type' : localKind;
-    }
-  }
-
-  return undefined;
-};
-
-const starExportSpecifiers = (
-  source: string
-): readonly StarExportSpecifier[] => {
-  const code = maskDeadSourceText(source, { strings: false });
-  const stringsMaskedCode = maskDeadSourceText(source, { strings: true });
-  return [
-    ...code.matchAll(
-      /\bexport\s+(?<typeOnly>type\s+)?\*\s+from\s+['"](?<specifier>[^'"]+)['"]/gu
-    ),
-  ]
-    .filter((match) => stringsMaskedCode.startsWith('export', match.index ?? 0))
-    .map((match) => ({
-      specifier: match.groups?.['specifier'] ?? '',
-      typeOnly: Boolean(match.groups?.['typeOnly']),
-    }));
-};
-
-const namedExportSpecifiers = (
-  source: string,
-  identifier: string
-): readonly NamedExportSpecifier[] => {
-  const code = maskDeadSourceText(source, { strings: false });
-  const stringsMaskedCode = maskDeadSourceText(source, { strings: true });
-  const exports: NamedExportSpecifier[] = [];
-  const pattern =
-    /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
-
-  for (const match of code.matchAll(pattern)) {
-    if (!stringsMaskedCode.startsWith('export', match.index ?? 0)) {
-      continue;
-    }
-
-    const specifier = match.groups?.['specifier'];
-    if (!specifier?.startsWith('.')) {
-      continue;
-    }
-
-    const declarationTypeOnly = Boolean(match.groups?.['typeOnly']);
-    const namedExports = match.groups?.['exports'] ?? '';
-    for (const item of namedExports.split(',')) {
-      const trimmedItem = item.trim();
-      if (!trimmedItem) {
-        continue;
-      }
-
-      const itemTypeOnly =
-        declarationTypeOnly || trimmedItem.startsWith('type ');
-      const specifierText = trimmedItem.replace(/^type\s+/u, '');
-      const exported =
-        /^(?<local>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<name>[A-Za-z_$][\w$]*))?$/u.exec(
-          specifierText
-        )?.groups;
-      const local = exported?.['local'];
-      if (!local || (exported?.['name'] ?? local) !== identifier) {
-        continue;
-      }
-
-      exports.push({
-        identifier: local,
-        specifier,
-        typeOnly: itemTypeOnly,
-      });
-    }
-  }
-
-  return exports;
-};
-
-const resolveLocalModuleSpecifier = (
-  sourcePath: string,
-  specifier: string
-): string | undefined => {
-  if (!specifier.startsWith('.')) {
-    return undefined;
-  }
-
-  const basePath = resolve(dirname(sourcePath), specifier);
-  const candidates = [
-    basePath,
-    basePath.endsWith('.js') ? `${basePath.slice(0, -3)}.ts` : undefined,
-    basePath.endsWith('.js') ? `${basePath.slice(0, -3)}.tsx` : undefined,
-    basePath.endsWith('.mjs') ? `${basePath.slice(0, -4)}.mts` : undefined,
-    `${basePath}.ts`,
-    `${basePath}.tsx`,
-    join(basePath, 'index.ts'),
-    join(basePath, 'index.tsx'),
-  ].filter((candidate): candidate is string => candidate !== undefined);
-
-  return candidates.find((candidate) => existsSync(candidate));
-};
-
-const namedExportKindFromFile = (
-  sourcePath: string,
-  identifier: string,
-  visited = new Set<string>()
-): ExportKind | undefined => {
-  const normalizedSourcePath = normalizeRealPath(sourcePath);
-  const visitKey = `${normalizedSourcePath}:${identifier}`;
-  if (visited.has(visitKey)) {
-    return undefined;
-  }
-  visited.add(visitKey);
-
-  let source: string;
-  try {
-    source = readFileSync(normalizedSourcePath, 'utf8');
-  } catch {
-    return undefined;
-  }
-
-  const directKind = namedExportKind(source, identifier, (importSpecifier) => {
-    const importTarget = resolveLocalModuleSpecifier(
-      normalizedSourcePath,
-      importSpecifier.specifier
-    );
-    if (!importTarget) {
-      return;
-    }
-    return namedExportKindFromFile(
-      importTarget,
-      importSpecifier.identifier,
-      new Set(visited)
-    );
-  });
-  if (directKind) {
-    return directKind;
-  }
-
-  let sawTypeExport = false;
-  for (const exportSpecifier of namedExportSpecifiers(source, identifier)) {
-    const exportTarget = resolveLocalModuleSpecifier(
-      normalizedSourcePath,
-      exportSpecifier.specifier
-    );
-    if (!exportTarget) {
-      continue;
-    }
-
-    const reexportedKind = namedExportKindFromFile(
-      exportTarget,
-      exportSpecifier.identifier,
-      new Set(visited)
-    );
-    if (exportKindHasValue(reexportedKind) && !exportSpecifier.typeOnly) {
-      return reexportedKind;
-    }
-    if (exportKindHasType(reexportedKind)) {
-      sawTypeExport = true;
-    }
-  }
-
-  for (const exportSpecifier of starExportSpecifiers(source)) {
-    const exportTarget = resolveLocalModuleSpecifier(
-      normalizedSourcePath,
-      exportSpecifier.specifier
-    );
-    if (!exportTarget) {
-      continue;
-    }
-
-    const reexportedKind = namedExportKindFromFile(
-      exportTarget,
-      identifier,
-      new Set(visited)
-    );
-    if (exportKindHasValue(reexportedKind) && !exportSpecifier.typeOnly) {
-      return reexportedKind;
-    }
-    if (exportKindHasType(reexportedKind)) {
-      sawTypeExport = true;
-    }
-  }
-
-  return sawTypeExport ? 'type' : undefined;
-};
-
 const conformanceExportDiagnostics = (
   context: AdapterTargetParseContext,
   target: string,
@@ -1114,11 +605,14 @@ const conformanceExportDiagnostics = (
     keyof AdapterTargetConformanceManifest,
     string,
   ][]) {
-    const exportKind = namedExportKindFromFile(testingExportTarget, identifier);
-    if (field === 'adapterType' && exportKindHasType(exportKind)) {
+    const exportKind = adapterSourceExportKind(testingExportTarget, identifier);
+    if (field === 'adapterType' && adapterSourceExportKindHasType(exportKind)) {
       continue;
     }
-    if (field !== 'adapterType' && exportKindHasValue(exportKind)) {
+    if (
+      field !== 'adapterType' &&
+      adapterSourceExportKindHasValue(exportKind)
+    ) {
       continue;
     }
     const expectedExport =

--- a/packages/adapter-kit/src/index.ts
+++ b/packages/adapter-kit/src/index.ts
@@ -13,6 +13,16 @@ export type {
   AdapterCheckSubject,
 } from './check.js';
 export {
+  adapterSourceExportKind,
+  adapterSourceExportKindHasType,
+  adapterSourceExportKindHasValue,
+  adapterSourceExports,
+} from './source.js';
+export type {
+  AdapterSourceExportExpectation,
+  AdapterSourceExportKind,
+} from './source.js';
+export {
   adapterTargetPlacements,
   deriveAdapterTargetCatalog,
   parseAdapterTargetsFromManifest,

--- a/packages/adapter-kit/src/source.ts
+++ b/packages/adapter-kit/src/source.ts
@@ -1,0 +1,680 @@
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+
+export type AdapterSourceExportExpectation = 'type' | 'value';
+
+export type AdapterSourceExportKind =
+  | 'interface-value'
+  | 'interface-value-erased'
+  | 'type'
+  | 'type-alias-value'
+  | 'type-alias-value-erased'
+  | 'type-value'
+  | 'type-value-erased'
+  | 'value';
+
+interface StarExportSpecifier {
+  readonly specifier: string;
+  readonly typeOnly: boolean;
+}
+
+interface NamedExportSpecifier {
+  readonly identifier: string;
+  readonly specifier: string;
+  readonly typeOnly: boolean;
+}
+
+interface NamedImportSpecifier {
+  readonly identifier: string;
+  readonly specifier: string;
+  readonly typeOnly: boolean;
+}
+
+interface ExportListSpecifier {
+  readonly exported: string;
+  readonly local: string;
+  readonly typeOnly: boolean;
+}
+
+type ImportKindResolver = (
+  importSpecifier: NamedImportSpecifier
+) => AdapterSourceExportKind | undefined;
+
+export const adapterSourceExportKindHasType = (
+  kind: AdapterSourceExportKind | undefined
+): boolean =>
+  kind === 'interface-value' ||
+  kind === 'interface-value-erased' ||
+  kind === 'type' ||
+  kind === 'type-alias-value' ||
+  kind === 'type-alias-value-erased' ||
+  kind === 'type-value' ||
+  kind === 'type-value-erased';
+
+export const adapterSourceExportKindHasValue = (
+  kind: AdapterSourceExportKind | undefined
+): boolean =>
+  kind === 'interface-value' ||
+  kind === 'type-alias-value' ||
+  kind === 'value' ||
+  kind === 'type-value';
+
+const eraseExportValue = (
+  kind: AdapterSourceExportKind | undefined
+): AdapterSourceExportKind | undefined => {
+  if (kind === 'interface-value' || kind === 'interface-value-erased') {
+    return 'interface-value-erased';
+  }
+  if (kind === 'type-alias-value' || kind === 'type-alias-value-erased') {
+    return 'type-alias-value-erased';
+  }
+  if (kind === 'type-value' || kind === 'type-value-erased') {
+    return 'type-value-erased';
+  }
+  return kind === 'type' ? 'type' : undefined;
+};
+
+const preferErasedExportKind = (
+  current: AdapterSourceExportKind | undefined,
+  candidate: AdapterSourceExportKind | undefined
+): AdapterSourceExportKind | undefined => {
+  const erasedCandidate = eraseExportValue(candidate);
+  if (current === 'interface-value-erased' || !erasedCandidate) {
+    return current;
+  }
+  if (erasedCandidate === 'interface-value-erased') {
+    return erasedCandidate;
+  }
+  if (current === 'type-alias-value-erased') {
+    return current;
+  }
+  if (erasedCandidate === 'type-alias-value-erased') {
+    return erasedCandidate;
+  }
+  if (current === 'type-value-erased' || !erasedCandidate) {
+    return current;
+  }
+  return erasedCandidate === 'type-value-erased'
+    ? erasedCandidate
+    : (current ?? erasedCandidate);
+};
+
+const combineExportKinds = (
+  left: AdapterSourceExportKind | undefined,
+  right: AdapterSourceExportKind | undefined
+): AdapterSourceExportKind | undefined => {
+  if (!left) {
+    return right;
+  }
+  if (!right) {
+    return left;
+  }
+
+  const hasType =
+    adapterSourceExportKindHasType(left) ||
+    adapterSourceExportKindHasType(right);
+  const hasValue =
+    adapterSourceExportKindHasValue(left) ||
+    adapterSourceExportKindHasValue(right);
+  if (!hasValue) {
+    return preferErasedExportKind(left, right);
+  }
+  if (!hasType) {
+    return 'value';
+  }
+  if (left.startsWith('interface') || right.startsWith('interface')) {
+    return 'interface-value';
+  }
+  if (left.startsWith('type-alias') || right.startsWith('type-alias')) {
+    return 'type-alias-value';
+  }
+  return 'type-value';
+};
+
+const normalizePath = (path: string): string => path.replaceAll('\\', '/');
+
+const normalizeRealPath = (path: string): string => {
+  try {
+    return normalizePath(realpathSync(path));
+  } catch {
+    return normalizePath(resolve(path));
+  }
+};
+
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/gu, '\\$&');
+
+const localDeclarationKind = (
+  code: string,
+  identifier: string,
+  exportedOnly = false
+): AdapterSourceExportKind | undefined => {
+  const escapedIdentifier = escapeRegExp(identifier);
+  const statementPrefix = '(?:^|[;\\n\\r])\\s*';
+  const exportPrefix = exportedOnly
+    ? `${statementPrefix}export\\s+`
+    : `${statementPrefix}(?:export\\s+)?`;
+  const valueDeclarationPattern = new RegExp(
+    `${exportPrefix}(?!declare\\s+)(?:(?:async\\s+)?function|const|let|var)\\s+${escapedIdentifier}\\b`,
+    'u'
+  );
+  const hasValueDeclaration = valueDeclarationPattern.test(code);
+
+  const typeValueDeclarationPattern = new RegExp(
+    `${exportPrefix}(?!declare\\s+)(?:abstract\\s+)?(?:class|enum)\\s+${escapedIdentifier}\\b`,
+    'u'
+  );
+  if (typeValueDeclarationPattern.test(code)) {
+    return 'type-value';
+  }
+
+  const interfaceDeclarationPattern = new RegExp(
+    `${exportPrefix}(?:declare\\s+)?interface\\s+${escapedIdentifier}\\b`,
+    'u'
+  );
+  const hasInterfaceDeclaration = interfaceDeclarationPattern.test(code);
+  const typeAliasDeclarationPattern = new RegExp(
+    `${exportPrefix}(?:declare\\s+)?type\\s+${escapedIdentifier}\\b`,
+    'u'
+  );
+  const hasTypeAliasDeclaration = typeAliasDeclarationPattern.test(code);
+  const hasTypeDeclaration = hasInterfaceDeclaration || hasTypeAliasDeclaration;
+  if (hasValueDeclaration && hasInterfaceDeclaration) {
+    return 'interface-value';
+  }
+  if (hasValueDeclaration && hasTypeAliasDeclaration) {
+    return 'type-alias-value';
+  }
+  if (hasValueDeclaration && hasTypeDeclaration) {
+    return 'type-value';
+  }
+  if (hasValueDeclaration) {
+    return 'value';
+  }
+  return hasTypeDeclaration ? 'type' : undefined;
+};
+
+const maskDeadSourceText = (
+  source: string,
+  options: { strings: boolean }
+): string => {
+  const output = [...source];
+  let index = 0;
+
+  const maskRange = (start: number, end: number): void => {
+    for (let cursor = start; cursor < end; cursor += 1) {
+      if (output[cursor] !== '\n') {
+        output[cursor] = ' ';
+      }
+    }
+  };
+
+  const skipQuoted = (quote: '"' | "'" | '`'): void => {
+    const start = index;
+    index += 1;
+    while (index < source.length) {
+      if (source[index] === '\\') {
+        index += 2;
+        continue;
+      }
+      if (source[index] === quote) {
+        index += 1;
+        break;
+      }
+      index += 1;
+    }
+    if (options.strings) {
+      maskRange(start, index);
+    }
+  };
+
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      const end = source.indexOf('\n', index + 2);
+      const stop = end === -1 ? source.length : end;
+      maskRange(index, stop);
+      index = stop;
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      const end = source.indexOf('*/', index + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      maskRange(index, stop);
+      index = stop;
+      continue;
+    }
+    const char = source[index];
+    if (char === '"' || char === "'" || char === '`') {
+      skipQuoted(char);
+      continue;
+    }
+    index += 1;
+  }
+
+  return output.join('');
+};
+
+const defaultExportKind = (
+  source: string
+): AdapterSourceExportKind | undefined => {
+  const code = maskDeadSourceText(source, { strings: true });
+  if (/\bexport\s+default\s+(?:async\s+)?function\*?\b/u.test(code)) {
+    return 'value';
+  }
+  if (/\bexport\s+default\s+(?:abstract\s+)?(?:class|enum)\b/u.test(code)) {
+    return 'type-value';
+  }
+  if (/\bexport\s+default\s+(?:interface|type)\b/u.test(code)) {
+    return 'type';
+  }
+
+  const expressionIdentifier =
+    /\bexport\s+default\s+(?<identifier>[A-Za-z_$][\w$]*)\b/u.exec(code)
+      ?.groups?.['identifier'];
+  if (expressionIdentifier) {
+    return localDeclarationKind(code, expressionIdentifier) ?? 'value';
+  }
+
+  return /\bexport\s+default\b/u.test(code) ? 'value' : undefined;
+};
+
+const localDefaultImportSpecifier = (
+  code: string,
+  stringsMaskedCode: string,
+  identifier: string
+): NamedImportSpecifier | undefined => {
+  const pattern =
+    /\bimport\s+(?<importTypeOnly>type\s+)?(?<local>[A-Za-z_$][\w$]*)(?:\s*,\s*(?:\{[\s\S]*?\}|\*\s+as\s+[A-Za-z_$][\w$]*))?\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
+
+  for (const match of code.matchAll(pattern)) {
+    if (!stringsMaskedCode.startsWith('import', match.index ?? 0)) {
+      continue;
+    }
+    if (match.groups?.['local'] !== identifier) {
+      continue;
+    }
+
+    return {
+      identifier: 'default',
+      specifier: match.groups?.['specifier'] ?? '',
+      typeOnly: Boolean(match.groups?.['importTypeOnly']),
+    };
+  }
+
+  return undefined;
+};
+
+const parseNamedImportSpecifier = (
+  item: string,
+  declarationTypeOnly: boolean,
+  specifier: string,
+  identifier: string
+): NamedImportSpecifier | undefined => {
+  const trimmedItem = item.trim();
+  if (!trimmedItem) {
+    return undefined;
+  }
+
+  const itemTypeOnly = declarationTypeOnly || trimmedItem.startsWith('type ');
+  const specifierText = trimmedItem.replace(/^type\s+/u, '');
+  const imported =
+    /^(?<imported>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<local>[A-Za-z_$][\w$]*))?$/u.exec(
+      specifierText
+    )?.groups;
+  const local = imported?.['local'] ?? imported?.['imported'];
+  const importedName = imported?.['imported'];
+  if (local !== identifier || !importedName) {
+    return undefined;
+  }
+
+  return {
+    identifier: importedName,
+    specifier,
+    typeOnly: itemTypeOnly,
+  };
+};
+
+const localNamedImportSpecifier = (
+  source: string,
+  identifier: string
+): NamedImportSpecifier | undefined => {
+  const code = maskDeadSourceText(source, { strings: false });
+  const stringsMaskedCode = maskDeadSourceText(source, { strings: true });
+  const defaultSpecifier = localDefaultImportSpecifier(
+    code,
+    stringsMaskedCode,
+    identifier
+  );
+  if (defaultSpecifier) {
+    return defaultSpecifier;
+  }
+
+  const pattern =
+    /\bimport\s+(?<importTypeOnly>type\s+)?\{(?<imports>[\s\S]*?)\}\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
+
+  for (const match of code.matchAll(pattern)) {
+    if (!stringsMaskedCode.startsWith('import', match.index ?? 0)) {
+      continue;
+    }
+
+    const declarationTypeOnly = Boolean(match.groups?.['importTypeOnly']);
+    const namedImports = match.groups?.['imports'] ?? '';
+    const specifier = match.groups?.['specifier'] ?? '';
+    for (const item of namedImports.split(',')) {
+      const namedSpecifier = parseNamedImportSpecifier(
+        item,
+        declarationTypeOnly,
+        specifier,
+        identifier
+      );
+      if (namedSpecifier) {
+        return namedSpecifier;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+const parseExportListSpecifier = (
+  item: string,
+  declarationTypeOnly: boolean
+): ExportListSpecifier | undefined => {
+  const trimmedItem = item.trim();
+  if (!trimmedItem) {
+    return undefined;
+  }
+
+  const typeOnly = declarationTypeOnly || trimmedItem.startsWith('type ');
+  const specifierText = trimmedItem.replace(/^type\s+/u, '');
+  const exported =
+    /^(?<local>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<name>[A-Za-z_$][\w$]*))?$/u.exec(
+      specifierText
+    )?.groups;
+  const local = exported?.['local'];
+  if (!local) {
+    return undefined;
+  }
+
+  return {
+    exported: exported?.['name'] ?? local,
+    local,
+    typeOnly,
+  };
+};
+
+const exportedLocalBindingKind = (
+  source: string,
+  code: string,
+  local: string,
+  resolveImportKind: ImportKindResolver
+): AdapterSourceExportKind | undefined => {
+  const localKind = localDeclarationKind(code, local);
+  if (localKind) {
+    return localKind;
+  }
+
+  const importSpecifier = localNamedImportSpecifier(source, local);
+  if (!importSpecifier) {
+    return undefined;
+  }
+  const importedKind = resolveImportKind(importSpecifier);
+  return importSpecifier.typeOnly
+    ? eraseExportValue(importedKind)
+    : importedKind;
+};
+
+const namedExportKind = (
+  source: string,
+  identifier: string,
+  resolveImportKind: ImportKindResolver
+): AdapterSourceExportKind | undefined => {
+  if (identifier === 'default') {
+    const defaultKind = defaultExportKind(source);
+    if (defaultKind) {
+      return defaultKind;
+    }
+  }
+
+  const stringsMaskedCode = maskDeadSourceText(source, { strings: true });
+  const directKind = localDeclarationKind(stringsMaskedCode, identifier, true);
+  if (directKind) {
+    return directKind;
+  }
+
+  const exportCode = maskDeadSourceText(source, { strings: false });
+  const exportListPattern =
+    /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}(?<from>\s+from\s+['"][^'"]+['"])?/gu;
+
+  for (const match of exportCode.matchAll(exportListPattern)) {
+    if (!stringsMaskedCode.startsWith('export', match.index ?? 0)) {
+      continue;
+    }
+    if (match.groups?.['from']) {
+      continue;
+    }
+
+    const declarationTypeOnly = Boolean(match.groups?.['typeOnly']);
+    const namedExports = match.groups?.['exports'] ?? '';
+    for (const item of namedExports.split(',')) {
+      const exported = parseExportListSpecifier(item, declarationTypeOnly);
+      if (exported?.exported !== identifier) {
+        continue;
+      }
+
+      const localKind = exportedLocalBindingKind(
+        source,
+        stringsMaskedCode,
+        exported.local,
+        resolveImportKind
+      );
+      if (!localKind) {
+        return undefined;
+      }
+      return exported.typeOnly ? eraseExportValue(localKind) : localKind;
+    }
+  }
+
+  return undefined;
+};
+
+const starExportSpecifiers = (
+  source: string
+): readonly StarExportSpecifier[] => {
+  const code = maskDeadSourceText(source, { strings: false });
+  const stringsMaskedCode = maskDeadSourceText(source, { strings: true });
+  return [
+    ...code.matchAll(
+      /\bexport\s+(?<typeOnly>type\s+)?\*\s+from\s+['"](?<specifier>[^'"]+)['"]/gu
+    ),
+  ]
+    .filter((match) => stringsMaskedCode.startsWith('export', match.index ?? 0))
+    .map((match) => ({
+      specifier: match.groups?.['specifier'] ?? '',
+      typeOnly: Boolean(match.groups?.['typeOnly']),
+    }));
+};
+
+const namedExportSpecifiers = (
+  source: string,
+  identifier: string
+): readonly NamedExportSpecifier[] => {
+  const code = maskDeadSourceText(source, { strings: false });
+  const stringsMaskedCode = maskDeadSourceText(source, { strings: true });
+  const exports: NamedExportSpecifier[] = [];
+  const pattern =
+    /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}\s+from\s+['"](?<specifier>[^'"]+)['"]/gu;
+
+  for (const match of code.matchAll(pattern)) {
+    if (!stringsMaskedCode.startsWith('export', match.index ?? 0)) {
+      continue;
+    }
+
+    const specifier = match.groups?.['specifier'];
+    if (!specifier?.startsWith('.')) {
+      continue;
+    }
+
+    const declarationTypeOnly = Boolean(match.groups?.['typeOnly']);
+    const namedExports = match.groups?.['exports'] ?? '';
+    for (const item of namedExports.split(',')) {
+      const trimmedItem = item.trim();
+      if (!trimmedItem) {
+        continue;
+      }
+
+      const itemTypeOnly =
+        declarationTypeOnly || trimmedItem.startsWith('type ');
+      const specifierText = trimmedItem.replace(/^type\s+/u, '');
+      const exported =
+        /^(?<local>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<name>[A-Za-z_$][\w$]*))?$/u.exec(
+          specifierText
+        )?.groups;
+      const local = exported?.['local'];
+      if (!local || (exported?.['name'] ?? local) !== identifier) {
+        continue;
+      }
+
+      exports.push({
+        identifier: local,
+        specifier,
+        typeOnly: itemTypeOnly,
+      });
+    }
+  }
+
+  return exports;
+};
+
+const resolveLocalModuleSpecifier = (
+  sourcePath: string,
+  specifier: string
+): string | undefined => {
+  if (!specifier.startsWith('.')) {
+    return undefined;
+  }
+
+  const basePath = resolve(dirname(sourcePath), specifier);
+  const candidates = [
+    basePath,
+    basePath.endsWith('.js') ? `${basePath.slice(0, -3)}.ts` : undefined,
+    basePath.endsWith('.js') ? `${basePath.slice(0, -3)}.tsx` : undefined,
+    basePath.endsWith('.mjs') ? `${basePath.slice(0, -4)}.mts` : undefined,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    join(basePath, 'index.ts'),
+    join(basePath, 'index.tsx'),
+  ].filter((candidate): candidate is string => candidate !== undefined);
+
+  return candidates.find((candidate) => existsSync(candidate));
+};
+
+const resolveAdapterSourceExportKind = (
+  sourcePath: string,
+  identifier: string,
+  visited = new Set<string>()
+): AdapterSourceExportKind | undefined => {
+  const normalizedSourcePath = normalizeRealPath(sourcePath);
+  const visitKey = `${normalizedSourcePath}:${identifier}`;
+  if (visited.has(visitKey)) {
+    return undefined;
+  }
+  visited.add(visitKey);
+
+  let source: string;
+  try {
+    source = readFileSync(normalizedSourcePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+
+  const directKind = namedExportKind(source, identifier, (importSpecifier) => {
+    const importTarget = resolveLocalModuleSpecifier(
+      normalizedSourcePath,
+      importSpecifier.specifier
+    );
+    if (!importTarget) {
+      return;
+    }
+    return resolveAdapterSourceExportKind(
+      importTarget,
+      importSpecifier.identifier,
+      new Set(visited)
+    );
+  });
+  let resolvedKind = directKind;
+  for (const exportSpecifier of namedExportSpecifiers(source, identifier)) {
+    const exportTarget = resolveLocalModuleSpecifier(
+      normalizedSourcePath,
+      exportSpecifier.specifier
+    );
+    if (!exportTarget) {
+      continue;
+    }
+
+    const reexportedKind = resolveAdapterSourceExportKind(
+      exportTarget,
+      exportSpecifier.identifier,
+      new Set(visited)
+    );
+    resolvedKind = combineExportKinds(
+      resolvedKind,
+      exportSpecifier.typeOnly
+        ? eraseExportValue(reexportedKind)
+        : reexportedKind
+    );
+  }
+
+  if (resolvedKind !== undefined) {
+    return resolvedKind;
+  }
+
+  for (const exportSpecifier of starExportSpecifiers(source)) {
+    const exportTarget = resolveLocalModuleSpecifier(
+      normalizedSourcePath,
+      exportSpecifier.specifier
+    );
+    if (!exportTarget) {
+      continue;
+    }
+
+    const reexportedKind = resolveAdapterSourceExportKind(
+      exportTarget,
+      identifier,
+      new Set(visited)
+    );
+    resolvedKind = combineExportKinds(
+      resolvedKind,
+      exportSpecifier.typeOnly
+        ? eraseExportValue(reexportedKind)
+        : reexportedKind
+    );
+  }
+
+  return resolvedKind;
+};
+
+/**
+ * Inspect a local TypeScript source path for the kind of named export it
+ * provides, following relative imports, named re-exports, and star re-exports.
+ */
+export const adapterSourceExportKind = (
+  sourcePath: string,
+  identifier: string
+): AdapterSourceExportKind | undefined =>
+  resolveAdapterSourceExportKind(sourcePath, identifier);
+
+/**
+ * Check whether a local TypeScript source path exports a named binding in the
+ * expected type or runtime value position.
+ */
+export const adapterSourceExports = (
+  sourcePath: string,
+  identifier: string,
+  expected: AdapterSourceExportExpectation
+): boolean => {
+  const exportKind = adapterSourceExportKind(sourcePath, identifier);
+  return expected === 'type'
+    ? adapterSourceExportKindHasType(exportKind)
+    : adapterSourceExportKindHasValue(exportKind);
+};


### PR DESCRIPTION
## Context
Part 1 of the shared adapter readiness stack. This lays the adapter-kit groundwork for moving source scanning out of app-local code.

## What changed
- Moved adapter source scanning helpers into `@ontrails/adapter-kit`.
- Updated Trails create/adapter-check call sites to use the shared scanner.
- Added release intent for the affected adapter-kit and Trails packages.

## Verification
- `bun run changeset:check`
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- Pre-push stable checks passed before submit.
- CI is green on this PR.

## Risks / rollout
Low behavioral risk: this is a helper ownership move that preserves existing adapter discovery behavior for later branches.
