### PR TITLE
feat(cloudflare): add queues activation support

### DIFF
--- a/.changeset/cloudflare-queues.md
+++ b/.changeset/cloudflare-queues.md
@@ -1,0 +1,19 @@
+---
+'@ontrails/core': minor
+'@ontrails/cloudflare': minor
+'@ontrails/warden': patch
+---
+
+Add first-class queue activation sources with `queue()` in `@ontrails/core`.
+Queue sources validate their runtime queue name and parse contract, project the
+queue name into durable topo facts, participate in activation input
+compatibility, and block established outputs when malformed.
+
+Add `@ontrails/cloudflare/queues` with `cloudflareQueue`, `createMemoryQueue`,
+and `createQueueHandler`. Cloudflare Workers now expose both `fetch` and
+`queue` entrypoints from `createWorkersHandler`, resolve env-bound resources for
+queue-activated trails, acknowledge successful/skipped/cancelled messages, and
+retry failed messages so Cloudflare's retry and DLQ settings own redelivery.
+
+`@ontrails/warden` now treats queue activation sources as materialized and
+requires `cloudflareQueue` public export example coverage.

--- a/adapters/cloudflare/README.md
+++ b/adapters/cloudflare/README.md
@@ -7,14 +7,14 @@ The Cloudflare adapter collection for Trails. One package, one subpath per Cloud
 | `@ontrails/cloudflare/workers` | HTTP surface materializer (fetch handler) | ✅ |
 | `@ontrails/cloudflare/kv` | Key-value resource | ✅ |
 | `@ontrails/cloudflare/d1` | D1-backed store resource | ✅ |
-| `/queues` | Activation source + outbound delivery | Planned |
+| `@ontrails/cloudflare/queues` | Queue producer resource + consumer materializer | ✅ |
 | `/r2` | Blob/object resource | Planned |
 
 Adapter composition doctrine applies throughout: subpaths take primitive-authored declarations (a resource definition, a surface config) and never shadow authoring verbs. Bindings arrive ambiently on the Worker `env`, so runtime dependencies are near-zero.
 
-## `/workers` — the fetch-handler materializer
+## `/workers` — the Worker materializer
 
