### PR TITLE
feat(adapter-kit): discover subpath adapter subjects

### DIFF
--- a/.changeset/subpath-adapter-readiness.md
+++ b/.changeset/subpath-adapter-readiness.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/adapter-kit": patch
+"@ontrails/trails": patch
+---
+
+Discover owner-package subpath adapter subjects in shared adapter checks and
+enable `trails create adapter --placement subpath` to generate immediately
+checkable owner subpaths.

--- a/apps/trails/src/__tests__/adapter-check.test.ts
+++ b/apps/trails/src/__tests__/adapter-check.test.ts
@@ -119,6 +119,36 @@ const writeHttpOwner = (root: string): void => {
   writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
 };
 
+const writeHttpOwnerWithSubpathAdapter = (root: string): void => {
+  writePackage(root, 'packages/http', {
+    exports: {
+      '.': './src/index.ts',
+      './edge': './src/edge/index.ts',
+      './package.json': './package.json',
+      './testing': './src/testing.ts',
+    },
+    name: '@ontrails/http',
+    trails: {
+      adapterTargets: {
+        http: {
+          placements: ['extracted', 'subpath'],
+          testingImport: '@ontrails/http/testing',
+        },
+      },
+      adapters: {
+        './edge': { target: 'http' },
+      },
+    },
+  });
+  writeFile(root, 'packages/http/src/index.ts', 'export {};\n');
+  writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
+  writeFile(
+    root,
+    'packages/http/src/edge/index.ts',
+    'export const edgeAdapter = {};\n'
+  );
+};
+
 const expectValidationError = (
   result: Awaited<ReturnType<typeof adapterCheckTrail.implementation>>
 ): ValidationError => {
@@ -176,7 +206,7 @@ describe('trails adapter check', () => {
 
   test('returns the same diagnostic codes as the Warden projection', async () => {
     const root = makeRoot();
-    writeHttpOwner(root);
+    writeHttpOwnerWithSubpathAdapter(root);
     writeHonoAdapter(root);
 
     const result = await adapterCheckTrail.implementation({ rootDir: root }, {
@@ -193,8 +223,11 @@ describe('trails adapter check', () => {
     const wardenCodes = runWardenAdapterChecks(root).map((entry) => entry.code);
 
     expect(result.value.passed).toBe(false);
-    expect(localCodes).toEqual(['missing-conformance']);
+    expect(localCodes).toEqual(['missing-conformance', 'missing-conformance']);
     expect(wardenCodes).toEqual(localCodes);
+    expect(result.value.subjects.map((subject) => subject.packageName)).toEqual(
+      ['@ontrails/hono', '@ontrails/http/edge']
+    );
   });
 
   test('runs locally and exits non-zero for adapter readiness failures', () => {

--- a/apps/trails/src/__tests__/create-adapter.test.ts
+++ b/apps/trails/src/__tests__/create-adapter.test.ts
@@ -147,7 +147,7 @@ describe('trails create adapter', () => {
     );
     expect(
       createAdapter?.flags.find((flag) => flag.name === 'placement')?.choices
-    ).toEqual(['extracted']);
+    ).toEqual(['extracted', 'subpath']);
   });
 
   test('scaffolds an extracted HTTP adapter from catalog facts', async () => {
@@ -727,11 +727,11 @@ describe('trails create adapter', () => {
     expect(existsSync(join(root, 'adapters/hono-lite'))).toBe(false);
   });
 
-  test('rejects subpath scaffolding until shared checks discover subpath subjects', async () => {
+  test('scaffolds an HTTP subpath adapter from owner catalog facts', async () => {
     const root = makeRoot();
     writeHttpOwner(root);
 
-    const error = expectValidationError(
+    const result = expectOk(
       await createAdapterTrail.implementation(
         {
           dryRun: false,
@@ -744,20 +744,48 @@ describe('trails create adapter', () => {
       )
     );
 
-    expect(error.message).toContain('Subpath adapter scaffolding is deferred');
+    expect(result.created).toEqual([
+      'packages/http/package.json',
+      'packages/http/src/edge/index.ts',
+      'packages/http/src/edge/__tests__/conformance.test.ts',
+    ]);
+    expect(result.adapterImport).toBe('@ontrails/http/edge');
+    expect(result.packageName).toBe('@ontrails/http/edge');
+    expect(result.placement).toBe('subpath');
+    expect(result.targetKey).toBe('@ontrails/http:http');
+
     const { exports: packageExports } = readJson(
       root,
       'packages/http/package.json'
     );
     expect(packageExports).toMatchObject({
       '.': './src/index.ts',
+      './edge': './src/edge/index.ts',
       './package.json': './package.json',
       './testing': './src/testing.ts',
     });
-    expect((packageExports as Record<string, unknown>)['./edge']).toBe(
-      undefined
+    expect(
+      readJson(root, 'packages/http/package.json')['trails']
+    ).toMatchObject({
+      adapters: {
+        './edge': { target: 'http' },
+      },
+    });
+    expect(readText(root, 'packages/http/src/edge/index.ts')).toContain(
+      'from "../index.js"'
     );
-    expect(existsSync(join(root, 'packages/http/src/edge.ts'))).toBe(false);
+    expect(
+      readText(root, 'packages/http/src/edge/__tests__/conformance.test.ts')
+    ).toContain('import { createApp } from "../index.js";');
+
+    const report = checkAdapters(root);
+    expect(report.subjects[0]).toMatchObject({
+      packageName: '@ontrails/http/edge',
+      placement: 'subpath',
+      target: 'http',
+      testingImport: '@ontrails/http/testing',
+    });
+    expect(report.diagnostics).toEqual([]);
   });
 
   test('fails before writing when owner conformance metadata is missing', async () => {

--- a/apps/trails/src/trails/create-adapter.ts
+++ b/apps/trails/src/trails/create-adapter.ts
@@ -24,7 +24,7 @@ import {
 } from '@ontrails/core';
 import type { WorkspaceRootManifest } from '@ontrails/core';
 import { existsSync, readFileSync, realpathSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import { z } from 'zod';
 
 import {
@@ -49,7 +49,7 @@ const packageNameMessage =
 
 type CreateAdapterPlacement = AdapterTargetPlacement;
 
-const createAdapterPlacements = ['extracted'] as const;
+const createAdapterPlacements = adapterTargetPlacements;
 
 interface CreateAdapterInput {
   readonly dryRun: boolean;
@@ -81,6 +81,7 @@ interface AdapterOperationPlan {
 interface WorkspacePackageManifest {
   readonly exports?: unknown;
   readonly name?: unknown;
+  readonly trails?: unknown;
 }
 
 const literal = (value: string): string => JSON.stringify(value);
@@ -159,6 +160,9 @@ const resolvePhysicalRootDir = (
 const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
 
+const toMutableRecord = (value: unknown): Record<string, unknown> =>
+  isRecord(value) ? { ...value } : {};
+
 const runtimeExportTarget = (value: unknown, depth = 0): string | undefined => {
   if (typeof value === 'string') {
     return value;
@@ -196,6 +200,15 @@ const packageRootExportTarget = (
   }
 
   return resolve(target.packageRoot, exportTarget);
+};
+
+const relativeImportSpecifier = (fromFile: string, toFile: string): string => {
+  const withoutExtension = relative(dirname(fromFile), toFile)
+    .replaceAll('\\', '/')
+    .replace(/\.ts$/u, '.js');
+  return withoutExtension.startsWith('.')
+    ? withoutExtension
+    : `./${withoutExtension}`;
 };
 
 const assertHttpOwnerSupport = (
@@ -379,6 +392,21 @@ export const createApp = (
 });
 `;
 
+const generateHttpSubpathIndex = (supportImportPath: string): string =>
+  `import type { Topo } from '@ontrails/core';
+import { createFetchHandler } from ${literal(supportImportPath)};
+import type { CreateFetchHandlerOptions } from ${literal(supportImportPath)};
+
+export interface CreateAppOptions extends CreateFetchHandlerOptions {}
+
+export const createApp = (
+  graph: Topo,
+  options: CreateAppOptions = {}
+) => ({
+  fetch: createFetchHandler(graph, options),
+});
+`;
+
 const generateConformanceTest = (
   target: AdapterTargetCatalogEntry,
   adapterImport: string,
@@ -494,13 +522,128 @@ const buildExtractedPlan = (
 };
 
 const buildSubpathPlan = (
-  _rootDir: string,
-  _input: CreateAdapterInput,
-  _target: AdapterTargetCatalogEntry
-): Result<AdapterOperationPlan, Error> =>
-  fail(
-    'Subpath adapter scaffolding is deferred until shared adapter checks discover subpath adapter subjects.'
+  rootDir: string,
+  input: CreateAdapterInput,
+  target: AdapterTargetCatalogEntry
+): Result<AdapterOperationPlan, Error> => {
+  if (input.packageName !== undefined) {
+    return fail(
+      'packageName is only supported for extracted adapter placement.'
+    );
+  }
+
+  const ownerPackage = findWorkspacePackage<WorkspacePackageManifest>(
+    rootDir,
+    target.ownerPackage
   );
+  if (!ownerPackage) {
+    return fail(
+      `Adapter target "${target.key}" owner package ${target.ownerPackage} is not a workspace package.`
+    );
+  }
+
+  const manifest = readJson<WorkspacePackageManifest>(
+    ownerPackage.packageJsonPath
+  );
+  if (!manifest || !isRecord(manifest)) {
+    return fail(
+      `Adapter target "${target.key}" owner package manifest could not be read.`
+    );
+  }
+
+  const manifestExports = manifest['exports'];
+  if (
+    manifestExports !== undefined &&
+    typeof manifestExports !== 'string' &&
+    !isRecord(manifestExports)
+  ) {
+    return fail(
+      `${target.ownerPackage} package.json exports must be an object before create.adapter can add a subpath adapter.`
+    );
+  }
+
+  const exportKey = `./${input.name}`;
+  const packageExports =
+    typeof manifestExports === 'string'
+      ? { '.': manifestExports }
+      : toMutableRecord(manifestExports);
+  if (Object.hasOwn(packageExports, exportKey)) {
+    return fail(`${target.ownerPackage} already exports "${exportKey}".`);
+  }
+
+  const manifestTrails = manifest['trails'];
+  const trails = toMutableRecord(manifestTrails);
+  if (manifestTrails !== undefined && !isRecord(manifestTrails)) {
+    return fail(
+      `${target.ownerPackage} package.json trails must be an object.`
+    );
+  }
+
+  const adapters = toMutableRecord(trails['adapters']);
+  if (trails['adapters'] !== undefined && !isRecord(trails['adapters'])) {
+    return fail(
+      `${target.ownerPackage} package.json trails.adapters must be an object before create.adapter can add a subpath adapter.`
+    );
+  }
+  if (Object.hasOwn(adapters, exportKey)) {
+    return fail(
+      `${target.ownerPackage} package.json trails.adapters already declares "${exportKey}".`
+    );
+  }
+
+  const sourcePath = `${ownerPackage.workspacePath}/src/${input.name}/index.ts`;
+  const sourceRoot = resolveProjectPath(
+    rootDir,
+    `${ownerPackage.workspacePath}/src/${input.name}`
+  );
+  if (sourceRoot.isErr()) {
+    return sourceRoot;
+  }
+  if (existsSync(sourceRoot.value)) {
+    return fail(
+      `Subpath adapter source already exists at ${ownerPackage.workspacePath}/src/${input.name}.`
+    );
+  }
+
+  const supportTarget = packageRootExportTarget(target);
+  if (!supportTarget) {
+    return fail(
+      `Adapter target "${target.key}" cannot use the HTTP subpath template because ${target.ownerPackage} does not expose a readable package root export.`
+    );
+  }
+
+  packageExports[exportKey] = `./src/${input.name}/index.ts`;
+  adapters[exportKey] = { target: target.target };
+  trails['adapters'] = adapters;
+
+  const adapterImport = `${target.ownerPackage}/${input.name}`;
+  const sourceFile = resolve(rootDir, sourcePath);
+  const packageJson = formatJson({
+    ...manifest,
+    exports: packageExports,
+    trails,
+  });
+  const operations = [
+    writeOperation(`${ownerPackage.workspacePath}/package.json`, packageJson),
+    writeOperation(
+      sourcePath,
+      generateHttpSubpathIndex(
+        relativeImportSpecifier(sourceFile, supportTarget)
+      )
+    ),
+    writeOperation(
+      `${ownerPackage.workspacePath}/src/${input.name}/__tests__/conformance.test.ts`,
+      generateConformanceTest(target, adapterImport, '../index.js')
+    ),
+  ];
+
+  return Result.ok({
+    adapterImport,
+    operations,
+    packageName: adapterImport,
+    targetKey: target.key,
+  });
+};
 
 const buildOperationPlan = (
   rootDir: string,
@@ -530,6 +673,11 @@ export const createAdapterTrail = trail('create.adapter', {
           hint: 'Standalone package under adapters/',
           label: 'Extracted',
           value: 'extracted',
+        },
+        {
+          hint: 'Owner package subpath export',
+          label: 'Subpath',
+          value: 'subpath',
         },
       ],
     },
@@ -576,7 +724,7 @@ export const createAdapterTrail = trail('create.adapter', {
       diagnostics: [...report.diagnostics],
       dryRun: input.dryRun,
       packageName: plan.value.packageName,
-      placement: 'extracted',
+      placement: input.placement,
       plannedOperations: [...plannedOperations.value],
       targetKey: plan.value.targetKey,
     } satisfies CreateAdapterResult);

--- a/docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md
+++ b/docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md
@@ -39,7 +39,8 @@ The owner package owns the truth an adapter must conform to. It already does —
 @ontrails/<owner>/adapter-support   support helpers an adapter needs
 @ontrails/<owner>/testing            conformance cases, as a factory
 @ontrails/<owner>/trails             owner-side trails where relevant
-package.json trails.adapterTargets   the small facts derivation can't know
+package.json trails.adapterTargets   owner target facts derivation can't know
+package.json trails.adapters         exported adapter subjects within one package
 ```
 
 This is not a new source of truth. It is the owner's existing contract, made explicit and reusable. The owner writes the contract and its conformance cases once; every adapter's scaffold, tests, and checks read from them. One write, many reads — applied to adapter authoring.
@@ -48,10 +49,10 @@ This is not a new source of truth. It is the owner's existing contract, made exp
 
 The choice between an extracted package and a subpath is **`placement`** — not `kind`, which already carries store-domain meaning in the lexicon ([ADR-0023](../0023-simplifying-the-trails-lexicon.md)).
 
-- **Extracted** adapters live under `adapters/` when they earn a dependency or release boundary — `@ontrails/hono`, `@ontrails/drizzle`, `@ontrails/commander`, `@ontrails/vite`.
+- **Extracted** adapters live under `adapters/` when they earn a dependency or release boundary — `@ontrails/hono`, `@ontrails/drizzle`, `@ontrails/commander`, `@ontrails/vite`. An extracted adapter collection may expose several targets through package subpaths, but those subjects remain extracted because they cross their owner packages' dependency boundaries.
 - **Subpath** adapters live inside the owner package when [ADR-0029](../0029-connector-extraction-and-the-with-packaging-model.md)'s dependency-boundary test says a standalone package would add ceremony without buying a real boundary — `@ontrails/http/bun`, `@ontrails/store/jsonfile`, platform-native and built-in materializers.
 
-The placement choice *is* the dependency-boundary test from ADR-0029. Subpath adapters are a first-class carve-out — they should get the same scaffold and conformance path as extracted ones, not hand-authored exception status. The first implementation scaffolds extracted HTTP adapters and owner-package HTTP subpath adapters from the same catalog facts. The shared check engine still discovers extracted workspace adapter subjects first; subpath subject discovery remains follow-up drift-check coverage, not a reason to block scaffold generation.
+The placement choice *is* the dependency-boundary test from ADR-0029. A slash in the public package route does not decide placement: `@ontrails/cloudflare/d1` remains extracted from its Store owner, while `@ontrails/store/jsonfile` is an owner-package subpath. Subpath adapters are a first-class carve-out — they should get the same scaffold and conformance path as extracted ones, not hand-authored exception status. The first implementation scaffolds extracted HTTP adapters and owner-package HTTP subpath adapters from the same catalog facts. The shared check engine discovers extracted package roots, extracted collection subjects, and owner-package subpath subjects, so every declared subject enters the same local and Warden readiness loop immediately.
 
 ```bash
 trails create adapter hono --target http  --placement extracted

--- a/packages/adapter-kit/src/__tests__/check.test.ts
+++ b/packages/adapter-kit/src/__tests__/check.test.ts
@@ -66,6 +66,7 @@ const writeHttpOwner = (
       },
     },
   });
+  writeFile(root, 'packages/http/src/index.ts', 'export const http = {};\n');
   writeFile(
     root,
     'packages/http/src/testing.ts',
@@ -120,6 +121,64 @@ const writeHttpConformanceTest = (
   );
 };
 
+const writeHttpSubpathAdapter = (
+  root: string,
+  options: {
+    readonly exportSubpath?: boolean;
+    readonly writeConformance?: boolean;
+  } = {}
+): void => {
+  const exportSubpath = options.exportSubpath ?? true;
+  const writeConformance = options.writeConformance ?? true;
+  writePackage(root, 'packages/http', {
+    exports: {
+      '.': './src/index.ts',
+      ...(exportSubpath ? { './edge': './src/edge/index.ts' } : {}),
+      './package.json': './package.json',
+      './testing': './src/testing.ts',
+    },
+    name: '@ontrails/http',
+    trails: {
+      adapterTargets: {
+        http: {
+          conformance: {
+            adapterType: 'HttpAdapterConformanceAdapter',
+            casesFactory: 'createHttpAdapterConformanceCases',
+            runner: 'runConformance',
+          },
+          placements: ['subpath'],
+          testingImport: '@ontrails/http/testing',
+        },
+      },
+      adapters: {
+        './edge': { target: 'http' },
+      },
+    },
+  });
+  writeFile(root, 'packages/http/src/index.ts', 'export const http = {};\n');
+  writeFile(
+    root,
+    'packages/http/src/testing.ts',
+    [
+      'export interface HttpAdapterConformanceAdapter {}',
+      'export const createHttpAdapterConformanceCases = () => [];',
+      'export const runConformance = () => undefined;',
+      '',
+    ].join('\n')
+  );
+  writeFile(
+    root,
+    'packages/http/src/edge/index.ts',
+    'export const edgeAdapter = {};\n'
+  );
+  if (writeConformance) {
+    writeHttpConformanceTest(
+      root,
+      'packages/http/src/edge/__tests__/conformance.test.ts'
+    );
+  }
+};
+
 const codes = (
   diagnostics: readonly { readonly code: AdapterCheckDiagnosticCode }[]
 ): readonly AdapterCheckDiagnosticCode[] =>
@@ -157,6 +216,226 @@ describe('checkAdapters', () => {
       targetKey: '@ontrails/http:http',
       testingImport: '@ontrails/http/testing',
     });
+  });
+
+  test('accepts a valid owner package subpath adapter', () => {
+    const root = makeRoot();
+    writeHttpSubpathAdapter(root);
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects).toHaveLength(1);
+    expect(report.subjects[0]).toMatchObject({
+      adapterType: 'HttpAdapterConformanceAdapter',
+      conformanceTestPaths: [
+        expect.stringContaining(
+          'packages/http/src/edge/__tests__/conformance.test.ts'
+        ),
+      ],
+      key: '@ontrails/http/edge',
+      ownerPackage: '@ontrails/http',
+      packageName: '@ontrails/http/edge',
+      placement: 'subpath',
+      target: 'http',
+      targetKey: '@ontrails/http:http',
+      testingImport: '@ontrails/http/testing',
+    });
+    expect(report.facts).toContainEqual(
+      expect.objectContaining({
+        key: '@ontrails/http/edge:http:configured',
+        kind: 'configured',
+        packageName: '@ontrails/http/edge',
+        placement: 'subpath',
+        provenance: expect.objectContaining({
+          source: 'owner-package-manifest',
+        }),
+      })
+    );
+  });
+
+  test('treats collection subpaths outside the owner as extracted adapters', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/store', {
+      exports: {
+        '.': './src/index.ts',
+        './package.json': './package.json',
+        './testing': './src/testing.ts',
+      },
+      name: '@ontrails/store',
+      trails: {
+        adapterTargets: {
+          store: {
+            placements: ['extracted', 'subpath'],
+            testingImport: '@ontrails/store/testing',
+          },
+        },
+      },
+    });
+    writeFile(
+      root,
+      'packages/store/src/index.ts',
+      'export const store = {};\n'
+    );
+    writeFile(
+      root,
+      'packages/store/src/testing.ts',
+      'export const createStoreAccessorContractCases = () => [];\n'
+    );
+    writePackage(root, 'adapters/cloudflare', {
+      exports: {
+        '.': './src/index.ts',
+        './d1': './src/d1/index.ts',
+        './package.json': './package.json',
+      },
+      name: '@ontrails/cloudflare',
+      peerDependencies: {
+        '@ontrails/store': 'workspace:^',
+      },
+      trails: {
+        adapters: {
+          './d1': { target: 'store' },
+        },
+      },
+    });
+    writeFile(root, 'adapters/cloudflare/src/index.ts', 'export {};\n');
+    writeFile(
+      root,
+      'adapters/cloudflare/src/d1/index.ts',
+      'export const cloudflareD1 = {};\n'
+    );
+    writeFile(
+      root,
+      'adapters/cloudflare/src/d1/__tests__/d1.test.ts',
+      [
+        "import { createStoreAccessorContractCases } from '@ontrails/store/testing';",
+        'createStoreAccessorContractCases();',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects).toContainEqual(
+      expect.objectContaining({
+        key: '@ontrails/cloudflare/d1',
+        ownerPackage: '@ontrails/store',
+        packageName: '@ontrails/cloudflare/d1',
+        placement: 'extracted',
+        target: 'store',
+      })
+    );
+  });
+
+  test('reports missing conformance for owner package subpath adapters', () => {
+    const root = makeRoot();
+    writeHttpSubpathAdapter(root, { writeConformance: false });
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/http/edge',
+      placement: 'subpath',
+      target: 'http',
+    });
+  });
+
+  test('scopes owner package subpath conformance to each export source area', () => {
+    const root = makeRoot();
+    writePackage(root, 'packages/http', {
+      exports: {
+        '.': './src/index.ts',
+        './edge': './src/edge/index.ts',
+        './package.json': './package.json',
+        './testing': './src/testing.ts',
+        './worker': './src/worker/index.ts',
+      },
+      name: '@ontrails/http',
+      trails: {
+        adapterTargets: {
+          http: {
+            conformance: {
+              adapterType: 'HttpAdapterConformanceAdapter',
+              casesFactory: 'createHttpAdapterConformanceCases',
+              runner: 'runConformance',
+            },
+            placements: ['subpath'],
+            testingImport: '@ontrails/http/testing',
+          },
+        },
+        adapters: {
+          './edge': { target: 'http' },
+          './worker': { target: 'http' },
+        },
+      },
+    });
+    writeFile(root, 'packages/http/src/index.ts', 'export const http = {};\n');
+    writeFile(
+      root,
+      'packages/http/src/testing.ts',
+      [
+        'export interface HttpAdapterConformanceAdapter {}',
+        'export const createHttpAdapterConformanceCases = () => [];',
+        'export const runConformance = () => undefined;',
+        '',
+      ].join('\n')
+    );
+    writeFile(
+      root,
+      'packages/http/src/edge/index.ts',
+      'export const edgeAdapter = {};\n'
+    );
+    writeFile(
+      root,
+      'packages/http/src/worker/index.ts',
+      'export const workerAdapter = {};\n'
+    );
+    writeHttpConformanceTest(
+      root,
+      'packages/http/src/edge/__tests__/conformance.test.ts'
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects).toHaveLength(2);
+    expect(
+      report.subjects.find(
+        (subject) => subject.packageName === '@ontrails/http/edge'
+      )?.conformanceTestPaths
+    ).toHaveLength(1);
+    expect(
+      report.subjects.find(
+        (subject) => subject.packageName === '@ontrails/http/worker'
+      )?.conformanceTestPaths
+    ).toEqual([]);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/http/worker',
+      placement: 'subpath',
+      target: 'http',
+    });
+  });
+
+  test('reports missing owner exports for subpath adapter metadata', () => {
+    const root = makeRoot();
+    writeHttpSubpathAdapter(root, { exportSubpath: false });
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects).toHaveLength(1);
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-package-export',
+      packageName: '@ontrails/http/edge',
+      placement: 'subpath',
+      target: 'http',
+    });
+    expect(report.diagnostics[0]?.message).toContain('export "./edge"');
   });
 
   test('accepts owner testing imports exported through wildcard keys', () => {

--- a/packages/adapter-kit/src/check.ts
+++ b/packages/adapter-kit/src/check.ts
@@ -114,9 +114,23 @@ interface AdapterMetadata {
   readonly target: string;
 }
 
+interface SubpathAdapterMetadata extends AdapterMetadata {
+  readonly exportKey: string;
+}
+
+interface AdapterCheckCandidate {
+  readonly exportKey?: string | undefined;
+  readonly key: string;
+  readonly metadata: AdapterMetadata;
+  readonly packageName: string;
+  readonly placement: AdapterTargetPlacement;
+}
+
 const adapterKitPackageName = '@ontrails/adapter-kit';
 
 const targetIdPattern = /^[a-z][a-z0-9-]*$/u;
+const subpathAdapterExportKeyPattern =
+  /^\.\/[a-z0-9][a-z0-9-]*(?:\/[a-z0-9][a-z0-9-]*)*$/u;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === 'object' && !Array.isArray(value));
@@ -169,38 +183,45 @@ const exportTargetIsFile = (packageRoot: string, target: string): boolean => {
   }
 };
 
-const hasResolvableExport = (
+const resolvableExportTarget = (
   workspace: WorkspacePackage,
   key: string
-): boolean => {
+): string | undefined => {
   const { exports: exportsValue } = workspace.manifest;
   if (typeof exportsValue === 'string') {
-    return (
-      key === '.' && exportTargetIsFile(workspace.packageRoot, exportsValue)
-    );
+    return key === '.' &&
+      exportTargetIsFile(workspace.packageRoot, exportsValue)
+      ? normalizeRealPath(resolve(workspace.packageRoot, exportsValue))
+      : undefined;
   }
 
   if (!isRecord(exportsValue)) {
-    return false;
+    return undefined;
   }
 
   if (!Object.hasOwn(exportsValue, key)) {
     if (key !== '.') {
-      return false;
+      return undefined;
     }
 
     const rootTarget = resolveExportTarget(exportsValue);
-    return (
-      rootTarget !== undefined &&
+    return rootTarget !== undefined &&
       exportTargetIsFile(workspace.packageRoot, rootTarget)
-    );
+      ? normalizeRealPath(resolve(workspace.packageRoot, rootTarget))
+      : undefined;
   }
 
   const target = resolveExportTarget(exportsValue[key]);
-  return (
-    target !== undefined && exportTargetIsFile(workspace.packageRoot, target)
-  );
+  return target !== undefined &&
+    exportTargetIsFile(workspace.packageRoot, target)
+    ? normalizeRealPath(resolve(workspace.packageRoot, target))
+    : undefined;
 };
+
+const hasResolvableExport = (
+  workspace: WorkspacePackage,
+  key: string
+): boolean => resolvableExportTarget(workspace, key) !== undefined;
 
 const dependencyMap = (value: unknown): Readonly<Record<string, unknown>> =>
   isRecord(value) ? value : {};
@@ -230,6 +251,37 @@ const trailAdapterMetadata = (
   return typeof target === 'string' && targetIdPattern.test(target)
     ? { target }
     : null;
+};
+
+const trailSubpathAdapterMetadata = (
+  manifest: AdapterCheckPackageManifest
+): readonly SubpathAdapterMetadata[] | undefined | null => {
+  const trails = isRecord(manifest.trails) ? manifest.trails : undefined;
+  const adapters = trails?.['adapters'];
+  if (adapters === undefined) {
+    return undefined;
+  }
+  if (!isRecord(adapters)) {
+    return null;
+  }
+
+  const metadata: SubpathAdapterMetadata[] = [];
+  for (const [exportKey, adapter] of Object.entries(adapters).toSorted()) {
+    if (!subpathAdapterExportKeyPattern.test(exportKey)) {
+      return null;
+    }
+    if (!isRecord(adapter)) {
+      return null;
+    }
+
+    const { target } = adapter;
+    if (typeof target !== 'string' || !targetIdPattern.test(target)) {
+      return null;
+    }
+    metadata.push({ exportKey, target });
+  }
+
+  return metadata;
 };
 
 const placementForWorkspace = (
@@ -302,7 +354,10 @@ const adapterFacts = (
       placement: subject.placement,
       provenance: {
         packageJsonPath: subject.packageJsonPath,
-        source: 'adapter-package-manifest',
+        source:
+          subject.placement === 'subpath'
+            ? 'owner-package-manifest'
+            : 'adapter-package-manifest',
       },
       target: subject.target,
       targetKey: subject.targetKey,
@@ -1923,30 +1978,189 @@ const assertToolingBoundary = (
   }
 };
 
+const sourceFilesForCandidate = (
+  workspace: WorkspacePackage,
+  candidate: AdapterCheckCandidate,
+  sourceFiles: readonly string[]
+): readonly string[] => {
+  if (!candidate.exportKey) {
+    return sourceFiles;
+  }
+
+  const exportTarget = resolvableExportTarget(workspace, candidate.exportKey);
+  if (!exportTarget) {
+    return sourceFiles;
+  }
+
+  const normalizedTarget = normalizePath(exportTarget);
+  const targetDir = normalizePath(dirname(normalizedTarget));
+  if (normalizedTarget.endsWith('/index.ts')) {
+    return sourceFiles.filter((sourceFile) =>
+      normalizePath(sourceFile).startsWith(`${targetDir}/`)
+    );
+  }
+
+  const targetStem = normalizedTarget.replace(/\.ts$/u, '');
+  return sourceFiles.filter((sourceFile) => {
+    const normalizedSourceFile = normalizePath(sourceFile);
+    return (
+      normalizedSourceFile === normalizedTarget ||
+      normalizedSourceFile.startsWith(`${targetStem}.`) ||
+      normalizedSourceFile.startsWith(`${targetStem}/`)
+    );
+  });
+};
+
 const checkAdapterPackage = (
   workspace: WorkspacePackage,
   targetById: ReadonlyMap<string, AdapterTargetCatalogEntry>
 ): {
   readonly diagnostics: readonly AdapterCheckDiagnostic[];
-  readonly subject?: AdapterCheckSubject | undefined;
+  readonly subjects: readonly AdapterCheckSubject[];
 } => {
   const packageName = workspace.manifest.name as string;
   const diagnostics: AdapterCheckDiagnostic[] = [];
   const placement = placementForWorkspace(workspace.workspacePath);
   const metadata = trailAdapterMetadata(workspace.manifest);
+  const subpathMetadata = trailSubpathAdapterMetadata(workspace.manifest);
 
-  if (!placement || metadata === undefined) {
-    return { diagnostics: [] };
+  if ((!placement || metadata === undefined) && subpathMetadata === undefined) {
+    return { diagnostics: [], subjects: [] };
   }
 
   assertPackageExports(workspace, diagnostics);
   const sourceFiles = collectSourceFiles(join(workspace.packageRoot, 'src'));
   assertToolingBoundary(workspace, sourceFiles, diagnostics);
 
-  if (metadata === null) {
+  const subjects: AdapterCheckSubject[] = [];
+  const checkCandidate = (
+    candidate: AdapterCheckCandidate
+  ): AdapterCheckSubject | undefined => {
+    if (
+      candidate.exportKey &&
+      !hasResolvableExport(workspace, candidate.exportKey)
+    ) {
+      diagnostics.push(
+        diagnostic(
+          workspace.packageJsonPath,
+          candidate.packageName,
+          'missing-package-export',
+          `${packageName} must export "${candidate.exportKey}" so ${candidate.packageName} can be resolved as a subpath adapter.`,
+          candidate.metadata.target,
+          candidate.placement
+        )
+      );
+    }
+
+    const targetEntry = targetById.get(candidate.metadata.target);
+    if (!targetEntry) {
+      diagnostics.push(
+        diagnostic(
+          workspace.packageJsonPath,
+          candidate.packageName,
+          'unknown-adapter-target',
+          `${candidate.packageName} declares unknown adapter target "${candidate.metadata.target}".`,
+          candidate.metadata.target,
+          candidate.placement
+        )
+      );
+      return undefined;
+    }
+
+    if (
+      candidate.placement === 'subpath' &&
+      targetEntry.ownerPackage !== packageName
+    ) {
+      diagnostics.push(
+        diagnostic(
+          workspace.packageJsonPath,
+          candidate.packageName,
+          'invalid-adapter-metadata',
+          `${candidate.packageName} declares target "${targetEntry.target}", but subpath adapters must live in the owner package ${targetEntry.ownerPackage}.`,
+          targetEntry.target,
+          candidate.placement
+        )
+      );
+      return undefined;
+    }
+
+    if (!targetEntry.placements.includes(candidate.placement)) {
+      diagnostics.push(
+        diagnostic(
+          workspace.packageJsonPath,
+          candidate.packageName,
+          'unsupported-placement',
+          `${targetEntry.ownerPackage}:${targetEntry.target} does not support ${candidate.placement} adapter placement.`,
+          targetEntry.target,
+          candidate.placement
+        )
+      );
+    }
+
+    if (candidate.placement === 'extracted') {
+      assertDependencyDirection(workspace, targetEntry, diagnostics);
+    }
+
+    const { conformance, testingImport } = targetEntry;
+    const candidateSourceFiles = sourceFilesForCandidate(
+      workspace,
+      candidate,
+      sourceFiles
+    );
+    const conformanceTestPaths = testingImport
+      ? pathsProvingConformance(
+          candidateSourceFiles.filter(isTestFile),
+          targetEntry
+        )
+      : [];
+
+    if (!testingImport) {
+      diagnostics.push(
+        diagnostic(
+          workspace.packageJsonPath,
+          candidate.packageName,
+          'missing-owner-conformance',
+          `${targetEntry.ownerPackage}:${targetEntry.target} must declare testingImport before adapters can prove conformance.`,
+          targetEntry.target,
+          candidate.placement
+        )
+      );
+    } else if (conformanceTestPaths.length === 0) {
+      const conformanceHint = conformance
+        ? ` and call ${conformance.runner}(adapter, ${conformance.casesFactory}(...))`
+        : '';
+      diagnostics.push(
+        diagnostic(
+          workspace.packageJsonPath,
+          candidate.packageName,
+          'missing-conformance',
+          `${candidate.packageName} must import ${testingImport} from a conformance test${conformanceHint}.`,
+          targetEntry.target,
+          candidate.placement
+        )
+      );
+    }
+
     return {
-      diagnostics: [
-        ...diagnostics,
+      conformanceTestPaths,
+      key: candidate.key,
+      ownerPackage: targetEntry.ownerPackage,
+      packageJsonPath: workspace.packageJsonPath,
+      packageName: candidate.packageName,
+      packageRoot: workspace.packageRoot,
+      placement: candidate.placement,
+      target: targetEntry.target,
+      targetKey: targetEntry.key,
+      ...(conformance?.adapterType
+        ? { adapterType: conformance.adapterType }
+        : {}),
+      ...(testingImport ? { testingImport } : {}),
+    };
+  };
+
+  if (placement && metadata !== undefined) {
+    if (metadata === null) {
+      diagnostics.push(
         diagnostic(
           workspace.packageJsonPath,
           packageName,
@@ -1954,95 +2168,54 @@ const checkAdapterPackage = (
           `${packageName} must declare trails.adapter as an object with a kebab-case target string.`,
           undefined,
           placement
-        ),
-      ],
-    };
+        )
+      );
+    } else {
+      const subject = checkCandidate({
+        key: packageName,
+        metadata,
+        packageName,
+        placement,
+      });
+      if (subject) {
+        subjects.push(subject);
+      }
+    }
   }
 
-  const targetEntry = targetById.get(metadata.target);
-  if (!targetEntry) {
-    return {
-      diagnostics: [
-        ...diagnostics,
-        diagnostic(
-          workspace.packageJsonPath,
-          packageName,
-          'unknown-adapter-target',
-          `${packageName} declares unknown adapter target "${metadata.target}".`,
-          metadata.target,
-          placement
-        ),
-      ],
-    };
-  }
-
-  if (!targetEntry.placements.includes(placement)) {
+  if (subpathMetadata === null) {
     diagnostics.push(
       diagnostic(
         workspace.packageJsonPath,
         packageName,
-        'unsupported-placement',
-        `${targetEntry.ownerPackage}:${targetEntry.target} does not support ${placement} adapter placement.`,
-        targetEntry.target,
-        placement
+        'invalid-adapter-metadata',
+        `${packageName} must declare trails.adapters as an object keyed by exported subpath, with each value declaring a kebab-case target string.`,
+        undefined,
+        'subpath'
       )
     );
+  } else if (subpathMetadata !== undefined) {
+    for (const subpathAdapter of subpathMetadata) {
+      const subpathPackageName = `${packageName}/${subpathAdapter.exportKey.slice(2)}`;
+      const targetEntry = targetById.get(subpathAdapter.target);
+      const subpathPlacement =
+        targetEntry?.ownerPackage === packageName
+          ? 'subpath'
+          : (placement ?? 'subpath');
+      const subject = checkCandidate({
+        exportKey: subpathAdapter.exportKey,
+        key: subpathPackageName,
+        metadata: subpathAdapter,
+        packageName: subpathPackageName,
+        placement: subpathPlacement,
+      });
+      if (subject) {
+        subjects.push(subject);
+      }
+    }
   }
 
-  if (placement === 'extracted') {
-    assertDependencyDirection(workspace, targetEntry, diagnostics);
-  }
-
-  const { conformance, testingImport } = targetEntry;
-  const conformanceTestPaths = testingImport
-    ? pathsProvingConformance(sourceFiles.filter(isTestFile), targetEntry)
-    : [];
-
-  if (!testingImport) {
-    diagnostics.push(
-      diagnostic(
-        workspace.packageJsonPath,
-        packageName,
-        'missing-owner-conformance',
-        `${targetEntry.ownerPackage}:${targetEntry.target} must declare testingImport before adapters can prove conformance.`,
-        targetEntry.target,
-        placement
-      )
-    );
-  } else if (conformanceTestPaths.length === 0) {
-    const conformanceHint = conformance
-      ? ` and call ${conformance.runner}(adapter, ${conformance.casesFactory}(...))`
-      : '';
-    diagnostics.push(
-      diagnostic(
-        workspace.packageJsonPath,
-        packageName,
-        'missing-conformance',
-        `${packageName} must import ${testingImport} from a conformance test${conformanceHint}.`,
-        targetEntry.target,
-        placement
-      )
-    );
-  }
-
-  return {
-    diagnostics,
-    subject: {
-      conformanceTestPaths,
-      key: packageName,
-      ownerPackage: targetEntry.ownerPackage,
-      packageJsonPath: workspace.packageJsonPath,
-      packageName,
-      packageRoot: workspace.packageRoot,
-      placement,
-      target: targetEntry.target,
-      targetKey: targetEntry.key,
-      ...(conformance?.adapterType
-        ? { adapterType: conformance.adapterType }
-        : {}),
-      ...(testingImport ? { testingImport } : {}),
-    },
-  };
+  return { diagnostics, subjects };
 };
 
 export const checkAdapters = (rootDir: string): AdapterCheckReport => {
@@ -2056,9 +2229,7 @@ export const checkAdapters = (rootDir: string): AdapterCheckReport => {
   for (const workspace of workspacePackages(rootDir)) {
     const result = checkAdapterPackage(workspace, targetById);
     diagnostics.push(...result.diagnostics);
-    if (result.subject) {
-      subjects.push(result.subject);
-    }
+    subjects.push(...result.subjects);
   }
 
   const sortedSubjects = subjects.toSorted((left, right) =>

--- a/packages/warden/src/__tests__/adapter-check.test.ts
+++ b/packages/warden/src/__tests__/adapter-check.test.ts
@@ -60,6 +60,36 @@ const writeHttpOwner = (root: string): void => {
   writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
 };
 
+const writeHttpOwnerWithSubpathAdapter = (root: string): void => {
+  writePackage(root, 'packages/http', {
+    exports: {
+      '.': './src/index.ts',
+      './edge': './src/edge/index.ts',
+      './package.json': './package.json',
+      './testing': './src/testing.ts',
+    },
+    name: '@ontrails/http',
+    trails: {
+      adapterTargets: {
+        http: {
+          placements: ['subpath'],
+          testingImport: '@ontrails/http/testing',
+        },
+      },
+      adapters: {
+        './edge': { target: 'http' },
+      },
+    },
+  });
+  writeFile(root, 'packages/http/src/index.ts', 'export {};\n');
+  writeFile(root, 'packages/http/src/testing.ts', 'export {};\n');
+  writeFile(
+    root,
+    'packages/http/src/edge/index.ts',
+    'export const edgeAdapter = {};\n'
+  );
+};
+
 const writeHonoAdapter = (root: string): void => {
   writePackage(root, 'adapters/hono', {
     exports: {
@@ -103,6 +133,22 @@ describe('Warden adapter checks', () => {
       rule: 'adapter-check',
       severity: 'warn',
     });
+    expect(diagnostics[0]?.message).toContain('@ontrails/http/testing');
+  });
+
+  test('maps subpath adapter diagnostics into Warden diagnostics', () => {
+    const root = makeRoot();
+    writeHttpOwnerWithSubpathAdapter(root);
+
+    const diagnostics = runWardenAdapterChecks(root);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      rule: 'adapter-check',
+      severity: 'warn',
+    });
+    expect(diagnostics[0]?.message).toContain('@ontrails/http/edge');
     expect(diagnostics[0]?.message).toContain('@ontrails/http/testing');
   });
 


### PR DESCRIPTION
## Context
Part 2 of the shared adapter readiness stack. This teaches adapter readiness checks about adapter subjects exposed through package subpaths.

## What changed
- Added subpath adapter subject discovery in the shared adapter-kit checks.
- Covered missing subpath conformance and per-subpath scoping in adapter-check tests.
- Kept CLI and Warden projections aligned with the shared adapter-check result.

## Verification
- `bun test packages/adapter-kit/src/__tests__/check.test.ts apps/trails/src/__tests__/create-adapter.test.ts apps/trails/src/__tests__/adapter-check.test.ts packages/warden/src/__tests__/adapter-check.test.ts`
- `bun run changeset:check`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- CI is green on this PR.

## Risks / rollout
Main risk is over-discovery of package subpaths; tests pin the supported conformance metadata path and missing-conformance diagnostics.
