### PR TITLE
feat(cloudflare): add d1 store resource

### DIFF
--- a/.changeset/cloudflare-d1-store.md
+++ b/.changeset/cloudflare-d1-store.md
@@ -1,0 +1,10 @@
+---
+'@ontrails/core': patch
+'@ontrails/cloudflare': minor
+'@ontrails/store': patch
+'@ontrails/warden': patch
+---
+
+Add `@ontrails/cloudflare/d1`, an env-bound Cloudflare D1 store resource for `@ontrails/store` definitions. The new subpath exports `cloudflareD1` and `connectD1`, supports the backend-agnostic store accessor contract (`get`, `list`, `upsert`, `remove`), versioned-table optimistic concurrency, fixture/mock seeding, store-derived write signals, Miniflare-backed conformance tests, and Worker env-bridge integration.
+
+`@ontrails/core` and `@ontrails/store` no longer require the Bun global for signal fire ids or late-bound store signal tokens, so store definitions and store-derived signal emission work inside Worker modules. `@ontrails/warden` now treats `cloudflareD1` as a required Cloudflare public export with `@example` coverage.

--- a/adapters/cloudflare/README.md
+++ b/adapters/cloudflare/README.md
@@ -6,7 +6,7 @@ The Cloudflare adapter collection for Trails. One package, one subpath per Cloud
 | --- | --- | --- |
 | `@ontrails/cloudflare/workers` | HTTP surface materializer (fetch handler) | ✅ |
 | `@ontrails/cloudflare/kv` | Key-value resource | ✅ |
-| `/d1` | Store driver | Planned |
+| `@ontrails/cloudflare/d1` | D1-backed store resource | ✅ |
 | `/queues` | Activation source + outbound delivery | Planned |
 | `/r2` | Blob/object resource | Planned |
 
@@ -96,9 +96,56 @@ testAll(graph);
 
 `createMemoryKv()` is also exported directly for hand-rolled tests, with an injectable clock for TTL assertions. Two documented divergences from the real binding: the mock does not enforce KV's 60-second minimum TTL, and when both `expiration` and `expirationTtl` are passed the mock prefers `expirationTtl` where the real binding rejects the combination.
 
+## `/d1` — the store resource
+
+`cloudflareD1(definition, { binding, id })` binds an `@ontrails/store` definition to a Cloudflare D1 database. Trails declare the returned resource and use the standard store accessors (`get`, `list`, `upsert`, `remove`) through `db.from(ctx)`.
+
+```ts
+import { cloudflareD1 } from '@ontrails/cloudflare/d1';
+import { trail, Result } from '@ontrails/core';
+import { store } from '@ontrails/store';
+import { z } from 'zod';
+
+const definition = store({
+  notes: {
+    identity: 'id',
+    schema: z.object({ id: z.string(), body: z.string() }),
+  },
+});
+
+const db = cloudflareD1(definition, { binding: 'DB', id: 'notes.store' });
+
+const saveNote = trail('note.save', {
+  implementation: async (input, ctx) =>
+    Result.ok(await db.from(ctx).notes.upsert(input)),
+  input: z.object({ id: z.string(), body: z.string() }),
+  intent: 'write',
+  output: z.object({ id: z.string(), body: z.string() }),
+  resources: [db],
+});
+```
+
+Declare the binding in wrangler config:
+
+```toml
+d1_databases = [
+  { binding = "DB", database_name = "my-worker", database_id = "<database-id>" }
+]
+```
+
+The first implementation stores one JSON entity per D1 row (`id TEXT PRIMARY KEY`, `entity TEXT NOT NULL`, nullable `version INTEGER`) in adapter-owned tables prefixed by the resource id. It preserves the backend-agnostic store contract, including generated identity fields, `createdAt`/`updatedAt` generation, versioned-table optimistic concurrency (`ConflictError` on stale `version`), fixture/mock seeding, and store-derived `created`/`updated`/`removed` signals.
+
+Capability boundaries are explicit:
+
+- `indexed`/`indexes`, `references`, and `search` stay store metadata for this driver; the D1 adapter does not create secondary indexes, foreign keys, or FTS tables yet.
+- `list(filters)` performs simple equality filtering in the adapter after reading table rows, then applies `offset`/`limit`.
+- `connectD1(definition, database, options)` is exported for tests and advanced runtimes that already hold a D1 binding. Schema creation and optional runtime `seed` run lazily before the first accessor call so the Workers env bridge can resolve resources synchronously. Runtime seed rows require explicit stable identities and are insert-only, so rematerializing a Worker cannot overwrite user edits.
+
+Every `cloudflareD1` resource carries an in-memory mock factory seeded from table fixtures or `mockSeed`, so `testAll(app)` remains configuration-free. Miniflare can provide a real D1 binding for local integration tests without a Cloudflare account.
+
 ## Local integration testing
 