-`createWorkersHandler(graph, options)` produces the `{ fetch(request, env, ctx) }` Worker export by delegating to the shared HTTP fetch kernel from `@ontrails/http` — the same kernel behind the Bun and Hono surfaces, so routes, validation, error projection, and webhook handling behave identically.
+`createWorkersHandler(graph, options)` produces the Worker export for Cloudflare runtime entrypoints. Its `fetch(request, env, ctx)` member delegates to the shared HTTP fetch kernel from `@ontrails/http` — the same kernel behind the Bun and Hono surfaces, so routes, validation, error projection, and webhook handling behave identically. Its `queue(batch, env, ctx)` member dispatches first-class core `queue()` activation sources through the `/queues` materializer.
 
 ```ts
 // src/worker.ts
@@ -143,9 +143,65 @@ Capability boundaries are explicit:
 
 Every `cloudflareD1` resource carries an in-memory mock factory seeded from table fixtures or `mockSeed`, so `testAll(app)` remains configuration-free. Miniflare can provide a real D1 binding for local integration tests without a Cloudflare account.
 
+## `/queues` — Queue producer and consumer support
+
+`cloudflareQueue(id, { binding })` authors a resource wrapping a Cloudflare Queue producer binding. Trails declare it with `resources: [...]` and send messages with `jobs.from(ctx).send(...)` or `sendBatch(...)`.
+
+```ts
+import { cloudflareQueue } from '@ontrails/cloudflare/queues';
+import { Result, queue, trail } from '@ontrails/core';
+import { z } from 'zod';
+
+const jobs = cloudflareQueue<{ id: string }>('jobs', { binding: 'JOBS' });
+
+const enqueueJob = trail('job.enqueue', {
+  implementation: async (input, ctx) => {
+    await jobs.from(ctx).send({ id: input.id });
+    return Result.ok({ queued: true });
+  },
+  input: z.object({ id: z.string() }),
+  output: z.object({ queued: z.boolean() }),
+  resources: [jobs],
+});
+```
+
+Queue consumers are authored with the core `queue()` activation source and materialized by `createWorkersHandler`:
+
+```ts
+const consumeJob = trail('job.consume', {
+  implementation: async (input) => Result.ok({ processed: input.id }),
+  input: z.object({ id: z.string() }),
+  on: [
+    queue('queue.jobs', {
+      queue: 'jobs',
+      parse: z.object({ id: z.string() }),
+    }),
+  ],
+  output: z.object({ processed: z.string() }),
+});
+```
+
+Declare the producer binding and consumer in wrangler config:
+
+```toml
+[[queues.producers]]
+binding = "JOBS"
+queue = "jobs"
+
+[[queues.consumers]]
+queue = "jobs"
+max_batch_size = 10
+max_retries = 3
+dead_letter_queue = "jobs-dlq"
+```
+
+The consumer materializer acknowledges each message after all matching Trails queue consumers succeed, skip by `where`, or return `CancelledError`. It also traces and acknowledges non-retryable Trails errors, including validation failures, so permanently invalid messages do not churn through the queue. Errors explicitly marked retryable call `message.retry(...)`; Cloudflare's retry and dead-letter configuration decides when a retried message moves to a DLQ. `RateLimitError.retryAfter` is passed through as `delaySeconds`.
+
+Every `cloudflareQueue` resource carries an in-memory mock (`createMemoryQueue`) so producer trails work in `testAll(app)` and unit tests can inspect sent messages. The local Worker-env regression test exercises a queue-activated trail using KV through the env bridge; the Miniflare lane remains focused on HTTP/webhook/KV/D1 until its queue harness is wired in this repo.
+
 ## Local integration testing
 
-Integration runs are local-first via [miniflare](https://miniflare.dev) (workerd in-process): the test lane bundles a demo Worker with `Bun.build`, boots it with real KV and D1 bindings, and exercises HTTP, webhook, KV, and D1 store routes. See `src/__tests__/miniflare.test.ts`. Real-account deploys are manual and never CI-required.
+Integration runs are local-first via [miniflare](https://miniflare.dev) (workerd in-process): the test lane bundles a demo Worker with `Bun.build`, boots it with real KV and D1 bindings, and exercises HTTP, webhook, KV, and D1 store routes. Queue producer and consumer behavior is covered by focused Worker-handler tests under `src/queues/__tests__/queues.test.ts`. Real-account deploys are manual and never CI-required.
 
 ## Lock facts
 

--- a/adapters/cloudflare/package.json
+++ b/adapters/cloudflare/package.json
@@ -15,6 +15,7 @@
     "./workers": "./src/workers/index.ts",
     "./kv": "./src/kv/index.ts",
     "./d1": "./src/d1/index.ts",
+    "./queues": "./src/queues/index.ts",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/adapters/cloudflare/src/__tests__/facts.test.ts
+++ b/adapters/cloudflare/src/__tests__/facts.test.ts
@@ -15,6 +15,7 @@ import { z } from 'zod';
 import { cloudflareOverlay } from '../facts.js';
 import { cloudflareD1 } from '../d1/index.js';
 import { cloudflareKv } from '../kv/index.js';
+import { cloudflareQueue } from '../queues/index.js';
 
 const flags = cloudflareKv('flags', { binding: 'FLAGS' });
 const notesStore = defineStore({
@@ -74,6 +75,25 @@ describe('cloudflareOverlay', () => {
 
     expect(cloudflareOverlay.derive(app)).toEqual({
       bindings: [{ binding: 'DB', resourceId: 'notes.store' }],
+    });
+  });
+
+  test('derives Queue producer resources through the shared env binding registry', () => {
+    const jobs = cloudflareQueue<{ id: string }>('jobs', { binding: 'JOBS' });
+    const enqueueJob = trail('job.enqueue', {
+      implementation: async (input, ctx) => {
+        await jobs.from(ctx).send(input);
+        return Result.ok({ queued: true });
+      },
+      input: z.object({ id: z.string() }),
+      intent: 'write',
+      output: z.object({ queued: z.boolean() }),
+      resources: [jobs],
+    });
+    const app = topo('cf-facts-queue', { enqueueJob, jobs });
+
+    expect(cloudflareOverlay.derive(app)).toEqual({
+      bindings: [{ binding: 'JOBS', resourceId: 'jobs' }],
     });
   });
 

--- a/adapters/cloudflare/src/env.ts
+++ b/adapters/cloudflare/src/env.ts
@@ -19,6 +19,7 @@ import {
   matchesTrailPattern,
   Result,
   filterSurfaceTrails,
+  isLiveTrailVersionEntry,
 } from '@ontrails/core';
 import type {
   AnyResource,
@@ -110,6 +111,10 @@ export interface BuildEnvResourceOverridesOptions extends Pick<
 > {
   /** Resource IDs already provided explicitly; env resolution skips them. */
   readonly except?: readonly string[] | undefined;
+  /** Worker entrypoint whose reachable resources should be materialized. */
+  readonly entrypoint?: 'fetch' | 'queue' | undefined;
+  /** Physical queue delivered to the current queue entrypoint. */
+  readonly queue?: string | undefined;
 }
 
 const isInternalTrail = (
@@ -134,18 +139,25 @@ const passesIncludeFilter = (
   matchesAnyPattern(trailId, include);
 
 /**
- * Mirror of the fetch kernel's webhook trail eligibility: webhook consumers
- * become HTTP routes even though `filterSurfaceTrails` skips
- * activation-driven trails, so the bridge applies the same rules here.
+ * Mirror of Worker activation eligibility for one entrypoint. Activation
+ * consumers are skipped by `filterSurfaceTrails`, so the bridge selects them
+ * explicitly without making fetch depend on queue-only resources.
  */
-const isEligibleWebhookTrail = (
+const isEligibleWorkerActivationTrail = (
   graphTrail: Trail<unknown, unknown, unknown>,
   options: BuildEnvResourceOverridesOptions
 ): boolean => {
-  const hasWebhookSource = graphTrail.activationSources.some(
-    (activation) => activation.source.kind === 'webhook'
+  const activationKind =
+    (options.entrypoint ?? 'fetch') === 'queue' ? 'queue' : 'webhook';
+  const hasWorkerActivationSource = graphTrail.activationSources.some(
+    (activation) =>
+      activation.source.kind === activationKind &&
+      (activationKind !== 'queue' ||
+        options.queue === undefined ||
+        (typeof activation.source.queue === 'string' &&
+          activation.source.queue.trim() === options.queue))
   );
-  if (!hasWebhookSource) {
+  if (!hasWorkerActivationSource) {
     return false;
   }
   if (
@@ -173,20 +185,41 @@ const collectSurfaceEligibleTrails = (
 ): readonly Trail<unknown, unknown, unknown>[] => {
   const trails = graph.list();
   const eligible = new Map<string, Trail<unknown, unknown, unknown>>();
-  const filtered = filterSurfaceTrails(trails, {
-    exclude: options.exclude,
-    include: options.include,
-    intent: options.intent,
-  });
-  for (const graphTrail of filtered) {
-    eligible.set(graphTrail.id, graphTrail);
+  if ((options.entrypoint ?? 'fetch') === 'fetch') {
+    const filtered = filterSurfaceTrails(trails, {
+      exclude: options.exclude,
+      include: options.include,
+      intent: options.intent,
+    });
+    for (const graphTrail of filtered) {
+      eligible.set(graphTrail.id, graphTrail);
+    }
   }
   for (const graphTrail of trails) {
     if (
       !eligible.has(graphTrail.id) &&
-      isEligibleWebhookTrail(graphTrail, options)
+      isEligibleWorkerActivationTrail(graphTrail, options)
     ) {
       eligible.set(graphTrail.id, graphTrail);
+    }
+  }
+  const byId = new Map(trails.map((graphTrail) => [graphTrail.id, graphTrail]));
+  const pending = [...eligible.values()];
+  for (const graphTrail of pending) {
+    const composedIds = [
+      ...graphTrail.composes,
+      ...Object.values(graphTrail.versions ?? {})
+        .filter(isLiveTrailVersionEntry)
+        .flatMap((entry) => entry.composes ?? []),
+    ];
+    for (const reference of composedIds) {
+      const composedId =
+        typeof reference === 'string' ? reference : reference.id;
+      const composed = byId.get(composedId);
+      if (composed !== undefined && !eligible.has(composed.id)) {
+        eligible.set(composed.id, composed);
+        pending.push(composed);
+      }
     }
   }
   return [...eligible.values()];
@@ -194,16 +227,16 @@ const collectSurfaceEligibleTrails = (
 
 /**
  * All resources a trail can execute with: the current contract's declarations
- * plus any fork version entry's own `resources`, since core runs historical
- * forks with the entry's resource set.
+ * plus any live fork version entry's own `resources`, since core runs
+ * supported historical forks with the entry's resource set.
  */
 const declaredTrailResources = (
   graphTrail: Trail<unknown, unknown, unknown>
 ): readonly AnyResource[] => [
   ...graphTrail.resources,
-  ...Object.values(graphTrail.versions ?? {}).flatMap(
-    (entry) => entry.resources ?? []
-  ),
+  ...Object.values(graphTrail.versions ?? {})
+    .filter(isLiveTrailVersionEntry)
+    .flatMap((entry) => entry.resources ?? []),
 ];
 
 const collectEnvBoundResources = (
@@ -228,8 +261,8 @@ const collectEnvBoundResources = (
 
 /**
  * Resolve every env-bound resource declared by the topo's surface-eligible
- * trails (including fork-version resources) into a resource override map for
- * one Worker env.
+ * trails (including live fork-version resources) into a resource override map
+ * for one Worker env.
  *
  * Returns `Result.err` when a required binding is missing from the env or a
  * binding value fails the resource's narrowing check. Trails filtered off the

--- a/adapters/cloudflare/src/index.ts
+++ b/adapters/cloudflare/src/index.ts
@@ -5,6 +5,8 @@
  * - `@ontrails/cloudflare/workers` — HTTP surface materializer (fetch handler)
  * - `@ontrails/cloudflare/kv` — key-value resource
  * - `@ontrails/cloudflare/d1` — D1-backed store resource
+ * - `@ontrails/cloudflare/queues` — Queue producer resource and consumer
+ *   materializer
  *
  * The root export re-exports the subpaths for convenience and adapter
  * tooling, and owns the adapter's `trails.lock` overlay overlay
@@ -44,6 +46,28 @@ export type {
   CloudflareKvPutOptions,
   CreateMemoryKvOptions,
 } from './kv/index.js';
+export {
+  cloudflareQueue,
+  createMemoryQueue,
+  createQueueHandler,
+} from './queues/index.js';
+export type {
+  CloudflareQueue,
+  CloudflareQueueBatch,
+  CloudflareQueueHandler,
+  CloudflareQueueMessage,
+  CloudflareQueueMetrics,
+  CloudflareQueueOptions,
+  CloudflareQueueRetryOptions,
+  CloudflareQueueSendBatchOptions,
+  CloudflareQueueSendOptions,
+  CloudflareQueueSendRequest,
+  CloudflareQueueSendResult,
+  CloudflareQueuesContentType,
+  CreateQueueHandlerOptions,
+  MemoryCloudflareQueue,
+  MemoryQueueMessage,
+} from './queues/index.js';
 export { createWorkersHandler } from './workers/index.js';
 export type {
   CloudflareWorker,

--- a/adapters/cloudflare/src/queues/__tests__/queues.test.ts
+++ b/adapters/cloudflare/src/queues/__tests__/queues.test.ts
@@ -1,0 +1,554 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  RateLimitError,
+  Result,
+  ValidationError,
+  queue,
+  topo,
+  trail,
+} from '@ontrails/core';
+import type { TraceRecord, TraceSink } from '@ontrails/core';
+import { z } from 'zod';
+
+import { createWorkersHandler, getEnvBinding } from '../../workers/index.js';
+import { createMemoryKv, cloudflareKv } from '../../kv/index.js';
+import {
+  cloudflareQueue,
+  createMemoryQueue,
+  createQueueHandler,
+} from '../index.js';
+import type {
+  CloudflareQueueBatch,
+  CloudflareQueueMessage,
+  CloudflareQueueRetryOptions,
+} from '../index.js';
+
+interface TestMessage<Body = unknown> extends CloudflareQueueMessage<Body> {
+  readonly ackCount: number;
+  readonly retriedWith: CloudflareQueueRetryOptions | undefined;
+}
+
+interface TestBatch<Body = unknown> extends CloudflareQueueBatch<Body> {
+  readonly ackAllCount: number;
+  readonly retryAllCount: number;
+  readonly retryAllOptions: CloudflareQueueRetryOptions | undefined;
+}
+
+const testMessage = <Body>(
+  body: Body,
+  overrides: Partial<Pick<CloudflareQueueMessage<Body>, 'attempts' | 'id'>> = {}
+): TestMessage<Body> => {
+  let ackCount = 0;
+  let retriedWith: CloudflareQueueRetryOptions | undefined;
+  return {
+    ack() {
+      ackCount += 1;
+    },
+    get ackCount() {
+      return ackCount;
+    },
+    attempts: overrides.attempts ?? 1,
+    body,
+    id: overrides.id ?? 'msg_1',
+    get retriedWith() {
+      return retriedWith;
+    },
+    retry(options) {
+      retriedWith = options ?? {};
+    },
+    timestamp: new Date('2026-07-07T00:00:00.000Z'),
+  };
+};
+
+const testBatch = <Body>(
+  queueName: string,
+  messages: readonly TestMessage<Body>[]
+): TestBatch<Body> => {
+  let ackAllCount = 0;
+  let retryAllCount = 0;
+  let retryAllOptions: CloudflareQueueRetryOptions | undefined;
+  return {
+    ackAll() {
+      ackAllCount += 1;
+    },
+    get ackAllCount() {
+      return ackAllCount;
+    },
+    messages,
+    queue: queueName,
+    retryAll(options) {
+      retryAllCount += 1;
+      retryAllOptions = options ?? {};
+    },
+    get retryAllCount() {
+      return retryAllCount;
+    },
+    get retryAllOptions() {
+      return retryAllOptions;
+    },
+  };
+};
+
+describe('cloudflareQueue', () => {
+  test('records producer sends in the in-memory mock', async () => {
+    const jobs = createMemoryQueue<{ id: string }>();
+
+    await jobs.send({ id: 'one' }, { delaySeconds: 5 });
+    await jobs.sendBatch([{ body: { id: 'two' } }], { delaySeconds: 10 });
+
+    expect(jobs.messages()).toEqual([
+      { body: { id: 'one' }, options: { delaySeconds: 5 } },
+      { body: { id: 'two' }, options: { delaySeconds: 10 } },
+    ]);
+    expect(await jobs.metrics()).toMatchObject({ backlogCount: 2 });
+  });
+
+  test('registers an env binding for Queue producer resources', async () => {
+    const jobs = cloudflareQueue<{ id: string }>('jobs', { binding: 'JOBS' });
+    const binding = getEnvBinding(jobs);
+    const producer = createMemoryQueue<{ id: string }>();
+
+    const resolved = binding?.fromEnv(producer);
+
+    expect(binding?.binding).toBe('JOBS');
+    expect(resolved?.isOk()).toBe(true);
+    if (resolved?.isOk()) {
+      await resolved.value.send({ id: 'job_1' });
+    }
+    expect(producer.messages()).toEqual([{ body: { id: 'job_1' } }]);
+  });
+});
+
+describe('createQueueHandler', () => {
+  test('acks a message after its queue consumer succeeds', async () => {
+    const consumed: string[] = [];
+    const consume = trail('job.consume', {
+      implementation: (input) => {
+        consumed.push(input.id);
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      on: [
+        queue('queue.jobs', {
+          parse: z.object({ id: z.string() }),
+          queue: 'jobs',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const handler = createQueueHandler(topo('queues', { consume }));
+    const message = testMessage({ id: 'job_1' });
+
+    await handler(testBatch('jobs', [message]));
+
+    expect(consumed).toEqual(['job_1']);
+    expect(message.ackCount).toBe(1);
+    expect(message.retriedWith).toBeUndefined();
+  });
+
+  test('normalizes manually authored queue names before registration', async () => {
+    const consumed: string[] = [];
+    const consume = trail('job.consume', {
+      implementation: (input) => {
+        consumed.push(input.id);
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      on: [
+        {
+          id: 'queue.jobs',
+          kind: 'queue',
+          parse: z.object({ id: z.string() }),
+          queue: ' jobs ',
+        },
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const handler = createQueueHandler(topo('queues-manual', { consume }));
+    const message = testMessage({ id: 'job_1' });
+
+    await handler(testBatch('jobs', [message]));
+
+    expect(consumed).toEqual(['job_1']);
+    expect(message.ackCount).toBe(1);
+  });
+
+  test('rejects incompatible source contracts on one physical queue', () => {
+    const consumeJob = trail('job.consume', {
+      implementation: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      on: [
+        queue('queue.jobs', {
+          parse: z.object({ id: z.string() }),
+          queue: 'shared',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const consumeEmail = trail('email.consume', {
+      implementation: () => Result.ok({ ok: true }),
+      input: z.object({ address: z.string().email() }),
+      on: [
+        queue('queue.email', {
+          parse: z.object({ address: z.string().email() }),
+          queue: 'shared',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    expect(() =>
+      createQueueHandler(
+        topo('queues-incompatible', { consumeEmail, consumeJob })
+      )
+    ).toThrow('incompatible activation source contracts');
+  });
+
+  test('rejects queue payloads incompatible with the consumer input', () => {
+    const consume = trail('job.consume', {
+      implementation: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      on: [
+        queue('queue.jobs', {
+          parse: z.object({ id: z.number() }),
+          queue: 'jobs',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+
+    expect(() =>
+      createQueueHandler(topo('queues-incompatible-input', { consume }))
+    ).toThrow(ValidationError);
+  });
+
+  test('allows multiple trails to share one queue source contract', async () => {
+    const source = queue('queue.jobs', {
+      parse: z.object({ id: z.string() }),
+      queue: 'jobs',
+    });
+    const consumed: string[] = [];
+    const first = trail('job.first', {
+      implementation: (input) => {
+        consumed.push(`first:${input.id}`);
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      on: [source],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const second = trail('job.second', {
+      implementation: (input) => {
+        consumed.push(`second:${input.id}`);
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      on: [source],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const handler = createQueueHandler(
+      topo('queues-shared', { first, second })
+    );
+    const message = testMessage({ id: 'job_1' });
+
+    await handler(testBatch('jobs', [message]));
+
+    expect(consumed).toEqual(['first:job_1', 'second:job_1']);
+    expect(message.ackCount).toBe(1);
+  });
+
+  test('acknowledges a permanently invalid message without retrying', async () => {
+    const consume = trail('job.consume', {
+      implementation: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      on: [
+        queue('queue.jobs', {
+          parse: z.object({ id: z.string() }),
+          queue: 'jobs',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const handler = createQueueHandler(topo('queues-invalid', { consume }));
+    const message = testMessage({ id: 42 });
+
+    await handler(testBatch('jobs', [message]));
+
+    expect(message.ackCount).toBe(1);
+    expect(message.retriedWith).toBeUndefined();
+  });
+
+  test('passes RateLimitError retryAfter through to Queue retry delay', async () => {
+    const consume = trail('job.consume', {
+      implementation: () =>
+        Result.err(new RateLimitError('slow down', { retryAfter: 30 })),
+      input: z.object({ id: z.string() }),
+      on: [
+        queue('queue.jobs', {
+          parse: z.object({ id: z.string() }),
+          queue: 'jobs',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const handler = createQueueHandler(topo('queues-rate-limit', { consume }));
+    const message = testMessage({ id: 'job_1' });
+
+    await handler(testBatch('jobs', [message]));
+
+    expect(message.ackCount).toBe(0);
+    expect(message.retriedWith).toEqual({ delaySeconds: 30 });
+  });
+
+  test('acknowledges a message when a queue where predicate throws', async () => {
+    const consume = trail('job.consume', {
+      implementation: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      on: [
+        {
+          source: queue('queue.jobs', {
+            parse: z.object({ id: z.string() }),
+            queue: 'jobs',
+          }),
+          where: () => {
+            throw new Error('predicate failed');
+          },
+        },
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const handler = createQueueHandler(
+      topo('queues-predicate-throw', { consume })
+    );
+    const message = testMessage({ id: 'job_1' });
+
+    await handler(testBatch('jobs', [message]));
+
+    expect(message.ackCount).toBe(1);
+    expect(message.retriedWith).toBeUndefined();
+  });
+
+  test('acknowledges a message when an async queue where predicate rejects', async () => {
+    const consume = trail('job.consume', {
+      implementation: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      on: [
+        {
+          source: queue('queue.jobs', {
+            parse: z.object({ id: z.string() }),
+            queue: 'jobs',
+          }),
+          where: () => Promise.reject(new Error('predicate rejected')),
+        },
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const handler = createQueueHandler(
+      topo('queues-predicate-reject', { consume })
+    );
+    const message = testMessage({ id: 'job_1' });
+
+    await handler(testBatch('jobs', [message]));
+
+    expect(message.ackCount).toBe(1);
+    expect(message.retriedWith).toBeUndefined();
+  });
+
+  test('writes queue activation records to topo-local trace sinks', async () => {
+    const records: TraceRecord[] = [];
+    const traceSink: TraceSink = {
+      write(record) {
+        records.push(record);
+      },
+    };
+    const consume = trail('job.consume', {
+      implementation: () => Result.ok({ ok: true }),
+      input: z.object({ id: z.string() }),
+      on: [
+        queue('queue.jobs', {
+          parse: z.object({ id: z.string() }),
+          queue: 'jobs',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const handler = createQueueHandler(
+      topo(
+        'queues-trace',
+        { consume },
+        topo.options({ observe: { trace: traceSink } })
+      )
+    );
+    const message = testMessage({ id: 'job_1' });
+
+    await handler(testBatch('jobs', [message]));
+
+    expect(records.map((record) => record.name)).toEqual([
+      'activation.queue',
+      'job.consume',
+    ]);
+    expect(records[1]?.parentId).toBe(records[0]?.id);
+  });
+
+  test('queue-activated trails resolve env-bound resources through Workers env', async () => {
+    const flags = cloudflareKv('flags.queue', { binding: 'FLAGS' });
+    const consume = trail('job.consume', {
+      implementation: async (input, ctx) => {
+        await flags.from(ctx).put(`queue/${input.id}`, 'done');
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      on: [
+        queue('queue.jobs', {
+          parse: z.object({ id: z.string() }),
+          queue: 'jobs',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+      resources: [flags],
+    });
+    const worker = createWorkersHandler(
+      topo('queues-worker-env', { consume, flags })
+    );
+    const kv = createMemoryKv();
+    const message = testMessage({ id: 'job_1' });
+
+    await worker.queue(testBatch('jobs', [message]), { FLAGS: kv });
+
+    expect(message.ackCount).toBe(1);
+    expect(await kv.get('queue/job_1')).toBe('done');
+  });
+
+  test('queue materialization includes composed trail resources', async () => {
+    const flags = cloudflareKv('flags.child', { binding: 'CHILD_FLAGS' });
+    const persist = trail('job.persist', {
+      implementation: async (input, ctx) => {
+        await flags.from(ctx).put(`child/${input.id}`, 'done');
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      output: z.object({ ok: z.boolean() }),
+      resources: [flags],
+      visibility: 'internal',
+    });
+    const consume = trail('job.consume', {
+      composes: [persist.id],
+      implementation: async (input, ctx) =>
+        await ctx.compose(persist.id, input),
+      input: z.object({ id: z.string() }),
+      on: [
+        queue('queue.jobs', {
+          parse: z.object({ id: z.string() }),
+          queue: 'jobs',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
+    const worker = createWorkersHandler(
+      topo('queues-composed-resource', { consume, flags, persist })
+    );
+    const kv = createMemoryKv();
+    const message = testMessage({ id: 'job_1' });
+
+    await worker.queue(testBatch('jobs', [message]), { CHILD_FLAGS: kv });
+
+    expect(message.ackCount).toBe(1);
+    expect(await kv.get('child/job_1')).toBe('done');
+  });
+
+  test('queue materialization requires bindings only for the delivered queue', async () => {
+    const jobFlags = cloudflareKv('flags.jobs', { binding: 'JOB_FLAGS' });
+    const emailFlags = cloudflareKv('flags.emails', {
+      binding: 'EMAIL_FLAGS',
+    });
+    const consumeJob = trail('job.consume', {
+      implementation: async (input, ctx) => {
+        await jobFlags.from(ctx).put(`job/${input.id}`, 'done');
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      on: [
+        queue('queue.jobs', {
+          parse: z.object({ id: z.string() }),
+          queue: 'jobs',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+      resources: [jobFlags],
+    });
+    const consumeEmail = trail('email.consume', {
+      implementation: async (input, ctx) => {
+        await emailFlags.from(ctx).put(`email/${input.id}`, 'done');
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      on: [
+        queue('queue.emails', {
+          parse: z.object({ id: z.string() }),
+          queue: 'emails',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+      resources: [emailFlags],
+    });
+    const worker = createWorkersHandler(
+      topo('queues-delivery-isolation', {
+        consumeEmail,
+        consumeJob,
+        emailFlags,
+        jobFlags,
+      })
+    );
+    const kv = createMemoryKv();
+    const message = testMessage({ id: 'job_1' });
+
+    await worker.queue(testBatch('jobs', [message]), { JOB_FLAGS: kv });
+
+    expect(message.ackCount).toBe(1);
+    expect(await kv.get('job/job_1')).toBe('done');
+  });
+
+  test('queue materialization ignores fetch-only env resources', async () => {
+    const queueFlags = cloudflareKv('flags.queue', { binding: 'QUEUE_FLAGS' });
+    const fetchFlags = cloudflareKv('flags.fetch', { binding: 'FETCH_FLAGS' });
+    const consume = trail('job.consume', {
+      implementation: async (input, ctx) => {
+        await queueFlags.from(ctx).put(`queue/${input.id}`, 'done');
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      on: [
+        queue('queue.jobs', {
+          parse: z.object({ id: z.string() }),
+          queue: 'jobs',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+      resources: [queueFlags],
+    });
+    const showFlag = trail('flag.show', {
+      implementation: async (input, ctx) =>
+        Result.ok({ value: await fetchFlags.from(ctx).get(input.key) }),
+      input: z.object({ key: z.string() }),
+      intent: 'read',
+      output: z.object({ value: z.string().nullable() }),
+      resources: [fetchFlags],
+    });
+    const worker = createWorkersHandler(
+      topo('queues-worker-entrypoint-isolation', {
+        consume,
+        fetchFlags,
+        queueFlags,
+        showFlag,
+      })
+    );
+    const kv = createMemoryKv();
+    const message = testMessage({ id: 'job_1' });
+
+    await worker.queue(testBatch('jobs', [message]), { QUEUE_FLAGS: kv });
+
+    expect(message.ackCount).toBe(1);
+    expect(await kv.get('queue/job_1')).toBe('done');
+  });
+});

--- a/adapters/cloudflare/src/queues/index.ts
+++ b/adapters/cloudflare/src/queues/index.ts
@@ -1,0 +1,744 @@
+/**
+ * Cloudflare Queues producer resource and Worker consumer materializer.
+ *
+ * `cloudflareQueue` authors a resource for producer trails that send messages
+ * through a Queue binding. `createQueueHandler` materializes first-class core
+ * `queue()` activation sources into a Workers `queue(batch, env, ctx)` handler.
+ */
+
+import {
+  CancelledError,
+  InternalError,
+  RateLimitError,
+  Result,
+  TRACE_CONTEXT_KEY,
+  ValidationError,
+  buildActivationProvenanceTraceAttrs,
+  getActivationWherePredicate,
+  getTraceSink,
+  isTrailsError,
+  matchesTrailPattern,
+  projectActivationSourceDeclaration,
+  resource,
+  run,
+  traceContextFromRecord,
+  validateSurfaceTopo,
+  writeActivationTraceRecord,
+  withActivationProvenance,
+} from '@ontrails/core';
+import type {
+  ActivationEntry,
+  AnyTrail,
+  BaseSurfaceOptions,
+  Layer,
+  QueueSource,
+  Resource,
+  ResourceOverrideMap,
+  Topo,
+  TraceContext,
+  TrailContextInit,
+} from '@ontrails/core';
+
+import { registerEnvBinding } from '../env.js';
+
+// ---------------------------------------------------------------------------
+// Producer binding shape
+// ---------------------------------------------------------------------------
+
+export type CloudflareQueuesContentType = 'bytes' | 'json' | 'text' | 'v8';
+
+export interface CloudflareQueueMetrics {
+  readonly backlogBytes: number;
+  readonly backlogCount: number;
+  readonly oldestMessageTimestamp: number;
+}
+
+export interface CloudflareQueueSendResult {
+  readonly metadata: {
+    readonly metrics: CloudflareQueueMetrics;
+  };
+}
+
+export interface CloudflareQueueSendOptions {
+  readonly contentType?: CloudflareQueuesContentType | undefined;
+  readonly delaySeconds?: number | undefined;
+}
+
+export interface CloudflareQueueSendBatchOptions {
+  readonly delaySeconds?: number | undefined;
+}
+
+export interface CloudflareQueueSendRequest<Body = unknown> {
+  readonly body: Body;
+  readonly contentType?: CloudflareQueuesContentType | undefined;
+  readonly delaySeconds?: number | undefined;
+}
+
+/**
+ * Structural subset of a Cloudflare Queue producer binding.
+ */
+export interface CloudflareQueue<Body = unknown> {
+  metrics(): Promise<CloudflareQueueMetrics>;
+  send(
+    body: Body,
+    options?: CloudflareQueueSendOptions
+  ): Promise<CloudflareQueueSendResult>;
+  sendBatch(
+    messages: Iterable<CloudflareQueueSendRequest<Body>>,
+    options?: CloudflareQueueSendBatchOptions
+  ): Promise<CloudflareQueueSendResult>;
+}
+
+export interface MemoryQueueMessage<Body = unknown> {
+  readonly body: Body;
+  readonly options?: CloudflareQueueSendOptions | undefined;
+}
+
+export interface MemoryCloudflareQueue<
+  Body = unknown,
+> extends CloudflareQueue<Body> {
+  clear(): void;
+  messages(): readonly MemoryQueueMessage<Body>[];
+}
+
+const emptyMetrics = (): CloudflareQueueMetrics => ({
+  backlogBytes: 0,
+  backlogCount: 0,
+  oldestMessageTimestamp: 0,
+});
+
+const sendResult = (): CloudflareQueueSendResult => ({
+  metadata: { metrics: emptyMetrics() },
+});
+
+/**
+ * Create an in-memory Queue producer binding.
+ *
+ * This is the mock behind `cloudflareQueue`, exported for tests that want to
+ * inspect sent messages without a Workers runtime.
+ *
+ * @example
+ * ```ts
+ * import { createMemoryQueue } from '@ontrails/cloudflare/queues';
+ *
+ * const queue = createMemoryQueue<{ id: string }>();
+ * await queue.send({ id: 'job-1' });
+ * queue.messages()[0]?.body.id; // 'job-1'
+ * ```
+ */
+export const createMemoryQueue = <
+  Body = unknown,
+>(): MemoryCloudflareQueue<Body> => {
+  const sent: MemoryQueueMessage<Body>[] = [];
+
+  return {
+    clear() {
+      sent.length = 0;
+    },
+    messages: () => Object.freeze([...sent]),
+    metrics: () =>
+      Promise.resolve({
+        backlogBytes: 0,
+        backlogCount: sent.length,
+        oldestMessageTimestamp: 0,
+      }),
+    send: (body, options) => {
+      sent.push(
+        options === undefined ? { body } : { body, options: { ...options } }
+      );
+      return Promise.resolve(sendResult());
+    },
+    sendBatch: (messages, options) => {
+      for (const message of messages) {
+        const sendOptions: CloudflareQueueSendOptions = {
+          ...(message.contentType === undefined
+            ? {}
+            : { contentType: message.contentType }),
+          ...(message.delaySeconds === undefined
+            ? {}
+            : { delaySeconds: message.delaySeconds }),
+        };
+        const mergedOptions =
+          options?.delaySeconds === undefined
+            ? sendOptions
+            : { delaySeconds: options.delaySeconds, ...sendOptions };
+        sent.push(
+          Object.keys(mergedOptions).length === 0
+            ? { body: message.body }
+            : { body: message.body, options: mergedOptions }
+        );
+      }
+      return Promise.resolve(sendResult());
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Resource factory
+// ---------------------------------------------------------------------------
+
+export interface CloudflareQueueOptions {
+  /** The wrangler binding name (a `queues.producers` entry's `binding`). */
+  readonly binding: string;
+  readonly description?: string | undefined;
+  readonly meta?: Readonly<Record<string, unknown>> | undefined;
+}
+
+const isQueueBinding = (value: unknown): value is CloudflareQueue => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<Record<keyof CloudflareQueue, unknown>>;
+  return (
+    typeof candidate.send === 'function' &&
+    typeof candidate.sendBatch === 'function' &&
+    typeof candidate.metrics === 'function'
+  );
+};
+
+/**
+ * Author a Trails resource wrapping a Cloudflare Queue producer binding.
+ *
+ * The real Queue binding arrives through the Workers env bridge. The resource
+ * mock records sent messages in memory so producer trails work in `testAll`.
+ *
+ * @example
+ * ```ts
+ * import { Result, trail } from '@ontrails/core';
+ * import { cloudflareQueue } from '@ontrails/cloudflare/queues';
+ * import { z } from 'zod';
+ *
+ * const jobs = cloudflareQueue<{ id: string }>('jobs', { binding: 'JOBS' });
+ *
+ * const enqueueJob = trail('job.enqueue', {
+ *   implementation: async (input, ctx) => {
+ *     await jobs.from(ctx).send({ id: input.id });
+ *     return Result.ok({ queued: true });
+ *   },
+ *   input: z.object({ id: z.string() }),
+ *   output: z.object({ queued: z.boolean() }),
+ *   resources: [jobs],
+ * });
+ * ```
+ */
+export const cloudflareQueue = <Body = unknown>(
+  id: string,
+  options: CloudflareQueueOptions
+): Resource<CloudflareQueue<Body>> => {
+  const definition = resource<CloudflareQueue<Body>>(id, {
+    create: () =>
+      Result.err(
+        new InternalError(
+          `Resource "${id}" wraps Cloudflare Queue binding "${options.binding}", which only exists on a Workers env. Serve the topo with createWorkersHandler from @ontrails/cloudflare/workers, or rely on the in-memory mock in tests.`,
+          { context: { binding: options.binding, resourceId: id } }
+        )
+      ),
+    description:
+      options.description ??
+      `Cloudflare Queue producer bound to "${options.binding}"`,
+    meta: {
+      ...options.meta,
+      'cloudflare.binding': options.binding,
+      'cloudflare.service': 'queues',
+    },
+    mock: () => createMemoryQueue<Body>(),
+  });
+  registerEnvBinding(definition, {
+    binding: options.binding,
+    fromEnv: (value) =>
+      isQueueBinding(value)
+        ? Result.ok(value)
+        : Result.err(
+            new InternalError(
+              `Worker env binding "${options.binding}" for resource "${id}" is not a Queue producer. Check the queues.producers entry in your wrangler configuration.`,
+              { context: { binding: options.binding, resourceId: id } }
+            )
+          ),
+  });
+  return definition;
+};
+
+// ---------------------------------------------------------------------------
+// Consumer materializer
+// ---------------------------------------------------------------------------
+
+export interface CloudflareQueueRetryOptions {
+  readonly delaySeconds?: number | undefined;
+}
+
+export interface CloudflareQueueMessage<Body = unknown> {
+  readonly attempts: number;
+  readonly body: Body;
+  readonly id: string;
+  readonly timestamp: Date;
+  ack(): void;
+  retry(options?: CloudflareQueueRetryOptions): void;
+}
+
+export interface CloudflareQueueBatch<Body = unknown> {
+  readonly messages: readonly CloudflareQueueMessage<Body>[];
+  readonly queue: string;
+  ackAll(): void;
+  retryAll(options?: CloudflareQueueRetryOptions): void;
+}
+
+export type CloudflareQueueHandler<Body = unknown> = (
+  batch: CloudflareQueueBatch<Body>
+) => Promise<void>;
+
+export interface CreateQueueHandlerOptions extends BaseSurfaceOptions {
+  readonly abortSignal?: AbortSignal | undefined;
+  readonly createContext?:
+    | (() => TrailContextInit | Promise<TrailContextInit>)
+    | undefined;
+  readonly layers?: readonly Layer[] | undefined;
+  readonly resources?: ResourceOverrideMap | undefined;
+}
+
+interface QueueConsumerRegistration {
+  readonly activation: ActivationEntry;
+  readonly source: QueueSource;
+  readonly trailId: string;
+}
+
+interface SchemaIssue {
+  readonly message: string;
+  readonly path?: readonly unknown[] | undefined;
+}
+
+type SafeParseResult =
+  | { readonly data: unknown; readonly success: true }
+  | {
+      readonly error: { readonly issues: readonly SchemaIssue[] };
+      readonly success: false;
+    };
+
+interface SafeParseSchema {
+  safeParse(value: unknown): SafeParseResult;
+}
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isSafeParseSchema = (value: unknown): value is SafeParseSchema =>
+  isObjectRecord(value) && typeof value['safeParse'] === 'function';
+
+const queueSourceFrom = (
+  activation: ActivationEntry
+): QueueSource | undefined =>
+  activation.source.kind === 'queue' &&
+  typeof activation.source.queue === 'string' &&
+  activation.source.queue.trim().length > 0
+    ? {
+        ...(activation.source as QueueSource),
+        queue: activation.source.queue.trim(),
+      }
+    : undefined;
+
+const matchesAnyPattern = (
+  trailId: string,
+  patterns: readonly string[] | undefined
+): boolean =>
+  patterns !== undefined &&
+  patterns.some((pattern) => matchesTrailPattern(trailId, pattern));
+
+const isExplicitInternalInclude = (
+  trailId: string,
+  include: readonly string[] | undefined
+): boolean => include !== undefined && include.includes(trailId);
+
+const isInternalTrail = (trail: AnyTrail): boolean =>
+  trail.visibility === 'internal' || trail.meta?.['internal'] === true;
+
+const shouldIncludeQueueTrail = (
+  trail: AnyTrail,
+  options: CreateQueueHandlerOptions
+): boolean => {
+  if (
+    isInternalTrail(trail) &&
+    !isExplicitInternalInclude(trail.id, options.include)
+  ) {
+    return false;
+  }
+  if (matchesAnyPattern(trail.id, options.exclude)) {
+    return false;
+  }
+  if (
+    options.include !== undefined &&
+    options.include.length > 0 &&
+    !matchesAnyPattern(trail.id, options.include)
+  ) {
+    return false;
+  }
+  return (
+    options.intent === undefined ||
+    options.intent.length === 0 ||
+    options.intent.includes(trail.intent)
+  );
+};
+
+const collectQueueConsumers = (
+  graph: Topo,
+  options: CreateQueueHandlerOptions
+): readonly QueueConsumerRegistration[] => {
+  const registrations: QueueConsumerRegistration[] = [];
+  for (const graphTrail of graph.list()) {
+    if (!shouldIncludeQueueTrail(graphTrail, options)) {
+      continue;
+    }
+    for (const activation of graphTrail.activationSources) {
+      const source = queueSourceFrom(activation);
+      if (source !== undefined) {
+        registrations.push({
+          activation,
+          source,
+          trailId: graphTrail.id,
+        });
+      }
+    }
+  }
+  return Object.freeze(registrations);
+};
+
+const queueInputContractSignature = (source: QueueSource): string =>
+  JSON.stringify(
+    projectActivationSourceDeclaration(source)['parseOutputSchema'] ?? null
+  );
+
+const assertQueueSourceCompatibility = (
+  queueName: string,
+  registrations: readonly QueueConsumerRegistration[]
+): void => {
+  const bySource = new Map<string, QueueConsumerRegistration>();
+  for (const registration of registrations) {
+    bySource.set(registration.source.id, registration);
+  }
+  const sources = [...bySource.values()];
+  const [expected] = sources;
+  if (expected === undefined) {
+    return;
+  }
+  const expectedSignature = queueInputContractSignature(expected.source);
+  const incompatible = sources.find(
+    (registration) =>
+      queueInputContractSignature(registration.source) !== expectedSignature
+  );
+  if (incompatible !== undefined) {
+    throw new ValidationError(
+      `Cloudflare queue "${queueName}" is bound to incompatible activation source contracts "${expected.source.id}" and "${incompatible.source.id}". Use one shared queue source contract, or bind distinct contracts to distinct physical queues.`
+    );
+  }
+};
+
+const schemaForSource = (source: QueueSource): SafeParseSchema | undefined => {
+  if (isSafeParseSchema(source.parse)) {
+    return source.parse;
+  }
+  if (
+    isObjectRecord(source.parse) &&
+    isSafeParseSchema(source.parse['output'])
+  ) {
+    return source.parse['output'];
+  }
+  return undefined;
+};
+
+const issuePathText = (path: readonly unknown[] | undefined): string =>
+  path === undefined || path.length === 0 ? '<root>' : path.join('.');
+
+const formatSchemaIssues = (issues: readonly SchemaIssue[]): string =>
+  issues
+    .map((issue) => `${issuePathText(issue.path)}: ${issue.message}`)
+    .join('; ');
+
+const parseQueueMessageBody = (
+  registration: QueueConsumerRegistration,
+  body: unknown
+): Result<unknown, Error> => {
+  const schema = schemaForSource(registration.source);
+  if (schema === undefined) {
+    return Result.err(
+      new InternalError(
+        `Queue source "${registration.source.id}" does not expose a parse schema.`
+      )
+    );
+  }
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return Result.err(
+      new ValidationError(
+        `Queue source "${registration.source.id}" rejected message "${registration.trailId}": ${formatSchemaIssues(parsed.error.issues)}`
+      )
+    );
+  }
+  return Result.ok(parsed.data);
+};
+
+const errorFromUnknown = (error: unknown): Error =>
+  error instanceof Error ? error : new Error(String(error));
+
+const createFireId = (): string =>
+  globalThis.crypto?.randomUUID?.() ??
+  `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+const activationFor = (
+  registration: QueueConsumerRegistration,
+  message: CloudflareQueueMessage
+) => {
+  const fireId = createFireId();
+  return {
+    fireId,
+    rootFireId: fireId,
+    source: {
+      id: registration.source.id,
+      kind: 'queue' as const,
+      ...(registration.source.meta === undefined
+        ? {}
+        : { meta: registration.source.meta }),
+      queue: registration.source.queue,
+    },
+    trigger: {
+      messageAttempts: message.attempts,
+      messageId: message.id,
+      messageTimestamp: message.timestamp.toISOString(),
+    },
+  };
+};
+
+const activationAttrs = (
+  registration: QueueConsumerRegistration,
+  message: CloudflareQueueMessage,
+  activation: ReturnType<typeof activationFor>
+): Readonly<Record<string, unknown>> => ({
+  ...buildActivationProvenanceTraceAttrs(activation),
+  'trails.activation.queue.message.attempts': message.attempts,
+  'trails.activation.queue.message.id': message.id,
+  'trails.activation.queue.message.timestamp': message.timestamp.toISOString(),
+  'trails.activation.target_trail.id': registration.trailId,
+});
+
+const recordQueueActivationTrace = async (
+  graph: Topo,
+  registration: QueueConsumerRegistration,
+  message: CloudflareQueueMessage,
+  activation: ReturnType<typeof activationFor>,
+  status: 'cancelled' | 'err' | 'ok',
+  error?: Error | undefined
+): Promise<TraceContext | undefined> => {
+  const record = await writeActivationTraceRecord(
+    'activation.queue',
+    activationAttrs(registration, message, activation),
+    status,
+    isTrailsError(error) ? error.category : undefined,
+    undefined,
+    graph.observe?.trace ?? getTraceSink()
+  );
+  return record === undefined ? undefined : traceContextFromRecord(record);
+};
+
+const contextForActivation = (
+  activation: ReturnType<typeof activationFor>,
+  traceContext: TraceContext | undefined
+): Partial<TrailContextInit> =>
+  withActivationProvenance(
+    {
+      extensions:
+        traceContext === undefined ? {} : { [TRACE_CONTEXT_KEY]: traceContext },
+    },
+    activation
+  );
+
+const shouldRunRegistration = async (
+  registration: QueueConsumerRegistration,
+  input: unknown
+): Promise<Result<boolean, Error>> => {
+  const predicate = getActivationWherePredicate(registration.activation.where);
+  if (predicate === undefined) {
+    return Result.ok(true);
+  }
+  try {
+    return Result.ok(await predicate(input));
+  } catch (error: unknown) {
+    const cause = errorFromUnknown(error);
+    return Result.err(
+      new InternalError(
+        `Queue activation predicate failed for source "${registration.source.id}" and trail "${registration.trailId}": ${cause.message}`,
+        {
+          cause,
+          context: {
+            sourceId: registration.source.id,
+            trailId: registration.trailId,
+          },
+        }
+      )
+    );
+  }
+};
+
+const retryOptionsFor = (
+  error: Error
+): CloudflareQueueRetryOptions | undefined =>
+  error instanceof RateLimitError && error.retryAfter !== undefined
+    ? { delaySeconds: Math.max(0, Math.ceil(error.retryAfter)) }
+    : undefined;
+
+interface MessageDecision {
+  readonly action: 'ack' | 'retry';
+  readonly retryOptions?: CloudflareQueueRetryOptions | undefined;
+}
+
+const ackDecision = Object.freeze({ action: 'ack' as const });
+
+const retryDecision = (error: Error): MessageDecision => ({
+  action: 'retry',
+  ...(retryOptionsFor(error) === undefined
+    ? {}
+    : { retryOptions: retryOptionsFor(error) }),
+});
+
+const failureDecision = (error: Error): MessageDecision =>
+  isTrailsError(error) && !error.retryable ? ackDecision : retryDecision(error);
+
+const runQueueConsumer = async (
+  graph: Topo,
+  registration: QueueConsumerRegistration,
+  message: CloudflareQueueMessage,
+  options: CreateQueueHandlerOptions
+): Promise<MessageDecision> => {
+  const parsed = parseQueueMessageBody(registration, message.body);
+  const activation = activationFor(registration, message);
+  if (parsed.isErr()) {
+    await recordQueueActivationTrace(
+      graph,
+      registration,
+      message,
+      activation,
+      'err',
+      parsed.error
+    );
+    return failureDecision(parsed.error);
+  }
+  const shouldRun = await shouldRunRegistration(registration, parsed.value);
+  if (shouldRun.isErr()) {
+    await recordQueueActivationTrace(
+      graph,
+      registration,
+      message,
+      activation,
+      'err',
+      shouldRun.error
+    );
+    return failureDecision(shouldRun.error);
+  }
+  if (!shouldRun.value) {
+    return ackDecision;
+  }
+
+  const traceContext = await recordQueueActivationTrace(
+    graph,
+    registration,
+    message,
+    activation,
+    'ok'
+  );
+  const result = await run(graph, registration.trailId, parsed.value, {
+    ...(options.abortSignal === undefined
+      ? {}
+      : { abortSignal: options.abortSignal }),
+    configValues: options.configValues,
+    createContext: options.createContext,
+    ctx: contextForActivation(activation, traceContext),
+    resources: options.resources,
+    surfaceLayers: options.layers,
+    topoLayers: graph.layers,
+  });
+  if (result.isOk()) {
+    return ackDecision;
+  }
+  if (result.error instanceof CancelledError) {
+    return ackDecision;
+  }
+  return failureDecision(result.error);
+};
+
+const processMessage = async (
+  graph: Topo,
+  registrations: readonly QueueConsumerRegistration[],
+  message: CloudflareQueueMessage,
+  options: CreateQueueHandlerOptions
+): Promise<MessageDecision> => {
+  for (const registration of registrations) {
+    try {
+      const decision = await runQueueConsumer(
+        graph,
+        registration,
+        message,
+        options
+      );
+      if (decision.action === 'retry') {
+        return decision;
+      }
+    } catch (error: unknown) {
+      return failureDecision(errorFromUnknown(error));
+    }
+  }
+  return ackDecision;
+};
+
+/**
+ * Build a Cloudflare Queues consumer handler for a topo.
+ *
+ * The handler dispatches each message to every matching first-class core
+ * `queue()` activation source for `batch.queue`. A message is acknowledged
+ * after all matching consumer trails succeed, skip, cancel, or fail with a
+ * non-retryable Trails error. Only failures explicitly marked retryable enter
+ * Cloudflare's configured retry/DLQ policy.
+ *
+ * @example
+ * ```ts
+ * import { createQueueHandler } from '@ontrails/cloudflare/queues';
+ *
+ * export const queue = createQueueHandler(graph);
+ * ```
+ */
+export const createQueueHandler = (
+  graph: Topo,
+  options: CreateQueueHandlerOptions = {}
+): CloudflareQueueHandler => {
+  const validated = validateSurfaceTopo(graph, options);
+  if (validated.isErr()) {
+    throw validated.error;
+  }
+
+  const byQueue = new Map<string, QueueConsumerRegistration[]>();
+  for (const registration of collectQueueConsumers(graph, options)) {
+    const current = byQueue.get(registration.source.queue) ?? [];
+    current.push(registration);
+    byQueue.set(registration.source.queue, current);
+  }
+  for (const [queueName, registrations] of byQueue) {
+    assertQueueSourceCompatibility(queueName, registrations);
+  }
+
+  return async (batch) => {
+    const registrations = byQueue.get(batch.queue) ?? [];
+    if (registrations.length === 0) {
+      batch.ackAll();
+      return;
+    }
+
+    for (const message of batch.messages) {
+      const decision = await processMessage(
+        graph,
+        registrations,
+        message,
+        options
+      );
+      if (decision.action === 'ack') {
+        message.ack();
+      } else {
+        message.retry(decision.retryOptions);
+      }
+    }
+  };
+};

