### PR TITLE
feat(cloudflare): add r2 blob resource

### DIFF
--- a/.changeset/cloudflare-r2.md
+++ b/.changeset/cloudflare-r2.md
@@ -1,0 +1,14 @@
+---
+'@ontrails/cloudflare': minor
+'@ontrails/warden': patch
+---
+
+Add `@ontrails/cloudflare/r2`, an env-bound Cloudflare R2 bucket resource with
+`cloudflareR2`, `createMemoryR2`, and `r2ObjectToBlobRef`. The resource
+materializes Worker `r2_buckets` bindings through the shared env bridge, records
+Cloudflare lock overlay facts, carries an in-memory object mock for
+configuration-free tests, and documents the supported object operations plus
+streaming/metadata boundaries.
+
+`@ontrails/warden` now treats `cloudflareR2` as a required Cloudflare public
+export with `@example` coverage.

--- a/adapters/cloudflare/README.md
+++ b/adapters/cloudflare/README.md
@@ -8,7 +8,7 @@ The Cloudflare adapter collection for Trails. One package, one subpath per Cloud
 | `@ontrails/cloudflare/kv` | Key-value resource | ✅ |
 | `@ontrails/cloudflare/d1` | D1-backed store resource | ✅ |
 | `@ontrails/cloudflare/queues` | Queue producer resource + consumer materializer | ✅ |
-| `/r2` | Blob/object resource | Planned |
+| `@ontrails/cloudflare/r2` | R2 blob/object resource | ✅ |
 
 Adapter composition doctrine applies throughout: subpaths take primitive-authored declarations (a resource definition, a surface config) and never shadow authoring verbs. Bindings arrive ambiently on the Worker `env`, so runtime dependencies are near-zero.
 
@@ -143,6 +143,55 @@ Capability boundaries are explicit:
 
 Every `cloudflareD1` resource carries an in-memory mock factory seeded from table fixtures or `mockSeed`, so `testAll(app)` remains configuration-free. Miniflare can provide a real D1 binding for local integration tests without a Cloudflare account.
 
+## `/r2` — blob/object resource
+
+`cloudflareR2(id, { binding })` authors a resource wrapping a Cloudflare R2 bucket binding. Trails declare it with `resources: [...]` and use `bucket.from(ctx)` to call the Worker binding's object operations (`put`, `get`, `head`, `delete`, and `list`).
+
+```ts
+import {
+  NotFoundError,
+  Result,
+  blobRefSchema,
+  trail,
+} from '@ontrails/core';
+import { cloudflareR2, r2ObjectToBlobRef } from '@ontrails/cloudflare/r2';
+import { z } from 'zod';
+
+const assets = cloudflareR2('assets', { binding: 'ASSETS' });
+
+const readAsset = trail('asset.read', {
+  implementation: async (input, ctx) => {
+    const object = await assets.from(ctx).get(input.key);
+    if (object === null || !('body' in object)) {
+      return Result.err(new NotFoundError(`Asset "${input.key}" not found`));
+    }
+    return Result.ok(r2ObjectToBlobRef(object));
+  },
+  input: z.object({ key: z.string() }),
+  intent: 'read',
+  output: blobRefSchema,
+  resources: [assets],
+});
+```
+
+Declare the binding in wrangler config:
+
+```toml
+[[r2_buckets]]
+binding = "ASSETS"
+bucket_name = "my-assets"
+```
+
+The resource surface follows the R2 Worker binding structurally. A real R2 bucket binding passes through unchanged, including Cloudflare's conditional operation behavior where `get()` can return metadata without a body and `put()` can return `null` when a precondition fails. `r2ObjectToBlobRef(object)` is the small bridge from a fetched R2 object body to core's `BlobRef` binary-output contract; the HTTP and MCP surfaces already know how to project `blobRefSchema`.
+
+Capability boundaries are explicit:
+
+- The adapter does not expose public bucket URLs, signed URLs, S3 clients, multipart upload helpers, or object-event subscriptions.
+- The in-memory mock implements object bytes, metadata, `put`, `get`, `head`, `delete`, and lexicographic `list` pagination with prefix/cursor/delimiter grouping. It accepts SSE-C option shapes for binding compatibility but does not encrypt objects, validate keys, or emit `ssecKeyMd5`; it also does not model R2 preconditions, range reads, checksums, storage-tier billing behavior, or multipart uploads.
+- For raw HTTP upload/download routes, keep authorization in your own trails or surface layer; the R2 resource only materializes the bucket binding.
+
+Every `cloudflareR2` resource carries an in-memory mock (`createMemoryR2`) so object trails work in `testAll(app)` and focused unit tests without a Cloudflare account or wrangler.
+
 ## `/queues` — Queue producer and consumer support
 
 `cloudflareQueue(id, { binding })` authors a resource wrapping a Cloudflare Queue producer binding. Trails declare it with `resources: [...]` and send messages with `jobs.from(ctx).send(...)` or `sendBatch(...)`.
@@ -201,7 +250,7 @@ Every `cloudflareQueue` resource carries an in-memory mock (`createMemoryQueue`)
 
 ## Local integration testing
 