-Integration runs are local-first via [miniflare](https://miniflare.dev) (workerd in-process): the test lane bundles a demo Worker with `Bun.build`, boots it with a real KV namespace, and exercises HTTP, webhook, and KV routes. See `src/__tests__/miniflare.test.ts`. Real-account deploys are manual and never CI-required.
+Integration runs are local-first via [miniflare](https://miniflare.dev) (workerd in-process): the test lane bundles a demo Worker with `Bun.build`, boots it with real KV and D1 bindings, and exercises HTTP, webhook, KV, and D1 store routes. See `src/__tests__/miniflare.test.ts`. Real-account deploys are manual and never CI-required.
 
 ## Lock facts
 
@@ -114,4 +161,4 @@ export const app = topo('my-worker', { readFlag });
 export const trailsOverlays = [cloudflareOverlay];
 ```
 
-`trails compile` validates the derived facts against the schema and embeds them as `overlays.cloudflare`; `trails wayfind --facts cloudflare` reads them back. Toolchains that predate a overlay's namespace preserve it byte-for-byte — adding a new fact family never edits the lock schema or graph type.
+`trails compile` validates the derived facts against the schema and embeds them as `overlays.cloudflare`; `trails wayfind --overlay cloudflare` reads them back. Toolchains that predate an overlay's namespace preserve it byte-for-byte — adding a new fact family never edits the lock schema or graph type.

--- a/adapters/cloudflare/package.json
+++ b/adapters/cloudflare/package.json
@@ -14,11 +14,12 @@
     ".": "./src/index.ts",
     "./workers": "./src/workers/index.ts",
     "./kv": "./src/kv/index.ts",
+    "./d1": "./src/d1/index.ts",
     "./package.json": "./package.json"
   },
   "scripts": {
     "build": "tsc -b",
-    "test": "bun test",
+    "test": "bun test --max-concurrency=1",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint ./src",
     "clean": "rm -rf dist *.tsbuildinfo"
@@ -33,11 +34,17 @@
   },
   "peerDependencies": {
     "@ontrails/http": "workspace:^",
+    "@ontrails/store": "workspace:^",
     "zod": "catalog:"
   },
   "trails": {
     "adapter": {
       "target": "http"
+    },
+    "adapters": {
+      "./d1": {
+        "target": "store"
+      }
     }
   }
 }

--- a/adapters/cloudflare/src/__tests__/facts.test.ts
+++ b/adapters/cloudflare/src/__tests__/facts.test.ts
@@ -9,12 +9,20 @@
 
 import { describe, expect, test } from 'bun:test';
 import { Result, topo, trail } from '@ontrails/core';
+import { store as defineStore } from '@ontrails/store';
 import { z } from 'zod';
 
 import { cloudflareOverlay } from '../facts.js';
+import { cloudflareD1 } from '../d1/index.js';
 import { cloudflareKv } from '../kv/index.js';
 
 const flags = cloudflareKv('flags', { binding: 'FLAGS' });
+const notesStore = defineStore({
+  notes: {
+    identity: 'id',
+    schema: z.object({ body: z.string(), id: z.string() }),
+  },
+});
 
 const showFlag = trail('flag.show', {
   implementation: async (input, ctx) => {
@@ -47,6 +55,26 @@ describe('cloudflareOverlay', () => {
       cloudflareOverlay.derive(app)
     );
     expect(parsed.success).toBe(true);
+  });
+
+  test('derives D1 store resources through the shared env binding registry', () => {
+    const notes = cloudflareD1(notesStore, {
+      binding: 'DB',
+      id: 'notes.store',
+    });
+    const saveNote = trail('note.save', {
+      implementation: async (input, ctx) =>
+        Result.ok(await notes.from(ctx).notes.upsert(input)),
+      input: z.object({ body: z.string(), id: z.string() }),
+      intent: 'write',
+      output: z.object({ body: z.string(), id: z.string() }),
+      resources: [notes],
+    });
+    const app = topo('cf-facts-d1', { notes, saveNote });
+
+    expect(cloudflareOverlay.derive(app)).toEqual({
+      bindings: [{ binding: 'DB', resourceId: 'notes.store' }],
+    });
   });
 
   test('derive is deterministic: same topo, deeply-equal and identically ordered facts', () => {

--- a/adapters/cloudflare/src/__tests__/fixtures/demo-worker.ts
+++ b/adapters/cloudflare/src/__tests__/fixtures/demo-worker.ts
@@ -14,12 +14,24 @@ import {
   trail,
   webhook,
 } from '@ontrails/core';
+import { store as defineStore } from '@ontrails/store';
 import { z } from 'zod';
 
+import { cloudflareD1 } from '../../d1/index.js';
 import { cloudflareKv } from '../../kv/index.js';
 import { createWorkersHandler } from '../../workers/index.js';
 
 const flags = cloudflareKv('flags', { binding: 'FLAGS' });
+const notesStore = defineStore({
+  notes: {
+    identity: 'id',
+    schema: z.object({ body: z.string(), id: z.string() }),
+  },
+});
+const notes = cloudflareD1(notesStore, {
+  binding: 'DB',
+  id: 'notes.store',
+});
 
 const ping = trail('ping', {
   implementation: (input) => Result.ok({ reply: `pong:${input.message}` }),
@@ -50,6 +62,26 @@ const showFlag = trail('flag.show', {
   resources: [flags],
 });
 
+const saveNote = trail('note.save', {
+  implementation: async (input, ctx) =>
+    Result.ok(await notes.from(ctx).notes.upsert(input)),
+  input: z.object({ body: z.string(), id: z.string() }),
+  intent: 'write',
+  output: z.object({ body: z.string(), id: z.string() }),
+  resources: [notes],
+});
+
+const showNote = trail('note.show', {
+  implementation: async (input, ctx) =>
+    Result.ok({ note: await notes.from(ctx).notes.get(input.id) }),
+  input: z.object({ id: z.string() }),
+  intent: 'read',
+  output: z.object({
+    note: z.object({ body: z.string(), id: z.string() }).nullable(),
+  }),
+  resources: [notes],
+});
+
 const deploySecret = 'demo-secret';
 const deployWebhook = webhook('webhook.deploy.finished', {
   parse: z.object({ deployId: z.string() }),
@@ -73,10 +105,13 @@ const recordDeploy = trail('deploy.record', {
 
 const graph = topo('cf-demo', {
   flags,
+  notes,
   ping,
   recordDeploy,
   saveFlag,
+  saveNote,
   showFlag,
+  showNote,
 });
 
 export default createWorkersHandler(graph);

--- a/adapters/cloudflare/src/__tests__/miniflare.test.ts
+++ b/adapters/cloudflare/src/__tests__/miniflare.test.ts
@@ -1,8 +1,8 @@
 /**
  * Miniflare integration lane: bundles the demo Worker fixture and executes it
  * under workerd. This is the local-first integration proof — no Cloudflare
- * account is required — covering HTTP routes, a webhook route, and the KV
- * resource served through the env bridge.
+ * account is required — covering HTTP routes, a webhook route, KV, and a D1
+ * store resource served through the env bridge.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
@@ -45,6 +45,7 @@ describe('demo worker under miniflare', () => {
     const script = await bundleWorkerScript();
     mf = new Miniflare({
       compatibilityDate: '2026-06-01',
+      d1Databases: ['DB'],
       kvNamespaces: ['FLAGS'],
       modules: true,
       script,
@@ -76,6 +77,26 @@ describe('demo worker under miniflare', () => {
     );
     expect(shown.status).toBe(200);
     expect(await shown.json()).toEqual({ data: { value: 'red' } });
+  });
+
+  test('serves D1-backed store trails through the env bridge', async () => {
+    const saved = await mf.dispatchFetch('http://localhost/note/save', {
+      body: JSON.stringify({ body: 'hello from d1', id: 'note_1' }),
+      headers: { 'Content-Type': 'application/json' },
+      method: 'POST',
+    });
+    expect(saved.status).toBe(200);
+    expect(await saved.json()).toEqual({
+      data: { body: 'hello from d1', id: 'note_1' },
+    });
+
+    const shown = await mf.dispatchFetch(
+      'http://localhost/note/show?id=note_1'
+    );
+    expect(shown.status).toBe(200);
+    expect(await shown.json()).toEqual({
+      data: { note: { body: 'hello from d1', id: 'note_1' } },
+    });
   });
 
   test('serves a webhook route with verification', async () => {

--- a/adapters/cloudflare/src/d1/__tests__/d1.test.ts
+++ b/adapters/cloudflare/src/d1/__tests__/d1.test.ts
@@ -1,0 +1,763 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import {
+  ConflictError,
+  createTrailContext,
+  Result,
+  topo,
+  trail,
+  ValidationError,
+} from '@ontrails/core';
+import { store as defineStore } from '@ontrails/store';
+import { createStoreAccessorContractCases } from '@ontrails/store/testing';
+import { testAll } from '@ontrails/testing';
+import { Miniflare } from 'miniflare';
+import { z } from 'zod';
+
+import { getEnvBinding } from '../../env.js';
+import { cloudflareD1, connectD1 } from '../index.js';
+import type {
+  CloudflareD1Database,
+  CloudflareD1PreparedStatement,
+} from '../index.js';
+
+const userSchema = z.object({
+  email: z.string().email(),
+  id: z.string(),
+});
+
+const userStore = defineStore({
+  users: {
+    generated: ['id'] as const,
+    identity: 'id',
+    schema: userSchema,
+  },
+});
+
+const datedStore = defineStore({
+  entries: {
+    identity: 'id',
+    schema: z.object({
+      id: z.string(),
+      observedAt: z.coerce.date(),
+    }),
+  },
+});
+
+const versionedDocumentSchema = z.object({
+  body: z.string(),
+  id: z.string(),
+});
+
+const versionedDocumentStore = defineStore({
+  documents: {
+    identity: 'id',
+    schema: versionedDocumentSchema,
+    versioned: true,
+  },
+});
+
+const createD1Fixture = async (): Promise<{
+  readonly database: CloudflareD1Database;
+  readonly dispose: () => Promise<void>;
+}> => {
+  const mf = new Miniflare({
+    compatibilityDate: '2026-06-01',
+    d1Databases: ['DB'],
+    modules: true,
+    script: 'export default { fetch() { return new Response("ok"); } }',
+  });
+  await mf.ready;
+  return {
+    database: (await mf.getD1Database('DB')) as CloudflareD1Database,
+    dispose: () => mf.dispose(),
+  };
+};
+
+let sharedD1Fixture: Awaited<ReturnType<typeof createD1Fixture>> | undefined;
+let d1FixtureSerial = 0;
+
+beforeAll(async () => {
+  sharedD1Fixture = await createD1Fixture();
+}, 120_000);
+
+afterAll(async () => {
+  await sharedD1Fixture?.dispose();
+});
+
+const nextD1Fixture = async () => {
+  if (sharedD1Fixture === undefined) {
+    throw new Error('D1 fixture was used before test setup completed.');
+  }
+  d1FixtureSerial += 1;
+  return {
+    database: sharedD1Fixture.database,
+    dispose: async () => {},
+    tablePrefix: `test_${d1FixtureSerial}`,
+  };
+};
+
+const withD1Fixture = async <TResult>(
+  run: (fixture: Awaited<ReturnType<typeof nextD1Fixture>>) => Promise<TResult>
+): Promise<TResult> => {
+  const fixture = await nextD1Fixture();
+
+  try {
+    return await run(fixture);
+  } finally {
+    await fixture.dispose();
+  }
+};
+
+const interceptD1 = (
+  database: CloudflareD1Database,
+  hooks: {
+    readonly beforeFirst?: (
+      sql: string,
+      values: readonly unknown[]
+    ) => Promise<void>;
+    readonly beforeRun?: (
+      sql: string,
+      values: readonly unknown[]
+    ) => Promise<void>;
+  }
+): CloudflareD1Database => ({
+  exec: (query) => database.exec(query),
+  prepare(sql) {
+    let values: readonly unknown[] = [];
+    const statement: CloudflareD1PreparedStatement = {
+      all: async <TRow>() =>
+        await database
+          .prepare(sql)
+          .bind(...values)
+          .all<TRow>(),
+      bind: (...nextValues) => {
+        values = nextValues;
+        return statement;
+      },
+      first: async <TRow>() => {
+        await hooks.beforeFirst?.(sql, values);
+        return await database
+          .prepare(sql)
+          .bind(...values)
+          .first<TRow>();
+      },
+      run: async () => {
+        await hooks.beforeRun?.(sql, values);
+        return await database
+          .prepare(sql)
+          .bind(...values)
+          .run();
+      },
+    };
+    return statement;
+  },
+});
+
+const contractCases = createStoreAccessorContractCases({
+  createInput: () => ({ email: 'contract@example.com' }),
+  async createSubject() {
+    const { database, dispose, tablePrefix } = await nextD1Fixture();
+    const connection = connectD1(userStore, database, {
+      generateIdentity: () => 'user-contract-id',
+      tablePrefix,
+    });
+
+    return {
+      accessor: connection.users,
+      dispose,
+    };
+  },
+  expectCreated(entity, input) {
+    expect(entity).toEqual(
+      expect.objectContaining({
+        email: input.email,
+        id: expect.any(String),
+      })
+    );
+  },
+  expectUpdated(entity, previous, input) {
+    expect(entity).toEqual({
+      email: input.email,
+      id: previous.id,
+    });
+  },
+  missingId: 'missing-user-id',
+  table: userStore.tables.users,
+  updateInput(existing) {
+    return {
+      email: 'contract+updated@example.com',
+      id: existing.id,
+    };
+  },
+});
+
+for (const contractCase of contractCases) {
+  test(`D1 store contract: ${contractCase.name}`, async () => {
+    await contractCase.run();
+  });
+}
+
+describe('connectD1', () => {
+  test('enforces optimistic concurrency on versioned tables', async () => {
+    await withD1Fixture(async ({ database, tablePrefix }) => {
+      const connection = connectD1(versionedDocumentStore, database, {
+        tablePrefix,
+      });
+
+      const created = await connection.documents.upsert({
+        body: 'first',
+        id: 'doc_1',
+      });
+      expect(created).toEqual({ body: 'first', id: 'doc_1', version: 1 });
+
+      const updated = await connection.documents.upsert({
+        ...created,
+        body: 'second',
+      });
+      expect(updated).toEqual({ body: 'second', id: 'doc_1', version: 2 });
+
+      await expect(
+        connection.documents.upsert({ ...created, body: 'stale' })
+      ).rejects.toThrow(ConflictError);
+
+      expect(await connection.documents.remove(created.id)).toEqual({
+        deleted: true,
+      });
+      await expect(
+        connection.documents.upsert({ ...updated, body: 'resurrected' })
+      ).rejects.toThrow(ConflictError);
+    });
+  });
+
+  test('reports a removal only when D1 deletes a row', async () => {
+    let deleteWasRun = false;
+    const database: CloudflareD1Database = {
+      async exec() {},
+      prepare(sql) {
+        const statement: CloudflareD1PreparedStatement = {
+          all: async <TRow>() => ({ results: [] as TRow[] }),
+          bind: () => statement,
+          first: async () => {
+            deleteWasRun = sql.startsWith('DELETE');
+            return null;
+          },
+          run: async () => ({ meta: { changes: 0 } }),
+        };
+        return statement;
+      },
+    };
+    const connection = connectD1(userStore, database);
+
+    expect(await connection.users.remove('missing')).toEqual({
+      deleted: false,
+    });
+    expect(deleteWasRun).toBe(true);
+  });
+
+  test('throws when an expected-version D1 update reports no changed rows', async () => {
+    let selectCount = 0;
+    let sawExpectedVersionUpdate = false;
+    const database: CloudflareD1Database = {
+      async exec() {},
+      prepare(sql) {
+        const statement: CloudflareD1PreparedStatement = {
+          all: async <TRow>() => ({ results: [] as TRow[] }),
+          bind: () => statement,
+          first: async <TRow>() => {
+            if (!sql.startsWith('SELECT')) {
+              return null;
+            }
+            selectCount += 1;
+            const row =
+              selectCount === 1
+                ? { body: 'current', id: 'doc_1', version: 1 }
+                : { body: 'other writer', id: 'doc_1', version: 2 };
+            return { entity: JSON.stringify(row) } as TRow;
+          },
+          run: async () => {
+            if (sql.startsWith('UPDATE')) {
+              sawExpectedVersionUpdate = sql.includes(
+                'WHERE id = ? AND entity = ? AND version = ?'
+              );
+              return { meta: { changes: 0 } };
+            }
+            return { meta: { changes: 1 } };
+          },
+        };
+        return statement;
+      },
+    };
+    const connection = connectD1(versionedDocumentStore, database);
+
+    await expect(
+      connection.documents.upsert({
+        body: 'mine',
+        id: 'doc_1',
+        version: 1,
+      })
+    ).rejects.toThrow(ConflictError);
+    expect(sawExpectedVersionUpdate).toBe(true);
+    expect(selectCount).toBe(2);
+  });
+
+  test('applies runtime seed rows during lazy initialization', async () => {
+    await withD1Fixture(async ({ database, tablePrefix }) => {
+      const connection = connectD1(userStore, database, {
+        seed: { users: [{ email: 'seed@example.com', id: 'seeded' }] },
+        tablePrefix,
+      });
+
+      expect(await connection.users.get('seeded')).toEqual({
+        email: 'seed@example.com',
+        id: 'seeded',
+      });
+    });
+  });
+
+  test('treats versioned runtime seed rows as initial state', async () => {
+    await withD1Fixture(async ({ database, tablePrefix }) => {
+      const connection = connectD1(versionedDocumentStore, database, {
+        seed: {
+          documents: [{ body: 'seed body', id: 'seeded', version: 3 }],
+        },
+        tablePrefix,
+      });
+
+      expect(await connection.documents.get('seeded')).toEqual({
+        body: 'seed body',
+        id: 'seeded',
+        version: 3,
+      });
+    });
+  });
+
+  test('runtime seed rematerialization preserves user edits', async () => {
+    await withD1Fixture(async ({ database, tablePrefix }) => {
+      const options = {
+        seed: { users: [{ email: 'seed@example.com', id: 'seeded' }] },
+        tablePrefix,
+      } as const;
+      const first = connectD1(userStore, database, options);
+      expect(await first.users.get('seeded')).toEqual({
+        email: 'seed@example.com',
+        id: 'seeded',
+      });
+      await first.users.upsert({
+        email: 'user-edit@example.com',
+        id: 'seeded',
+      });
+
+      const rematerialized = connectD1(userStore, database, options);
+
+      expect(await rematerialized.users.get('seeded')).toEqual({
+        email: 'user-edit@example.com',
+        id: 'seeded',
+      });
+    });
+  });
+
+  test('runtime seed rows require stable identities', async () => {
+    await withD1Fixture(async ({ database, tablePrefix }) => {
+      const connection = connectD1(userStore, database, {
+        seed: { users: [{ email: 'seed@example.com' }] },
+        tablePrefix,
+      });
+
+      await expect(connection.users.list()).rejects.toThrow(ValidationError);
+    });
+  });
+});
+
+describe('cloudflareD1 resource', () => {
+  test('declares binding metadata, store shape, signals, and mock factory', () => {
+    const db = cloudflareD1(userStore, {
+      binding: 'DB',
+      id: 'users.store',
+    });
+
+    expect(db.access).toBe('readwrite');
+    expect(db.id).toBe('users.store');
+    expect(db.meta?.['cloudflare.binding']).toBe('DB');
+    expect(db.meta?.['cloudflare.service']).toBe('d1');
+    expect(db.signals.map((signal) => signal.id)).toEqual([
+      'users.store:users.created',
+      'users.store:users.updated',
+      'users.store:users.removed',
+    ]);
+    expect(db.store.tables.users.signals.created.id).toBe(
+      'users.store:users.created'
+    );
+    expect(typeof db.mock).toBe('function');
+    expect(getEnvBinding(db)?.binding).toBe('DB');
+  });
+
+  test('create refuses to run outside a Workers env with guidance', async () => {
+    const db = cloudflareD1(userStore, {
+      binding: 'DB',
+      id: 'users.store',
+    });
+    const created = await db.create({
+      config: undefined,
+      cwd: '/',
+      env: {},
+      workspaceRoot: undefined,
+    });
+
+    expect(created.isErr()).toBe(true);
+    if (created.isErr()) {
+      expect(created.error.message).toContain('DB');
+      expect(created.error.message).toContain('createWorkersHandler');
+    }
+  });
+
+  test('rejects a non-D1 env binding', () => {
+    const db = cloudflareD1(userStore, {
+      binding: 'DB',
+      id: 'users.store',
+    });
+    const result = getEnvBinding(db)?.fromEnv('not-a-d1');
+
+    expect(result?.isErr()).toBe(true);
+    if (result?.isErr()) {
+      expect(result.error.message).toContain('d1_databases');
+    }
+  });
+
+  test('env materialization honors an explicit table prefix', async () => {
+    const statements: string[] = [];
+    const database: CloudflareD1Database = {
+      async exec(query) {
+        statements.push(query);
+      },
+      prepare(sql) {
+        statements.push(sql);
+        const statement: CloudflareD1PreparedStatement = {
+          all: async <TRow>() => ({ results: [] as TRow[] }),
+          bind: () => statement,
+          first: async () => null,
+          run: async () => ({ meta: { changes: 0 } }),
+        };
+        return statement;
+      },
+    };
+    const db = cloudflareD1(userStore, {
+      binding: 'DB',
+      id: 'users.store',
+      tablePrefix: 'legacy',
+    });
+    const resolved = getEnvBinding(db)?.fromEnv(database);
+
+    expect(resolved?.isOk()).toBe(true);
+    if (resolved?.isOk()) {
+      await resolved.value.users.get('missing');
+    }
+    expect(statements.some((sql) => sql.includes('"legacy.users"'))).toBe(true);
+    expect(statements.some((sql) => sql.includes('"users.store.users"'))).toBe(
+      false
+    );
+  });
+
+  test('mock factory seeds table fixtures and mockSeed overrides', async () => {
+    const fixtureStore = defineStore({
+      users: {
+        fixtures: [{ email: 'fixture@example.com', id: 'fixture' }],
+        identity: 'id',
+        schema: userSchema,
+      },
+    });
+    const db = cloudflareD1(fixtureStore, {
+      binding: 'DB',
+      id: 'fixture.store',
+      mockSeed: {
+        users: [{ email: 'override@example.com', id: 'override' }],
+      },
+    });
+
+    const connection = await db.mock?.();
+
+    expect(connection).toBeDefined();
+    expect(await connection?.users.get('fixture')).toBeNull();
+    expect(await connection?.users.get('override')).toEqual({
+      email: 'override@example.com',
+      id: 'override',
+    });
+  });
+
+  test('mock seed preserves explicit generated versions', async () => {
+    const db = cloudflareD1(versionedDocumentStore, {
+      binding: 'DB',
+      id: 'documents.store',
+      mockSeed: {
+        documents: [{ body: 'seed body', id: 'seeded', version: 3 }],
+      },
+    });
+
+    const connection = await db.mock?.();
+
+    expect(await connection?.documents.get('seeded')).toEqual({
+      body: 'seed body',
+      id: 'seeded',
+      version: 3,
+    });
+  });
+
+  test('mock seed requires the same stable identities as runtime D1', async () => {
+    const db = cloudflareD1(userStore, {
+      binding: 'DB',
+      id: 'users.store',
+      mockSeed: { users: [{ email: 'seed@example.com' }] },
+    });
+
+    await expect(db.mock?.()).rejects.toThrow(ValidationError);
+  });
+
+  test('from(ctx) emits store-derived signals after writes', async () => {
+    await withD1Fixture(async ({ database, tablePrefix }) => {
+      const db = cloudflareD1(userStore, {
+        binding: 'DB',
+        generateIdentity: () => 'signal-user',
+        id: 'signal.store',
+      });
+      const connection = connectD1(db.store, database, {
+        generateIdentity: () => 'signal-user',
+        tablePrefix,
+      });
+      const events: { readonly payload: unknown; readonly signalId: string }[] =
+        [];
+      const ctx = createTrailContext({
+        abortSignal: new AbortController().signal,
+        extensions: { [db.id]: connection },
+        fire: async (signal, payload) => {
+          events.push({ payload, signalId: signal.id });
+        },
+        requestId: 'd1-signals',
+      });
+
+      const bound = db.from(ctx);
+      const created = await bound.users.upsert({ email: 'signal@example.com' });
+      const updated = await bound.users.upsert({
+        ...created,
+        email: 'signal+updated@example.com',
+      });
+      await bound.users.remove(created.id);
+
+      expect(events.map((event) => event.signalId)).toEqual([
+        'signal.store:users.created',
+        'signal.store:users.updated',
+        'signal.store:users.removed',
+      ]);
+      expect(events[0]?.payload).toEqual(created);
+      expect(events[1]?.payload).toEqual(updated);
+      expect(events[2]?.payload).toEqual(updated);
+    });
+  });
+
+  test('concurrent explicit-id upserts emit one created and one updated signal', async () => {
+    await withD1Fixture(async ({ database, tablePrefix }) => {
+      const db = cloudflareD1(userStore, {
+        binding: 'DB',
+        id: 'race.store',
+      });
+      const connection = connectD1(db.store, database, { tablePrefix });
+      const signalIds: string[] = [];
+      const ctx = createTrailContext({
+        abortSignal: new AbortController().signal,
+        extensions: { [db.id]: connection },
+        fire: async (signal) => {
+          signalIds.push(signal.id);
+        },
+        requestId: 'd1-signal-race',
+      });
+      const bound = db.from(ctx);
+
+      await Promise.all([
+        bound.users.upsert({ email: 'first@example.com', id: 'same' }),
+        bound.users.upsert({ email: 'second@example.com', id: 'same' }),
+      ]);
+
+      expect(signalIds).toEqual([
+        'race.store:users.created',
+        'race.store:users.updated',
+      ]);
+    });
+  });
+
+  test('upsert emits created when a concurrent remove wins before commit', async () => {
+    await withD1Fixture(async ({ database, tablePrefix }) => {
+      const base = connectD1(userStore, database, { tablePrefix });
+      await base.users.upsert({ email: 'before@example.com', id: 'same' });
+      let removed = false;
+      const racingDatabase = interceptD1(database, {
+        async beforeRun(sql) {
+          if (!removed && sql.startsWith('UPDATE')) {
+            removed = true;
+            await base.users.remove('same');
+          }
+        },
+      });
+      const db = cloudflareD1(userStore, {
+        binding: 'DB',
+        id: 'recreate.store',
+        tablePrefix,
+      });
+      const connection = connectD1(userStore, racingDatabase, { tablePrefix });
+      const events: string[] = [];
+      const ctx = createTrailContext({
+        abortSignal: new AbortController().signal,
+        extensions: { [db.id]: connection },
+        fire: async (signal) => {
+          events.push(signal.id);
+        },
+        requestId: 'd1-recreate-race',
+      });
+
+      await db.from(ctx).users.upsert({
+        email: 'after@example.com',
+        id: 'same',
+      });
+
+      expect(events).toEqual(['recreate.store:users.created']);
+    });
+  });
+
+  test('remove signal carries the row deleted after a concurrent update', async () => {
+    await withD1Fixture(async ({ database, tablePrefix }) => {
+      const base = connectD1(userStore, database, { tablePrefix });
+      await base.users.upsert({ email: 'before@example.com', id: 'same' });
+      let updated = false;
+      const racingDatabase = interceptD1(database, {
+        async beforeFirst(sql) {
+          if (!updated && sql.startsWith('DELETE')) {
+            updated = true;
+            await base.users.upsert({ email: 'after@example.com', id: 'same' });
+          }
+        },
+      });
+      const db = cloudflareD1(userStore, {
+        binding: 'DB',
+        id: 'remove.store',
+        tablePrefix,
+      });
+      const connection = connectD1(userStore, racingDatabase, { tablePrefix });
+      const events: unknown[] = [];
+      const ctx = createTrailContext({
+        abortSignal: new AbortController().signal,
+        extensions: { [db.id]: connection },
+        fire: async (_signal, payload) => {
+          events.push(payload);
+        },
+        requestId: 'd1-remove-race',
+      });
+
+      await db.from(ctx).users.remove('same');
+
+      expect(events).toEqual([{ email: 'after@example.com', id: 'same' }]);
+    });
+  });
+
+  test('date-only updates emit the derived updated signal', async () => {
+    await withD1Fixture(async ({ database, tablePrefix }) => {
+      const db = cloudflareD1(datedStore, {
+        binding: 'DB',
+        id: 'dated.store',
+      });
+      const connection = connectD1(db.store, database, { tablePrefix });
+      const signalIds: string[] = [];
+      const ctx = createTrailContext({
+        abortSignal: new AbortController().signal,
+        extensions: { [db.id]: connection },
+        fire: async (signal) => {
+          signalIds.push(signal.id);
+        },
+        requestId: 'd1-date-change',
+      });
+      const bound = db.from(ctx);
+
+      await bound.entries.upsert({
+        id: 'dated',
+        observedAt: new Date('2026-07-10T00:00:00.000Z'),
+      });
+      await bound.entries.upsert({
+        id: 'dated',
+        observedAt: new Date('2026-07-11T00:00:00.000Z'),
+      });
+
+      expect(signalIds).toEqual([
+        'dated.store:entries.created',
+        'dated.store:entries.updated',
+      ]);
+    });
+  });
+
+  test('filters D1 rows by Date value instead of object identity', async () => {
+    await withD1Fixture(async ({ database, tablePrefix }) => {
+      const db = cloudflareD1(datedStore, {
+        binding: 'DB',
+        id: 'dated.filter.store',
+      });
+      const connection = connectD1(db.store, database, { tablePrefix });
+      const ctx = createTrailContext({
+        abortSignal: new AbortController().signal,
+        extensions: { [db.id]: connection },
+        requestId: 'd1-date-filter',
+      });
+      const bound = db.from(ctx);
+
+      await bound.entries.upsert({
+        id: 'dated',
+        observedAt: new Date('2026-07-11T00:00:00.000Z'),
+      });
+
+      await expect(
+        bound.entries.list({
+          observedAt: new Date('2026-07-11T00:00:00.000Z'),
+        })
+      ).resolves.toEqual([
+        {
+          id: 'dated',
+          observedAt: new Date('2026-07-11T00:00:00.000Z'),
+        },
+      ]);
+    });
+  });
+});
+
+const usersDb = cloudflareD1(userStore, {
+  binding: 'DB',
+  generateIdentity: () => 'example-user-id',
+  id: 'example.users',
+});
+
+const saveUser = trail('user.save', {
+  examples: [
+    {
+      expected: { email: 'test@example.com', id: 'example-user-id' },
+      input: { email: 'test@example.com' },
+      name: 'saves a user',
+    },
+  ],
+  implementation: async (input, ctx) =>
+    Result.ok(await usersDb.from(ctx).users.upsert(input)),
+  input: z.object({ email: z.string().email() }),
+  intent: 'write',
+  output: userSchema,
+  resources: [usersDb],
+});
+
+const showUser = trail('user.show', {
+  examples: [
+    {
+      expected: { user: null },
+      input: { id: 'missing-user' },
+      name: 'reads a missing user',
+    },
+  ],
+  implementation: async (input, ctx) =>
+    Result.ok({ user: await usersDb.from(ctx).users.get(input.id) }),
+  input: z.object({ id: z.string() }),
+  intent: 'read',
+  output: z.object({ user: userSchema.nullable() }),
+  resources: [usersDb],
+});
+
+testAll(topo('cf-d1', { saveUser, showUser, usersDb }));

--- a/adapters/cloudflare/src/d1/index.ts
+++ b/adapters/cloudflare/src/d1/index.ts
@@ -1,0 +1,1087 @@
+/**
+ * Cloudflare D1 store resource for Trails.
+ *
+ * `cloudflareD1` binds an `@ontrails/store` definition to a Cloudflare D1
+ * database binding. The Workers env bridge resolves the binding per env, then
+ * each table accessor persists full entities as JSON rows in D1.
+ */
+
+import {
+  ConflictError,
+  InternalError,
+  Result,
+  resource,
+  ValidationError,
+} from '@ontrails/core';
+import type { Resource, Signal, TrailContext } from '@ontrails/core';
+import { versionFieldName } from '@ontrails/store';
+import type {
+  AnyStoreDefinition,
+  AnyStoreTable,
+  EntityOf,
+  FiltersOf,
+  FixtureInputOf,
+  StoreAccessor,
+  StoreAdapterOptions,
+  StoreConnection,
+  StoreIdentifierOf,
+  StoreListOptions,
+  StoreMockSeed,
+  UpsertOf,
+} from '@ontrails/store';
+import { bindStoreDefinition } from '@ontrails/store/adapter-support';
+
+import { registerEnvBinding } from '../env.js';
+
+// ---------------------------------------------------------------------------
+// D1 binding shape
+// ---------------------------------------------------------------------------
+
+/** Result shape returned by D1 prepared statement `all()`. */
+export interface CloudflareD1AllResult<TRow> {
+  readonly results?: readonly TRow[] | undefined;
+}
+
+/** Minimal structural shape returned by D1 prepared statement `run()`. */
+export interface CloudflareD1RunResult {
+  readonly meta?: { readonly changes?: number | undefined } | undefined;
+}
+
+/** Minimal structural shape used from a D1 prepared statement. */
+export interface CloudflareD1PreparedStatement {
+  bind(...values: unknown[]): CloudflareD1PreparedStatement;
+  first<TRow = Record<string, unknown>>(): Promise<TRow | null>;
+  all<TRow = Record<string, unknown>>(): Promise<CloudflareD1AllResult<TRow>>;
+  run(): Promise<CloudflareD1RunResult>;
+}
+
+/** Minimal structural shape used from a Cloudflare D1 database binding. */
+export interface CloudflareD1Database {
+  exec(query: string): Promise<unknown>;
+  prepare(query: string): CloudflareD1PreparedStatement;
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/** Connection shape returned by {@link connectD1}. */
+export type CloudflareD1Connection<TStore extends AnyStoreDefinition> =
+  StoreConnection<TStore>;
+
+/** Options for {@link connectD1}. */
+export interface ConnectD1Options<
+  TStore extends AnyStoreDefinition = AnyStoreDefinition,
+> {
+  /**
+   * Optional identity generator for generated identity fields. Defaults to
+   * `crypto.randomUUID()`.
+   */
+  readonly generateIdentity?: (() => string) | undefined;
+  /** Optional runtime seed rows inserted during lazy schema initialization. */
+  readonly seed?: StoreMockSeed<TStore> | undefined;
+  /**
+   * Optional D1 table-name prefix. Defaults to `"store"`.
+   *
+   * `cloudflareD1` sets this to the resource id so multiple store resources
+   * can share one D1 database without colliding on table names.
+   */
+  readonly tablePrefix?: string | undefined;
+}
+
+/** Options for {@link cloudflareD1}. */
+export interface CloudflareD1Options<
+  TStore extends AnyStoreDefinition = AnyStoreDefinition,
+>
+  extends StoreAdapterOptions<TStore>, ConnectD1Options<TStore> {
+  /** The wrangler binding name (a `d1_databases` entry's `binding`). */
+  readonly binding: string;
+}
+
+/** Resource shape returned by {@link cloudflareD1}. */
+export type CloudflareD1Resource<TStore extends AnyStoreDefinition> = Resource<
+  CloudflareD1Connection<TStore>
+> & {
+  readonly access: 'readwrite';
+  readonly signals: TStore['signals'];
+  readonly store: TStore;
+  from(ctx: TrailContext): CloudflareD1Connection<TStore>;
+};
+
+// ---------------------------------------------------------------------------
+// Shared row helpers
+// ---------------------------------------------------------------------------
+
+const defaultResourceId = 'store';
+
+const defaultGenerateIdentity = (): string => {
+  if (globalThis.crypto?.randomUUID !== undefined) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+const encodeIdentifier = (id: unknown): string =>
+  JSON.stringify(id) ?? String(id);
+
+const quoteIdentifier = (value: string): string =>
+  `"${value.replaceAll('"', '""')}"`;
+
+const storageTableName = (scope: string, table: AnyStoreTable): string =>
+  `${scope}.${table.name}`;
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null;
+
+const deepEqual = (left: unknown, right: unknown): boolean => {
+  if (Object.is(left, right)) {
+    return true;
+  }
+  if (left instanceof Date || right instanceof Date) {
+    return (
+      left instanceof Date &&
+      right instanceof Date &&
+      left.getTime() === right.getTime()
+    );
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => deepEqual(value, right[index]))
+    );
+  }
+  if (!isRecord(left) || !isRecord(right)) {
+    return false;
+  }
+  const leftKeys = Object.keys(left).toSorted();
+  const rightKeys = Object.keys(right).toSorted();
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key, index) =>
+        key === rightKeys[index] && deepEqual(left[key], right[key])
+    )
+  );
+};
+
+const matchesFilters = (
+  entity: Record<string, unknown>,
+  filters: Record<string, unknown>
+): boolean => {
+  for (const [key, value] of Object.entries(filters)) {
+    if (!deepEqual(entity[key], value)) {
+      return false;
+    }
+  }
+  return true;
+};
+
+const applyPagination = <T>(
+  items: readonly T[],
+  options?: StoreListOptions
+): readonly T[] => {
+  if (options === undefined) {
+    return items;
+  }
+  const offset = options.offset ?? 0;
+  const limit = options.limit ?? items.length;
+  return items.slice(offset, offset + limit);
+};
+
+const cloneEntity = <TTable extends AnyStoreTable>(
+  entity: EntityOf<TTable>
+): EntityOf<TTable> => structuredClone(entity);
+
+const formatIssues = (issues: readonly { readonly message: string }[]) =>
+  issues.map((issue) => issue.message).join('; ');
+
+const parseStoredEntity = <TTable extends AnyStoreTable>(
+  table: TTable,
+  raw: unknown
+): EntityOf<TTable> => {
+  const parsed = table.schema.safeParse(raw);
+  if (!parsed.success) {
+    throw new InternalError(
+      `D1 table "${table.name}" contains a row that does not match the store schema: ${formatIssues(parsed.error.issues)}`
+    );
+  }
+  return parsed.data as EntityOf<TTable>;
+};
+
+const parseWrittenEntity = <TTable extends AnyStoreTable>(
+  table: TTable,
+  raw: unknown
+): EntityOf<TTable> => {
+  const parsed = table.schema.safeParse(raw);
+  if (!parsed.success) {
+    throw new ValidationError(
+      `D1 table "${table.name}" received an invalid entity: ${formatIssues(parsed.error.issues)}`
+    );
+  }
+  return parsed.data as EntityOf<TTable>;
+};
+
+const readIdentity = <TTable extends AnyStoreTable>(
+  table: TTable,
+  entity: EntityOf<TTable>
+): StoreIdentifierOf<TTable> =>
+  (entity as Record<string, unknown>)[
+    table.identity
+  ] as StoreIdentifierOf<TTable>;
+
+const assignIdentity = (
+  payload: Record<string, unknown>,
+  identityField: string,
+  generate: () => string
+): void => {
+  if (payload[identityField] === undefined) {
+    payload[identityField] = generate();
+  }
+};
+
+const assignTimestamp = (
+  payload: Record<string, unknown>,
+  generatedFields: ReadonlySet<string>,
+  isNew: boolean
+): void => {
+  if (generatedFields.has('createdAt') && isNew) {
+    payload['createdAt'] = new Date().toISOString();
+  }
+  if (generatedFields.has('updatedAt')) {
+    payload['updatedAt'] = new Date().toISOString();
+  }
+};
+
+const resolveNextVersion = (
+  existing: Record<string, unknown> | undefined
+): number =>
+  existing === undefined ? 1 : (existing[versionFieldName] as number) + 1;
+
+const assignVersion = (
+  payload: Record<string, unknown>,
+  isVersioned: boolean,
+  existing: Record<string, unknown> | undefined
+): void => {
+  if (isVersioned) {
+    payload[versionFieldName] = resolveNextVersion(existing);
+  }
+};
+
+const checkVersionConflict = (
+  tableName: string,
+  isVersioned: boolean,
+  input: Record<string, unknown>,
+  existing: Record<string, unknown> | undefined
+): void => {
+  if (!isVersioned) {
+    return;
+  }
+  const inputVersion = input[versionFieldName] as number | undefined;
+  if (inputVersion === undefined) {
+    return;
+  }
+  if (existing === undefined) {
+    throw new ConflictError(
+      `Version conflict on "${tableName}": expected ${String(inputVersion)}, actual missing`
+    );
+  }
+  const currentVersion = existing[versionFieldName] as number;
+  if (inputVersion !== currentVersion) {
+    throw new ConflictError(
+      `Version conflict on "${tableName}": expected ${String(inputVersion)}, actual ${String(currentVersion)}`
+    );
+  }
+};
+
+const buildUpsertEntity = <TTable extends AnyStoreTable>(
+  table: TTable,
+  input: UpsertOf<TTable>,
+  existing: EntityOf<TTable> | undefined,
+  generateIdentity: () => string
+): EntityOf<TTable> => {
+  const raw = input as Record<string, unknown>;
+  const merged =
+    existing === undefined
+      ? { ...raw }
+      : { ...(existing as Record<string, unknown>), ...raw };
+  checkVersionConflict(
+    table.name,
+    table.versioned,
+    raw,
+    existing as Record<string, unknown> | undefined
+  );
+  assignIdentity(merged, table.identity, generateIdentity);
+  assignTimestamp(merged, new Set(table.generated), existing === undefined);
+  assignVersion(merged, table.versioned, existing as Record<string, unknown>);
+  return parseWrittenEntity(table, merged);
+};
+
+const buildSeedEntity = <TTable extends AnyStoreTable>(
+  table: TTable,
+  input: FixtureInputOf<TTable>
+): EntityOf<TTable> => {
+  const entity = { ...(input as Record<string, unknown>) };
+  const generatedFields = new Set(table.generated);
+  if (entity[table.identity] === undefined) {
+    throw new ValidationError(
+      `D1 runtime seed rows for "${table.name}" must define the stable identity field "${table.identity}"`
+    );
+  }
+  const now = new Date().toISOString();
+  if (generatedFields.has('createdAt') && entity['createdAt'] === undefined) {
+    entity['createdAt'] = now;
+  }
+  if (generatedFields.has('updatedAt') && entity['updatedAt'] === undefined) {
+    entity['updatedAt'] = now;
+  }
+  if (table.versioned && entity[versionFieldName] === undefined) {
+    entity[versionFieldName] = 1;
+  }
+  return parseWrittenEntity(table, entity);
+};
+
+const fixtureRowsFor = (
+  tableName: string,
+  table: AnyStoreTable,
+  seed: StoreMockSeed<AnyStoreDefinition> | undefined,
+  includeTableFixtures: boolean
+): readonly FixtureInputOf<AnyStoreTable>[] => {
+  const seeded = seed?.[tableName] as
+    | readonly FixtureInputOf<AnyStoreTable>[]
+    | undefined;
+  if (seeded !== undefined) {
+    return seeded;
+  }
+  return includeTableFixtures ? table.fixtures : [];
+};
+
+const insertSeed = Symbol('cloudflare.d1.insertSeed');
+
+type SeedAwareAccessor<TTable extends AnyStoreTable> = StoreAccessor<TTable> & {
+  [insertSeed](input: FixtureInputOf<TTable>): Promise<void>;
+};
+
+const seedConnection = async <TStore extends AnyStoreDefinition>(
+  connection: CloudflareD1Connection<TStore>,
+  definition: TStore,
+  seed: StoreMockSeed<TStore> | undefined,
+  includeTableFixtures: boolean
+): Promise<void> => {
+  const accessors = connection as unknown as Record<
+    string,
+    SeedAwareAccessor<AnyStoreTable>
+  >;
+  for (const tableName of definition.tableNames) {
+    const table = definition.tables[tableName];
+    const accessor = accessors[tableName];
+    if (table === undefined || accessor === undefined) {
+      continue;
+    }
+    for (const fixture of fixtureRowsFor(
+      tableName,
+      table,
+      seed as StoreMockSeed<AnyStoreDefinition> | undefined,
+      includeTableFixtures
+    )) {
+      await accessor[insertSeed](fixture);
+    }
+  }
+};
+
+// ---------------------------------------------------------------------------
+// D1 storage implementation
+// ---------------------------------------------------------------------------
+
+interface D1TableRow {
+  readonly entity: string;
+}
+
+const ensureD1Table = async (
+  database: CloudflareD1Database,
+  tableName: string
+): Promise<void> => {
+  await database.exec(
+    `CREATE TABLE IF NOT EXISTS ${quoteIdentifier(tableName)} (id TEXT PRIMARY KEY, entity TEXT NOT NULL, version INTEGER)`
+  );
+};
+
+const getD1Row = async <TTable extends AnyStoreTable>(
+  database: CloudflareD1Database,
+  tableName: string,
+  table: TTable,
+  id: StoreIdentifierOf<TTable>
+): Promise<EntityOf<TTable> | null> => {
+  const row = await database
+    .prepare(`SELECT entity FROM ${quoteIdentifier(tableName)} WHERE id = ?`)
+    .bind(encodeIdentifier(id))
+    .first<D1TableRow>();
+  return row === null ? null : parseStoredEntity(table, JSON.parse(row.entity));
+};
+
+const listD1Rows = async <TTable extends AnyStoreTable>(
+  database: CloudflareD1Database,
+  tableName: string,
+  table: TTable,
+  filters?: FiltersOf<TTable>,
+  options?: StoreListOptions
+): Promise<readonly EntityOf<TTable>[]> => {
+  const rows = await database
+    .prepare(`SELECT entity FROM ${quoteIdentifier(tableName)} ORDER BY id`)
+    .all<D1TableRow>();
+  const entities = (rows.results ?? []).map((row) =>
+    parseStoredEntity(table, JSON.parse(row.entity))
+  );
+  const filtered =
+    filters === undefined
+      ? entities
+      : entities.filter((entity) =>
+          matchesFilters(
+            entity as Record<string, unknown>,
+            filters as Record<string, unknown>
+          )
+        );
+  return applyPagination(filtered, options).map((entity) =>
+    cloneEntity(entity)
+  );
+};
+
+const d1ChangeCount = (result: CloudflareD1RunResult): number =>
+  result.meta?.changes ?? 0;
+
+const entityVersion = <TTable extends AnyStoreTable>(
+  entity: EntityOf<TTable>
+): number | undefined =>
+  (entity as Record<string, unknown>)[versionFieldName] as number | undefined;
+
+interface D1UpsertOutcome<TTable extends AnyStoreTable> {
+  readonly entity: EntityOf<TTable>;
+  readonly previous: EntityOf<TTable> | null;
+}
+
+interface D1RemoveOutcome<TTable extends AnyStoreTable> {
+  readonly deleted: boolean;
+  readonly entity: EntityOf<TTable> | null;
+}
+
+const upsertWithOutcome = Symbol('cloudflare.d1.upsertWithOutcome');
+const removeWithOutcome = Symbol('cloudflare.d1.removeWithOutcome');
+
+type OutcomeAwareAccessor<TTable extends AnyStoreTable> =
+  StoreAccessor<TTable> & {
+    [removeWithOutcome](
+      id: StoreIdentifierOf<TTable>
+    ): Promise<D1RemoveOutcome<TTable>>;
+    [upsertWithOutcome](
+      input: UpsertOf<TTable>
+    ): Promise<D1UpsertOutcome<TTable>>;
+  };
+
+const throwVersionConflict = <TTable extends AnyStoreTable>(
+  table: TTable,
+  expectedVersion: number,
+  current: EntityOf<TTable> | null
+): never => {
+  const actualVersion =
+    current === null ? 'missing' : String(entityVersion(current));
+  throw new ConflictError(
+    `Version conflict on "${table.name}": expected ${String(expectedVersion)}, actual ${actualVersion}`
+  );
+};
+
+const updateD1RowIfUnchanged = async <TTable extends AnyStoreTable>(
+  database: CloudflareD1Database,
+  tableName: string,
+  table: TTable,
+  entity: EntityOf<TTable>,
+  previous: EntityOf<TTable>,
+  expectedVersion: number | undefined
+): Promise<boolean> => {
+  const id = readIdentity(table, entity);
+  const expectedVersionClause =
+    expectedVersion === undefined ? '' : ' AND version = ?';
+  const result = await database
+    .prepare(
+      `UPDATE ${quoteIdentifier(tableName)} SET entity = ?, version = ? WHERE id = ? AND entity = ?${expectedVersionClause}`
+    )
+    .bind(
+      JSON.stringify(entity),
+      entityVersion(entity) ?? null,
+      encodeIdentifier(id),
+      JSON.stringify(previous),
+      ...(expectedVersion === undefined ? [] : [expectedVersion])
+    )
+    .run();
+  return d1ChangeCount(result) > 0;
+};
+
+const insertD1RowIfMissing = async <TTable extends AnyStoreTable>(
+  database: CloudflareD1Database,
+  tableName: string,
+  table: TTable,
+  entity: EntityOf<TTable>
+): Promise<boolean> => {
+  const result = await database
+    .prepare(
+      `INSERT INTO ${quoteIdentifier(tableName)} (id, entity, version) VALUES (?, ?, ?) ON CONFLICT(id) DO NOTHING`
+    )
+    .bind(
+      encodeIdentifier(readIdentity(table, entity)),
+      JSON.stringify(entity),
+      entityVersion(entity) ?? null
+    )
+    .run();
+  return d1ChangeCount(result) > 0;
+};
+
+const seedD1Tables = async <TStore extends AnyStoreDefinition>(
+  database: CloudflareD1Database,
+  definition: TStore,
+  tablePrefix: string,
+  seed: StoreMockSeed<TStore> | undefined,
+  includeTableFixtures: boolean
+): Promise<void> => {
+  for (const tableName of definition.tableNames) {
+    const table = definition.tables[tableName];
+    if (table === undefined) {
+      continue;
+    }
+    const d1TableName = storageTableName(tablePrefix, table);
+    for (const fixture of fixtureRowsFor(
+      tableName,
+      table,
+      seed as StoreMockSeed<AnyStoreDefinition> | undefined,
+      includeTableFixtures
+    )) {
+      await insertD1RowIfMissing(
+        database,
+        d1TableName,
+        table,
+        buildSeedEntity(table, fixture)
+      );
+    }
+  }
+};
+
+const removeD1Row = async <TTable extends AnyStoreTable>(
+  database: CloudflareD1Database,
+  tableName: string,
+  table: TTable,
+  id: StoreIdentifierOf<TTable>
+): Promise<D1RemoveOutcome<TTable>> => {
+  const row = await database
+    .prepare(
+      `DELETE FROM ${quoteIdentifier(tableName)} WHERE id = ? RETURNING entity`
+    )
+    .bind(encodeIdentifier(id))
+    .first<D1TableRow>();
+  if (row === null) {
+    return { deleted: false, entity: null };
+  }
+  return {
+    deleted: true,
+    entity: parseStoredEntity(table, JSON.parse(row.entity)),
+  };
+};
+
+const createD1Accessor = <TTable extends AnyStoreTable>(
+  database: CloudflareD1Database,
+  tableName: string,
+  table: TTable,
+  ensureReady: () => Promise<void>,
+  generateIdentity: () => string
+): StoreAccessor<TTable> => {
+  const writeWithOutcome = async (
+    input: UpsertOf<TTable>
+  ): Promise<D1UpsertOutcome<TTable>> => {
+    await ensureReady();
+    const raw = input as Record<string, unknown>;
+    const inputId = raw[table.identity] as
+      | StoreIdentifierOf<TTable>
+      | undefined;
+    const expectedVersion = table.versioned
+      ? (raw[versionFieldName] as number | undefined)
+      : undefined;
+    for (let attempt = 0; attempt < 8; attempt += 1) {
+      const observed =
+        inputId === undefined
+          ? null
+          : await getD1Row(database, tableName, table, inputId);
+      const candidate = buildUpsertEntity(
+        table,
+        input,
+        observed ?? undefined,
+        generateIdentity
+      );
+      if (observed === null) {
+        if (await insertD1RowIfMissing(database, tableName, table, candidate)) {
+          return { entity: cloneEntity(candidate), previous: null };
+        }
+        continue;
+      }
+      if (
+        await updateD1RowIfUnchanged(
+          database,
+          tableName,
+          table,
+          candidate,
+          observed,
+          expectedVersion
+        )
+      ) {
+        return {
+          entity: cloneEntity(candidate),
+          previous: observed,
+        };
+      }
+      if (expectedVersion !== undefined) {
+        return throwVersionConflict(
+          table,
+          expectedVersion,
+          await getD1Row(
+            database,
+            tableName,
+            table,
+            readIdentity(table, observed)
+          )
+        );
+      }
+    }
+    throw new InternalError(
+      `D1 upsert for "${table.name}" could not commit after repeated concurrent writes`
+    );
+  };
+
+  const removeAndReturn = async (
+    id: StoreIdentifierOf<TTable>
+  ): Promise<D1RemoveOutcome<TTable>> => {
+    await ensureReady();
+    return await removeD1Row(database, tableName, table, id);
+  };
+
+  const accessor: OutcomeAwareAccessor<TTable> = {
+    async get(id) {
+      await ensureReady();
+      const entity = await getD1Row(database, tableName, table, id);
+      return entity === null ? null : cloneEntity(entity);
+    },
+    async list(filters, options) {
+      await ensureReady();
+      return await listD1Rows(database, tableName, table, filters, options);
+    },
+    async remove(id) {
+      const outcome = await removeAndReturn(id);
+      return { deleted: outcome.deleted };
+    },
+    async upsert(input) {
+      const outcome = await writeWithOutcome(input);
+      return outcome.entity;
+    },
+    [removeWithOutcome]: removeAndReturn,
+    [upsertWithOutcome]: writeWithOutcome,
+  };
+  return accessor;
+};
+
+// ---------------------------------------------------------------------------
+// In-memory mock implementation
+// ---------------------------------------------------------------------------
+
+const sortedMemoryRows = <TTable extends AnyStoreTable>(
+  rows: ReadonlyMap<string, EntityOf<TTable>>
+): readonly EntityOf<TTable>[] =>
+  [...rows.entries()]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([, value]) => value);
+
+const createMemoryAccessor = <TTable extends AnyStoreTable>(
+  table: TTable,
+  generateIdentity: () => string
+): StoreAccessor<TTable> => {
+  const rows = new Map<string, EntityOf<TTable>>();
+
+  const writeWithOutcome = (
+    input: UpsertOf<TTable>
+  ): Promise<D1UpsertOutcome<TTable>> => {
+    const raw = input as Record<string, unknown>;
+    const inputId = raw[table.identity] as
+      | StoreIdentifierOf<TTable>
+      | undefined;
+    const existing =
+      inputId === undefined ? undefined : rows.get(encodeIdentifier(inputId));
+    const entity = buildUpsertEntity(table, input, existing, generateIdentity);
+    rows.set(encodeIdentifier(readIdentity(table, entity)), entity);
+    return Promise.resolve({
+      entity: cloneEntity(entity),
+      previous: existing === undefined ? null : cloneEntity(existing),
+    });
+  };
+
+  const accessor: OutcomeAwareAccessor<TTable> & SeedAwareAccessor<TTable> = {
+    get: (id) => {
+      const entity = rows.get(encodeIdentifier(id));
+      return Promise.resolve(entity === undefined ? null : cloneEntity(entity));
+    },
+    list: (filters, options) => {
+      const all = sortedMemoryRows(rows);
+      const filtered =
+        filters === undefined
+          ? all
+          : all.filter((entity) =>
+              matchesFilters(
+                entity as Record<string, unknown>,
+                filters as Record<string, unknown>
+              )
+            );
+      return Promise.resolve(
+        applyPagination(filtered, options).map((entity) => cloneEntity(entity))
+      );
+    },
+    remove: async (id) => {
+      const outcome = await accessor[removeWithOutcome](id);
+      return { deleted: outcome.deleted };
+    },
+    async upsert(input) {
+      const outcome = await writeWithOutcome(input);
+      return outcome.entity;
+    },
+    [removeWithOutcome]: (id) => {
+      const key = encodeIdentifier(id);
+      const existing = rows.get(key);
+      const deleted = rows.delete(key);
+      return Promise.resolve({
+        deleted,
+        entity: existing === undefined ? null : cloneEntity(existing),
+      });
+    },
+    [insertSeed]: (input) => {
+      const entity = buildSeedEntity(table, input);
+      const key = encodeIdentifier(readIdentity(table, entity));
+      if (!rows.has(key)) {
+        rows.set(key, entity);
+      }
+      return Promise.resolve();
+    },
+    [upsertWithOutcome]: writeWithOutcome,
+  };
+  return accessor;
+};
+
+const buildConnection = <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  createAccessor: <TTable extends AnyStoreTable>(
+    table: TTable,
+    tableName: string
+  ) => StoreAccessor<TTable>
+): CloudflareD1Connection<TStore> => {
+  const connection = {} as Record<string, StoreAccessor<AnyStoreTable>>;
+  for (const tableName of definition.tableNames) {
+    const table = definition.tables[tableName];
+    if (table !== undefined) {
+      connection[tableName] = createAccessor(table, tableName);
+    }
+  }
+  return Object.freeze(connection) as CloudflareD1Connection<TStore>;
+};
+
+const createMemoryConnection = <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  options: ConnectD1Options<TStore> = {}
+): CloudflareD1Connection<TStore> =>
+  buildConnection(definition, (table) =>
+    createMemoryAccessor(
+      table,
+      options.generateIdentity ?? defaultGenerateIdentity
+    )
+  );
+
+// ---------------------------------------------------------------------------
+// Signals
+// ---------------------------------------------------------------------------
+
+type BoundFireFn = NonNullable<TrailContext['fire']>;
+
+const fireDerivedSignal = async <TTable extends AnyStoreTable>(
+  fire: BoundFireFn,
+  signal: Signal<unknown>,
+  entity: EntityOf<TTable>
+): Promise<void> => {
+  try {
+    await fire(signal, entity);
+  } catch (error) {
+    console.warn(
+      `[cloudflare:d1] signal "${signal.id}" emission threw:`,
+      error
+    );
+  }
+};
+
+const inputIdentity = <TTable extends AnyStoreTable>(
+  table: TTable,
+  input: UpsertOf<TTable>
+): StoreIdentifierOf<TTable> | undefined =>
+  input[table.identity as keyof UpsertOf<TTable> & string] as
+    | StoreIdentifierOf<TTable>
+    | undefined;
+
+const changedEntity = <TTable extends AnyStoreTable>(
+  previous: EntityOf<TTable> | null,
+  next: EntityOf<TTable> | null
+): next is EntityOf<TTable> =>
+  previous !== null && next !== null && !deepEqual(previous, next);
+
+const isOutcomeAwareAccessor = <TTable extends AnyStoreTable>(
+  accessor: StoreAccessor<TTable>
+): accessor is OutcomeAwareAccessor<TTable> => upsertWithOutcome in accessor;
+
+const bindWritableAccessorSignals = <TTable extends AnyStoreTable>(
+  table: TTable,
+  accessor: StoreAccessor<TTable>,
+  fire: BoundFireFn
+): StoreAccessor<TTable> =>
+  Object.freeze({
+    ...accessor,
+    async remove(id: StoreIdentifierOf<TTable>) {
+      if (isOutcomeAwareAccessor(accessor)) {
+        const outcome = await accessor[removeWithOutcome](id);
+        if (outcome.entity !== null) {
+          await fireDerivedSignal(fire, table.signals.removed, outcome.entity);
+        }
+        return { deleted: outcome.deleted };
+      }
+      const existing = await accessor.get(id);
+      const removed = await accessor.remove(id);
+      if (removed.deleted && existing !== null) {
+        await fireDerivedSignal(fire, table.signals.removed, existing);
+      }
+      return removed;
+    },
+    async upsert(input: UpsertOf<TTable>) {
+      if (isOutcomeAwareAccessor(accessor)) {
+        const outcome = await accessor[upsertWithOutcome](input);
+        if (outcome.previous === null) {
+          await fireDerivedSignal(fire, table.signals.created, outcome.entity);
+        } else if (changedEntity(outcome.previous, outcome.entity)) {
+          await fireDerivedSignal(fire, table.signals.updated, outcome.entity);
+        }
+        return outcome.entity;
+      }
+
+      const existingId = inputIdentity(table, input);
+      const existing =
+        existingId === undefined ? null : await accessor.get(existingId);
+      const written = await accessor.upsert(input);
+
+      if (existing === null) {
+        await fireDerivedSignal(fire, table.signals.created, written);
+        return written;
+      }
+      if (changedEntity(existing, written)) {
+        await fireDerivedSignal(fire, table.signals.updated, written);
+      }
+      return written;
+    },
+  });
+
+const bindConnectionSignals = <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  connection: CloudflareD1Connection<TStore>,
+  fire: BoundFireFn
+): CloudflareD1Connection<TStore> => {
+  const bound = {} as Record<string, StoreAccessor<AnyStoreTable>>;
+  for (const tableName of definition.tableNames) {
+    const table = definition.tables[tableName];
+    const accessor = connection[tableName];
+    if (table !== undefined && accessor !== undefined) {
+      bound[tableName] = bindWritableAccessorSignals(
+        table,
+        accessor as StoreAccessor<typeof table>,
+        fire
+      );
+    }
+  }
+  return Object.freeze(bound) as CloudflareD1Connection<TStore>;
+};
+
+const bindResourceConnection = <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  connection: CloudflareD1Connection<TStore>,
+  fire: TrailContext['fire']
+): CloudflareD1Connection<TStore> =>
+  fire === undefined
+    ? connection
+    : bindConnectionSignals(definition, connection, fire);
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Connect a store definition to a D1 database binding.
+ *
+ * The returned connection is synchronous to create so it can flow through the
+ * Workers env bridge. Schema creation and optional seeding run lazily before
+ * the first accessor operation.
+ *
+ * @example
+ * ```ts
+ * import { connectD1 } from '@ontrails/cloudflare/d1';
+ *
+ * const conn = connectD1(definition, env.DB);
+ * const note = await conn.notes.upsert({ id: 'n1', title: 'Hello' });
+ * ```
+ */
+export const connectD1 = <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  database: CloudflareD1Database,
+  options: ConnectD1Options<TStore> = {}
+): CloudflareD1Connection<TStore> => {
+  const generateIdentity = options.generateIdentity ?? defaultGenerateIdentity;
+  const tablePrefix = options.tablePrefix ?? defaultResourceId;
+  let ready: Promise<void> | undefined;
+
+  const initialize = async (): Promise<void> => {
+    for (const tableName of definition.tableNames) {
+      const table = definition.tables[tableName];
+      if (table !== undefined) {
+        await ensureD1Table(database, storageTableName(tablePrefix, table));
+      }
+    }
+    await seedD1Tables(database, definition, tablePrefix, options.seed, false);
+  };
+
+  const initializeReady = async (): Promise<void> => {
+    try {
+      await initialize();
+    } catch (error) {
+      ready = undefined;
+      throw error;
+    }
+  };
+
+  const ensureReady = (): Promise<void> => {
+    ready ??= initializeReady();
+    return ready;
+  };
+
+  return buildConnection(definition, (table) =>
+    createD1Accessor(
+      database,
+      storageTableName(tablePrefix, table),
+      table,
+      ensureReady,
+      generateIdentity
+    )
+  );
+};
+
+const isD1Binding = (value: unknown): value is CloudflareD1Database => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<
+    Record<keyof CloudflareD1Database, unknown>
+  >;
+  return (
+    typeof candidate.exec === 'function' &&
+    typeof candidate.prepare === 'function'
+  );
+};
+
+const createD1Mock = async <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  options: CloudflareD1Options<TStore>
+): Promise<CloudflareD1Connection<TStore>> => {
+  const connection = createMemoryConnection(definition, options);
+  await seedConnection(connection, definition, options.mockSeed, true);
+  return connection;
+};
+
+/**
+ * Author a Trails resource wrapping a Cloudflare D1 database binding.
+ *
+ * The binding arrives through the Workers env bridge, so `create` refuses to
+ * run outside a Worker. Tests use the in-memory mock factory, seeded from
+ * table fixtures or `mockSeed`, and Miniflare can provide a real D1 binding
+ * without a Cloudflare account.
+ *
+ * @example
+ * ```ts
+ * import { cloudflareD1 } from '@ontrails/cloudflare/d1';
+ * import { store } from '@ontrails/store';
+ * import { trail, Result } from '@ontrails/core';
+ * import { z } from 'zod';
+ *
+ * const definition = store({
+ *   notes: {
+ *     identity: 'id',
+ *     schema: z.object({ id: z.string(), title: z.string() }),
+ *   },
+ * });
+ * const db = cloudflareD1(definition, { binding: 'DB', id: 'notes.store' });
+ *
+ * const saveNote = trail('note.save', {
+ *   implementation: async (input, ctx) => Result.ok(await db.from(ctx).notes.upsert(input)),
+ *   input: z.object({ id: z.string(), title: z.string() }),
+ *   intent: 'write',
+ *   output: z.object({ id: z.string(), title: z.string() }),
+ *   resources: [db],
+ * });
+ * ```
+ */
+export const cloudflareD1 = <TStore extends AnyStoreDefinition>(
+  definition: TStore,
+  options: CloudflareD1Options<TStore>
+): CloudflareD1Resource<TStore> => {
+  const scope = options.id ?? defaultResourceId;
+  const store = bindStoreDefinition(definition, scope) as TStore;
+  const base = resource<CloudflareD1Connection<TStore>>(scope, {
+    create: () =>
+      Result.err(
+        new InternalError(
+          `Resource "${scope}" wraps Cloudflare D1 binding "${options.binding}", which only exists on a Workers env. Serve the topo with createWorkersHandler from @ontrails/cloudflare/workers, or rely on the in-memory mock in tests.`,
+          { context: { binding: options.binding, resourceId: scope } }
+        )
+      ),
+    description:
+      options.description ??
+      `Cloudflare D1 database bound to "${options.binding}"`,
+    meta: {
+      ...options.meta,
+      'cloudflare.binding': options.binding,
+      'cloudflare.service': 'd1',
+    },
+    mock: () => createD1Mock(store, options),
+    signals: store.signals,
+  });
+  const d1Resource = Object.freeze({
+    ...base,
+    access: 'readwrite' as const,
+    from(ctx: TrailContext) {
+      return bindResourceConnection(store, base.from(ctx), ctx.fire);
+    },
+    signals: store.signals,
+    store,
+  }) as CloudflareD1Resource<TStore>;
+
+  registerEnvBinding(d1Resource, {
+    binding: options.binding,
+    fromEnv: (value) =>
+      isD1Binding(value)
+        ? Result.ok(
+            connectD1(store, value, {
+              generateIdentity: options.generateIdentity,
+              seed: options.seed,
+              tablePrefix: options.tablePrefix ?? scope,
+            })
+          )
+        : Result.err(
+            new InternalError(
+              `Worker env binding "${options.binding}" for resource "${scope}" is not a D1 database. Check the d1_databases entry in your wrangler configuration.`,
+              { context: { binding: options.binding, resourceId: scope } }
+            )
+          ),
+  });
+  return d1Resource;
+};