--- a/adapters/cloudflare/src/workers/__tests__/env-bridge.test.ts
+++ b/adapters/cloudflare/src/workers/__tests__/env-bridge.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
-import { Result, topo, trail } from '@ontrails/core';
+import { queue, Result, topo, trail } from '@ontrails/core';
 import { z } from 'zod';
 
 import { cloudflareKv, createMemoryKv } from '../../kv/index.js';
@@ -172,6 +172,41 @@ describe('workers env bridge', () => {
     expect(filteredOut.status).toBe(404);
   });
 
+  test('fetch materialization ignores queue-only env resources', async () => {
+    const ping = trail('ping', {
+      implementation: (input) => Result.ok({ reply: input.message }),
+      input: z.object({ message: z.string() }),
+      intent: 'read',
+      output: z.object({ reply: z.string() }),
+    });
+    const consume = trail('job.consume', {
+      implementation: async (input, ctx) => {
+        await flags.from(ctx).put(input.id, 'done');
+        return Result.ok({ ok: true });
+      },
+      input: z.object({ id: z.string() }),
+      on: [
+        queue('queue.jobs', {
+          parse: z.object({ id: z.string() }),
+          queue: 'jobs',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+      resources: [flags],
+    });
+    const worker = createWorkersHandler(
+      topo('cf-env-bridge-queue-isolation', { consume, flags, ping })
+    );
+
+    const response = await worker.fetch(
+      new Request('http://localhost/ping?message=hi'),
+      {}
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ data: { reply: 'hi' } });
+  });
+
   test('resolves env bindings declared only by fork version entries', async () => {
     const versionedFlag = trail('flag.versioned', {
       implementation: (input) => Result.ok({ value: `static:${input.key}` }),
@@ -211,5 +246,84 @@ describe('workers env bridge', () => {
       { FLAGS: kv }
     );
     expect(await readValue(currentResponse)).toBe('static:color');
+  });
+
+  test('does not materialize resources reachable only from archived versions', async () => {
+    const archivedChild = trail('flag.archived.child', {
+      implementation: async (input, ctx) => {
+        const value = await flags.from(ctx).get(input.key);
+        return Result.ok({ value });
+      },
+      input: z.object({ key: z.string() }),
+      intent: 'read',
+      output: z.object({ value: z.string().nullable() }),
+      resources: [flags],
+      visibility: 'internal',
+    });
+    const archivedParent = trail('flag.archived', {
+      implementation: (input) => Result.ok({ value: `static:${input.key}` }),
+      input: z.object({ key: z.string() }),
+      intent: 'read',
+      output: z.object({ value: z.string().nullable() }),
+      version: 2,
+      versions: {
+        1: {
+          composes: [archivedChild],
+          implementation: async (input, ctx) =>
+            await ctx.compose(archivedChild, input),
+          input: z.object({ key: z.string() }),
+          output: z.object({ value: z.string().nullable() }),
+          status: { state: 'archived' },
+        },
+      },
+    });
+    const worker = createWorkersHandler(
+      topo('cf-env-bridge-archived-compose', {
+        archivedChild,
+        archivedParent,
+        flags,
+      })
+    );
+
+    const response = await worker.fetch(
+      new Request('http://localhost/flag/archived?key=color'),
+      {}
+    );
+
+    expect(response.status).toBe(200);
+    expect(await readValue(response)).toBe('static:color');
+  });
+
+  test('does not materialize resources declared directly by archived versions', async () => {
+    const archivedResource = trail('flag.archived-resource', {
+      implementation: (input) => Result.ok({ value: `static:${input.key}` }),
+      input: z.object({ key: z.string() }),
+      intent: 'read',
+      output: z.object({ value: z.string().nullable() }),
+      version: 2,
+      versions: {
+        1: {
+          implementation: async (input, ctx) => {
+            const value = await flags.from(ctx).get(input.key);
+            return Result.ok({ value });
+          },
+          input: z.object({ key: z.string() }),
+          output: z.object({ value: z.string().nullable() }),
+          resources: [flags],
+          status: { state: 'archived' },
+        },
+      },
+    });
+    const worker = createWorkersHandler(
+      topo('cf-env-bridge-archived-resource', { archivedResource, flags })
+    );
+
+    const response = await worker.fetch(
+      new Request('http://localhost/flag/archived-resource?key=color'),
+      {}
+    );
+
+    expect(response.status).toBe(200);
+    expect(await readValue(response)).toBe('static:color');
   });
 });

--- a/adapters/cloudflare/src/workers/index.ts
+++ b/adapters/cloudflare/src/workers/index.ts
@@ -28,6 +28,8 @@ import type { ResolveHttpPermit } from '@ontrails/http';
 
 import { buildEnvResourceOverrides } from '../env.js';
 import type { WorkersEnv } from '../env.js';
+import { createQueueHandler } from '../queues/index.js';
+import type { CloudflareQueueBatch } from '../queues/index.js';
 
 export {
   buildEnvResourceOverrides,
@@ -89,6 +91,11 @@ export interface CloudflareWorker {
     env?: WorkersEnv | undefined,
     executionCtx?: WorkersExecutionContext | undefined
   ): Promise<Response>;
+  queue(
+    batch: CloudflareQueueBatch,
+    env?: WorkersEnv | undefined,
+    executionCtx?: WorkersExecutionContext | undefined
+  ): Promise<void>;
 }
 
 // ---------------------------------------------------------------------------
@@ -121,6 +128,18 @@ const mapCaughtError = (error: unknown): Response => {
   );
 };
 
+const mapCaughtQueueError = (
+  error: unknown,
+  batch: CloudflareQueueBatch
+): void => {
+  const err = error instanceof Error ? error : new Error(String(error));
+  console.error(
+    '[ontrails:cloudflare/workers] Failed to materialize queue handler',
+    projectErrorDiagnostics(err)
+  );
+  batch.retryAll();
+};
+
 // ---------------------------------------------------------------------------
 // createWorkersHandler
 // ---------------------------------------------------------------------------
@@ -128,7 +147,9 @@ const mapCaughtError = (error: unknown): Response => {
 const resolveResourceOverrides = (
   graph: Topo,
   env: WorkersEnv,
-  options: CreateWorkersHandlerOptions
+  options: CreateWorkersHandlerOptions,
+  entrypoint: 'fetch' | 'queue',
+  queueName?: string
 ): ResourceOverrideMap => {
   // Explicit overrides are the documented escape hatch, so they resolve
   // first: an overridden resource never requires its env binding. Surface
@@ -139,10 +160,12 @@ const resolveResourceOverrides = (
       ? options.resources(env)
       : (options.resources ?? {});
   const envOverrides = buildEnvResourceOverrides(graph, env, {
+    entrypoint,
     except: Object.keys(userOverrides),
     exclude: options.exclude,
     include: options.include,
     intent: options.intent,
+    queue: queueName,
   });
   if (envOverrides.isErr()) {
     throw envOverrides.error;
@@ -153,6 +176,12 @@ const resolveResourceOverrides = (
 interface MaterializedHandler {
   readonly env: WorkersEnv | undefined;
   readonly handle: (request: Request) => Promise<Response>;
+}
+
+interface MaterializedQueueHandler {
+  readonly env: WorkersEnv | undefined;
+  readonly handle: (batch: CloudflareQueueBatch) => Promise<void>;
+  readonly queue: string;
 }
 
 /**
@@ -176,6 +205,7 @@ export const createWorkersHandler = (
   options: CreateWorkersHandlerOptions = {}
 ): CloudflareWorker => {
   let materialized: MaterializedHandler | undefined;
+  let materializedQueue: MaterializedQueueHandler | undefined;
 
   const handlerFor = (
     env: WorkersEnv | undefined
@@ -193,10 +223,41 @@ export const createWorkersHandler = (
       layers: options.layers,
       maxJsonBodyBytes: options.maxJsonBodyBytes,
       resolvePermit: options.resolvePermit,
-      resources: resolveResourceOverrides(graph, env ?? {}, options),
+      resources: resolveResourceOverrides(graph, env ?? {}, options, 'fetch'),
       validate: options.validate,
     });
     materialized = { env, handle };
+    return handle;
+  };
+
+  const queueHandlerFor = (
+    env: WorkersEnv | undefined,
+    queueName: string
+  ): ((batch: CloudflareQueueBatch) => Promise<void>) => {
+    if (
+      materializedQueue !== undefined &&
+      materializedQueue.env === env &&
+      materializedQueue.queue === queueName
+    ) {
+      return materializedQueue.handle;
+    }
+    const handle = createQueueHandler(graph, {
+      configValues: options.configValues,
+      createContext: options.createContext,
+      exclude: options.exclude,
+      include: options.include,
+      intent: options.intent,
+      layers: options.layers,
+      resources: resolveResourceOverrides(
+        graph,
+        env ?? {},
+        options,
+        'queue',
+        queueName
+      ),
+      validate: options.validate,
+    });
+    materializedQueue = { env, handle, queue: queueName };
     return handle;
   };
 
@@ -206,6 +267,13 @@ export const createWorkersHandler = (
         return await handlerFor(env)(request);
       } catch (error: unknown) {
         return mapCaughtError(error);
+      }
+    },
+    queue: async (batch, env, _executionCtx) => {
+      try {
+        await queueHandlerFor(env, batch.queue)(batch);
+      } catch (error: unknown) {
+        mapCaughtQueueError(error, batch);
       }
     },
   };

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,6 +10,7 @@ Canonical public surface-facing reference. For naming conventions and decision h
 // Definitions
 trail(id, spec)                    // define a unit of work (with optional composes for composition)
 signal(id, spec)                    // define a payload schema with provenance
+queue(id, spec)                     // define an inert queue activation source
 schedule(id, spec)                  // define an inert cron activation source
 webhook(id, spec)                   // define an inert HTTP webhook activation source
 entity(name, shape, options)        // define a first-class domain object with identity metadata
@@ -29,9 +30,9 @@ deriveTrailsStateHome(options?), deriveTrailsProjectKey(options?)
 // has moved to @ontrails/topography per ADR-0042. See that section below.
 
 // Types
-Trail<I, O>, Signal<T>, ScheduleSource, WebhookSource<T>, Entity<TName, TShape, TIdentity>, Resource<T>, Topo, Intent
+Trail<I, O>, Signal<T>, QueueSource<T>, ScheduleSource, WebhookSource<T>, Entity<TName, TShape, TIdentity>, Resource<T>, Topo, Intent
 ObserveConfig, ObserveInput, LogSink, TraceSink
-TrailSpec<I, O>, SignalSpec<T>, ScheduleSpec, WebhookSpec<T>, ResourceSpec<T>, TrailExample<I, O>
+TrailSpec<I, O>, SignalSpec<T>, QueueSpec<T>, ScheduleSpec, WebhookSpec<T>, ResourceSpec<T>, TrailExample<I, O>
 AnyTrail, AnySignal, AnyEntity, AnyResource, ResourceContext, ResourceOverrideMap
 BlobRef, BlobRefDescriptor
 EntityOptions, EntityIdBrand, EntityIdMetadata, EntityIdSchema, EntityIdValue, EntityReference
@@ -108,6 +109,9 @@ GlobConfig, TrailIdGlob, PathGlob, PathScope
 validateSurfaceTopo(topo, options?) // shared established-topo guard for surface projections
 withSurfaceMarker(surface, ctx?)    // merge a surface marker into execution context extensions
 BaseSurfaceOptions, SurfaceSelectionOptions, SurfaceValidationOptions, SurfaceConfigValues
+
+// Queue activation sources
+validateQueueSource(source)          // validate queue name and parse shape
 
 // Webhook activation sources
 webhookMethods

--- a/packages/core/src/__tests__/activation-source-projection.test.ts
+++ b/packages/core/src/__tests__/activation-source-projection.test.ts
@@ -9,6 +9,23 @@ import {
 import { Result } from '../result.js';
 
 describe('activation source projection', () => {
+  test('projects queue names as durable source facts', () => {
+    const source = {
+      id: 'queue.email.outbox',
+      kind: 'queue' as const,
+      parse: z.object({ messageId: z.string() }),
+      queue: ' email-outbox ',
+    };
+
+    expect(projectActivationSourceDeclaration(source)).toMatchObject({
+      key: 'queue:queue.email.outbox',
+      queue: 'email-outbox',
+    });
+    expect(activationSourceDeclarationSignature(source)).toContain(
+      '"queue":"email-outbox"'
+    );
+  });
+
   test('canonicalizes webhook paths in declaration signatures', () => {
     const source = {
       id: 'billing.payment-received',

--- a/packages/core/src/__tests__/queue.test.ts
+++ b/packages/core/src/__tests__/queue.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+
+import { z } from 'zod';
+
+import { ValidationError } from '../errors.js';
+import { queue, validateQueueSource } from '../queue.js';
+
+describe('queue()', () => {
+  test('returns frozen inert queue source data', () => {
+    const source = queue('queue.email.outbox', {
+      meta: { owner: 'email' },
+      parse: z.object({ messageId: z.string() }),
+      queue: ' email-outbox ',
+    });
+
+    expect(source).toMatchObject({
+      id: 'queue.email.outbox',
+      kind: 'queue',
+      meta: { owner: 'email' },
+      queue: 'email-outbox',
+    });
+    expect(Object.isFrozen(source)).toBe(true);
+    expect(Object.isFrozen(source.meta)).toBe(true);
+  });
+
+  test('defaults the runtime queue name to the source id', () => {
+    const source = queue({
+      id: 'queue.audit.events',
+      parse: z.object({ eventId: z.string() }),
+    });
+
+    expect(source.queue).toBe('queue.audit.events');
+  });
+
+  test('rejects missing parse and empty queue names', () => {
+    expect(() =>
+      queue('queue.invalid', {
+        parse: z.object({}),
+        queue: ' ',
+      })
+    ).toThrow(ValidationError);
+
+    expect(() =>
+      queue('queue.invalid', {
+        // oxlint-disable-next-line no-explicit-any -- intentionally malformed source spec.
+        parse: undefined as any,
+      })
+    ).toThrow('parse');
+  });
+
+  test('validates manually-authored queue source shape', () => {
+    expect(
+      validateQueueSource({
+        id: 'queue.invalid',
+        kind: 'queue',
+        queue: '',
+      })
+    ).toEqual([
+      {
+        field: 'queue',
+        message: 'Queue source must define a non-empty queue name',
+      },
+      {
+        field: 'parse',
+        message: 'Queue sources must define parse',
+      },
+    ]);
+  });
+});

--- a/packages/core/src/__tests__/topo.test.ts
+++ b/packages/core/src/__tests__/topo.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 
 import { entity } from '../entity.js';
 import { ValidationError } from '../errors.js';
+import { queue } from '../queue.js';
 import {
   attachLateBoundSignalRef,
   cloneSignalWithId,
@@ -881,10 +882,14 @@ describe('topo', () => {
       );
     });
 
-    test('keeps schedule and webhook activation sources inert during topo construction', () => {
+    test('keeps schedule, webhook, and queue activation sources inert during topo construction', () => {
       const scheduleSource = schedule('schedule.nightly-close', {
         cron: '0 2 * * *',
         input: { olderThanDays: 90 },
+      });
+      const queueSource = queue('queue.stripe.payment', {
+        parse: z.object({ paymentId: z.string() }),
+        queue: 'stripe-payment',
       });
       const webhookSource = webhook('webhook.stripe.payment', {
         parse: z.object({ paymentId: z.string() }),
@@ -895,13 +900,14 @@ describe('topo', () => {
         reconcile: trail('billing.reconcile', {
           implementation: () => Result.ok({ ok: true }),
           input: z.object({}),
-          on: [scheduleSource, { source: webhookSource }],
+          on: [scheduleSource, queueSource, { source: webhookSource }],
           output: z.object({ ok: z.boolean() }),
         }),
       });
 
       expect(app.get('billing.reconcile')?.activationSources).toEqual([
         { source: scheduleSource },
+        { source: queueSource },
         { source: webhookSource },
       ]);
     });

--- a/packages/core/src/__tests__/tracing.test.ts
+++ b/packages/core/src/__tests__/tracing.test.ts
@@ -32,6 +32,25 @@ describe('writeActivationTraceRecord', () => {
     expect(record?.name).toBe('activation.webhook');
   });
 
+  test('accepts queue activation records', async () => {
+    const writes: unknown[] = [];
+    const sink: TraceSink = {
+      write(record) {
+        writes.push(record);
+      },
+    };
+    registerTraceSink(sink);
+
+    const record = await writeActivationTraceRecord(
+      'activation.queue',
+      { 'trails.activation.source.queue': 'email-outbox' },
+      'ok'
+    );
+
+    expect(record?.name).toBe('activation.queue');
+    expect(writes).toHaveLength(1);
+  });
+
   test('returns undefined when the sink synchronously throws', async () => {
     const sink: TraceSink = {
       write() {

--- a/packages/core/src/__tests__/trail.test.ts
+++ b/packages/core/src/__tests__/trail.test.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { entity } from '../entity';
 import { createTrailContext } from '../context';
 import { ConflictError, ValidationError } from '../errors';
+import { queue } from '../queue';
 import { Result } from '../result';
 import { resource } from '../resource';
 import { schedule } from '../schedule';
@@ -1018,11 +1019,15 @@ describe('trail() fires/on normalization', () => {
     expect(Object.isFrozen(t.activationSources[0]?.source.meta)).toBe(true);
   });
 
-  test('schedule and webhook source objects stay inert and normalized', () => {
+  test('schedule, webhook, and queue source objects stay inert and normalized', () => {
     const scheduleSource = schedule('schedule.nightly-close', {
       cron: '0 2 * * *',
       input: { olderThanDays: 90 },
       timezone: 'UTC',
+    });
+    const queueSource = queue('queue.billing.settled', {
+      parse: z.object({ paymentId: z.string() }),
+      queue: 'billing-settled',
     });
     const webhookSource = webhook('webhook.stripe.payment', {
       meta: { provider: 'stripe' },
@@ -1035,6 +1040,7 @@ describe('trail() fires/on normalization', () => {
       input: z.object({}),
       on: [
         scheduleSource,
+        queueSource,
         { meta: { owner: 'billing' }, source: webhookSource },
       ],
     });
@@ -1042,6 +1048,7 @@ describe('trail() fires/on normalization', () => {
     expect(t.on).toEqual([]);
     expect(t.activationSources).toEqual([
       { source: scheduleSource },
+      { source: queueSource },
       {
         meta: { owner: 'billing' },
         source: webhookSource,

--- a/packages/core/src/__tests__/validate-topo.test.ts
+++ b/packages/core/src/__tests__/validate-topo.test.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { deriveDraftReport, isDraftId } from '../draft.js';
 import { entity } from '../entity.js';
 import { validateEstablishedTopo } from '../validate-established-topo.js';
+import { queue } from '../queue.js';
 import { resource } from '../resource.js';
 import { Result } from '../result.js';
 import { trail } from '../trail.js';
@@ -755,7 +756,7 @@ describe('validateTopo', () => {
         consumer: trail('entity.consume', {
           implementation: noop,
           input: z.object({}),
-          on: [{ id: 'queue.entity.created', kind: 'queue' }],
+          on: [{ id: 'mailbox.entity.created', kind: 'mailbox' }],
         }),
       });
 
@@ -765,8 +766,8 @@ describe('validateTopo', () => {
       const issues = extractIssues(result);
       expect(issues).toHaveLength(1);
       expect(issues[0]?.rule).toBe('activation-source-kind-known');
-      expect(issues[0]?.message).toContain('queue.entity.created');
-      expect(issues[0]?.message).toContain('queue');
+      expect(issues[0]?.message).toContain('mailbox.entity.created');
+      expect(issues[0]?.message).toContain('mailbox');
     });
 
     test('duplicate source-to-trail activation entries produce diagnostics', () => {
@@ -1172,6 +1173,62 @@ describe('validateTopo', () => {
       );
     });
 
+    test('invalid queue name and parse shape produce source diagnostics', () => {
+      const app = topo('app', {
+        receive: trail('payment.receive', {
+          implementation: noop,
+          input: z.object({ paymentId: z.string() }),
+          on: [
+            {
+              id: 'queue.stripe.payment',
+              kind: 'queue',
+              queue: '',
+            },
+          ],
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isErr()).toBe(true);
+
+      const issues = extractIssues(result).filter(
+        (entry) => entry.rule === 'activation-queue-valid'
+      );
+      expect(issues).toHaveLength(2);
+      expect(issues.map((issue) => issue.inputPath)).toEqual([
+        ['queue'],
+        ['parse'],
+      ]);
+      expect(issues.every((issue) => issue.sourceKind === 'queue')).toBe(true);
+    });
+
+    test('malformed queue value produces diagnostics instead of throwing', () => {
+      const app = topo('app', {
+        receive: trail('payment.receive', {
+          implementation: noop,
+          input: z.object({ paymentId: z.string() }),
+          on: [
+            {
+              id: 'queue.stripe.payment',
+              kind: 'queue',
+              parse: z.object({ paymentId: z.string() }),
+              queue: 42,
+            } as never,
+          ],
+        }),
+      });
+
+      const result = validateTopo(app);
+      expect(result.isErr()).toBe(true);
+      expect(
+        extractIssues(result).some(
+          (issue) =>
+            issue.rule === 'activation-queue-valid' &&
+            issue.inputPath?.[0] === 'queue'
+        )
+      ).toBe(true);
+    });
+
     test('invalid webhook path and parse shape produce source diagnostics', () => {
       const app = topo('app', {
         receive: trail('payment.receive', {
@@ -1202,6 +1259,25 @@ describe('validateTopo', () => {
       expect(issues.every((issue) => issue.sourceKind === 'webhook')).toBe(
         true
       );
+    });
+
+    test('compatible queue parse output and trail input pass', () => {
+      const app = topo('app', {
+        receive: trail('payment.receive', {
+          implementation: noop,
+          input: z.object({ paymentId: z.string() }),
+          on: [
+            queue('queue.stripe.payment', {
+              parse: {
+                output: z.object({ paymentId: z.string() }),
+              },
+              queue: 'stripe-payment',
+            }),
+          ],
+        }),
+      });
+
+      expect(validateTopo(app).isOk()).toBe(true);
     });
 
     test('compatible webhook parse output and trail input pass', () => {
@@ -1547,7 +1623,7 @@ describe('validateEstablishedTopo', () => {
     expect(issues[0]?.rule).toBe('signal-fire-exists');
   });
 
-  test('allows activation source compatibility issues outside projection checks', () => {
+  test('allows signal compatibility issues outside projection checks', () => {
     const app = topo('app', {
       consumer: trail('order.consume', {
         implementation: noop,
@@ -1571,12 +1647,37 @@ describe('validateEstablishedTopo', () => {
     expect(established.isOk()).toBe(true);
   });
 
+  test('blocks incompatible queue payloads from established projections', () => {
+    const app = topo('app', {
+      consumer: trail('job.consume', {
+        implementation: noop,
+        input: z.object({ id: z.string() }),
+        on: [
+          queue('queue.jobs', {
+            parse: z.object({ id: z.number() }),
+            queue: 'jobs',
+          }),
+        ],
+      }),
+    });
+
+    const result = validateEstablishedTopo(app);
+
+    expect(result.isErr()).toBe(true);
+    expect(extractIssues(result)).toEqual([
+      expect.objectContaining({
+        rule: 'activation-source-input-compatible',
+        sourceKind: 'queue',
+      }),
+    ]);
+  });
+
   test('fails when established activation source kind is unsupported', () => {
     const app = topo('app', {
-      consume: trail('queue.consume', {
+      consume: trail('mailbox.consume', {
         implementation: noop,
         input: z.object({}),
-        on: [{ id: 'queue.work', kind: 'queue' }],
+        on: [{ id: 'mailbox.work', kind: 'mailbox' }],
       }),
     });
 
@@ -1609,6 +1710,54 @@ describe('validateEstablishedTopo', () => {
     const issues = extractIssues(result);
     expect(issues).toHaveLength(1);
     expect(issues[0]?.rule).toBe('activation-schedule-valid');
+  });
+
+  test('treats equivalent manual queue names as one source declaration', () => {
+    const parse = z.object({ jobId: z.string() });
+    const app = topo('app', {
+      first: trail('job.first', {
+        implementation: noop,
+        input: parse,
+        on: [{ id: 'queue.jobs', kind: 'queue', parse, queue: 'jobs' }],
+      }),
+      second: trail('job.second', {
+        implementation: noop,
+        input: parse,
+        on: [{ id: 'queue.jobs', kind: 'queue', parse, queue: ' jobs ' }],
+      }),
+    });
+
+    const result = validateTopo(app);
+    expect(
+      extractIssues(result).some(
+        (issue) => issue.rule === 'activation-source-definition-unique'
+      )
+    ).toBe(false);
+  });
+
+  test('fails when established queue activation source is invalid', () => {
+    const app = topo('app', {
+      consume: trail('queue.consume', {
+        implementation: noop,
+        input: z.object({}),
+        on: [
+          {
+            id: 'queue.invalid',
+            kind: 'queue',
+            queue: '',
+          },
+        ],
+      }),
+    });
+
+    const result = validateEstablishedTopo(app);
+    expect(result.isErr()).toBe(true);
+
+    const issues = extractIssues(result);
+    expect(issues).toHaveLength(2);
+    expect(
+      issues.every((issue) => issue.rule === 'activation-queue-valid')
+    ).toBe(true);
   });
 
   test('fails when established trails depend on draft signal edges', () => {

--- a/packages/core/src/activation-provenance.ts
+++ b/packages/core/src/activation-provenance.ts
@@ -12,6 +12,7 @@ export interface ActivationProvenanceSource {
   readonly kind: ActivationSourceKind;
   readonly meta?: ActivationSourceMeta | undefined;
   readonly producerTrailId?: string | undefined;
+  readonly queue?: string | undefined;
   readonly timezone?: string | undefined;
 }
 
@@ -41,6 +42,7 @@ const isActivationProvenanceSource = (
   typeof value['kind'] === 'string' &&
   optionalString(value['cron']) &&
   optionalString(value['producerTrailId']) &&
+  optionalString(value['queue']) &&
   optionalString(value['timezone']) &&
   (value['meta'] === undefined || isObjectRecord(value['meta']));
 
@@ -99,6 +101,9 @@ export const buildActivationProvenanceTraceAttrs = (
   if (activation.source.producerTrailId !== undefined) {
     attrs['trails.activation.source.producer_trail.id'] =
       activation.source.producerTrailId;
+  }
+  if (activation.source.queue !== undefined) {
+    attrs['trails.activation.source.queue'] = activation.source.queue;
   }
   if (activation.source.cron !== undefined) {
     attrs['trails.activation.source.cron'] = activation.source.cron;

--- a/packages/core/src/activation-source-projection.ts
+++ b/packages/core/src/activation-source-projection.ts
@@ -159,6 +159,12 @@ export const projectActivationSourceDeclaration = (
       record['payloadSchema'] = toSortedJsonSchema(source.payload);
     }
   }
+  if (source.queue !== undefined) {
+    record['queue'] =
+      typeof source.queue === 'string'
+        ? source.queue.trim()
+        : canonicalize(source.queue);
+  }
   if (source.timezone !== undefined) {
     record['timezone'] = source.timezone;
   }

--- a/packages/core/src/activation-source.ts
+++ b/packages/core/src/activation-source.ts
@@ -3,6 +3,7 @@ import type { z } from 'zod';
 import type { AnySignal } from './signal.js';
 
 export const activationSourceKinds = Object.freeze([
+  'queue',
   'signal',
   'schedule',
   'webhook',
@@ -31,6 +32,7 @@ export interface ActivationSource {
   readonly parse?: ActivationSourceParse | undefined;
   readonly path?: string | undefined;
   readonly payload?: z.ZodType<unknown> | undefined;
+  readonly queue?: string | undefined;
   readonly timezone?: string | undefined;
   readonly verify?: unknown;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -300,6 +300,8 @@ export { inputOf, outputOf } from './type-utils.js';
 // Signal
 export { signal } from './signal.js';
 export type { AnySignal, Signal, SignalSpec } from './signal.js';
+export { queue, validateQueueSource } from './queue.js';
+export type { QueueSource, QueueSpec, QueueValidationIssue } from './queue.js';
 export { schedule, validateScheduleSource } from './schedule.js';
 export type {
   ScheduleSource,

--- a/packages/core/src/queue.ts
+++ b/packages/core/src/queue.ts
@@ -1,0 +1,163 @@
+import type {
+  ActivationSource,
+  ActivationSourceMeta,
+  ActivationSourceParse,
+} from './activation-source.js';
+import { ValidationError } from './errors.js';
+
+export interface QueueSpec<TOutput = unknown> {
+  readonly meta?: ActivationSourceMeta | undefined;
+  readonly parse: ActivationSourceParse<TOutput>;
+  readonly payload?: ActivationSource['payload'] | undefined;
+  /**
+   * Runtime queue name. Defaults to the source id, so authored queue
+   * contracts can stay stable while host bindings choose their own names.
+   */
+  readonly queue?: string | undefined;
+  /** Reserved for future queue-specific design; trail versioning is trail-only. */
+  readonly version?: never;
+}
+
+export interface QueueSource<TOutput = unknown> extends ActivationSource {
+  readonly kind: 'queue';
+  readonly meta?: ActivationSourceMeta | undefined;
+  readonly parse: ActivationSourceParse<TOutput>;
+  readonly payload?: ActivationSource['payload'] | undefined;
+  readonly queue: string;
+}
+
+export interface QueueValidationIssue {
+  readonly field: 'parse' | 'queue';
+  readonly message: string;
+}
+
+const normalizeQueueName = (queueName: string): string => queueName.trim();
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isZodSchema = (value: unknown): boolean =>
+  isObjectRecord(value) && typeof value['safeParse'] === 'function';
+
+const validateQueueName = (queueName: unknown): QueueValidationIssue[] =>
+  typeof queueName === 'string' && queueName.trim().length > 0
+    ? []
+    : [
+        {
+          field: 'queue',
+          message: 'Queue source must define a non-empty queue name',
+        },
+      ];
+
+const validateRequiredParse = (parse: unknown): QueueValidationIssue[] =>
+  parse === undefined
+    ? [
+        {
+          field: 'parse',
+          message: 'Queue sources must define parse',
+        },
+      ]
+    : [];
+
+const validateParseShape = (parse: unknown): QueueValidationIssue[] => {
+  if (parse === undefined || isZodSchema(parse)) {
+    return [];
+  }
+  if (isObjectRecord(parse) && isZodSchema(parse['output'])) {
+    return [];
+  }
+  return [
+    {
+      field: 'parse',
+      message: 'Queue parse must be a Zod schema or define parse.output',
+    },
+  ];
+};
+
+const queueIssuesMessage = (
+  id: string,
+  issues: readonly QueueValidationIssue[]
+): string =>
+  `queue("${id}") is invalid: ${issues.map((issue) => `${issue.field}: ${issue.message}`).join('; ')}`;
+
+const assertQueueSpec = <TOutput>(
+  id: string,
+  spec: QueueSpec<TOutput>
+): {
+  readonly queue: string;
+} => {
+  const queueName = spec.queue === undefined ? id : spec.queue;
+  const issues = [
+    ...validateQueueName(queueName),
+    ...validateRequiredParse(spec.parse),
+    ...validateParseShape(spec.parse),
+  ];
+
+  if (issues.length > 0) {
+    throw new ValidationError(queueIssuesMessage(id, issues), {
+      context: { issues },
+    });
+  }
+
+  return { queue: normalizeQueueName(queueName) };
+};
+
+export const validateQueueSource = (
+  source: ActivationSource
+): readonly QueueValidationIssue[] => {
+  if (source.kind !== 'queue') {
+    return [];
+  }
+
+  return [
+    ...validateQueueName(source.queue),
+    ...validateRequiredParse(source.parse),
+    ...validateParseShape(source.parse),
+  ];
+};
+
+/**
+ * Define a queue activation source.
+ *
+ * Queue sources are inert contract data: they describe which runtime queue
+ * wakes a trail and how the message body becomes trail input. A host adapter
+ * such as `@ontrails/cloudflare/workers` owns delivery.
+ *
+ * @example
+ * ```ts
+ * import { queue } from '@ontrails/core';
+ * import { z } from 'zod';
+ *
+ * const source = queue('queue.email.outbox', {
+ *   queue: 'email-outbox',
+ *   parse: z.object({ messageId: z.string() }),
+ * });
+ * ```
+ */
+export function queue<TOutput>(
+  id: string,
+  spec: QueueSpec<TOutput>
+): QueueSource<TOutput>;
+export function queue<TOutput>(
+  spec: QueueSpec<TOutput> & { readonly id: string }
+): QueueSource<TOutput>;
+export function queue<TOutput>(
+  idOrSpec: string | (QueueSpec<TOutput> & { readonly id: string }),
+  maybeSpec?: QueueSpec<TOutput>
+): QueueSource<TOutput> {
+  const id = typeof idOrSpec === 'string' ? idOrSpec : idOrSpec.id;
+  // oxlint-disable-next-line no-non-null-assertion -- overload guarantees maybeSpec when idOrSpec is string
+  const spec = typeof idOrSpec === 'string' ? maybeSpec! : idOrSpec;
+  const normalized = assertQueueSpec(id, spec);
+
+  return Object.freeze({
+    id,
+    kind: 'queue' as const,
+    parse: spec.parse,
+    queue: normalized.queue,
+    ...(spec.meta === undefined
+      ? {}
+      : { meta: Object.freeze({ ...spec.meta }) }),
+    ...(spec.payload === undefined ? {} : { payload: spec.payload }),
+  });
+}

--- a/packages/core/src/tracing.ts
+++ b/packages/core/src/tracing.ts
@@ -28,6 +28,7 @@ export type SignalTraceRecordName =
 /** Activation boundary records emitted by runtime materializers. */
 export type ActivationTraceRecordName =
   | 'activation.cycle_detected'
+  | 'activation.queue'
   | 'activation.scheduled'
   | 'activation.webhook'
   | 'activation.webhook.invalid';

--- a/packages/core/src/validate-established-topo.ts
+++ b/packages/core/src/validate-established-topo.ts
@@ -12,12 +12,18 @@ const PROJECTION_BLOCKING_RULES = new Set([
   'activation-source-definition-unique',
   'activation-source-edge-unique',
   'activation-source-kind-known',
+  'activation-queue-valid',
   'activation-schedule-valid',
   'resource-exists',
   'signal-fire-exists',
   'signal-on-exists',
   'signal-origin-exists',
 ]);
+
+const isProjectionBlockingIssue = (issue: TopoDiagnostic): boolean =>
+  PROJECTION_BLOCKING_RULES.has(issue.rule) ||
+  (issue.rule === 'activation-source-input-compatible' &&
+    issue.sourceKind === 'queue');
 
 const keepProjectionBlockingIssues = (
   result: ReturnType<typeof validateTopo>
@@ -29,9 +35,7 @@ const keepProjectionBlockingIssues = (
   const issues = (
     result.error.context as { issues?: readonly TopoDiagnostic[] } | undefined
   )?.issues;
-  const remainingIssues = issues?.filter((issue) =>
-    PROJECTION_BLOCKING_RULES.has(issue.rule)
-  );
+  const remainingIssues = issues?.filter(isProjectionBlockingIssue);
 
   if (remainingIssues === undefined || remainingIssues.length === 0) {
     return Result.ok();

--- a/packages/core/src/validate-topo.ts
+++ b/packages/core/src/validate-topo.ts
@@ -18,6 +18,7 @@ import { ValidationError } from './errors.js';
 import type { ActivationEntry } from './activation-source.js';
 import { isKnownActivationSourceKind } from './activation-source.js';
 import { isDraftId } from './draft.js';
+import { validateQueueSource } from './queue.js';
 import type { AnySignal } from './signal.js';
 import { validateScheduleSource } from './schedule.js';
 import { Result } from './result.js';
@@ -524,6 +525,21 @@ const checkActivationSources = (
             trailId: id,
           });
         }
+      }
+
+      const queueIssues = validateQueueSource(activation.source);
+      for (const issue of queueIssues) {
+        issues.push({
+          inputPath: [issue.field],
+          message: `Trail declares queue source "${activation.source.id}" with invalid ${issue.field}: ${issue.message}`,
+          rule: 'activation-queue-valid',
+          schemaIssues: [
+            { code: issue.field, message: issue.message, path: [issue.field] },
+          ],
+          sourceId: activation.source.id,
+          sourceKind: activation.source.kind,
+          trailId: id,
+        });
       }
 
       const scheduleIssues = validateScheduleSource(activation.source);

--- a/packages/warden/src/__tests__/unmaterialized-activation-source.test.ts
+++ b/packages/warden/src/__tests__/unmaterialized-activation-source.test.ts
@@ -3,7 +3,15 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { Result, schedule, signal, topo, trail, webhook } from '@ontrails/core';
+import {
+  Result,
+  queue,
+  schedule,
+  signal,
+  topo,
+  trail,
+  webhook,
+} from '@ontrails/core';
 import { z } from 'zod';
 
 import { runWarden } from '../cli.js';
@@ -64,7 +72,18 @@ describe('unmaterialized-activation-source', () => {
     expect(diagnostics).toEqual([]);
   });
 
-  test('stays quiet for schedule, signal, and webhook activation sources', async () => {
+  test('stays quiet for queue, schedule, signal, and webhook activation sources', async () => {
+    const queueConsumer = trail('invoice.queue-consume', {
+      blaze: () => Result.ok({ ok: true }),
+      input: z.object({ invoiceId: z.string() }),
+      on: [
+        queue('queue.invoice.paid', {
+          parse: z.object({ invoiceId: z.string() }),
+          queue: 'invoice-paid',
+        }),
+      ],
+      output: z.object({ ok: z.boolean() }),
+    });
     const scheduleConsumer = trail('invoice.reconcile', {
       implementation: () => Result.ok({ ok: true }),
       input: z.object({}),
@@ -75,6 +94,7 @@ describe('unmaterialized-activation-source', () => {
     const diagnostics = await unmaterializedActivationSource.checkTopo(
       topo('materialized-sources', {
         created,
+        queueConsumer,
         scheduleConsumer,
         signalConsumer,
         signalProducer,

--- a/packages/warden/src/rules/public-export-example-coverage.ts
+++ b/packages/warden/src/rules/public-export-example-coverage.ts
@@ -115,7 +115,12 @@ export const PUBLIC_API_EXAMPLE_TARGETS: readonly PublicApiPackageTarget[] = [
   },
   {
     indexPath: 'adapters/cloudflare/src/index.ts',
-    minimumExports: ['createWorkersHandler', 'cloudflareKv', 'cloudflareD1'],
+    minimumExports: [
+      'createWorkersHandler',
+      'cloudflareKv',
+      'cloudflareD1',
+      'cloudflareQueue',
+    ],
     packageName: '@ontrails/cloudflare',
   },
 ] as const;

--- a/packages/warden/src/rules/unmaterialized-activation-source.ts
+++ b/packages/warden/src/rules/unmaterialized-activation-source.ts
@@ -6,6 +6,7 @@ const RULE_NAME = 'unmaterialized-activation-source';
 const TOPO_FILE = '<topo>';
 
 const MATERIALIZED_SOURCE_KINDS = new Set<ActivationSourceKind>([
+  'queue',
   'schedule',
   'signal',
   'webhook',


### PR DESCRIPTION
## Context
Part 6 of the stack. This adds Cloudflare Queues as an activation source and queue producer resource.

## What changed
- Added queue producer resource support plus an in-memory mock for tests.
- Added `createQueueHandler` for queue-activated trails with ack/retry behavior and rate-limit delay propagation.
- Threaded queue activation through env-bound Workers resources and topo-local trace sinks.
- Updated Cloudflare overlay facts, README guidance, public export docs, and release intent.

## Verification
- `bun test adapters/cloudflare/src`
- `bun run typecheck`
- `bun run lint`
- `bun run test`
- Pre-push stable checks passed before resubmit.

## Risks / rollout
Miniflare queue harnessing is not yet wired in this repo; this PR covers the handler contract and in-memory/mock path.
