### PR TITLE
feat(regrade): harden blaze transition planning

### DIFF
--- a/.changeset/trl-1018-blaze-plan-readiness.md
+++ b/.changeset/trl-1018-blaze-plan-readiness.md
@@ -1,0 +1,9 @@
+---
+'@ontrails/warden': patch
+'@ontrails/regrade': patch
+---
+
+Harden governed v1 vocabulary transitions with property-key-only blaze literal
+rewrites, structured review for ambiguous literal positions, explicit
+scratch/history boundaries, and scan-only preservation for migration plans and
+historical decision evidence.

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -49,10 +49,24 @@ const parseJson = (text: string | undefined): unknown => {
 const makeTempDir = (): string =>
   mkdtempSync(join(tmpdir(), `trails-mcp-regrade-test-${Date.now()}-`));
 const facetTrailheadRegistryExcludes = [
+  '.agents/goals/**',
+  '**/.agents/goals/**',
   '.agents/memory/**',
+  '**/.agents/memory/**',
+  '.agents/notes/**',
+  '**/.agents/notes/**',
+  '.claude/agent-memory/**',
+  '**/.claude/agent-memory/**',
   '.agents/plans/archive/**',
+  '**/.agents/plans/archive/**',
   '.changeset/**',
+  '**/.changeset/**',
+  '.scratch/**',
+  '**/.scratch/**',
+  '.trails/regrade/history/**',
+  '**/.trails/regrade/history/**',
   '**/CHANGELOG.md',
+  '**/.tmp-tests/**',
   'packages/warden/src/rules/retired-vocabulary.ts',
 ];
 
@@ -580,11 +594,7 @@ describe('Trails MCP surface shaping', () => {
         from: 'facet',
         id: 'v1-facet-trailhead',
         scope: {
-          exclude: [
-            ...facetTrailheadRegistryExcludes,
-            '.agents/notes/**',
-            '.scratch/**',
-          ],
+          exclude: facetTrailheadRegistryExcludes,
         },
         to: 'trailhead',
       });

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -27,12 +27,42 @@ const trailsBinPath = fileURLToPath(
 );
 const cliTimeoutMs = 30_000;
 const facetTrailheadRegistryExcludes = [
+  '.agents/goals/**',
+  '**/.agents/goals/**',
   '.agents/memory/**',
+  '**/.agents/memory/**',
+  '.agents/notes/**',
+  '**/.agents/notes/**',
+  '.claude/agent-memory/**',
+  '**/.claude/agent-memory/**',
   '.agents/plans/archive/**',
+  '**/.agents/plans/archive/**',
   '.changeset/**',
+  '**/.changeset/**',
+  '.scratch/**',
+  '**/.scratch/**',
+  '.trails/regrade/history/**',
+  '**/.trails/regrade/history/**',
   '**/CHANGELOG.md',
+  '**/.tmp-tests/**',
   'packages/warden/src/rules/retired-vocabulary.ts',
 ];
+const facetTrailheadRegistryHistoricalPreserve = {
+  paths: [
+    '.agents/plans/**',
+    '**/.agents/plans/**',
+    'docs/adr/0*.md',
+    'docs/adr/decision-map.json',
+    'docs/migration/**',
+    'docs/releases/beta*.md',
+    'docs/releases/v1-vocabulary-reset.md',
+    'docs/releases/v1-vocabulary-transition-workflow.md',
+    'scripts/vocab-cutover-*.ts',
+  ],
+  pattern: '(?:facet|facets|Facet)',
+  reason:
+    'Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.',
+};
 
 interface RawCliRun {
   readonly exitCode: number;
@@ -2593,11 +2623,7 @@ describe('trails regrade', () => {
         from: 'facet',
         id: 'v1-facet-trailhead',
         scope: {
-          exclude: [
-            ...facetTrailheadRegistryExcludes,
-            '.agents/notes/**',
-            '.scratch/**',
-          ],
+          exclude: facetTrailheadRegistryExcludes,
         },
         to: 'trailhead',
       });
@@ -2934,10 +2960,10 @@ describe('trails regrade', () => {
   test('CLI accepts path-scope exclude globs for vocabulary regrades', () => {
     const dir = makeTempDir();
     try {
-      writeFile(dir, '.agents/notes/history.md', 'facet\n');
       writeFile(dir, '.agents/skills/trails/SKILL.md', 'facet\n');
-      writeFile(dir, '.scratch/history.md', 'facet\n');
+      writeFile(dir, 'docs/ignored/history.md', 'facet\n');
       writeFile(dir, 'plugin/skills/trails/SKILL.md', 'facet\n');
+      writeFile(dir, 'private/history.md', 'facet\n');
 
       const result = runRawCli([
         'regrade',
@@ -2946,9 +2972,9 @@ describe('trails regrade', () => {
         '--root-dir',
         dir,
         '--exclude',
-        '.scratch/**',
+        'private/**',
         '--exclude',
-        '.agents/notes/**',
+        'docs/ignored/**',
         '--json',
       ]);
 
@@ -2981,8 +3007,8 @@ describe('trails regrade', () => {
       };
       expect(parsed.run?.plan?.scope?.exclude).toEqual([
         ...facetTrailheadRegistryExcludes,
-        '.scratch/**',
-        '.agents/notes/**',
+        'private/**',
+        'docs/ignored/**',
       ]);
       expect(parsed.run?.ledger?.occurrences?.map((o) => o.path)).toEqual([
         '.agents/skills/trails/SKILL.md',
@@ -3112,6 +3138,7 @@ describe('trails regrade', () => {
         };
       };
       expect(parsed.run?.plan?.preserve).toEqual([
+        facetTrailheadRegistryHistoricalPreserve,
         {
           disposition: 'preserve-current-live-api',
           paths: ['src/**'],
@@ -3519,14 +3546,14 @@ describe('trails regrade', () => {
         'trails.config.json',
         JSON.stringify({
           regrade: {
-            scope: { exclude: ['.scratch/**', '.agents/notes/**'] },
+            scope: { exclude: ['private/**', 'docs/ignored/**'] },
           },
         })
       );
-      writeFile(dir, '.agents/notes/history.md', 'facet\n');
       writeFile(dir, '.agents/skills/trails/SKILL.md', 'facet\n');
-      writeFile(dir, '.scratch/history.md', 'facet\n');
+      writeFile(dir, 'docs/ignored/history.md', 'facet\n');
       writeFile(dir, 'plugin/skills/trails/SKILL.md', 'facet\n');
+      writeFile(dir, 'private/history.md', 'facet\n');
 
       const result = runRawCli([
         'regrade',
@@ -3549,8 +3576,8 @@ describe('trails regrade', () => {
       };
       expect(parsed.run?.plan?.scope?.exclude).toEqual([
         ...facetTrailheadRegistryExcludes,
-        '.scratch/**',
-        '.agents/notes/**',
+        'private/**',
+        'docs/ignored/**',
       ]);
       expect(parsed.run?.ledger?.occurrences?.map((o) => o.path)).toEqual([
         '.agents/skills/trails/SKILL.md',
@@ -3570,17 +3597,17 @@ describe('trails regrade', () => {
         'trails.config.json',
         JSON.stringify({
           regrade: {
-            scope: { exclude: ['.agents/notes/**'] },
+            scope: { exclude: ['private/**'] },
           },
         })
       );
-      writeFile(dir, '.agents/notes/history.md', 'facet\n');
-      writeFile(dir, '.scratch/history.md', 'facet\n');
+      writeFile(dir, 'docs/ignored/history.md', 'facet\n');
       writeFile(dir, 'docs/keep.md', 'facet\n');
+      writeFile(dir, 'private/history.md', 'facet\n');
 
       const result = await regradeTrail.blaze(
         {
-          exclude: ['.scratch/**'],
+          exclude: ['docs/ignored/**'],
           from: 'facet',
           rootDir: dir,
           to: 'trailhead',
@@ -3594,11 +3621,11 @@ describe('trails regrade', () => {
       }
       expect(result.value.run?.plan.scope?.exclude).toEqual([
         ...facetTrailheadRegistryExcludes,
-        '.scratch/**',
+        'docs/ignored/**',
       ]);
       expect(result.value.run?.ledger.occurrences.map((o) => o.path)).toEqual([
-        '.agents/notes/history.md',
         'docs/keep.md',
+        'private/history.md',
       ]);
       expect(result.value.skipsByReason).toMatchObject({ 'ignored-glob': 1 });
     } finally {

--- a/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
+++ b/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
@@ -354,6 +354,81 @@ describe('createAstIdentifierRenameClass', () => {
     );
   });
 
+  test('rewrites governed blaze string literal keys exactly', () => {
+    const transition = getGovernedVocabularyTransition(
+      'v1-blaze-implementation'
+    );
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected blaze vocabulary transition.');
+    }
+
+    const classes = createGovernedAstIdentifierRenameClasses(transition);
+    const blazeLiteralClass = classes.find((cls) =>
+      cls.id.includes(
+        'ast-string-literal-rename:v1-blaze-implementation:blaze->implementation'
+      )
+    );
+    expect(blazeLiteralClass).toBeDefined();
+    if (blazeLiteralClass === undefined) {
+      throw new Error('Expected blaze literal rename class.');
+    }
+
+    const result = blazeLiteralClass.apply(
+      [
+        "const authored = { ['blaze']: implementation };",
+        'const keyed = { "blaze": implementation };',
+        'const idiomatic = ["blazing", "trailblaze"];',
+        '',
+      ].join('\n'),
+      { path: 'src/trails.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        "const authored = { ['implementation']: implementation };",
+        'const keyed = { "implementation": implementation };',
+        'const idiomatic = ["blazing", "trailblaze"];',
+        '',
+      ].join('\n')
+    );
+
+    for (const source of [
+      'type Runtime = Pick<TrailContract, "blaze">;',
+      'const label = "blaze";',
+    ]) {
+      expect(
+        blazeLiteralClass.apply(source, { path: 'src/trails.ts' })
+      ).toMatchObject({
+        kind: 'needs-review',
+        reason: 'ast-string-literal-review-position',
+      });
+    }
+
+    const preservingClasses = createGovernedAstIdentifierRenameClasses(
+      transition,
+      {
+        shouldPreserve: (occurrence) =>
+          occurrence.path === 'scripts/vocab-cutover-map.ts',
+      }
+    );
+    const preservingLiteralClass = preservingClasses.find((cls) =>
+      cls.id.includes(
+        'ast-string-literal-rename:v1-blaze-implementation:blaze->implementation'
+      )
+    );
+    expect(preservingLiteralClass).toBeDefined();
+    if (preservingLiteralClass === undefined) {
+      throw new Error('Expected preserving blaze literal rename class.');
+    }
+    expect(
+      preservingLiteralClass.apply("const historical = 'blaze';", {
+        path: 'scripts/vocab-cutover-map.ts',
+      })
+    ).toMatchObject({ kind: 'no-op' });
+  });
+
   test('routes governed registry shadow declarations to review', () => {
     const transition = getGovernedVocabularyTransition('cross-compose');
     expect(transition).toBeDefined();

--- a/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
+++ b/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
@@ -44,14 +44,44 @@ describe('runVocabularyRegrade', () => {
       from: 'facet',
       id: 'v1-facet-trailhead',
       kind: 'vocabulary',
+      preserve: [
+        {
+          paths: [
+            '.agents/plans/**',
+            '**/.agents/plans/**',
+            'docs/adr/0*.md',
+            'docs/adr/decision-map.json',
+            'docs/migration/**',
+            'docs/releases/beta*.md',
+            'docs/releases/v1-vocabulary-reset.md',
+            'docs/releases/v1-vocabulary-transition-workflow.md',
+            'scripts/vocab-cutover-*.ts',
+          ],
+          pattern: '(?:facet|facets|Facet)',
+          reason:
+            'Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.',
+        },
+      ],
       scope: {
-        exclude: [
+        exclude: expect.arrayContaining([
+          '.agents/goals/**',
+          '**/.agents/goals/**',
           '.agents/memory/**',
+          '**/.agents/memory/**',
+          '.agents/notes/**',
+          '**/.agents/notes/**',
           '.agents/plans/archive/**',
+          '**/.agents/plans/archive/**',
           '.changeset/**',
+          '**/.changeset/**',
+          '.scratch/**',
+          '**/.scratch/**',
+          '.trails/regrade/history/**',
+          '**/.trails/regrade/history/**',
           '**/CHANGELOG.md',
+          '**/.tmp-tests/**',
           'packages/warden/src/rules/retired-vocabulary.ts',
-        ],
+        ]),
       },
       to: 'trailhead',
     });
@@ -164,6 +194,72 @@ describe('runVocabularyRegrade', () => {
       expect(result.value.run.report.gate.reasons).toContain(
         'deferred-forms-or-occurrences'
       );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('registry historical preserves hide compounds only in historical paths', () => {
+    const transition = getGovernedVocabularyTransition(
+      'v1-blaze-implementation'
+    );
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected blaze vocabulary transition.');
+    }
+    const plan = vocabularyRegradePlanFromTransition(transition);
+    if (plan === null) {
+      throw new Error(
+        'Expected blaze vocabulary transition to produce a plan.'
+      );
+    }
+
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        '.agents/plans/v1-vocabulary-plan.md',
+        'Preserve blazeBody as authored historical planning evidence.\n'
+      );
+      writeFile(
+        dir,
+        'docs/live.md',
+        'Current docs must still review blazeBody before migration closes.\n'
+      );
+      writeFile(
+        dir,
+        'packages/store/.agents/notes/history.md',
+        'Nested agent notes keep the historical blazeBody untouched.\n'
+      );
+
+      const result = runVocabularyRegrade({
+        plan: { ...plan, scope: { ...plan.scope, extensions: ['.md'] } },
+        root: dir,
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.run.ledger.occurrences).toMatchObject([
+        {
+          form: 'blazeBody',
+          path: '.agents/plans/v1-vocabulary-plan.md',
+          verdict: 'skipped',
+        },
+        {
+          form: 'blazeBody',
+          path: 'docs/live.md',
+          verdict: 'deferred',
+        },
+      ]);
+      expect(result.value.run.report).toMatchObject({
+        deferred: 1,
+        gate: { status: 'open' },
+        open: 1,
+        skipped: 1,
+      });
+      expect(result.value.skipsByReason).toMatchObject({ 'ignored-glob': 1 });
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/regrade/src/downstream/ast-rewrite.ts
+++ b/packages/regrade/src/downstream/ast-rewrite.ts
@@ -253,6 +253,7 @@ export interface AstStringLiteralRenameClassOptions {
   readonly describe?: string;
   readonly from: string;
   readonly id?: string;
+  readonly match?: 'exact' | 'property-key';
   readonly shouldPreserve?: (
     occurrence: AstIdentifierRenameOccurrence
   ) => boolean;
@@ -439,6 +440,35 @@ export const createAstStringLiteralRenameClass = (
         return null;
       }
 
+      if (options.match === 'property-key' && context.key !== 'key') {
+        const location = offsetToLineColumn(context.source, node.start);
+        const caution = `String literal "${options.from}" is not an authored property key; routed to review.`;
+        return {
+          detail: {
+            candidateReplacement: options.to,
+            expectedTarget: `Review whether string literal "${options.from}" names the authored contract field before renaming it to "${options.to}".`,
+            judgment: 'unresolved',
+            matchedForm: options.from,
+            nodeKind: node.type,
+            preserveCautions: [caution],
+            reason: 'ast-string-literal-review-position',
+            signals: ['ast:string-literal-rename', 'ast:property-key-required'],
+            span: {
+              column: location.column,
+              end: node.end,
+              line: location.line,
+              start: node.start,
+            },
+            suggestedValidation:
+              'Confirm the literal is a trail contract field before changing it.',
+            symbol: options.from,
+          },
+          kind: 'review',
+          note: caution,
+          reason: 'ast-string-literal-review-position',
+        };
+      }
+
       return {
         edit: createSourceEdit(span.start, span.end, options.to),
         kind: 'edit',
@@ -472,6 +502,7 @@ export const createGovernedAstIdentifierRenameClasses = (
       describe: `Rename governed string literal "${rename.from}" to "${rename.to}" for ${transition.id}.`,
       from: rename.from,
       id: `ast-string-literal-rename:${transition.id}:${rename.from}->${rename.to}`,
+      ...(rename.match === undefined ? {} : { match: rename.match }),
       ...(options.shouldPreserve === undefined
         ? {}
         : { shouldPreserve: options.shouldPreserve }),

--- a/packages/warden/src/__tests__/retired-vocabulary.test.ts
+++ b/packages/warden/src/__tests__/retired-vocabulary.test.ts
@@ -67,6 +67,64 @@ describe('governed vocabulary registry', () => {
     }
   });
 
+  test('separates ignored state from scanned historical evidence', () => {
+    const v1Transitions = listGovernedVocabularyTransitions().filter(
+      (transition) => transition.id.startsWith('v1-')
+    );
+
+    for (const transition of v1Transitions) {
+      expect(transition.scope?.exclude).toContain('.scratch/**');
+      expect(transition.scope?.exclude).toContain('.agents/goals/**');
+      expect(transition.scope?.exclude).toContain('**/.agents/goals/**');
+      expect(transition.scope?.exclude).toContain('.agents/notes/**');
+      expect(transition.scope?.exclude).toContain('**/.agents/notes/**');
+      expect(transition.scope?.exclude).toContain('.claude/agent-memory/**');
+      expect(transition.scope?.exclude).toContain('**/.claude/agent-memory/**');
+      expect(transition.scope?.exclude).toContain('**/.tmp-tests/**');
+
+      const historical = transition.preserve.find((rule) =>
+        rule.paths?.includes('docs/adr/0*.md')
+      );
+      expect(historical?.paths).toContain('.agents/plans/**');
+      expect(historical?.paths).toContain('**/.agents/plans/**');
+      expect(historical?.paths).toContain('docs/adr/decision-map.json');
+      expect(historical?.paths).toContain('docs/migration/**');
+      expect(historical?.paths).toContain('docs/releases/beta*.md');
+      expect(historical?.paths).toContain('scripts/vocab-cutover-*.ts');
+      expect(historical?.pattern).toBeDefined();
+    }
+  });
+
+  test('preserves historical compounds with escaped old-form patterns', () => {
+    const blaze = getGovernedVocabularyTransition('v1-blaze-implementation');
+
+    const blazeHistorical = blaze?.preserve.find((rule) =>
+      rule.paths?.includes('.agents/plans/**')
+    );
+
+    expect(blazeHistorical?.pattern).toBe(
+      '(?:blaze|blazes|Blaze|blazing|blazed|trailblaze)'
+    );
+    expect('blazeBody').toMatch(new RegExp(blazeHistorical?.pattern ?? ''));
+  });
+
+  test('governs exact blaze string literals without inflected literal rewrites', () => {
+    const blaze = getGovernedVocabularyTransition('v1-blaze-implementation');
+
+    expect(blaze?.status).toBe('planned');
+    expect(blaze?.stringLiteralRenames).toEqual([
+      { from: 'blaze', match: 'property-key', to: 'implementation' },
+    ]);
+
+    const literalSources =
+      blaze?.stringLiteralRenames.map((rename) => rename.from) ?? [];
+    expect(literalSources).not.toContain('Blaze');
+    expect(literalSources).not.toContain('blazes');
+    expect(literalSources).not.toContain('blazing');
+    expect(literalSources).not.toContain('blazed');
+    expect(literalSources).not.toContain('trailblaze');
+  });
+
   test('rejects duplicate ids and duplicate source terms', () => {
     const [transition] = governedVocabularyTransitions;
     if (transition === undefined) {

--- a/packages/warden/src/rules/retired-vocabulary.ts
+++ b/packages/warden/src/rules/retired-vocabulary.ts
@@ -50,6 +50,7 @@ export const governedVocabularySymbolRenameSchema = z.object({
 
 export const governedVocabularyLiteralRenameSchema = z.object({
   from: z.string().min(1),
+  match: z.enum(['exact', 'property-key']).optional(),
   to: z.string().min(1),
 });
 
@@ -136,10 +137,36 @@ const reviewFunctionParamDeclarations = {
 };
 
 const v1VocabularyHistoricalExcludes = [
+  '.agents/goals/**',
+  '**/.agents/goals/**',
   '.agents/memory/**',
+  '**/.agents/memory/**',
+  '.agents/notes/**',
+  '**/.agents/notes/**',
+  '.claude/agent-memory/**',
+  '**/.claude/agent-memory/**',
   '.agents/plans/archive/**',
+  '**/.agents/plans/archive/**',
   '.changeset/**',
+  '**/.changeset/**',
+  '.scratch/**',
+  '**/.scratch/**',
+  '.trails/regrade/history/**',
+  '**/.trails/regrade/history/**',
   '**/CHANGELOG.md',
+  '**/.tmp-tests/**',
+];
+
+const v1VocabularyHistoricalPreservePaths = [
+  '.agents/plans/**',
+  '**/.agents/plans/**',
+  'docs/adr/0*.md',
+  'docs/adr/decision-map.json',
+  'docs/migration/**',
+  'docs/releases/beta*.md',
+  'docs/releases/v1-vocabulary-reset.md',
+  'docs/releases/v1-vocabulary-transition-workflow.md',
+  'scripts/vocab-cutover-*.ts',
 ];
 
 const v1VocabularySelfExcludes = [
@@ -148,11 +175,28 @@ const v1VocabularySelfExcludes = [
 
 const unique = (values: readonly string[]): string[] => [...new Set(values)];
 
+const escapeRegExp = (value: string): string =>
+  value.replaceAll(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const formsPattern = (forms: readonly string[]): string =>
+  `(?:${forms.map(escapeRegExp).join('|')})`;
+
 const defineV1Transition = (
   input: GovernedVocabularyTransitionInput
 ): GovernedVocabularyTransition =>
   defineTransition({
     ...input,
+    preserve: [
+      {
+        paths: v1VocabularyHistoricalPreservePaths,
+        pattern: formsPattern(
+          unique([...(input.oldForms ?? []), ...(input.reviewForms ?? [])])
+        ),
+        reason:
+          'Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.',
+      },
+      ...(input.preserve ?? []),
+    ],
     scope: {
       ...input.scope,
       exclude: unique([
@@ -221,6 +265,9 @@ export const governedVocabularyTransitions =
         blazes: 'implementations',
       },
       status: 'planned',
+      stringLiteralRenames: [
+        { from: 'blaze', match: 'property-key', to: 'implementation' },
+      ],
       symbolRenames: [
         {
           ...reviewFunctionParamDeclarations,


### PR DESCRIPTION
## Context

Implements the planning/readiness half of [TRL-1018](https://linear.app/outfitter/issue/TRL-1018/) before the public `blaze` to `implementation` cutover.

## What changed

- Harden the governed Regrade transition plan for literal keys, compound identifiers, and explicit historical/policy preserves.
- Keep the migration plan authored and reviewable before any apply step.
- Add CLI/MCP and transition-registry coverage for the planned family.

## Verification

- Focused Regrade, Warden, CLI, and MCP transition tests.
- GPT-5.5 local review reached 5/5 after fixing the generated-plan expectation.
- Full final-stack check/test/build/publish-pack gates passed.

## Risk

This branch prepares the migration engine and plan only. The actual hard cut is isolated in [#934](https://github.com/outfitter-dev/trails/pull/934).