--- a/adapters/cloudflare/src/env.ts
+++ b/adapters/cloudflare/src/env.ts
@@ -260,7 +260,7 @@ export const buildEnvResourceOverrides = (
     if (value === undefined) {
       return Result.err(
         new InternalError(
-          `Worker env is missing binding "${spec.binding}" required by resource "${declared.id}". Declare the binding in your wrangler configuration (for example a kv_namespaces entry) or provide an explicit resource override.`,
+          `Worker env is missing binding "${spec.binding}" required by resource "${declared.id}". Declare the binding in your wrangler configuration (for example kv_namespaces, d1_databases, r2_buckets, or queues) or provide an explicit resource override.`,
           { context: { binding: spec.binding, resourceId: declared.id } }
         )
       );

--- a/adapters/cloudflare/src/index.ts
+++ b/adapters/cloudflare/src/index.ts
@@ -4,6 +4,7 @@
  * Service subpaths are the primary entry points:
  * - `@ontrails/cloudflare/workers` — HTTP surface materializer (fetch handler)
  * - `@ontrails/cloudflare/kv` — key-value resource
+ * - `@ontrails/cloudflare/d1` — D1-backed store resource
  *
  * The root export re-exports the subpaths for convenience and adapter
  * tooling, and owns the adapter's `trails.lock` overlay overlay
@@ -12,6 +13,17 @@
 
 export { cloudflareOverlay } from './facts.js';
 export type { CloudflareLockFacts } from './facts.js';
+export { cloudflareD1, connectD1 } from './d1/index.js';
+export type {
+  CloudflareD1AllResult,
+  CloudflareD1Connection,
+  CloudflareD1Database,
+  CloudflareD1Options,
+  CloudflareD1PreparedStatement,
+  CloudflareD1Resource,
+  CloudflareD1RunResult,
+  ConnectD1Options,
+} from './d1/index.js';
 export {
   buildEnvResourceOverrides,
   getEnvBinding,

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
       },
       "peerDependencies": {
         "@ontrails/http": "workspace:^",
+        "@ontrails/store": "workspace:^",
         "zod": "catalog:",
       },
     },

--- a/packages/adapter-kit/src/__tests__/dogfood.test.ts
+++ b/packages/adapter-kit/src/__tests__/dogfood.test.ts
@@ -18,6 +18,16 @@ const expectedAdapters = [
     testingImport: '@ontrails/http/testing',
   },
   {
+    conformancePath: 'adapters/cloudflare/src/d1/__tests__/d1.test.ts',
+    key: '@ontrails/cloudflare/d1',
+    ownerPackage: '@ontrails/store',
+    packageName: '@ontrails/cloudflare/d1',
+    placement: 'extracted',
+    target: 'store',
+    targetKey: '@ontrails/store:store',
+    testingImport: '@ontrails/store/testing',
+  },
+  {
     conformancePath: 'adapters/drizzle/src/__tests__/drizzle.test.ts',
     key: '@ontrails/drizzle',
     ownerPackage: '@ontrails/store',

--- a/packages/core/src/__tests__/topo.test.ts
+++ b/packages/core/src/__tests__/topo.test.ts
@@ -4,7 +4,12 @@ import { z } from 'zod';
 
 import { entity } from '../entity.js';
 import { ValidationError } from '../errors.js';
-import { attachLateBoundSignalRef, cloneSignalWithId } from '../signal-ref.js';
+import {
+  attachLateBoundSignalRef,
+  cloneSignalWithId,
+  createLateBoundSignalMarker,
+  parseLateBoundSignalMarker,
+} from '../signal-ref.js';
 import { resource } from '../resource.js';
 import { Result } from '../result.js';
 import { run } from '../run.js';
@@ -1026,6 +1031,21 @@ describe('topo', () => {
         output: z.object({ ok: z.boolean() }),
       });
       expect(canonicalConsumer.on).toEqual(['identity:users.created']);
+    });
+
+    test('late-bound markers round-trip delimiter-bearing opaque tokens', () => {
+      const marker = createLateBoundSignalMarker(
+        { kind: 'store-derived', token: 'tenant:created' },
+        'audit:items.created'
+      );
+
+      expect(parseLateBoundSignalMarker(marker)).toEqual({
+        displayId: 'audit:items.created',
+        token: 'tenant:created',
+      });
+      expect(
+        parseLateBoundSignalMarker('@@trails:late-bound-signal-ref:%:items')
+      ).toBeNull();
     });
 
     test('rejects ambiguous late-bound store signal refs', () => {

--- a/packages/core/src/fire.ts
+++ b/packages/core/src/fire.ts
@@ -98,6 +98,9 @@ const frameworkFireFns = new WeakSet<FireFn>();
 export const isFrameworkFireFn = (fire: FireFn | undefined): boolean =>
   fire !== undefined && frameworkFireFns.has(fire);
 
+const createFireId = (): string =>
+  typeof Bun === 'undefined' ? crypto.randomUUID() : Bun.randomUUIDv7();
+
 type FireDispatchTracker = Set<Promise<void>>;
 
 const getFireDispatchTracker = (
@@ -284,7 +287,7 @@ const deriveFireDiagnosticMetadata = (
 ): FireDiagnosticMetadata => {
   const trace = producerCtx ? getTraceContext(producerCtx) : undefined;
   const parent = getActivationProvenance(producerCtx);
-  const fireId = Bun.randomUUIDv7();
+  const fireId = createFireId();
   return {
     activation: {
       fireId,

--- a/packages/core/src/signal-ref.ts
+++ b/packages/core/src/signal-ref.ts
@@ -11,6 +11,7 @@ export interface LateBoundSignalMarker {
 }
 
 const LATE_BOUND_SIGNAL_REF = Symbol('trails.late-bound-signal-ref');
+const LATE_BOUND_SIGNAL_BOUND = Symbol('trails.late-bound-signal-bound');
 const LATE_BOUND_SIGNAL_MARKER_PREFIX = '@@trails:late-bound-signal-ref:';
 
 const defineLateBoundSignalRef = <T extends object>(
@@ -25,6 +26,22 @@ const defineLateBoundSignalRef = <T extends object>(
   });
   return value;
 };
+
+const defineLateBoundSignalBound = <T extends object>(value: T): T => {
+  Object.defineProperty(value, LATE_BOUND_SIGNAL_BOUND, {
+    configurable: false,
+    enumerable: false,
+    value: true,
+    writable: false,
+  });
+  return value;
+};
+
+export const isBoundLateBoundSignal = (
+  signal: Pick<AnySignal, 'id'> | undefined
+): boolean =>
+  signal !== undefined &&
+  (signal as Record<PropertyKey, unknown>)[LATE_BOUND_SIGNAL_BOUND] === true;
 
 export const getLateBoundSignalRef = (
   signal: Pick<AnySignal, 'id'> | undefined
@@ -58,14 +75,17 @@ export const cloneSignalWithId = <T>(
   };
   const ref = getLateBoundSignalRef(signal);
   return Object.freeze(
-    ref ? defineLateBoundSignalRef(clone, ref) : clone
+    ref
+      ? defineLateBoundSignalBound(defineLateBoundSignalRef(clone, ref))
+      : clone
   ) as Signal<T>;
 };
 
 export const createLateBoundSignalMarker = (
   ref: LateBoundSignalRef,
   displayId: string
-): string => `${LATE_BOUND_SIGNAL_MARKER_PREFIX}${ref.token}:${displayId}`;
+): string =>
+  `${LATE_BOUND_SIGNAL_MARKER_PREFIX}${encodeURIComponent(ref.token)}:${displayId}`;
 
 export const parseLateBoundSignalMarker = (
   value: string
@@ -80,8 +100,12 @@ export const parseLateBoundSignalMarker = (
     return null;
   }
 
-  return {
-    displayId: remainder.slice(separator + 1),
-    token: remainder.slice(0, separator),
-  };
+  try {
+    const token = decodeURIComponent(remainder.slice(0, separator));
+    return token.length === 0
+      ? null
+      : { displayId: remainder.slice(separator + 1), token };
+  } catch {
+    return null;
+  }
 };

--- a/packages/core/src/trail.ts
+++ b/packages/core/src/trail.ts
@@ -24,6 +24,7 @@ import type { AnySignal } from './signal.js';
 import {
   createLateBoundSignalMarker,
   getLateBoundSignalRef,
+  isBoundLateBoundSignal,
 } from './signal-ref.js';
 import type { TrailsError } from './errors.js';
 import type {
@@ -629,18 +630,6 @@ export interface Trail<I, O, CI = never> extends Omit<
 // Factory
 // ---------------------------------------------------------------------------
 
-/**
- * Canonical scoped-signal id shape: `<scope>:<table>.<event>`.
- *
- * Matches exactly one `:` separating a non-empty scope from a non-empty
- * dotted tail of at least two segments (e.g. `identity:users.created`).
- * The scope forbids only `:` and whitespace so resource ids may contain
- * dots for namespacing (e.g. `demo.store:gists.created`). Tail segments
- * forbid both `:` and `.` so strings like `foo:bar` (no dot) or
- * `a:b.c.d` stay unambiguous.
- */
-const SCOPED_SIGNAL_ID = /^[^:\s]+:[^:.\s]+(?:\.[^:.\s]+)+$/;
-
 const normalizeSignalRef = (entry: string | AnySignal): string => {
   if (typeof entry === 'string') {
     return entry;
@@ -651,19 +640,10 @@ const normalizeSignalRef = (entry: string | AnySignal): string => {
     return entry.id;
   }
 
-  // Already-scoped canonical ids (e.g. "identity:users.created") must pass
-  // through unchanged. Rewriting them to a bare marker token collapses
-  // multi-binding cases where the same store definition is bound under two
-  // separate resources: both bindings share the late-bound token, so the
-  // caller's explicit choice of scope would be lost and topo resolution
-  // would throw an ambiguity error.
-  //
-  // Use a strict predicate that matches the canonical scoped shape
-  // `<scope>:<table>.<event>` (exactly one `:` separating a non-empty scope
-  // from a non-empty dotted tail of at least two segments). A looser
-  // `includes(':')` check would let unscoped ids that happen to contain `:`
-  // slip past markerization and then fail to resolve at topo finalization.
-  if (SCOPED_SIGNAL_ID.test(entry.id)) {
+  // Bound refs preserve an explicit resource choice. Authored refs always
+  // become markers, even when a table name contains the scope separator.
+  // Ownership is a contract fact; do not infer it from signal ID grammar.
+  if (isBoundLateBoundSignal(entry)) {
     return entry.id;
   }
 

--- a/packages/store/src/__tests__/jsonfile.test.ts
+++ b/packages/store/src/__tests__/jsonfile.test.ts
@@ -518,6 +518,30 @@ describe('signal registration', () => {
     );
   });
 
+  test('late-binds signal ids when table names contain the scope separator', () => {
+    const definition = defineStore({
+      'audit:items': { identity: 'id', schema: itemSchema },
+    });
+    const storeResource = jsonFile(definition, {
+      dir: topoDir,
+      id: 'primary-store',
+    });
+    const onCreated = trail('audit.items.on-created', {
+      implementation: () => Result.ok({ seen: true }),
+      input: z.object({}).passthrough(),
+      on: [definition.tables['audit:items'].signals.created],
+    });
+
+    const graph = topo('jsonfile-delimiter-safe-signals', {
+      onCreated,
+      storeResource,
+    } as Record<string, unknown>);
+
+    expect(graph.get('audit.items.on-created')?.on).toContain(
+      'primary-store:audit:items.created'
+    );
+  });
+
   test('rejects unresolved pre-bind handles when the same store is bound twice', () => {
     const definition = defineStore({
       items: { identity: 'id', schema: itemSchema },

--- a/packages/store/src/__tests__/store.test.ts
+++ b/packages/store/src/__tests__/store.test.ts
@@ -261,6 +261,24 @@ describe('@ontrails/store', () => {
     });
   });
 
+  test('keeps late-bound tokens unique across loaded package copies', async () => {
+    const moduleUrl = new URL('../adapter-support.ts', import.meta.url).href;
+    const firstSupport = await import(`${moduleUrl}?duplicate-copy=first`);
+    const secondSupport = await import(`${moduleUrl}?duplicate-copy=second`);
+    const first = firstSupport.createStoreTableSignals('gists', gistSchema);
+    const second = secondSupport.createStoreTableSignals('gists', gistSchema);
+    const firstTokens = new Set(
+      Object.values(first).map(
+        (candidate) => getLateBoundSignalRef(candidate)?.token
+      )
+    );
+    const secondTokens = Object.values(second).map(
+      (candidate) => getLateBoundSignalRef(candidate)?.token
+    );
+
+    expect(secondTokens.every((token) => !firstTokens.has(token))).toBe(true);
+  });
+
   test('accepts an explicit backend-agnostic kind', () => {
     const db = store(
       {

--- a/packages/store/src/adapter-support.ts
+++ b/packages/store/src/adapter-support.ts
@@ -19,6 +19,21 @@ type MutableTables<TStore extends AnyStoreDefinition> = {
 
 type StoreSignalChange = 'created' | 'removed' | 'updated';
 
+const storeSignalTokenCounter = Symbol.for(
+  '@ontrails/store.late-bound-signal-counter'
+);
+
+const takeStoreSignalTokenCounter = (): number => {
+  const globals = globalThis as Record<PropertyKey, unknown>;
+  const current = globals[storeSignalTokenCounter];
+  const next = typeof current === 'number' ? current : 0;
+  globals[storeSignalTokenCounter] = next + 1;
+  return next;
+};
+
+const createStoreSignalToken = (change: StoreSignalChange): string =>
+  `store-${change}-${takeStoreSignalTokenCounter()}`;
+
 const createStoreSignalDescription = (
   tableName: string,
   change: StoreSignalChange
@@ -51,7 +66,7 @@ const createStoreSignal = <TPayload>(
     }),
     {
       kind: 'store-derived',
-      token: Bun.randomUUIDv7(),
+      token: createStoreSignalToken(change),
     }
   );
 

--- a/packages/warden/src/rules/public-export-example-coverage.ts
+++ b/packages/warden/src/rules/public-export-example-coverage.ts
@@ -115,7 +115,7 @@ export const PUBLIC_API_EXAMPLE_TARGETS: readonly PublicApiPackageTarget[] = [
   },
   {
     indexPath: 'adapters/cloudflare/src/index.ts',
-    minimumExports: ['createWorkersHandler', 'cloudflareKv'],
+    minimumExports: ['createWorkersHandler', 'cloudflareKv', 'cloudflareD1'],
     packageName: '@ontrails/cloudflare',
   },
 ] as const;


### PR DESCRIPTION
## Context
Part 5 of the stack. This adds the Cloudflare D1 store resource and env bridge integration.

## What changed
- Added `cloudflareD1` and `connectD1` support for Trails store resources on Cloudflare D1.
- Added Miniflare-backed D1 contract tests, lazy seed support, store signal emission, and conflict coverage.
- Added Cloudflare overlay/env-binding metadata, README guidance, public export docs, and release intent.
- Stabilized CI by serializing the Cloudflare package test command and sharing one D1 Miniflare runtime with per-case table prefixes.

## Verification
- `bun run --cwd adapters/cloudflare test` (repeated locally)
- `bun run --cwd adapters/cloudflare typecheck`
- `bun run --cwd adapters/cloudflare lint`
- `bun run changeset:check`
- `bun run test` (one local timeout on `run > example: Run trail by ID`, exact file rerun passed; Graphite pre-push rerun passed)
- Graphite pre-push stable checks passed before resubmit.
- GitHub CI green on PR #927 after the D1 runtime-churn fix.

## Risks / rollout
D1 coverage is local/Miniflare based; real Cloudflare account behavior remains a future integration lane.