-Integration runs are local-first via [miniflare](https://miniflare.dev) (workerd in-process): the test lane bundles a demo Worker with `Bun.build`, boots it with real KV and D1 bindings, and exercises HTTP, webhook, KV, and D1 store routes. Queue producer and consumer behavior is covered by focused Worker-handler tests under `src/queues/__tests__/queues.test.ts`. Real-account deploys are manual and never CI-required.
+Integration runs are local-first via [miniflare](https://miniflare.dev) (workerd in-process): the test lane bundles a demo Worker with `Bun.build`, boots it with real KV and D1 bindings, and exercises HTTP, webhook, KV, and D1 store routes. Queue producer/consumer behavior and R2 object behavior are covered by focused structural tests under `src/queues/__tests__/queues.test.ts` and `src/r2/__tests__/r2.test.ts`. Real-account deploys are manual and never CI-required.
 
 ## Lock facts
 

--- a/adapters/cloudflare/package.json
+++ b/adapters/cloudflare/package.json
@@ -15,6 +15,7 @@
     "./workers": "./src/workers/index.ts",
     "./kv": "./src/kv/index.ts",
     "./d1": "./src/d1/index.ts",
+    "./r2": "./src/r2/index.ts",
     "./queues": "./src/queues/index.ts",
     "./package.json": "./package.json"
   },

--- a/adapters/cloudflare/src/__tests__/facts.test.ts
+++ b/adapters/cloudflare/src/__tests__/facts.test.ts
@@ -16,6 +16,7 @@ import { cloudflareOverlay } from '../facts.js';
 import { cloudflareD1 } from '../d1/index.js';
 import { cloudflareKv } from '../kv/index.js';
 import { cloudflareQueue } from '../queues/index.js';
+import { cloudflareR2 } from '../r2/index.js';
 
 const flags = cloudflareKv('flags', { binding: 'FLAGS' });
 const notesStore = defineStore({
@@ -94,6 +95,25 @@ describe('cloudflareOverlay', () => {
 
     expect(cloudflareOverlay.derive(app)).toEqual({
       bindings: [{ binding: 'JOBS', resourceId: 'jobs' }],
+    });
+  });
+
+  test('derives R2 bucket resources through the shared env binding registry', () => {
+    const assets = cloudflareR2('assets', { binding: 'ASSETS' });
+    const inspectAsset = trail('asset.inspect', {
+      implementation: async (input, ctx) => {
+        const object = await assets.from(ctx).head(input.key);
+        return Result.ok({ size: object?.size ?? null });
+      },
+      input: z.object({ key: z.string() }),
+      intent: 'read',
+      output: z.object({ size: z.number().nullable() }),
+      resources: [assets],
+    });
+    const app = topo('cf-facts-r2', { assets, inspectAsset });
+
+    expect(cloudflareOverlay.derive(app)).toEqual({
+      bindings: [{ binding: 'ASSETS', resourceId: 'assets' }],
     });
   });
 

--- a/adapters/cloudflare/src/env.ts
+++ b/adapters/cloudflare/src/env.ts
@@ -10,8 +10,8 @@
  *
  * Overrides are re-resolved whenever a new `env` object arrives, and core
  * resolves overrides before its singleton resource cache, so no resource
- * instance can capture a stale env. Every Cloudflare subpath (`/kv` today,
- * `/d1`, `/queues`, `/r2` later) consumes this one seam.
+ * instance can capture a stale env. Every Cloudflare service subpath consumes
+ * this one seam.
  */
 
 import {
@@ -32,7 +32,8 @@ import type {
 /**
  * The ambient Worker environment: bindings keyed by their wrangler-configured
  * names. Values are runtime binding objects (KV namespaces, D1 databases,
- * queues), so they are typed as `unknown` and narrowed by each subpath.
+ * R2 buckets, queues), so they are typed as `unknown` and narrowed by each
+ * subpath.
  */
 export type WorkersEnv = Readonly<Record<string, unknown>>;
 

--- a/adapters/cloudflare/src/index.ts
+++ b/adapters/cloudflare/src/index.ts
@@ -5,6 +5,7 @@
  * - `@ontrails/cloudflare/workers` — HTTP surface materializer (fetch handler)
  * - `@ontrails/cloudflare/kv` — key-value resource
  * - `@ontrails/cloudflare/d1` — D1-backed store resource
+ * - `@ontrails/cloudflare/r2` — R2 blob/object resource
  * - `@ontrails/cloudflare/queues` — Queue producer resource and consumer
  *   materializer
  *
@@ -46,6 +47,24 @@ export type {
   CloudflareKvPutOptions,
   CreateMemoryKvOptions,
 } from './kv/index.js';
+export { cloudflareR2, createMemoryR2, r2ObjectToBlobRef } from './r2/index.js';
+export type {
+  CloudflareR2Bucket,
+  CloudflareR2Conditional,
+  CloudflareR2GetOptions,
+  CloudflareR2HttpMetadata,
+  CloudflareR2ListOptions,
+  CloudflareR2Object,
+  CloudflareR2ObjectBody,
+  CloudflareR2Objects,
+  CloudflareR2Options,
+  CloudflareR2PutBody,
+  CloudflareR2PutOptions,
+  CloudflareR2Range,
+  CloudflareR2StorageClass,
+  MemoryCloudflareR2Bucket,
+  R2ObjectToBlobRefOptions,
+} from './r2/index.js';
 export {
   cloudflareQueue,
   createMemoryQueue,

--- a/adapters/cloudflare/src/r2/__tests__/r2.test.ts
+++ b/adapters/cloudflare/src/r2/__tests__/r2.test.ts
@@ -1,0 +1,377 @@
+import { describe, expect, test } from 'bun:test';
+import { Result, topo, trail } from '@ontrails/core';
+import { testAll } from '@ontrails/testing';
+import { z } from 'zod';
+
+import { getEnvBinding } from '../../env.js';
+import { cloudflareR2, createMemoryR2, r2ObjectToBlobRef } from '../index.js';
+import type {
+  CloudflareR2GetOptions,
+  CloudflareR2ObjectBody,
+} from '../index.js';
+
+const expectBody = (
+  object: Awaited<ReturnType<ReturnType<typeof createMemoryR2>['get']>>
+): CloudflareR2ObjectBody => {
+  expect(object).not.toBeNull();
+  expect(object !== null && 'body' in object).toBe(true);
+  return object as CloudflareR2ObjectBody;
+};
+
+describe('createMemoryR2', () => {
+  test('keeps get conditions and ranges aligned with Workers R2', () => {
+    const options = {
+      onlyIf: { uploadedAfter: new Date(0) },
+      range: { length: 10, offset: 0 },
+    } satisfies CloudflareR2GetOptions;
+    const invalidOptions: CloudflareR2GetOptions = {
+      // @ts-expect-error R2 ranges use offset/length or suffix, not start/end.
+      range: { end: 10, start: 0 },
+    };
+
+    expect(options.range).toEqual({ length: 10, offset: 0 });
+    expect(invalidOptions.range).toEqual({ end: 10, start: 0 });
+  });
+
+  test('round-trips put/get/head/delete with metadata', async () => {
+    const bucket = createMemoryR2();
+
+    await bucket.put('notes.txt', 'hello', {
+      customMetadata: { owner: 'trails' },
+      httpMetadata: { contentLanguage: 'en', contentType: 'text/plain' },
+      ssecKey: new ArrayBuffer(32),
+    });
+
+    const head = await bucket.head('notes.txt');
+    expect(head).not.toBeNull();
+    expect(head?.key).toBe('notes.txt');
+    expect(head?.size).toBe(5);
+    expect(head?.customMetadata).toEqual({ owner: 'trails' });
+    expect('body' in (head ?? {})).toBe(false);
+
+    const object = expectBody(
+      await bucket.get('notes.txt', { ssecKey: '0'.repeat(64) })
+    );
+    const headers = new Headers();
+    object.writeHttpMetadata(headers);
+    expect(headers.get('content-type')).toBe('text/plain');
+    expect(headers.get('content-language')).toBe('en');
+    expect(object.bodyUsed).toBe(false);
+    expect(await object.text()).toBe('hello');
+    expect(object.bodyUsed).toBe(true);
+
+    const withoutSsecKey = expectBody(await bucket.get('notes.txt'));
+    expect(await withoutSsecKey.text()).toBe('hello');
+    expect(withoutSsecKey.ssecKeyMd5).toBeUndefined();
+
+    await bucket.delete('notes.txt');
+    expect(await bucket.head('notes.txt')).toBeNull();
+    expect(await bucket.get('notes.txt')).toBeNull();
+  });
+
+  test('lists keys lexicographically with prefix, cursor, and multi-delete', async () => {
+    const bucket = createMemoryR2();
+
+    await bucket.put('assets/c.txt', 'c');
+    await bucket.put('assets/a.txt', 'a');
+    await bucket.put('docs/b.txt', 'b');
+
+    const first = await bucket.list({ limit: 1, prefix: 'assets/' });
+    expect(first.objects.map((object) => object.key)).toEqual(['assets/a.txt']);
+    expect(first.truncated).toBe(true);
+    expect(first.cursor).toBeDefined();
+
+    const second = await bucket.list({
+      cursor: first.cursor,
+      limit: 1,
+      prefix: 'assets/',
+    });
+    expect(second.objects.map((object) => object.key)).toEqual([
+      'assets/c.txt',
+    ]);
+    expect(second.truncated).toBe(false);
+
+    await bucket.delete(['assets/a.txt', 'assets/c.txt']);
+    const emptyAssets = await bucket.list({ prefix: 'assets/' });
+    const remaining = await bucket.list();
+    expect(emptyAssets.objects).toEqual([]);
+    expect(remaining.objects.map((object) => object.key)).toEqual([
+      'docs/b.txt',
+    ]);
+  });
+
+  test('rejects multi-delete batches above the R2 service limit', async () => {
+    const bucket = createMemoryR2();
+    const keys = Array.from({ length: 1001 }, (_, index) => `key-${index}`);
+
+    await expect(bucket.delete(keys)).rejects.toThrow(
+      'accept at most 1000 keys per call'
+    );
+  });
+
+  test('paginates objects and prefixes that share the same key', async () => {
+    const bucket = createMemoryR2();
+    await bucket.put('foo', 'object');
+    await bucket.put('foo/bar', 'nested');
+
+    const first = await bucket.list({ delimiter: '/', limit: 1 });
+    expect(first.objects.map((object) => object.key)).toEqual(['foo']);
+    expect(first.delimitedPrefixes).toEqual([]);
+    expect(first.truncated).toBe(true);
+    expect(first.cursor).toBeDefined();
+
+    const second = await bucket.list({
+      cursor: first.cursor,
+      delimiter: '/',
+      limit: 1,
+    });
+    expect(second.objects).toEqual([]);
+    expect(second.delimitedPrefixes).toEqual(['foo']);
+    expect(second.truncated).toBe(false);
+  });
+
+  test('uses list ordering for key-only pagination boundaries', async () => {
+    const bucket = createMemoryR2();
+    await bucket.put('a', 'lowercase');
+    await bucket.put('B', 'uppercase-b');
+    await bucket.put('Z', 'uppercase-z');
+
+    const ordered = await bucket.list();
+    const startAfter = await bucket.list({ startAfter: 'B' });
+    const legacyCursor = await bucket.list({ cursor: 'B' });
+
+    expect(ordered.objects.map((object) => object.key)).toEqual([
+      'B',
+      'Z',
+      'a',
+    ]);
+    expect(startAfter.objects.map((object) => object.key)).toEqual(['Z', 'a']);
+    expect(legacyCursor.objects.map((object) => object.key)).toEqual([
+      'Z',
+      'a',
+    ]);
+  });
+
+  test('does not confuse legacy keys with issued opaque cursor shapes', async () => {
+    const bucket = createMemoryR2();
+    const tupleKey = '["object","a"]';
+    await bucket.put(tupleKey, 'tuple');
+    await bucket.put('a', 'a');
+    await bucket.put('z', 'z');
+
+    const page = await bucket.list({ cursor: tupleKey });
+
+    expect(page.objects.map((object) => object.key)).toEqual(['a', 'z']);
+  });
+
+  test('clamps requested list pages to the R2 service maximum', async () => {
+    const bucket = createMemoryR2();
+    await Promise.all(
+      Array.from({ length: 1001 }, (_, index) =>
+        bucket.put(`entry-${index.toString().padStart(4, '0')}`, 'value')
+      )
+    );
+
+    const first = await bucket.list({ limit: 5000 });
+    expect(first.objects).toHaveLength(1000);
+    expect(first.truncated).toBe(true);
+    expect(first.cursor).toBeDefined();
+
+    const second = await bucket.list({ cursor: first.cursor, limit: 5000 });
+    expect(second.objects).toHaveLength(1);
+    expect(second.truncated).toBe(false);
+  });
+
+  test('returns list metadata only when requested through include', async () => {
+    const bucket = createMemoryR2();
+    await bucket.put('notes.txt', 'hello', {
+      customMetadata: { owner: 'trails' },
+      httpMetadata: { contentType: 'text/plain' },
+    });
+
+    const plainList = await bucket.list();
+    const [plain] = plainList.objects;
+    expect(plain?.customMetadata).toBeUndefined();
+    expect(plain?.httpMetadata).toBeUndefined();
+
+    const customList = await bucket.list({ include: ['customMetadata'] });
+    const [custom] = customList.objects;
+    expect(custom?.customMetadata).toEqual({ owner: 'trails' });
+    expect(custom?.httpMetadata).toBeUndefined();
+
+    const completeList = await bucket.list({
+      include: ['customMetadata', 'httpMetadata'],
+    });
+    const [complete] = completeList.objects;
+    expect(complete?.customMetadata).toEqual({ owner: 'trails' });
+    expect(complete?.httpMetadata).toEqual({ contentType: 'text/plain' });
+  });
+
+  test('groups delimited prefixes when listing directory-shaped keys', async () => {
+    const bucket = createMemoryR2();
+
+    await bucket.put('foo/bar/baz.txt', 'nested');
+    await bucket.put('foo/root.txt', 'root');
+    await bucket.put('photos/1.jpg', 'photo');
+    await bucket.put('readme.txt', 'readme');
+
+    const root = await bucket.list({ delimiter: '/' });
+    expect(root.delimitedPrefixes).toEqual(['foo', 'photos']);
+    expect(root.objects.map((object) => object.key)).toEqual(['readme.txt']);
+
+    const foo = await bucket.list({ delimiter: '/', prefix: 'foo/' });
+    expect(foo.delimitedPrefixes).toEqual(['foo/bar']);
+    expect(foo.objects.map((object) => object.key)).toEqual(['foo/root.txt']);
+  });
+
+  test('converts fetched objects into BlobRef values', async () => {
+    const bucket = createMemoryR2();
+    await bucket.put('image.svg', '<svg></svg>', {
+      httpMetadata: { contentType: 'image/svg+xml' },
+    });
+
+    const object = expectBody(await bucket.get('image.svg'));
+    const blob = r2ObjectToBlobRef(object);
+
+    expect(blob.name).toBe('image.svg');
+    expect(blob.mimeType).toBe('image/svg+xml');
+    expect(blob.size).toBe(11);
+    expect(blob.data).toBeInstanceOf(ReadableStream);
+    expect(await new Response(blob.data).text()).toBe('<svg></svg>');
+    expect(object.bodyUsed).toBe(true);
+    await expect(object.text()).rejects.toThrow(
+      'R2 object body has already been consumed'
+    );
+  });
+
+  test('uses the returned range length for BlobRef size', async () => {
+    const bucket = createMemoryR2();
+    await bucket.put('readme.txt', 'hello', {
+      httpMetadata: { contentType: 'text/plain' },
+    });
+
+    const object = expectBody(await bucket.get('readme.txt'));
+    const rangedObject: CloudflareR2ObjectBody = {
+      ...object,
+      body: new Response('ell').body as ReadableStream<Uint8Array>,
+      range: { length: 3, offset: 1 },
+    };
+    const blob = r2ObjectToBlobRef(rangedObject);
+
+    expect(blob.size).toBe(3);
+    expect(await new Response(blob.data).text()).toBe('ell');
+  });
+
+  test('keeps BlobRef streams single-use after the object body is consumed', async () => {
+    const bucket = createMemoryR2();
+    await bucket.put('readme.txt', 'hello', {
+      httpMetadata: { contentType: 'text/plain' },
+    });
+
+    const object = expectBody(await bucket.get('readme.txt'));
+    expect(await object.text()).toBe('hello');
+    expect(object.bodyUsed).toBe(true);
+
+    const blob = r2ObjectToBlobRef(object);
+    await expect(new Response(blob.data).text()).rejects.toThrow(
+      'R2 object body has already been consumed'
+    );
+  });
+});
+
+describe('cloudflareR2 resource', () => {
+  test('declares binding metadata, env binding, and mock factory', async () => {
+    const assets = cloudflareR2('assets', { binding: 'ASSETS' });
+    const binding = getEnvBinding(assets);
+    const bucket = createMemoryR2();
+
+    const resolved = binding?.fromEnv(bucket);
+
+    expect(assets.id).toBe('assets');
+    expect(assets.meta?.['cloudflare.binding']).toBe('ASSETS');
+    expect(assets.meta?.['cloudflare.service']).toBe('r2');
+    expect(typeof assets.mock).toBe('function');
+    expect(binding?.binding).toBe('ASSETS');
+    expect(resolved?.isOk()).toBe(true);
+    if (resolved?.isOk()) {
+      await resolved.value.put('ok.txt', 'ok');
+    }
+    expect(await bucket.head('ok.txt')).not.toBeNull();
+  });
+
+  test('create refuses to run outside a Workers env with guidance', async () => {
+    const assets = cloudflareR2('assets', { binding: 'ASSETS' });
+    const created = await assets.create({
+      config: undefined,
+      cwd: '/',
+      env: {},
+      workspaceRoot: undefined,
+    });
+
+    expect(created.isErr()).toBe(true);
+    if (created.isErr()) {
+      expect(created.error.message).toContain('ASSETS');
+      expect(created.error.message).toContain('createWorkersHandler');
+    }
+  });
+
+  test('rejects a non-R2 env binding', () => {
+    const assets = cloudflareR2('assets', { binding: 'ASSETS' });
+    const result = getEnvBinding(assets)?.fromEnv('not-r2');
+
+    expect(result?.isErr()).toBe(true);
+    if (result?.isErr()) {
+      expect(result.error.message).toContain('r2_buckets');
+    }
+  });
+});
+
+const assets = cloudflareR2('assets.test', { binding: 'ASSETS' });
+
+const writeAsset = trail('asset.write', {
+  examples: [
+    {
+      expected: { stored: true },
+      input: {
+        body: 'hello',
+        contentType: 'text/plain',
+        key: 'hello.txt',
+      },
+      name: 'stores an asset',
+    },
+  ],
+  implementation: async (input, ctx) => {
+    await assets.from(ctx).put(input.key, input.body, {
+      httpMetadata: { contentType: input.contentType },
+    });
+    return Result.ok({ stored: true });
+  },
+  input: z.object({
+    body: z.string(),
+    contentType: z.string(),
+    key: z.string(),
+  }),
+  intent: 'write',
+  output: z.object({ stored: z.boolean() }),
+  resources: [assets],
+});
+
+const statAsset = trail('asset.stat', {
+  examples: [
+    {
+      expected: { size: null },
+      input: { key: 'missing.txt' },
+      name: 'missing asset',
+    },
+  ],
+  implementation: async (input, ctx) => {
+    const object = await assets.from(ctx).head(input.key);
+    return Result.ok({ size: object?.size ?? null });
+  },
+  input: z.object({ key: z.string() }),
+  intent: 'read',
+  output: z.object({ size: z.number().nullable() }),
+  resources: [assets],
+});
+
+testAll(topo('cf-r2', { assets, statAsset, writeAsset }));

--- a/adapters/cloudflare/src/r2/index.ts
+++ b/adapters/cloudflare/src/r2/index.ts
@@ -1,0 +1,736 @@
+/**
+ * Cloudflare R2 blob/object resource for Trails.
+ *
+ * `cloudflareR2` authors an ordinary resource definition for an R2 bucket
+ * binding. Trails can store and fetch object bytes through the standard
+ * resource accessor, then return `BlobRef` values when HTTP/MCP surfaces should
+ * project the fetched object as binary output.
+ */
+
+import {
+  InternalError,
+  Result,
+  ValidationError,
+  createBlobRef,
+  resource,
+} from '@ontrails/core';
+import type { BlobRef, Resource } from '@ontrails/core';
+
+import { registerEnvBinding } from '../env.js';
+
+// ---------------------------------------------------------------------------
+// Binding shape
+// ---------------------------------------------------------------------------
+
+export type CloudflareR2StorageClass = 'Standard' | 'InfrequentAccess';
+
+export type CloudflareR2PutBody =
+  | ArrayBuffer
+  | ArrayBufferView
+  | Blob
+  | ReadableStream<Uint8Array>
+  | string
+  | null;
+
+export interface CloudflareR2HttpMetadata {
+  readonly cacheControl?: string | undefined;
+  readonly cacheExpiry?: Date | undefined;
+  readonly contentDisposition?: string | undefined;
+  readonly contentEncoding?: string | undefined;
+  readonly contentLanguage?: string | undefined;
+  readonly contentType?: string | undefined;
+}
+
+export interface CloudflareR2Conditional {
+  readonly etagDoesNotMatch?: string | undefined;
+  readonly etagMatches?: string | undefined;
+  readonly uploadedAfter?: Date | undefined;
+  readonly uploadedBefore?: Date | undefined;
+}
+
+export type CloudflareR2Range =
+  | {
+      readonly length?: number | undefined;
+      readonly offset: number;
+      readonly suffix?: never;
+    }
+  | {
+      readonly length: number;
+      readonly offset?: number | undefined;
+      readonly suffix?: never;
+    }
+  | {
+      readonly length?: never;
+      readonly offset?: never;
+      readonly suffix: number;
+    };
+
+export interface CloudflareR2GetOptions {
+  readonly onlyIf?: CloudflareR2Conditional | Headers | undefined;
+  readonly range?: CloudflareR2Range | undefined;
+  /** Accepted by the memory mock but enforced only by real R2 bindings. */
+  readonly ssecKey?: ArrayBuffer | string | undefined;
+}
+
+export interface CloudflareR2PutOptions {
+  readonly customMetadata?: Readonly<Record<string, string>> | undefined;
+  readonly httpMetadata?: CloudflareR2HttpMetadata | Headers | undefined;
+  readonly md5?: ArrayBuffer | string | undefined;
+  readonly onlyIf?: CloudflareR2Conditional | Headers | undefined;
+  readonly sha1?: ArrayBuffer | string | undefined;
+  readonly sha256?: ArrayBuffer | string | undefined;
+  readonly sha384?: ArrayBuffer | string | undefined;
+  readonly sha512?: ArrayBuffer | string | undefined;
+  /** Accepted by the memory mock but enforced only by real R2 bindings. */
+  readonly ssecKey?: ArrayBuffer | string | undefined;
+  readonly storageClass?: CloudflareR2StorageClass | undefined;
+}
+
+export interface CloudflareR2ListOptions {
+  readonly cursor?: string | undefined;
+  readonly delimiter?: string | undefined;
+  readonly include?: readonly ('customMetadata' | 'httpMetadata')[] | undefined;
+  readonly limit?: number | undefined;
+  readonly prefix?: string | undefined;
+  readonly startAfter?: string | undefined;
+}
+
+export interface CloudflareR2Object {
+  readonly customMetadata: Readonly<Record<string, string>>;
+  readonly etag: string;
+  readonly httpEtag: string;
+  readonly httpMetadata: CloudflareR2HttpMetadata;
+  readonly key: string;
+  readonly range?: CloudflareR2Range | undefined;
+  readonly ssecKeyMd5?: string | undefined;
+  readonly size: number;
+  readonly storageClass?: CloudflareR2StorageClass | undefined;
+  readonly uploaded: Date;
+  readonly version: string;
+  writeHttpMetadata(headers: Headers): void;
+}
+
+export interface CloudflareR2ListedObject extends Omit<
+  CloudflareR2Object,
+  'customMetadata' | 'httpMetadata'
+> {
+  readonly customMetadata?: Readonly<Record<string, string>> | undefined;
+  readonly httpMetadata?: CloudflareR2HttpMetadata | undefined;
+}
+
+export interface CloudflareR2ObjectBody extends CloudflareR2Object {
+  readonly body: ReadableStream<Uint8Array>;
+  readonly bodyUsed: boolean;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  blob(): Promise<Blob>;
+  json<T = unknown>(): Promise<T>;
+  text(): Promise<string>;
+}
+
+export interface CloudflareR2Objects {
+  readonly cursor?: string | undefined;
+  readonly delimitedPrefixes?: readonly string[] | undefined;
+  readonly objects: readonly CloudflareR2ListedObject[];
+  readonly truncated: boolean;
+}
+
+/**
+ * Structural subset of a Cloudflare R2 bucket binding.
+ */
+export interface CloudflareR2Bucket {
+  delete(key: string | readonly string[]): Promise<void>;
+  get(
+    key: string,
+    options?: CloudflareR2GetOptions
+  ): Promise<CloudflareR2ObjectBody | CloudflareR2Object | null>;
+  head(key: string): Promise<CloudflareR2Object | null>;
+  list(options?: CloudflareR2ListOptions): Promise<CloudflareR2Objects>;
+  put(
+    key: string,
+    value: CloudflareR2PutBody,
+    options?: CloudflareR2PutOptions
+  ): Promise<CloudflareR2Object | null>;
+}
+
+export interface MemoryCloudflareR2Bucket extends CloudflareR2Bucket {
+  clear(): void;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory mock
+// ---------------------------------------------------------------------------
+
+interface MemoryR2Entry {
+  readonly bytes: Uint8Array;
+  readonly customMetadata: Readonly<Record<string, string>>;
+  readonly etag: string;
+  readonly httpMetadata: CloudflareR2HttpMetadata;
+  readonly key: string;
+  readonly storageClass?: CloudflareR2StorageClass | undefined;
+  readonly uploaded: Date;
+  readonly version: string;
+}
+
+const DEFAULT_LIST_LIMIT = 1000;
+const MAX_LIST_LIMIT = 1000;
+const MAX_MULTI_DELETE_KEYS = 1000;
+const DEFAULT_BLOB_MIME_TYPE = 'application/octet-stream';
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const isBlobValue = (value: unknown): value is Blob =>
+  typeof Blob !== 'undefined' && value instanceof Blob;
+
+const isHeadersValue = (value: unknown): value is Headers =>
+  typeof Headers !== 'undefined' && value instanceof Headers;
+
+const copyBytes = (bytes: Uint8Array): Uint8Array => {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy;
+};
+
+const readStream = async (
+  stream: ReadableStream<Uint8Array>
+): Promise<Uint8Array> => {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  while (true) {
+    const read = await reader.read();
+    if (read.done) {
+      break;
+    }
+    chunks.push(read.value);
+    size += read.value.byteLength;
+  }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+};
+
+const normalizePutBody = async (
+  value: CloudflareR2PutBody
+): Promise<Uint8Array> => {
+  if (value === null) {
+    return new Uint8Array();
+  }
+  if (typeof value === 'string') {
+    return encoder.encode(value);
+  }
+  if (isBlobValue(value)) {
+    return new Uint8Array(await value.arrayBuffer());
+  }
+  if (value instanceof ArrayBuffer) {
+    return copyBytes(new Uint8Array(value));
+  }
+  if (ArrayBuffer.isView(value)) {
+    return copyBytes(
+      new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+    );
+  }
+  return readStream(value);
+};
+
+const normalizeHttpMetadata = (
+  metadata: CloudflareR2PutOptions['httpMetadata']
+): CloudflareR2HttpMetadata => {
+  if (metadata === undefined) {
+    return {};
+  }
+  if (isHeadersValue(metadata)) {
+    const normalized: {
+      cacheControl?: string;
+      cacheExpiry?: Date;
+      contentDisposition?: string;
+      contentEncoding?: string;
+      contentLanguage?: string;
+      contentType?: string;
+    } = {};
+    const cacheControl = metadata.get('cache-control');
+    const contentDisposition = metadata.get('content-disposition');
+    const contentEncoding = metadata.get('content-encoding');
+    const contentLanguage = metadata.get('content-language');
+    const contentType = metadata.get('content-type');
+    const expires = metadata.get('expires');
+    if (cacheControl !== null) {
+      normalized.cacheControl = cacheControl;
+    }
+    if (contentDisposition !== null) {
+      normalized.contentDisposition = contentDisposition;
+    }
+    if (contentEncoding !== null) {
+      normalized.contentEncoding = contentEncoding;
+    }
+    if (contentLanguage !== null) {
+      normalized.contentLanguage = contentLanguage;
+    }
+    if (contentType !== null) {
+      normalized.contentType = contentType;
+    }
+    if (expires !== null) {
+      normalized.cacheExpiry = new Date(expires);
+    }
+    return normalized;
+  }
+  return { ...metadata };
+};
+
+const writeHttpMetadata = (
+  headers: Headers,
+  metadata: CloudflareR2HttpMetadata
+): void => {
+  if (metadata.cacheControl !== undefined) {
+    headers.set('Cache-Control', metadata.cacheControl);
+  }
+  if (metadata.cacheExpiry !== undefined) {
+    headers.set('Expires', metadata.cacheExpiry.toUTCString());
+  }
+  if (metadata.contentDisposition !== undefined) {
+    headers.set('Content-Disposition', metadata.contentDisposition);
+  }
+  if (metadata.contentEncoding !== undefined) {
+    headers.set('Content-Encoding', metadata.contentEncoding);
+  }
+  if (metadata.contentLanguage !== undefined) {
+    headers.set('Content-Language', metadata.contentLanguage);
+  }
+  if (metadata.contentType !== undefined) {
+    headers.set('Content-Type', metadata.contentType);
+  }
+};
+
+const createEtag = (bytes: Uint8Array, version: number): string => {
+  let checksum = 0;
+  for (const [index, byte] of bytes.entries()) {
+    checksum = (checksum + byte * (index + 1)) % Number.MAX_SAFE_INTEGER;
+  }
+  return `${version.toString(16)}-${bytes.byteLength.toString(16)}-${checksum.toString(16)}`;
+};
+
+const objectMetadata = (entry: MemoryR2Entry): CloudflareR2Object => ({
+  customMetadata: Object.freeze({ ...entry.customMetadata }),
+  etag: entry.etag,
+  httpEtag: `"${entry.etag}"`,
+  httpMetadata: { ...entry.httpMetadata },
+  key: entry.key,
+  size: entry.bytes.byteLength,
+  ...(entry.storageClass === undefined
+    ? {}
+    : { storageClass: entry.storageClass }),
+  uploaded: new Date(entry.uploaded),
+  version: entry.version,
+  writeHttpMetadata(headers) {
+    writeHttpMetadata(headers, entry.httpMetadata);
+  },
+});
+
+const listedObjectMetadata = (
+  entry: MemoryR2Entry,
+  include: CloudflareR2ListOptions['include']
+): CloudflareR2ListedObject => {
+  const includeCustomMetadata = include?.includes('customMetadata') ?? false;
+  const includeHttpMetadata = include?.includes('httpMetadata') ?? false;
+  return {
+    etag: entry.etag,
+    httpEtag: `"${entry.etag}"`,
+    key: entry.key,
+    size: entry.bytes.byteLength,
+    ...(entry.storageClass === undefined
+      ? {}
+      : { storageClass: entry.storageClass }),
+    uploaded: new Date(entry.uploaded),
+    version: entry.version,
+    writeHttpMetadata(headers) {
+      if (includeHttpMetadata) {
+        writeHttpMetadata(headers, entry.httpMetadata);
+      }
+    },
+    ...(includeCustomMetadata
+      ? { customMetadata: Object.freeze({ ...entry.customMetadata }) }
+      : {}),
+    ...(includeHttpMetadata ? { httpMetadata: { ...entry.httpMetadata } } : {}),
+  };
+};
+
+const bodyConsumedError = (): TypeError =>
+  new TypeError('R2 object body has already been consumed');
+
+const objectBody = (entry: MemoryR2Entry): CloudflareR2ObjectBody => {
+  let bodyUsed = false;
+  const consume = (): Uint8Array => {
+    if (bodyUsed) {
+      throw bodyConsumedError();
+    }
+    bodyUsed = true;
+    return copyBytes(entry.bytes);
+  };
+  const body = new ReadableStream<Uint8Array>(
+    {
+      pull(controller) {
+        try {
+          controller.enqueue(consume());
+          controller.close();
+        } catch (error) {
+          controller.error(error);
+        }
+      },
+    },
+    { highWaterMark: 0 }
+  );
+  const arrayBuffer = async (): Promise<ArrayBuffer> => {
+    const bytes = consume();
+    return bytes.buffer as ArrayBuffer;
+  };
+  const text = async (): Promise<string> =>
+    decoder.decode(new Uint8Array(await arrayBuffer()));
+  return {
+    ...objectMetadata(entry),
+    arrayBuffer,
+    blob: async () => {
+      const bytes = consume();
+      return new Blob([bytes.buffer as ArrayBuffer], {
+        type: entry.httpMetadata.contentType ?? DEFAULT_BLOB_MIME_TYPE,
+      });
+    },
+    body,
+    get bodyUsed() {
+      return bodyUsed;
+    },
+    json: async <T = unknown>() => JSON.parse(await text()) as T,
+    text,
+  };
+};
+
+type MemoryR2ListItem =
+  | { readonly kind: 'object'; readonly key: string }
+  | { readonly kind: 'prefix'; readonly key: string };
+
+const compareR2Keys = (left: string, right: string): number => {
+  const leftBytes = encoder.encode(left);
+  const rightBytes = encoder.encode(right);
+  const length = Math.min(leftBytes.length, rightBytes.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference = (leftBytes[index] ?? 0) - (rightBytes[index] ?? 0);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return leftBytes.length - rightBytes.length;
+};
+
+const compareListItemKinds = (
+  left: MemoryR2ListItem['kind'],
+  right: MemoryR2ListItem['kind']
+): number => {
+  if (left === right) {
+    return 0;
+  }
+  return left === 'object' ? -1 : 1;
+};
+
+const compareListItems = (
+  left: MemoryR2ListItem,
+  right: MemoryR2ListItem
+): number =>
+  compareR2Keys(left.key, right.key) ||
+  compareListItemKinds(left.kind, right.kind);
+
+const listItems = (
+  entries: ReadonlyMap<string, MemoryR2Entry>,
+  options: CloudflareR2ListOptions | undefined
+): readonly MemoryR2ListItem[] => {
+  const prefix = options?.prefix ?? '';
+  const delimiter = options?.delimiter;
+  const prefixes = new Set<string>();
+  const items: MemoryR2ListItem[] = [];
+  for (const name of entries.keys()) {
+    if (!name.startsWith(prefix)) {
+      continue;
+    }
+    if (delimiter !== undefined && delimiter.length > 0) {
+      const remainder = name.slice(prefix.length);
+      const delimiterIndex = remainder.indexOf(delimiter);
+      if (delimiterIndex !== -1) {
+        const delimitedPrefix = name.slice(0, prefix.length + delimiterIndex);
+        if (!prefixes.has(delimitedPrefix)) {
+          prefixes.add(delimitedPrefix);
+          items.push({ key: delimitedPrefix, kind: 'prefix' });
+        }
+        continue;
+      }
+    }
+    items.push({ key: name, kind: 'object' });
+  }
+  return items.toSorted(compareListItems);
+};
+
+/**
+ * Create an in-memory R2 bucket binding.
+ *
+ * This is the mock behind `cloudflareR2`, exported for tests that want a
+ * bucket without a Workers runtime.
+ *
+ * @example
+ * ```ts
+ * import { createMemoryR2 } from '@ontrails/cloudflare/r2';
+ *
+ * const bucket = createMemoryR2();
+ * await bucket.put('notes.txt', 'hello', {
+ *   httpMetadata: { contentType: 'text/plain' },
+ * });
+ * await (await bucket.get('notes.txt'))?.text(); // 'hello'
+ * ```
+ */
+export const createMemoryR2 = (): MemoryCloudflareR2Bucket => {
+  const entries = new Map<string, MemoryR2Entry>();
+  const cursorPositions = new Map<string, MemoryR2ListItem>();
+  let version = 0;
+
+  return {
+    clear() {
+      entries.clear();
+      cursorPositions.clear();
+    },
+    delete: (key) => {
+      const keys = Array.isArray(key) ? key : [key];
+      if (keys.length > MAX_MULTI_DELETE_KEYS) {
+        return Promise.reject(
+          new ValidationError(
+            `Cloudflare R2 deletes accept at most ${String(MAX_MULTI_DELETE_KEYS)} keys per call; received ${String(keys.length)}. Chunk larger deletes before invoking the bucket.`
+          )
+        );
+      }
+      for (const name of keys) {
+        entries.delete(name);
+      }
+      return Promise.resolve();
+    },
+    get: (key) => {
+      const entry = entries.get(key);
+      return Promise.resolve(entry === undefined ? null : objectBody(entry));
+    },
+    head: (key) => {
+      const entry = entries.get(key);
+      return Promise.resolve(
+        entry === undefined ? null : objectMetadata(entry)
+      );
+    },
+    list: (options) => {
+      const limit = Math.min(
+        MAX_LIST_LIMIT,
+        Math.max(1, options?.limit ?? DEFAULT_LIST_LIMIT)
+      );
+      const items = listItems(entries, options);
+      const decodedCursor =
+        options?.cursor === undefined
+          ? undefined
+          : cursorPositions.get(options.cursor);
+      const startIndex = items.findIndex((item) => {
+        if (decodedCursor !== undefined) {
+          return compareListItems(item, decodedCursor) > 0;
+        }
+        const keyLowerBound = options?.cursor ?? options?.startAfter;
+        return (
+          keyLowerBound === undefined ||
+          compareR2Keys(item.key, keyLowerBound) > 0
+        );
+      });
+      const pageStart = startIndex === -1 ? items.length : startIndex;
+      const page = items.slice(pageStart, pageStart + limit);
+      const truncated = pageStart + page.length < items.length;
+      const lastItem = page.at(-1);
+      const cursor =
+        truncated && lastItem !== undefined ? crypto.randomUUID() : undefined;
+      if (cursor !== undefined && lastItem !== undefined) {
+        cursorPositions.set(cursor, lastItem);
+      }
+      return Promise.resolve({
+        ...(cursor === undefined ? {} : { cursor }),
+        delimitedPrefixes: page.flatMap((item) =>
+          item.kind === 'prefix' ? [item.key] : []
+        ),
+        objects: page.flatMap((item) => {
+          if (item.kind === 'prefix') {
+            return [];
+          }
+          const entry = entries.get(item.key);
+          return entry === undefined
+            ? []
+            : [listedObjectMetadata(entry, options?.include)];
+        }),
+        truncated,
+      });
+    },
+    put: async (key, value, options) => {
+      version += 1;
+      const bytes = await normalizePutBody(value);
+      const etag = createEtag(bytes, version);
+      const entry: MemoryR2Entry = {
+        bytes,
+        customMetadata: Object.freeze({ ...options?.customMetadata }),
+        etag,
+        httpMetadata: normalizeHttpMetadata(options?.httpMetadata),
+        key,
+        ...(options?.storageClass === undefined
+          ? {}
+          : { storageClass: options.storageClass }),
+        uploaded: new Date(),
+        version: String(version),
+      };
+      entries.set(key, entry);
+      return objectMetadata(entry);
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// BlobRef bridge
+// ---------------------------------------------------------------------------
+
+/** Options for {@link r2ObjectToBlobRef}. */
+export interface R2ObjectToBlobRefOptions {
+  readonly mimeType?: string | undefined;
+  readonly name?: string | undefined;
+}
+
+const returnedObjectSize = (object: CloudflareR2ObjectBody): number => {
+  const { range } = object;
+  if (range === undefined) {
+    return object.size;
+  }
+  if (range.length !== undefined) {
+    const offset = range.offset ?? 0;
+    return Math.min(
+      Math.max(0, range.length),
+      Math.max(0, object.size - offset)
+    );
+  }
+  if (range.suffix !== undefined) {
+    return Math.min(Math.max(0, range.suffix), object.size);
+  }
+  return Math.max(0, object.size - (range.offset ?? 0));
+};
+
+/**
+ * Convert a fetched R2 object body into a core BlobRef.
+ *
+ * @example
+ * ```ts
+ * import { r2ObjectToBlobRef } from '@ontrails/cloudflare/r2';
+ *
+ * const object = await bucket.get('report.pdf');
+ * if (object !== null && 'body' in object) {
+ *   return Result.ok(r2ObjectToBlobRef(object));
+ * }
+ * ```
+ */
+export const r2ObjectToBlobRef = (
+  object: CloudflareR2ObjectBody,
+  options: R2ObjectToBlobRefOptions = {}
+): BlobRef =>
+  createBlobRef({
+    data: object.body,
+    mimeType:
+      options.mimeType ??
+      object.httpMetadata.contentType ??
+      DEFAULT_BLOB_MIME_TYPE,
+    name: options.name ?? object.key,
+    size: returnedObjectSize(object),
+  });
+
+// ---------------------------------------------------------------------------
+// Resource factory
+// ---------------------------------------------------------------------------
+
+/** Options for {@link cloudflareR2}. */
+export interface CloudflareR2Options {
+  /** The wrangler binding name (an `r2_buckets` entry's `binding`). */
+  readonly binding: string;
+  readonly description?: string | undefined;
+  readonly meta?: Readonly<Record<string, unknown>> | undefined;
+}
+
+const isR2BucketBinding = (value: unknown): value is CloudflareR2Bucket => {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<Record<keyof CloudflareR2Bucket, unknown>>;
+  return (
+    typeof candidate.get === 'function' &&
+    typeof candidate.put === 'function' &&
+    typeof candidate.delete === 'function' &&
+    typeof candidate.head === 'function' &&
+    typeof candidate.list === 'function'
+  );
+};
+
+/**
+ * Author a Trails resource wrapping a Cloudflare R2 bucket binding.
+ *
+ * The real R2 binding arrives through the Workers env bridge. The resource
+ * mock stores object bytes in memory so trails work in `testAll`.
+ *
+ * @example
+ * ```ts
+ * import { NotFoundError, Result, blobRefSchema, trail } from '@ontrails/core';
+ * import { cloudflareR2, r2ObjectToBlobRef } from '@ontrails/cloudflare/r2';
+ * import { z } from 'zod';
+ *
+ * const assets = cloudflareR2('assets', { binding: 'ASSETS' });
+ *
+ * const readAsset = trail('asset.read', {
+ *   implementation: async (input, ctx) => {
+ *     const object = await assets.from(ctx).get(input.key);
+ *     if (object === null || !('body' in object)) {
+ *       return Result.err(new NotFoundError(`Asset "${input.key}" not found`));
+ *     }
+ *     return Result.ok(r2ObjectToBlobRef(object));
+ *   },
+ *   input: z.object({ key: z.string() }),
+ *   output: blobRefSchema,
+ *   resources: [assets],
+ * });
+ * ```
+ */
+export const cloudflareR2 = (
+  id: string,
+  options: CloudflareR2Options
+): Resource<CloudflareR2Bucket> => {
+  const definition = resource<CloudflareR2Bucket>(id, {
+    create: () =>
+      Result.err(
+        new InternalError(
+          `Resource "${id}" wraps Cloudflare R2 binding "${options.binding}", which only exists on a Workers env. Serve the topo with createWorkersHandler from @ontrails/cloudflare/workers, or rely on the in-memory mock in tests.`,
+          { context: { binding: options.binding, resourceId: id } }
+        )
+      ),
+    description:
+      options.description ??
+      `Cloudflare R2 bucket bound to "${options.binding}"`,
+    meta: {
+      ...options.meta,
+      'cloudflare.binding': options.binding,
+      'cloudflare.service': 'r2',
+    },
+    mock: () => createMemoryR2(),
+  });
+  registerEnvBinding(definition, {
+    binding: options.binding,
+    fromEnv: (value) =>
+      isR2BucketBinding(value)
+        ? Result.ok(value)
+        : Result.err(
+            new InternalError(
+              `Worker env binding "${options.binding}" for resource "${id}" is not an R2 bucket. Check the r2_buckets entry in your wrangler configuration.`,
+              { context: { binding: options.binding, resourceId: id } }
+            )
+          ),
+  });
+  return definition;
+};

--- a/packages/warden/src/rules/public-export-example-coverage.ts
+++ b/packages/warden/src/rules/public-export-example-coverage.ts
@@ -120,6 +120,7 @@ export const PUBLIC_API_EXAMPLE_TARGETS: readonly PublicApiPackageTarget[] = [
       'cloudflareKv',
       'cloudflareD1',
       'cloudflareQueue',
+      'cloudflareR2',
     ],
     packageName: '@ontrails/cloudflare',
   },


### PR DESCRIPTION
## Context
Part 7 of the stack. This adds Cloudflare R2 as a blob resource and closes the Cloudflare collection slice.

## What changed
- Added `cloudflareR2`, `createMemoryR2`, and `r2ObjectToBlobRef`.
- Added object put/get/head/delete/list behavior, delimiter grouping, cursor pagination, multi-delete, and single-consumption BlobRef stream tests.
- Updated Cloudflare overlay facts, README guidance, package exports, public export docs, and release intent.

## Verification
- `bun test adapters/cloudflare/src/r2/__tests__/r2.test.ts adapters/cloudflare/src/__tests__/facts.test.ts packages/warden/src/__tests__/public-export-example-coverage.test.ts`
- `bun test adapters/cloudflare/src`
- `bun run typecheck`
- `bun run lint`
- `bun run build`
- `bun run test`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun run lock:roundtrip`
- Pre-push stable checks passed before resubmit.

## Risks / rollout
R2 support intentionally excludes preconditions, ranges, checksums, multipart upload, public URLs, signed URLs, and event integration until those contracts are designed.
