### PR TITLE
chore(adapter-kit): dogfood verified first-party adapters

### DIFF
--- a/.changeset/verified-first-party-adapters.md
+++ b/.changeset/verified-first-party-adapters.md
@@ -1,0 +1,8 @@
+---
+"@ontrails/adapter-kit": patch
+"@ontrails/drizzle": patch
+"@ontrails/http": patch
+"@ontrails/store": patch
+---
+
+Declare verified first-party adapter metadata for Drizzle, HTTP/Bun, and Store/Jsonfile so shared adapter checks can dogfood real owner targets.

--- a/adapters/drizzle/package.json
+++ b/adapters/drizzle/package.json
@@ -28,5 +28,10 @@
   "peerDependencies": {
     "@ontrails/store": "workspace:^",
     "zod": "catalog:"
+  },
+  "trails": {
+    "adapter": {
+      "target": "store"
+    }
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -251,6 +251,7 @@
       "version": "1.0.0-beta.39",
       "dependencies": {
         "@ontrails/core": "workspace:^",
+        "@ontrails/source": "workspace:^",
       },
       "peerDependencies": {
         "zod": "catalog:",

--- a/docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md
+++ b/docs/adr/drafts/20260528-adapter-authoring-as-a-paved-path.md
@@ -190,7 +190,7 @@ Tracer-first, so the hardest, most-coupled pieces (the owner conformance factory
    the proven loop.
 6. **Subpath subject discovery** so local checks can discover generated
    owner-package subpath adapters after the scaffold path exists.
-7. **Dogfood** — bring existing first-party adapters (`hono`, `commander`, `vite`, `drizzle`, `http/fetch`, `http/bun`, `store/jsonfile`, `permits/jwt`) into the model.
+7. **Dogfood verified owner targets** — bring existing first-party adapters with real owner bundles (`hono`, `cloudflare`, `drizzle`, `http/bun`, `store/jsonfile`) into the model, and leave candidate families such as `commander`, `vite`, `http/fetch`, and `permits/jwt` out until their owner-target and conformance posture is explicit.
 8. **`catalog` / `describe` + docs/fieldguide.**
 
 ## References

--- a/packages/adapter-kit/package.json
+++ b/packages/adapter-kit/package.json
@@ -21,7 +21,8 @@
     "clean": "rm -rf dist *.tsbuildinfo"
   },
   "dependencies": {
-    "@ontrails/core": "workspace:^"
+    "@ontrails/core": "workspace:^",
+    "@ontrails/source": "workspace:^"
   },
   "peerDependencies": {
     "zod": "catalog:"

--- a/packages/adapter-kit/src/__tests__/check.test.ts
+++ b/packages/adapter-kit/src/__tests__/check.test.ts
@@ -1437,7 +1437,7 @@ describe('checkAdapters', () => {
     });
   });
 
-  test('accepts mixed value and type adapter conformance imports', () => {
+  test('accepts called value bindings from mixed conformance imports', () => {
     const root = makeRoot();
     writeHttpOwner(root, { conformance: undefined });
     writeHonoAdapter(root);
@@ -1446,7 +1446,7 @@ describe('checkAdapters', () => {
       'adapters/hono/src/__tests__/conformance.test.ts',
       [
         "import { createHttpAdapterConformanceCases, type HttpAdapterConformanceAdapter } from '@ontrails/http/testing';",
-        'void createHttpAdapterConformanceCases;',
+        'createHttpAdapterConformanceCases({});',
         '',
       ].join('\n')
     );
@@ -1457,7 +1457,7 @@ describe('checkAdapters', () => {
     expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
   });
 
-  test('accepts dynamic adapter conformance imports until owners declare helper metadata', () => {
+  test('accepts called dynamic adapter conformance imports without helper metadata', () => {
     const root = makeRoot();
     writeHttpOwner(root, { conformance: undefined });
     writeHonoAdapter(root);
@@ -1466,7 +1466,7 @@ describe('checkAdapters', () => {
       'adapters/hono/src/__tests__/conformance.test.ts',
       [
         "const testing = await import('@ontrails/http/testing');",
-        'void testing.createHttpAdapterConformanceCases;',
+        'testing.createHttpAdapterConformanceCases({});',
         '',
       ].join('\n')
     );
@@ -1475,6 +1475,260 @@ describe('checkAdapters', () => {
 
     expect(report.diagnostics).toEqual([]);
     expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts typed dynamic namespace imports without helper metadata', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const testing: typeof import('@ontrails/http/testing') = await import('@ontrails/http/testing');",
+        'testing.createHttpAdapterConformanceCases({});',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('rejects shadowed calls without helper metadata', () => {
+    for (const [name, lines] of [
+      [
+        'static',
+        [
+          "import { createHttpAdapterConformanceCases } from '@ontrails/http/testing';",
+          'function fake(createHttpAdapterConformanceCases: () => unknown) {',
+          '  createHttpAdapterConformanceCases();',
+          '}',
+          'fake(() => []);',
+        ],
+      ],
+      [
+        'destructured',
+        [
+          "const { createHttpAdapterConformanceCases } = await import('@ontrails/http/testing');",
+          'function fake(createHttpAdapterConformanceCases: () => unknown) {',
+          '  createHttpAdapterConformanceCases();',
+          '}',
+          'fake(() => []);',
+        ],
+      ],
+      [
+        'namespace',
+        [
+          "const testing = await import('@ontrails/http/testing');",
+          'function fake(testing: { run(): void }) {',
+          '  testing.run();',
+          '}',
+          'fake({ run() {} });',
+        ],
+      ],
+    ] as const) {
+      const root = makeRoot();
+      writeHttpOwner(root, { conformance: undefined });
+      writeHonoAdapter(root);
+      writeFile(
+        root,
+        `adapters/hono/src/__tests__/${name}.test.ts`,
+        `${lines.join('\n')}\n`
+      );
+
+      const report = checkAdapters(root);
+
+      expect(report.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+        'missing-conformance'
+      );
+    }
+  });
+
+  test('rejects conformance calls on properties named like namespace imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const testing = await import('@ontrails/http/testing');",
+        'void testing;',
+        'fake.testing.createHttpAdapterConformanceCases({});',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('rejects longer identifiers ending with a namespace import name', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const testing = await import('@ontrails/http/testing');",
+        'void testing;',
+        'fake$testing.createHttpAdapterConformanceCases({});',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('accepts dollar-prefixed dynamic namespace bindings', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const $testing = await import('@ontrails/http/testing');",
+        '$testing.createHttpAdapterConformanceCases({});',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts called inline dynamic imports without helper metadata', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "(await import('@ontrails/http/testing')).createHttpAdapterConformanceCases({});",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('rejects uncalled inline dynamic imports without helper metadata', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "void (await import('@ontrails/http/testing')).createHttpAdapterConformanceCases;",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('rejects promise methods on bare dynamic imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      ["void import('@ontrails/http/testing').then(() => undefined);", ''].join(
+        '\n'
+      )
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('rejects promise methods on bound and awaited dynamic imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const testing = import('@ontrails/http/testing');",
+        'testing.then(() => undefined);',
+        "void (await import('@ontrails/http/testing')).then(() => undefined);",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('rejects inline dynamic import examples inside string literals', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "void import('@ontrails/http/testing');",
+        'const example = "(await import(\\\'@ontrails/http/testing\\\')).createHttpAdapterConformanceCases({})";',
+        'void example;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
   });
 
   test('accepts dynamic adapter conformance imports after semicolonless type aliases', () => {
@@ -1507,9 +1761,10 @@ describe('checkAdapters', () => {
       'adapters/hono/src/__tests__/conformance.test.ts',
       [
         'async function loadTesting(): Promise<unknown> {',
-        "  return await import('@ontrails/http/testing');",
+        '  return undefined;',
         '}',
-        'const testing = await loadTesting() as typeof import("@ontrails/http/testing");',
+        'void loadTesting;',
+        "const testing = await import('@ontrails/http/testing');",
         "testing.runConformance({ name: '@ontrails/hono' }, testing.createHttpAdapterConformanceCases());",
         '',
       ].join('\n')
@@ -1541,7 +1796,364 @@ describe('checkAdapters', () => {
     expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
   });
 
-  test('accepts dynamic adapter conformance imports in object literal values', () => {
+  test('accepts a static runner with dynamically imported conformance cases', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance } from '@ontrails/http/testing';",
+        "const { createHttpAdapterConformanceCases: createCases } = await import('@ontrails/http/testing');",
+        "runConformance({ name: '@ontrails/hono' }, createCases());",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts a dynamic runner with statically imported conformance cases', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { createHttpAdapterConformanceCases } from '@ontrails/http/testing';",
+        "const { runConformance } = await import('@ontrails/http/testing');",
+        "runConformance({ name: '@ontrails/hono' }, createHttpAdapterConformanceCases());",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts a top-level alias of a dynamic conformance namespace', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const testing = await import('@ontrails/http/testing');",
+        'const alias = testing;',
+        "alias.runConformance({ name: '@ontrails/hono' }, alias.createHttpAdapterConformanceCases());",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('rejects reassigned dynamic conformance namespaces and aliases', () => {
+    for (const [name, lines] of [
+      [
+        'namespace',
+        [
+          "let testing = await import('@ontrails/http/testing');",
+          'testing = fakeTesting;',
+          "testing.runConformance({ name: '@ontrails/hono' }, testing.createHttpAdapterConformanceCases());",
+        ],
+      ],
+      [
+        'alias',
+        [
+          "const testing = await import('@ontrails/http/testing');",
+          'let alias = testing;',
+          'alias = fakeTesting;',
+          "alias.runConformance({ name: '@ontrails/hono' }, alias.createHttpAdapterConformanceCases());",
+        ],
+      ],
+    ] as const) {
+      const root = makeRoot();
+      writeHttpOwner(root);
+      writeHonoAdapter(root);
+      writeFile(
+        root,
+        `adapters/hono/src/__tests__/${name}.test.ts`,
+        [
+          'declare const fakeTesting: {',
+          '  runConformance(...args: unknown[]): void;',
+          '  createHttpAdapterConformanceCases(): unknown;',
+          '};',
+          ...lines,
+          '',
+        ].join('\n')
+      );
+
+      const report = checkAdapters(root);
+
+      expect(report.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+        'missing-conformance'
+      );
+    }
+  });
+
+  test('rejects conformance calls through shadowed imported helpers', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance, createHttpAdapterConformanceCases } from '@ontrails/http/testing';",
+        'function fake(runConformance: (...args: unknown[]) => unknown) {',
+        "  runConformance({ name: '@ontrails/hono' }, createHttpAdapterConformanceCases());",
+        '}',
+        'fake(() => undefined);',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+      'missing-conformance'
+    );
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+  });
+
+  test('rejects conformance calls through shadowed cases factories', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance, createHttpAdapterConformanceCases } from '@ontrails/http/testing';",
+        'function fake(createHttpAdapterConformanceCases: () => unknown) {',
+        "  runConformance({ name: '@ontrails/hono' }, createHttpAdapterConformanceCases());",
+        '}',
+        'fake(() => []);',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+      'missing-conformance'
+    );
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+  });
+
+  test('rejects cases factories shadowed inside runner arguments', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "import { runConformance, createHttpAdapterConformanceCases } from '@ontrails/http/testing';",
+        'runConformance({}, (() => {',
+        '  const createHttpAdapterConformanceCases = () => [];',
+        '  return createHttpAdapterConformanceCases();',
+        '})());',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
+      'missing-conformance'
+    );
+  });
+
+  test('accepts later dynamic aliases when earlier aliases are unused', () => {
+    const root = makeRoot();
+    writeHttpOwner(root);
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const { runConformance: unusedRunner } = await import('@ontrails/http/testing');",
+        "const { runConformance: run } = await import('@ontrails/http/testing');",
+        "const { createHttpAdapterConformanceCases: unusedCases } = await import('@ontrails/http/testing');",
+        "const { createHttpAdapterConformanceCases: cases } = await import('@ontrails/http/testing');",
+        'void unusedRunner;',
+        'void unusedCases;',
+        "run({ name: '@ontrails/hono' }, cases());",
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts called destructured dynamic imports without helper metadata', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const { createHttpAdapterConformanceCases: createCases } = await import('@ontrails/http/testing');",
+        'createCases({});',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts dollar-prefixed destructured dynamic bindings', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const { createHttpAdapterConformanceCases: $cases } = await import('@ontrails/http/testing');",
+        '$cases({});',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts typed destructured dynamic bindings', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const { createHttpAdapterConformanceCases: cases }: typeof import('@ontrails/http/testing') = await import('@ontrails/http/testing');",
+        'cases({});',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts destructured dynamic bindings with nested defaults', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const { createHttpAdapterConformanceCases: cases = { fallback: true } }: typeof import('@ontrails/http/testing') = await import('@ontrails/http/testing');",
+        'cases({});',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('accepts destructured dynamic bindings with regex defaults', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const { createHttpAdapterConformanceCases: cases = () => /}/ }: typeof import('@ontrails/http/testing') = await import('@ontrails/http/testing');",
+        'cases({});',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.diagnostics).toEqual([]);
+    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+  });
+
+  test('does not span unrelated destructuring into typed dynamic imports', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        'const local = { fake: () => undefined, ignored: true };',
+        'const { fake, ignored } = local;',
+        "const { createHttpAdapterConformanceCases: cases }: typeof import('@ontrails/http/testing') = await import('@ontrails/http/testing');",
+        'fake();',
+        'void [ignored, cases];',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('rejects uncalled destructured dynamic imports without helper metadata', () => {
+    const root = makeRoot();
+    writeHttpOwner(root, { conformance: undefined });
+    writeHonoAdapter(root);
+    writeFile(
+      root,
+      'adapters/hono/src/__tests__/conformance.test.ts',
+      [
+        "const { createHttpAdapterConformanceCases: createCases } = await import('@ontrails/http/testing');",
+        'void createCases;',
+        '',
+      ].join('\n')
+    );
+
+    const report = checkAdapters(root);
+
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
+  });
+
+  test('rejects uninvoked dynamic imports stored in object literals', () => {
     const root = makeRoot();
     writeHttpOwner(root, { conformance: undefined });
     writeHonoAdapter(root);
@@ -1559,11 +2171,15 @@ describe('checkAdapters', () => {
 
     const report = checkAdapters(root);
 
-    expect(report.diagnostics).toEqual([]);
-    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
   });
 
-  test('accepts dynamic conditional imports until owners declare helper metadata', () => {
+  test('rejects uninvoked conditional dynamic imports', () => {
     const root = makeRoot();
     writeHttpOwner(root, { conformance: undefined });
     writeHonoAdapter(root);
@@ -1581,8 +2197,12 @@ describe('checkAdapters', () => {
 
     const report = checkAdapters(root);
 
-    expect(report.diagnostics).toEqual([]);
-    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
   });
 
   test('ignores direct, type-argument, and nested type-query adapter conformance imports', () => {
@@ -1943,7 +2563,7 @@ describe('checkAdapters', () => {
     });
   });
 
-  test('accepts import-only conformance coverage until owners declare helper metadata', () => {
+  test('rejects import-only conformance coverage without helper metadata', () => {
     const root = makeRoot();
     writeHttpOwner(root, { conformance: undefined });
     writeHonoAdapter(root);
@@ -1955,8 +2575,12 @@ describe('checkAdapters', () => {
 
     const report = checkAdapters(root);
 
-    expect(report.diagnostics).toEqual([]);
-    expect(report.subjects[0]?.conformanceTestPaths).toHaveLength(1);
+    expect(report.subjects[0]?.conformanceTestPaths).toEqual([]);
+    expect(report.diagnostics[0]).toMatchObject({
+      code: 'missing-conformance',
+      packageName: '@ontrails/hono',
+      target: 'http',
+    });
   });
 
   test('reports missing owner conformance facts', () => {

--- a/packages/adapter-kit/src/__tests__/dogfood.test.ts
+++ b/packages/adapter-kit/src/__tests__/dogfood.test.ts
@@ -5,26 +5,110 @@ import { checkAdapters } from '../check.js';
 
 const repoRoot = fileURLToPath(new URL('../../../..', import.meta.url));
 
-describe('first-party adapter dogfood', () => {
-  test('@ontrails/hono declares and proves the HTTP adapter target', () => {
-    const report = checkAdapters(repoRoot);
-    const hono = report.subjects.find(
-      (subject) => subject.packageName === '@ontrails/hono'
-    );
+const expectedAdapters = [
+  {
+    conformancePath:
+      'adapters/cloudflare/src/workers/__tests__/conformance.test.ts',
+    key: '@ontrails/cloudflare',
+    ownerPackage: '@ontrails/http',
+    packageName: '@ontrails/cloudflare',
+    placement: 'extracted',
+    target: 'http',
+    targetKey: '@ontrails/http:http',
+    testingImport: '@ontrails/http/testing',
+  },
+  {
+    conformancePath: 'adapters/drizzle/src/__tests__/drizzle.test.ts',
+    key: '@ontrails/drizzle',
+    ownerPackage: '@ontrails/store',
+    packageName: '@ontrails/drizzle',
+    placement: 'extracted',
+    target: 'store',
+    targetKey: '@ontrails/store:store',
+    testingImport: '@ontrails/store/testing',
+  },
+  {
+    conformancePath: 'adapters/hono/src/__tests__/conformance.test.ts',
+    key: '@ontrails/hono',
+    ownerPackage: '@ontrails/http',
+    packageName: '@ontrails/hono',
+    placement: 'extracted',
+    target: 'http',
+    targetKey: '@ontrails/http:http',
+    testingImport: '@ontrails/http/testing',
+  },
+  {
+    conformancePath: 'packages/http/src/bun.conformance.test.ts',
+    key: '@ontrails/http/bun',
+    ownerPackage: '@ontrails/http',
+    packageName: '@ontrails/http/bun',
+    placement: 'subpath',
+    target: 'http',
+    targetKey: '@ontrails/http:http',
+    testingImport: '@ontrails/http/testing',
+  },
+  {
+    conformancePath: 'packages/store/src/jsonfile/conformance.test.ts',
+    key: '@ontrails/store/jsonfile',
+    ownerPackage: '@ontrails/store',
+    packageName: '@ontrails/store/jsonfile',
+    placement: 'subpath',
+    target: 'store',
+    targetKey: '@ontrails/store:store',
+    testingImport: '@ontrails/store/testing',
+  },
+] as const;
 
-    expect(hono).toMatchObject({
-      key: '@ontrails/hono',
-      ownerPackage: '@ontrails/http',
-      placement: 'extracted',
-      target: 'http',
-      targetKey: '@ontrails/http:http',
-      testingImport: '@ontrails/http/testing',
-    });
-    expect(hono?.conformanceTestPaths).toEqual([
-      expect.stringContaining(
-        'adapters/hono/src/__tests__/conformance.test.ts'
-      ),
+describe('first-party adapter dogfood', () => {
+  test('verified first-party adapters declare and prove owner targets', () => {
+    const report = checkAdapters(repoRoot);
+
+    expect(report.targets.map((target) => target.key)).toEqual([
+      '@ontrails/http:http',
+      '@ontrails/store:store',
     ]);
+
+    for (const expected of expectedAdapters) {
+      const subject = report.subjects.find(
+        (candidate) => candidate.packageName === expected.packageName
+      );
+
+      expect(subject).toMatchObject({
+        key: expected.key,
+        ownerPackage: expected.ownerPackage,
+        placement: expected.placement,
+        target: expected.target,
+        targetKey: expected.targetKey,
+        testingImport: expected.testingImport,
+      });
+      expect(subject?.conformanceTestPaths).toEqual([
+        expect.stringContaining(expected.conformancePath),
+      ]);
+
+      expect(report.facts).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: `${expected.packageName}:${expected.target}:configured`,
+            kind: 'configured',
+            packageName: expected.packageName,
+            target: expected.target,
+            targetKey: expected.targetKey,
+          }),
+          expect.objectContaining({
+            key: `${expected.packageName}:${expected.target}:used`,
+            kind: 'used',
+            packageName: expected.packageName,
+            provenance: expect.objectContaining({
+              paths: [expect.stringContaining(expected.conformancePath)],
+              source: 'conformance-test',
+            }),
+            target: expected.target,
+            targetKey: expected.targetKey,
+          }),
+        ])
+      );
+    }
+
     expect(report.facts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -35,38 +119,17 @@ describe('first-party adapter dogfood', () => {
           targetKey: '@ontrails/http:http',
         }),
         expect.objectContaining({
-          key: '@ontrails/hono:http:configured',
-          kind: 'configured',
-          packageName: '@ontrails/hono',
-          target: 'http',
-          targetKey: '@ontrails/http:http',
-        }),
-        expect.objectContaining({
-          key: '@ontrails/hono:http:used',
-          kind: 'used',
-          packageName: '@ontrails/hono',
-          provenance: expect.objectContaining({
-            paths: [
-              expect.stringContaining(
-                'adapters/hono/src/__tests__/conformance.test.ts'
-              ),
-            ],
-            source: 'conformance-test',
-          }),
-          target: 'http',
-          targetKey: '@ontrails/http:http',
+          key: '@ontrails/store:store:available',
+          kind: 'available',
+          ownerPackage: '@ontrails/store',
+          target: 'store',
+          targetKey: '@ontrails/store:store',
         }),
       ])
     );
     expect(report.facts).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ kind: 'observed' })])
     );
-    expect(report.diagnostics).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          packageName: '@ontrails/hono',
-        }),
-      ])
-    );
+    expect(report.diagnostics).toEqual([]);
   });
 });

--- a/packages/adapter-kit/src/__tests__/source.test.ts
+++ b/packages/adapter-kit/src/__tests__/source.test.ts
@@ -26,6 +26,42 @@ afterEach(() => {
 });
 
 describe('adapter source export scanning', () => {
+  test('combines split type and value export lists regardless of order', () => {
+    const root = makeRoot();
+    writeFile(
+      root,
+      'src/values.ts',
+      ['export interface Shared {}', 'export const SharedValue = {};', ''].join(
+        '\n'
+      )
+    );
+    for (const [name, statements] of [
+      [
+        'type-first.ts',
+        [
+          "import type { Shared } from './values.js';",
+          "import { SharedValue } from './values.js';",
+          'export type { Shared };',
+          'export { SharedValue as Shared };',
+        ],
+      ],
+      [
+        'value-first.ts',
+        [
+          "import type { Shared } from './values.js';",
+          "import { SharedValue } from './values.js';",
+          'export { SharedValue as Shared };',
+          'export type { Shared };',
+        ],
+      ],
+    ] as const) {
+      writeFile(root, `src/${name}`, `${statements.join('\n')}\n`);
+      expect(adapterSourceExportKind(join(root, 'src', name), 'Shared')).toBe(
+        'type-value'
+      );
+    }
+  });
+
   test('classifies direct source exports by type and value position', () => {
     const root = makeRoot();
     writeFile(

--- a/packages/adapter-kit/src/check.ts
+++ b/packages/adapter-kit/src/check.ts
@@ -19,6 +19,13 @@ import type {
   DiagnosticBase,
   WorkspacePackage as CoreWorkspacePackage,
 } from '@ontrails/core';
+import {
+  identifierName,
+  isShadowed,
+  parse,
+  walkWithScopes,
+} from '@ontrails/source';
+import type { AstNode } from '@ontrails/source';
 
 import { deriveAdapterTargetCatalog } from './catalog.js';
 import type {
@@ -1160,48 +1167,147 @@ const dynamicImportNamespaceBindings = (
   const stringsMaskedCode = maskSource(source, { strings: true });
   const escapedSpecifier = escapeRegExp(specifier);
   const pattern = new RegExp(
-    `\\b(?:const|let|var)\\s+(?<local>[A-Za-z_$][\\w$]*)\\s*=\\s*(?:await\\s+)?import\\s*\\(\\s*['"]${escapedSpecifier}['"]\\s*\\)`,
+    `\\bconst\\s+(?<local>[A-Za-z_$][\\w$]*)(?:\\s*:\\s*[^=;]+)?\\s*=\\s*await\\s+import\\s*\\(\\s*['"]${escapedSpecifier}['"]\\s*\\)`,
     'gu'
   );
 
   return [...code.matchAll(pattern)]
     .filter((match) =>
-      matchStartsWithAnyKeyword(stringsMaskedCode, match, [
-        'const',
-        'let',
-        'var',
-      ])
+      matchStartsWithAnyKeyword(stringsMaskedCode, match, ['const'])
     )
     .map((match) => match.groups?.['local'])
     .filter((local): local is string => local !== undefined);
 };
 
-const dynamicImportNamedBinding = (
+const topLevelNamespaceAliases = (
+  ast: AstNode,
+  namespaceBindings: ReadonlySet<string>
+): readonly string[] => {
+  if (ast.type !== 'Program') {
+    return [];
+  }
+
+  const aliases = new Set(namespaceBindings);
+  const body = (ast as unknown as { body?: readonly AstNode[] }).body ?? [];
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const statement of body) {
+      if (statement.type !== 'VariableDeclaration') {
+        continue;
+      }
+      if (statement['kind'] !== 'const') {
+        continue;
+      }
+      const declarations =
+        (statement as unknown as { declarations?: readonly AstNode[] })
+          .declarations ?? [];
+      for (const declaration of declarations) {
+        const declarator = declaration as unknown as {
+          id?: AstNode;
+          init?: AstNode;
+        };
+        const local = identifierName(declarator.id);
+        const sourceBinding = identifierName(declarator.init);
+        if (
+          local &&
+          sourceBinding &&
+          aliases.has(sourceBinding) &&
+          !aliases.has(local)
+        ) {
+          aliases.add(local);
+          changed = true;
+        }
+      }
+    }
+  }
+
+  return [...aliases].filter((binding) => !namespaceBindings.has(binding));
+};
+
+interface DynamicNamedImportBinding {
+  readonly imported: string;
+  readonly local: string;
+}
+
+const closingDestructuringBrace = (
   source: string,
-  specifier: string,
-  exportedName: string
-): string | undefined => {
+  openingBrace: number
+): number | undefined => {
+  let depth = 0;
+  for (let index = openingBrace; index < source.length; index += 1) {
+    const skippedIndex = skipImportScanIgnoredToken(source, index);
+    if (skippedIndex !== undefined) {
+      index = skippedIndex - 1;
+      continue;
+    }
+    const char = source[index];
+    if (char === '{') {
+      depth += 1;
+    } else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) {
+        return index;
+      }
+    }
+  }
+  return undefined;
+};
+
+const splitDestructuringBindings = (source: string): readonly string[] => {
+  const bindings: string[] = [];
+  let start = 0;
+  let depth = 0;
+  for (let index = 0; index < source.length; index += 1) {
+    const skippedIndex = skipImportScanIgnoredToken(source, index);
+    if (skippedIndex !== undefined) {
+      index = skippedIndex - 1;
+      continue;
+    }
+    const char = source[index];
+    if (char === '{' || char === '[' || char === '(') {
+      depth += 1;
+    } else if (char === '}' || char === ']' || char === ')') {
+      depth = Math.max(0, depth - 1);
+    } else if (char === ',' && depth === 0) {
+      bindings.push(source.slice(start, index));
+      start = index + 1;
+    }
+  }
+  bindings.push(source.slice(start));
+  return bindings;
+};
+
+const dynamicImportNamedBindings = (
+  source: string,
+  specifier: string
+): readonly DynamicNamedImportBinding[] => {
   const code = maskSource(source, { strings: false });
   const stringsMaskedCode = maskSource(source, { strings: true });
   const escapedSpecifier = escapeRegExp(specifier);
-  const pattern = new RegExp(
-    `\\b(?:const|let|var)\\s*\\{(?<imports>[\\s\\S]*?)\\}\\s*=\\s*(?:await\\s+)?import\\s*\\(\\s*['"]${escapedSpecifier}['"]\\s*\\)`,
-    'gu'
+  const bindings: DynamicNamedImportBinding[] = [];
+  const declarationPattern = /\bconst\s*\{/gu;
+  const assignmentPattern = new RegExp(
+    `^\\s*(?::\\s*typeof\\s+import\\s*\\(\\s*['"]${escapedSpecifier}['"]\\s*\\))?\\s*=\\s*(?:await\\s+)?import\\s*\\(\\s*['"]${escapedSpecifier}['"]\\s*\\)`,
+    'u'
   );
 
-  for (const match of code.matchAll(pattern)) {
+  for (const match of code.matchAll(declarationPattern)) {
+    if (!matchStartsWithAnyKeyword(stringsMaskedCode, match, ['const'])) {
+      continue;
+    }
+
+    const openingBrace = (match.index ?? 0) + match[0].lastIndexOf('{');
+    const closingBrace = closingDestructuringBrace(code, openingBrace);
     if (
-      !matchStartsWithAnyKeyword(stringsMaskedCode, match, [
-        'const',
-        'let',
-        'var',
-      ])
+      closingBrace === undefined ||
+      !assignmentPattern.test(code.slice(closingBrace + 1))
     ) {
       continue;
     }
 
-    const namedImports = match.groups?.['imports'] ?? '';
-    for (const item of namedImports.split(',')) {
+    const namedImports = code.slice(openingBrace + 1, closingBrace);
+    for (const item of splitDestructuringBindings(namedImports)) {
       const specifierText = item.trim();
       if (specifierText.length === 0 || specifierText.startsWith('...')) {
         continue;
@@ -1211,14 +1317,26 @@ const dynamicImportNamedBinding = (
         /^(?<imported>[A-Za-z_$][\w$]*)(?:\s*:\s*(?<local>[A-Za-z_$][\w$]*))?(?:\s*=.*)?$/u.exec(
           specifierText
         )?.groups;
-      if (imported?.['imported'] === exportedName) {
-        return imported['local'] ?? imported['imported'];
+      if (imported?.['imported']) {
+        bindings.push({
+          imported: imported['imported'],
+          local: imported['local'] ?? imported['imported'],
+        });
       }
     }
   }
 
-  return undefined;
+  return bindings;
 };
+
+const dynamicImportNamedLocals = (
+  source: string,
+  specifier: string,
+  exportedName: string
+): readonly string[] =>
+  dynamicImportNamedBindings(source, specifier)
+    .filter((binding) => binding.imported === exportedName)
+    .map((binding) => binding.local);
 
 interface LocalValueExport {
   readonly identifier: string;
@@ -1550,90 +1668,218 @@ const previousNonWhitespace = (source: string, index: number): string => {
 
 const containsCall = (source: string, identifier: string): boolean => {
   const escapedIdentifier = escapeRegExp(identifier);
-  const callPattern = new RegExp(`\\b${escapedIdentifier}\\s*\\(`, 'gu');
+  const callPattern = new RegExp(`${escapedIdentifier}\\s*\\(`, 'gu');
   for (const match of source.matchAll(callPattern)) {
-    if (previousNonWhitespace(source, match.index ?? 0) !== '.') {
+    const index = match.index ?? 0;
+    if (
+      !isIdentifierChar(source[index - 1]) &&
+      previousNonWhitespace(source, index) !== '.'
+    ) {
       return true;
     }
   }
   return false;
 };
 
-const splitTopLevelArguments = (source: string): readonly string[] => {
-  const args: string[] = [];
-  let start = 0;
-  let parenDepth = 0;
-  let braceDepth = 0;
-  let bracketDepth = 0;
+const promiseMethodNames = new Set(['then', 'catch', 'finally']);
 
-  for (let index = 0; index < source.length; index += 1) {
-    const char = source[index];
-    if (char === '(') {
-      parenDepth += 1;
-      continue;
+const inlineDynamicImportMemberIsCalled = (
+  source: string,
+  specifier: string
+): boolean => {
+  const searchableCode = maskSource(source, { strings: false });
+  const codePositions = maskSource(source, { strings: true });
+  const escapedSpecifier = escapeRegExp(specifier);
+  const pattern = new RegExp(
+    `\\(\\s*await\\s+import\\s*\\(\\s*['"]${escapedSpecifier}['"]\\s*\\)\\s*\\)\\s*\\.\\s*(?<member>[A-Za-z_$][\\w$]*)\\s*\\(`,
+    'gu'
+  );
+  return [...searchableCode.matchAll(pattern)].some(
+    (match) =>
+      codePositions[match.index ?? 0] !== ' ' &&
+      !promiseMethodNames.has(match.groups?.['member'] ?? '')
+  );
+};
+
+interface RuntimeImportBindings {
+  readonly direct: readonly string[];
+  readonly namespaces: readonly string[];
+}
+
+const staticRuntimeImportBindings = (
+  source: string,
+  specifier: string
+): RuntimeImportBindings => {
+  const direct = new Set<string>();
+  const namespaces = new Set<string>();
+  for (const clause of staticImportClausesForSpecifier(source, specifier)) {
+    const importCode = maskSource(clause, { strings: false });
+    const namespaceBinding =
+      /(?:^|,)\s*\*\s+as\s+(?<local>[A-Za-z_$][\w$]*)(?:\s*$|,)/u.exec(
+        importCode
+      )?.groups?.['local'];
+    if (namespaceBinding) {
+      namespaces.add(namespaceBinding);
     }
-    if (char === ')') {
-      parenDepth = Math.max(0, parenDepth - 1);
-      continue;
+
+    const namedImports = /\{(?<imports>[\s\S]*?)\}/u.exec(importCode)?.groups?.[
+      'imports'
+    ];
+    for (const item of namedImports?.split(',') ?? []) {
+      const trimmedItem = item.trim();
+      const imported =
+        /^(?<imported>[A-Za-z_$][\w$]*)(?:\s+as\s+(?<local>[A-Za-z_$][\w$]*))?$/u.exec(
+          trimmedItem.replace(/^type\s+/u, '')
+        )?.groups;
+      if (!trimmedItem.startsWith('type ') && imported?.['imported']) {
+        direct.add(imported['local'] ?? imported['imported']);
+      }
     }
-    if (char === '{') {
-      braceDepth += 1;
-      continue;
+
+    const defaultBinding = /^(?<local>[A-Za-z_$][\w$]*)(?:\s*,|\s*$)/u.exec(
+      importCode.trim()
+    )?.groups?.['local'];
+    if (defaultBinding) {
+      direct.add(defaultBinding);
     }
-    if (char === '}') {
-      braceDepth = Math.max(0, braceDepth - 1);
-      continue;
+  }
+
+  return { direct: [...direct], namespaces: [...namespaces] };
+};
+
+interface RunnerCall {
+  readonly arguments: readonly string[];
+  readonly argumentNodes: readonly AstNode[];
+}
+
+const namespacedCalleeName = (
+  callee: AstNode
+): { readonly property: string; readonly receiver: string } | undefined => {
+  if (
+    (callee.type !== 'MemberExpression' &&
+      callee.type !== 'StaticMemberExpression') ||
+    callee['computed'] === true
+  ) {
+    return undefined;
+  }
+  const receiver = identifierName(callee['object'] as AstNode | undefined);
+  const property = identifierName(callee['property'] as AstNode | undefined);
+  return receiver && property ? { property, receiver } : undefined;
+};
+
+interface ProvenBindingCall {
+  readonly arguments: readonly AstNode[];
+  readonly end: number;
+  readonly start: number;
+}
+
+const provenBindingCalls = (
+  ast: AstNode,
+  binding: string
+): readonly ProvenBindingCall[] => {
+  const calls: ProvenBindingCall[] = [];
+  walkWithScopes(ast, (node, scopes) => {
+    if (node.type !== 'CallExpression') {
+      return;
     }
-    if (char === '[') {
-      bracketDepth += 1;
-      continue;
+    const callee = node['callee'] as AstNode | undefined;
+    if (!callee) {
+      return;
     }
-    if (char === ']') {
-      bracketDepth = Math.max(0, bracketDepth - 1);
-      continue;
+
+    const member = namespacedCalleeName(callee);
+    const bare = identifierName(callee);
+    const matches = member
+      ? `${member.receiver}.${member.property}` === binding &&
+        !isShadowed(member.receiver, scopes)
+      : bare === binding && !isShadowed(binding, scopes);
+    if (!matches) {
+      return;
     }
+
+    calls.push({
+      arguments:
+        (node as unknown as { arguments?: readonly AstNode[] }).arguments ?? [],
+      end: node.end,
+      start: node.start,
+    });
+  });
+  return calls;
+};
+
+const provenNamespaceIsCalled = (ast: AstNode, binding: string): boolean => {
+  let called = false;
+  walkWithScopes(ast, (node, scopes) => {
+    if (called || node.type !== 'CallExpression') {
+      return;
+    }
+    const callee = node['callee'] as AstNode | undefined;
+    const member = callee && namespacedCalleeName(callee);
     if (
-      char === ',' &&
-      parenDepth === 0 &&
-      braceDepth === 0 &&
-      bracketDepth === 0
+      member?.receiver === binding &&
+      !promiseMethodNames.has(member.property) &&
+      !isShadowed(binding, scopes)
     ) {
-      args.push(source.slice(start, index).trim());
-      start = index + 1;
+      called = true;
     }
-  }
-
-  const trailing = source.slice(start).trim();
-  if (trailing || args.length > 0) {
-    args.push(trailing);
-  }
-  return args;
+  });
+  return called;
 };
 
 const runnerCallArguments = (
   source: string,
-  runner: string
-): readonly (readonly string[])[] => {
-  const code = maskSource(source, { strings: true });
-  const escapedRunner = escapeRegExp(runner);
-  const runnerPattern = new RegExp(`\\b${escapedRunner}\\s*\\(`, 'gu');
-  const calls: (readonly string[])[] = [];
+  runner: string,
+  ast: AstNode
+): readonly RunnerCall[] =>
+  provenBindingCalls(ast, runner).map((call) => ({
+    argumentNodes: call.arguments,
+    arguments: call.arguments.map((argument) =>
+      source.slice(argument.start, argument.end)
+    ),
+  }));
 
-  for (const match of code.matchAll(runnerPattern)) {
-    const matchIndex = match.index ?? 0;
-    if (previousNonWhitespace(code, matchIndex) === '.') {
-      continue;
-    }
+const argumentContainsProvenCall = (
+  argument: AstNode | undefined,
+  ast: AstNode,
+  binding: string
+): boolean =>
+  argument !== undefined &&
+  provenBindingCalls(ast, binding).some(
+    (call) => call.start >= argument.start && call.end <= argument.end
+  );
 
-    const openIndex = code.indexOf('(', matchIndex);
-    const closeIndex = findClosingParen(code, openIndex);
-    if (closeIndex === -1) {
-      continue;
-    }
-    calls.push(splitTopLevelArguments(code.slice(openIndex + 1, closeIndex)));
+const importedRuntimeBindingIsCalled = (
+  source: string,
+  specifier: string,
+  ast: AstNode
+): boolean => {
+  const staticBindings = staticRuntimeImportBindings(source, specifier);
+  const directBindings = new Set([
+    ...staticBindings.direct,
+    ...dynamicImportNamedBindings(source, specifier).map(
+      (binding) => binding.local
+    ),
+  ]);
+  if (
+    [...directBindings].some(
+      (binding) => provenBindingCalls(ast, binding).length > 0
+    )
+  ) {
+    return true;
   }
 
-  return calls;
+  const namespaceBindings = new Set([
+    ...staticBindings.namespaces,
+    ...dynamicImportNamespaceBindings(source, specifier),
+  ]);
+  for (const alias of topLevelNamespaceAliases(ast, namespaceBindings)) {
+    namespaceBindings.add(alias);
+  }
+  return (
+    [...namespaceBindings].some((binding) =>
+      provenNamespaceIsCalled(ast, binding)
+    ) || inlineDynamicImportMemberIsCalled(source, specifier)
+  );
 };
 
 const isSentinelAdapterArgument = (argument: string): boolean =>
@@ -1641,33 +1887,42 @@ const isSentinelAdapterArgument = (argument: string): boolean =>
 
 const runnerInvokesCasesFactory = (
   source: string,
+  ast: AstNode,
   runner: string,
   casesFactory: string
 ): boolean =>
-  runnerCallArguments(source, runner).some((args) => {
+  runnerCallArguments(source, runner, ast).some((call) => {
+    const args = call.arguments;
     const adapterArgument = args[0]?.trim();
     return (
       adapterArgument !== undefined &&
       adapterArgument.length > 0 &&
       !isSentinelAdapterArgument(adapterArgument) &&
-      !containsCall(adapterArgument, casesFactory) &&
-      args.slice(1).some((argument) => containsCall(argument, casesFactory))
+      !argumentContainsProvenCall(call.argumentNodes[0], ast, casesFactory) &&
+      call.argumentNodes
+        .slice(1)
+        .some((argument) =>
+          argumentContainsProvenCall(argument, ast, casesFactory)
+        )
     );
   });
 
 const runnerInvokedWithAdapterArgument = (
   source: string,
+  ast: AstNode,
   runner: string,
   casesFactories: readonly string[] = []
 ): boolean =>
-  runnerCallArguments(source, runner).some((args) => {
+  runnerCallArguments(source, runner, ast).some((call) => {
+    const args = call.arguments;
     const adapterArgument = args[0]?.trim();
     return (
       adapterArgument !== undefined &&
       adapterArgument.length > 0 &&
       !isSentinelAdapterArgument(adapterArgument) &&
       casesFactories.every(
-        (casesFactory) => !containsCall(adapterArgument, casesFactory)
+        (casesFactory) =>
+          !argumentContainsProvenCall(call.argumentNodes[0], ast, casesFactory)
       )
     );
   });
@@ -1744,12 +1999,15 @@ const ownerRunnerDefaultsCasesFactory = (
 
 const runnerBindingProvesConformance = (
   source: string,
+  ast: AstNode,
   targetEntry: AdapterTargetCatalogEntry,
   runnerBinding: string,
   casesFactoryBindings: readonly string[]
 ): boolean => {
   for (const casesFactoryBinding of casesFactoryBindings) {
-    if (runnerInvokesCasesFactory(source, runnerBinding, casesFactoryBinding)) {
+    if (
+      runnerInvokesCasesFactory(source, ast, runnerBinding, casesFactoryBinding)
+    ) {
       return true;
     }
   }
@@ -1758,6 +2016,7 @@ const runnerBindingProvesConformance = (
     ownerRunnerDefaultsCasesFactory(targetEntry) &&
     runnerInvokedWithAdapterArgument(
       source,
+      ast,
       runnerBinding,
       casesFactoryBindings
     )
@@ -1779,72 +2038,63 @@ const provesConformance = (
     return false;
   }
 
-  if (!conformance) {
-    return true;
+  const ast = parse('adapter-conformance.ts', source);
+  if (!ast) {
+    return false;
   }
 
-  const runnerBindings = namedImportBindings(
+  if (!conformance) {
+    return importedRuntimeBindingIsCalled(source, testingImport, ast);
+  }
+
+  const runnerBindings = new Set(
+    namedImportBindings(source, testingImport, conformance.runner)
+  );
+  const casesFactoryBindings = new Set(
+    namedImportBindings(source, testingImport, conformance.casesFactory)
+  );
+  const dynamicRunnerBindings = dynamicImportNamedLocals(
     source,
     testingImport,
     conformance.runner
   );
-  const casesFactoryBindings = namedImportBindings(
+  for (const dynamicRunnerBinding of dynamicRunnerBindings) {
+    runnerBindings.add(dynamicRunnerBinding);
+  }
+  const dynamicCasesFactoryBindings = dynamicImportNamedLocals(
     source,
     testingImport,
     conformance.casesFactory
   );
-  if (runnerBindings.length === 0) {
-    const dynamicRunnerBinding = dynamicImportNamedBinding(
-      source,
-      testingImport,
-      conformance.runner
-    );
-    const dynamicCasesFactoryBinding = dynamicImportNamedBinding(
-      source,
-      testingImport,
-      conformance.casesFactory
-    );
-    const dynamicCasesFactoryBindings = dynamicCasesFactoryBinding
-      ? [dynamicCasesFactoryBinding]
-      : [];
-    if (
-      dynamicRunnerBinding &&
-      runnerBindingProvesConformance(
-        source,
-        targetEntry,
-        dynamicRunnerBinding,
-        dynamicCasesFactoryBindings
-      )
-    ) {
-      return true;
-    }
-
-    for (const namespaceBinding of dynamicImportNamespaceBindings(
-      source,
-      testingImport
-    )) {
-      const namespaceRunnerBinding = `${namespaceBinding}.${conformance.runner}`;
-      const namespaceCasesFactoryBinding = `${namespaceBinding}.${conformance.casesFactory}`;
-      if (
-        runnerBindingProvesConformance(
-          source,
-          targetEntry,
-          namespaceRunnerBinding,
-          [namespaceCasesFactoryBinding]
-        )
-      ) {
-        return true;
-      }
-    }
-
-    return false;
+  for (const dynamicCasesFactoryBinding of dynamicCasesFactoryBindings) {
+    casesFactoryBindings.add(dynamicCasesFactoryBinding);
   }
-  return runnerBindings.some((runnerBinding) =>
+  for (const namespaceBinding of dynamicImportNamespaceBindings(
+    source,
+    testingImport
+  )) {
+    runnerBindings.add(`${namespaceBinding}.${conformance.runner}`);
+    casesFactoryBindings.add(`${namespaceBinding}.${conformance.casesFactory}`);
+  }
+
+  const namespaceBindings = new Set(
+    [...runnerBindings]
+      .filter((binding) => binding.endsWith(`.${conformance.runner}`))
+      .map((binding) => binding.slice(0, -conformance.runner.length - 1))
+  );
+  for (const alias of topLevelNamespaceAliases(ast, namespaceBindings)) {
+    runnerBindings.add(`${alias}.${conformance.runner}`);
+    casesFactoryBindings.add(`${alias}.${conformance.casesFactory}`);
+  }
+
+  const allCasesFactoryBindings = [...casesFactoryBindings];
+  return [...runnerBindings].some((runnerBinding) =>
     runnerBindingProvesConformance(
       source,
+      ast,
       targetEntry,
       runnerBinding,
-      casesFactoryBindings
+      allCasesFactoryBindings
     )
   );
 };

--- a/packages/adapter-kit/src/source.ts
+++ b/packages/adapter-kit/src/source.ts
@@ -445,6 +445,7 @@ const namedExportKind = (
   const exportCode = maskDeadSourceText(source, { strings: false });
   const exportListPattern =
     /\bexport\s+(?<typeOnly>type\s+)?\{(?<exports>[\s\S]*?)\}(?<from>\s+from\s+['"][^'"]+['"])?/gu;
+  let resolvedKind: AdapterSourceExportKind | undefined;
 
   for (const match of exportCode.matchAll(exportListPattern)) {
     if (!stringsMaskedCode.startsWith('export', match.index ?? 0)) {
@@ -469,13 +470,16 @@ const namedExportKind = (
         resolveImportKind
       );
       if (!localKind) {
-        return undefined;
+        continue;
       }
-      return exported.typeOnly ? eraseExportValue(localKind) : localKind;
+      resolvedKind = combineExportKinds(
+        resolvedKind,
+        exported.typeOnly ? eraseExportValue(localKind) : localKind
+      );
     }
   }
 
-  return undefined;
+  return resolvedKind;
 };
 
 const starExportSpecifiers = (

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -31,6 +31,11 @@
     "zod": "catalog:"
   },
   "trails": {
+    "adapters": {
+      "./bun": {
+        "target": "http"
+      }
+    },
     "adapterTargets": {
       "http": {
         "conformance": {

--- a/packages/http/src/bun.conformance.test.ts
+++ b/packages/http/src/bun.conformance.test.ts
@@ -1,0 +1,14 @@
+import {
+  createHttpAdapterConformanceCases,
+  runConformance,
+} from '@ontrails/http/testing';
+import type { HttpAdapterConformanceAdapter } from '@ontrails/http/testing';
+
+import { createApp } from './bun.js';
+
+const bunAdapter = {
+  createApp,
+  name: '@ontrails/http/bun',
+} satisfies HttpAdapterConformanceAdapter;
+
+runConformance(bunAdapter, createHttpAdapterConformanceCases());

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -32,6 +32,11 @@
     "zod": "catalog:"
   },
   "trails": {
+    "adapters": {
+      "./jsonfile": {
+        "target": "store"
+      }
+    },
     "adapterTargets": {
       "store": {
         "placements": [

--- a/packages/store/src/jsonfile/conformance.test.ts
+++ b/packages/store/src/jsonfile/conformance.test.ts
@@ -1,0 +1,66 @@
+import { expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createStoreAccessorContractCases } from '@ontrails/store/testing';
+import { z } from 'zod';
+
+import { store as defineStore } from '../store.js';
+
+import { connectJsonFile } from './index.js';
+
+const userSchema = z.object({
+  email: z.string().email(),
+  id: z.string(),
+});
+
+const userStore = defineStore({
+  users: {
+    generated: ['id'] as const,
+    identity: 'id',
+    schema: userSchema,
+  },
+});
+
+const contractCases = createStoreAccessorContractCases({
+  createInput: () => ({ email: 'contract@example.com' }),
+  async createSubject() {
+    const dir = await mkdtemp(join(tmpdir(), 'jsonfile-conformance-'));
+    const connection = await connectJsonFile(userStore, { dir });
+
+    return {
+      accessor: connection.users,
+      dispose: async () => {
+        await rm(dir, { force: true, recursive: true });
+      },
+    };
+  },
+  expectCreated(entity, input) {
+    expect(entity).toEqual(
+      expect.objectContaining({
+        email: input.email,
+        id: expect.any(String),
+      })
+    );
+  },
+  expectUpdated(entity, previous, input) {
+    expect(entity).toEqual({
+      email: input.email,
+      id: previous.id,
+    });
+  },
+  missingId: 'missing-user-id',
+  table: userStore.tables.users,
+  updateInput(existing) {
+    return {
+      email: 'contract+updated@example.com',
+      id: existing.id,
+    };
+  },
+});
+
+for (const contractCase of contractCases) {
+  test(contractCase.name, async () => {
+    await contractCase.run();
+  });
+}


### PR DESCRIPTION
## Context
Part 3 of the shared adapter readiness stack. This dogfoods the adapter-check framework against verified first-party adapters.

## What changed
- Enrolled verified HTTP and store adapters in adapter-check dogfood coverage.
- Added conformance coverage for the current Bun HTTP, Jsonfile store, and Drizzle store lanes.
- Left unverified candidates out until they have explicit owner-target/conformance posture.

## Verification
- `bun test packages/http/src/bun.conformance.test.ts packages/store/src/jsonfile/conformance.test.ts adapters/drizzle/src/__tests__/drizzle.test.ts packages/adapter-kit/src/__tests__/dogfood.test.ts`
- `bun apps/trails/bin/trails.ts adapter check --root-dir . --json`
- `bun apps/trails/bin/trails.ts warden --adapter-check --root-dir . --lock skip --json`
- CI is green on this PR.

## Risks / rollout
This intentionally limits dogfood enrollment to adapters with verified conformance hooks, so additional first-party adapters remain follow-up work.
