### PR TITLE
feat(regrade): govern identifier segment renames

### DIFF
--- a/.changeset/trl-1250-identifier-segment-renames.md
+++ b/.changeset/trl-1250-identifier-segment-renames.md
@@ -1,0 +1,10 @@
+---
+'@ontrails/regrade': minor
+'@ontrails/warden': minor
+---
+
+Add governed identifier-segment renames for AST-backed migrations. Regrade can
+now migrate camelCase, PascalCase, leading-underscore, and SCREAMING_SNAKE
+identifier segments, including single-segment forms such as `BLAZE` and
+`_BLAZE`, while preserving exact-mode behavior and rejecting lowercase
+substring, concatenated acronym, or inflection matches.

--- a/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
+++ b/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
@@ -207,6 +207,127 @@ describe('createAstIdentifierRenameClass', () => {
     );
   });
 
+  test('keeps exact mode from rewriting identifier segments', () => {
+    const cls = createAstIdentifierRenameClass({
+      from: 'blaze',
+      to: 'implementation',
+    });
+    const result = cls.apply(
+      [
+        'const blaze = 1;',
+        'const blazeInput = blaze;',
+        'type BlazeInput = { value: typeof blazeInput };',
+        'const findBlazeBodies = () => blazeInput;',
+        'const _blaze = blaze;',
+        'const FORK_WITHOUT_PRESERVED_BLAZE = blaze;',
+        '',
+      ].join('\n'),
+      { path: 'src/blaze.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        'const implementation = 1;',
+        'const blazeInput = implementation;',
+        'type BlazeInput = { value: typeof blazeInput };',
+        'const findBlazeBodies = () => blazeInput;',
+        'const _blaze = implementation;',
+        'const FORK_WITHOUT_PRESERVED_BLAZE = implementation;',
+        '',
+      ].join('\n')
+    );
+  });
+
+  test('renames identifier segments across supported identifier shapes', () => {
+    const cls = createAstIdentifierRenameClass({
+      from: 'blaze',
+      match: 'identifier-segment',
+      to: 'implementation',
+    });
+    const result = cls.apply(
+      [
+        'const blaze = 1;',
+        'const blazeInput = blaze;',
+        'type BlazeInput = { value: typeof blazeInput };',
+        'const findBlazeBodies = () => blazeInput;',
+        'const _blaze = findBlazeBodies;',
+        'const BLAZE = _blaze;',
+        'const _BLAZE = BLAZE;',
+        'const FORK_WITHOUT_PRESERVED_BLAZE = _blaze;',
+        'const _BLAZE_INPUT = FORK_WITHOUT_PRESERVED_BLAZE;',
+        '',
+      ].join('\n'),
+      { path: 'src/blaze.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        'const implementation = 1;',
+        'const implementationInput = implementation;',
+        'type ImplementationInput = { value: typeof implementationInput };',
+        'const findImplementationBodies = () => implementationInput;',
+        'const _implementation = findImplementationBodies;',
+        'const IMPLEMENTATION = _implementation;',
+        'const _IMPLEMENTATION = IMPLEMENTATION;',
+        'const FORK_WITHOUT_PRESERVED_IMPLEMENTATION = _implementation;',
+        'const _IMPLEMENTATION_INPUT = FORK_WITHOUT_PRESERVED_IMPLEMENTATION;',
+        '',
+      ].join('\n')
+    );
+  });
+
+  test('does not treat substrings or inflections as identifier segments', () => {
+    const cls = createAstIdentifierRenameClass({
+      from: 'blaze',
+      match: 'identifier-segment',
+      to: 'implementation',
+    });
+    const source = [
+      'const trailblaze = 1;',
+      'const blazed = trailblaze;',
+      'const blazing = blazed;',
+      'const bblaze = blazing;',
+      'const nblazed = bblaze;',
+      'const TRAILBLAZE = nblazed;',
+      'const BLAZED = TRAILBLAZE;',
+      '',
+    ].join('\n');
+
+    const result = cls.apply(source, { path: 'src/blaze.ts' });
+
+    expect(result.kind).toBe('no-op');
+    expect(result.nextSource).toBeUndefined();
+  });
+
+  test('does not rewrite comments or string literal text in segment mode', () => {
+    const cls = createAstIdentifierRenameClass({
+      from: 'blaze',
+      match: 'identifier-segment',
+      to: 'implementation',
+    });
+    const result = cls.apply(
+      [
+        '// blazeInput, BlazeInput, findBlazeBodies, and _blaze stay prose',
+        'const label = "blazeInput BlazeInput findBlazeBodies _blaze";',
+        'const blazeInput = 1;',
+        '',
+      ].join('\n'),
+      { path: 'src/blaze.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        '// blazeInput, BlazeInput, findBlazeBodies, and _blaze stay prose',
+        'const label = "blazeInput BlazeInput findBlazeBodies _blaze";',
+        'const implementationInput = 1;',
+        '',
+      ].join('\n')
+    );
+  });
+
   test('preserves individual identifier occurrences when requested', () => {
     const cls = createAstIdentifierRenameClass({
       from: 'sourceTerm',
@@ -229,6 +350,50 @@ describe('createAstIdentifierRenameClass', () => {
       [
         'export const sourceTerm = 1;',
         'export const other = targetTerm;',
+        '',
+      ].join('\n')
+    );
+  });
+
+  test('preserves one concrete identifier-segment occurrence when requested', () => {
+    const preservedOccurrences: { from: string; to: string }[] = [];
+    const cls = createAstIdentifierRenameClass({
+      from: 'blaze',
+      match: 'identifier-segment',
+      shouldPreserve: (occurrence) => {
+        if (
+          occurrence.from === 'blazeInput' &&
+          preservedOccurrences.length === 0
+        ) {
+          preservedOccurrences.push({
+            from: occurrence.from,
+            to: occurrence.to,
+          });
+          return true;
+        }
+        return false;
+      },
+      to: 'implementation',
+    });
+    const result = cls.apply(
+      [
+        'const blazeInput = 1;',
+        'const current = blazeInput;',
+        'const findBlazeBodies = blazeInput;',
+        '',
+      ].join('\n'),
+      { path: 'src/blaze.ts' }
+    );
+
+    expect(preservedOccurrences).toEqual([
+      { from: 'blazeInput', to: 'implementationInput' },
+    ]);
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        'const blazeInput = 1;',
+        'const current = implementationInput;',
+        'const findImplementationBodies = implementationInput;',
         '',
       ].join('\n')
     );
@@ -291,6 +456,47 @@ describe('createAstIdentifierRenameClass', () => {
         symbol: 'sourceTerm',
       },
     ]);
+  });
+
+  test('routes shadowed identifier-segment declarations to review with concrete details', () => {
+    const cls = createAstIdentifierRenameClass({
+      from: 'blaze',
+      match: 'identifier-segment',
+      reviewDeclarationTypes: new Set(['FunctionParam']),
+      to: 'implementation',
+    });
+
+    const result = cls.apply(
+      [
+        "import { blazeInput } from './runtime';",
+        'export const current = blazeInput();',
+        'function local(blazeInput: () => void) {',
+        '  return blazeInput();',
+        '}',
+        '',
+      ].join('\n'),
+      { path: 'src/blaze.ts' }
+    );
+
+    expect(result.kind).toBe('needs-review');
+    expect(result.reason).toBe('ast-identifier-review-declaration');
+    expect(result.nextSource).toBeUndefined();
+    expect(result.notes.join('\n')).toContain(
+      'Identifier "blazeInput" resolves to FunctionParam; routed to review.'
+    );
+    const details = result.reviewDetails ?? [];
+    expect(details).toHaveLength(2);
+    for (const detail of details) {
+      expect(detail.candidateReplacement).toBe('implementationInput');
+      expect(detail.expectedTarget).toBe(
+        'Rename identifier "blazeInput" to "implementationInput".'
+      );
+      expect(detail.matchedForm).toBe('blazeInput');
+      expect(detail.symbol).toBe('blazeInput');
+      expect(detail.preserveCautions).toEqual([
+        'Identifier "blazeInput" resolves to FunctionParam; routed to review.',
+      ]);
+    }
   });
 
   test('creates governed identifier rename classes from registry symbols', () => {
@@ -427,6 +633,108 @@ describe('createAstIdentifierRenameClass', () => {
         path: 'scripts/vocab-cutover-map.ts',
       })
     ).toMatchObject({ kind: 'no-op' });
+  });
+
+  test('uses identifier-segment mode for the governed blaze symbol rename', () => {
+    const transition = getGovernedVocabularyTransition(
+      'v1-blaze-implementation'
+    );
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected blaze vocabulary transition.');
+    }
+
+    const classes = createGovernedAstIdentifierRenameClasses(transition);
+    const blazeSymbolClass = classes.find((cls) =>
+      cls.id.includes(
+        'ast-symbol-rename:v1-blaze-implementation:blaze->implementation'
+      )
+    );
+    expect(blazeSymbolClass).toBeDefined();
+    if (blazeSymbolClass === undefined) {
+      throw new Error('Expected blaze symbol rename class.');
+    }
+
+    const result = blazeSymbolClass.apply(
+      [
+        '// findBlazeBodies stays prose in identifier rewriting',
+        'const label = "blazeInput stays a string";',
+        'const blaze = 1;',
+        'const blazeInput = blaze;',
+        'type BlazeInput = { value: typeof blazeInput };',
+        'const findBlazeBodies = () => blazeInput;',
+        'const _blaze = findBlazeBodies;',
+        'const FORK_WITHOUT_PRESERVED_BLAZE = _blaze;',
+        'const trailblaze = 1;',
+        'const blazed = trailblaze;',
+        'const blazing = blazed;',
+        'const bblaze = blazing;',
+        'const nblazed = bblaze;',
+        '',
+      ].join('\n'),
+      { path: 'src/blaze.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        '// findBlazeBodies stays prose in identifier rewriting',
+        'const label = "blazeInput stays a string";',
+        'const implementation = 1;',
+        'const implementationInput = implementation;',
+        'type ImplementationInput = { value: typeof implementationInput };',
+        'const findImplementationBodies = () => implementationInput;',
+        'const _implementation = findImplementationBodies;',
+        'const FORK_WITHOUT_PRESERVED_IMPLEMENTATION = _implementation;',
+        'const trailblaze = 1;',
+        'const blazed = trailblaze;',
+        'const blazing = blazed;',
+        'const bblaze = blazing;',
+        'const nblazed = bblaze;',
+        '',
+      ].join('\n')
+    );
+  });
+
+  test('keeps the governed blazes symbol rename exact', () => {
+    const transition = getGovernedVocabularyTransition(
+      'v1-blaze-implementation'
+    );
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected blaze vocabulary transition.');
+    }
+
+    const classes = createGovernedAstIdentifierRenameClasses(transition);
+    const blazesSymbolClass = classes.find((cls) =>
+      cls.id.includes(
+        'ast-symbol-rename:v1-blaze-implementation:blazes->implementations'
+      )
+    );
+    expect(blazesSymbolClass).toBeDefined();
+    if (blazesSymbolClass === undefined) {
+      throw new Error('Expected blazes symbol rename class.');
+    }
+
+    const result = blazesSymbolClass.apply(
+      [
+        'const blazes = 1;',
+        'const blazesInput = blazes;',
+        'const BlazeInput = blazesInput;',
+        '',
+      ].join('\n'),
+      { path: 'src/blazes.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        'const implementations = 1;',
+        'const blazesInput = implementations;',
+        'const BlazeInput = blazesInput;',
+        '',
+      ].join('\n')
+    );
   });
 
   test('routes governed registry shadow declarations to review', () => {

--- a/packages/regrade/src/downstream/ast-rewrite.ts
+++ b/packages/regrade/src/downstream/ast-rewrite.ts
@@ -233,12 +233,15 @@ export interface AstIdentifierRenameClassOptions {
   readonly describe?: string;
   readonly from: string;
   readonly id?: string;
+  readonly match?: AstIdentifierRenameMatchMode;
   readonly reviewDeclarationTypes?: ReadonlySet<string>;
   readonly shouldPreserve?: (
     occurrence: AstIdentifierRenameOccurrence
   ) => boolean;
   readonly to: string;
 }
+
+export type AstIdentifierRenameMatchMode = 'exact' | 'identifier-segment';
 
 export interface AstIdentifierRenameOccurrence {
   readonly end: number;
@@ -274,9 +277,167 @@ const identifierTokenSpan = (
     : null;
 };
 
+const toPascalIdentifierSegment = (value: string): string =>
+  value.length === 0
+    ? value
+    : `${value[0]?.toUpperCase() ?? ''}${value.slice(1)}`;
+
+const isScreamingSnakeIdentifier = (name: string): boolean =>
+  /^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*$/.test(name);
+
+const replaceScreamingSnakeIdentifierSegment = (
+  name: string,
+  from: string,
+  to: string
+): string | null => {
+  if (!isScreamingSnakeIdentifier(name)) {
+    return null;
+  }
+
+  const fromSegment = from.toUpperCase();
+  const toSegment = to.toUpperCase();
+  let changed = false;
+  const nextName = name
+    .split('_')
+    .map((segment) => {
+      if (segment !== fromSegment) {
+        return segment;
+      }
+      changed = true;
+      return toSegment;
+    })
+    .join('_');
+
+  return changed ? nextName : null;
+};
+
+const replaceCamelOrPascalIdentifierSegment = (
+  name: string,
+  from: string,
+  to: string
+): string | null => {
+  if (!/^[A-Za-z][A-Za-z0-9]*$/.test(name)) {
+    return null;
+  }
+
+  const fromPascalSegment = toPascalIdentifierSegment(from);
+  const toPascalSegment = toPascalIdentifierSegment(to);
+  const segmentPattern = /[A-Z]+(?=[A-Z][a-z]|$)|[A-Z]?[a-z]+|[0-9]+/g;
+  let cursor = 0;
+  let changed = false;
+  let nextName = '';
+
+  for (const match of name.matchAll(segmentPattern)) {
+    const [segment] = match;
+    const { index } = match;
+    if (index === undefined || index !== cursor) {
+      return null;
+    }
+
+    if (segment === from) {
+      changed = true;
+      nextName += to;
+    } else if (segment === fromPascalSegment) {
+      changed = true;
+      nextName += toPascalSegment;
+    } else {
+      nextName += segment;
+    }
+
+    cursor = index + segment.length;
+  }
+
+  if (cursor !== name.length || !changed) {
+    return null;
+  }
+
+  return nextName;
+};
+
+const deriveIdentifierSegmentTarget = (
+  name: string,
+  from: string,
+  to: string
+): string | null => {
+  const leadingUnderscores = /^_+/.exec(name)?.[0] ?? '';
+  const coreName =
+    leadingUnderscores.length > 0
+      ? name.slice(leadingUnderscores.length)
+      : name;
+  if (coreName.length === 0) {
+    return null;
+  }
+
+  const screamingSnakeTarget = replaceScreamingSnakeIdentifierSegment(
+    coreName,
+    from,
+    to
+  );
+  if (screamingSnakeTarget !== null) {
+    return `${leadingUnderscores}${screamingSnakeTarget}`;
+  }
+
+  const camelOrPascalTarget = replaceCamelOrPascalIdentifierSegment(
+    coreName,
+    from,
+    to
+  );
+  return camelOrPascalTarget === null
+    ? null
+    : `${leadingUnderscores}${camelOrPascalTarget}`;
+};
+
+interface AstIdentifierRenameMatch {
+  readonly from: string;
+  readonly span: { readonly end: number; readonly start: number } | null;
+  readonly to: string;
+}
+
+const resolveIdentifierRenameMatch = (
+  node: AstNode,
+  source: string,
+  options: {
+    readonly from: string;
+    readonly match: AstIdentifierRenameMatchMode;
+    readonly to: string;
+  }
+): AstIdentifierRenameMatch | null => {
+  if (options.match === 'exact') {
+    if (!isIdentifierNamed(node, options.from)) {
+      return null;
+    }
+
+    return {
+      from: options.from,
+      span: identifierTokenSpan(node, source, options.from),
+      to: options.to,
+    };
+  }
+
+  if (node.type !== 'Identifier') {
+    return null;
+  }
+
+  const name = identifierName(node);
+  if (name === null) {
+    return null;
+  }
+  const target = deriveIdentifierSegmentTarget(name, options.from, options.to);
+  if (target === null) {
+    return null;
+  }
+
+  return {
+    from: name,
+    span: identifierTokenSpan(node, source, name),
+    to: target,
+  };
+};
+
 export const createAstIdentifierRenameClass = (
   options: AstIdentifierRenameClassOptions
 ): RegradeClass => {
+  const matchMode = options.match ?? 'exact';
   const reviewDeclarationTypes =
     options.reviewDeclarationTypes ?? new Set<string>();
 
@@ -286,20 +447,25 @@ export const createAstIdentifierRenameClass = (
       `Rename identifier "${options.from}" to "${options.to}".`,
     id: options.id ?? `ast-identifier-rename:${options.from}->${options.to}`,
     visit: (node, context) => {
-      if (!isIdentifierNamed(node, options.from)) {
+      const match = resolveIdentifierRenameMatch(node, context.source, {
+        from: options.from,
+        match: matchMode,
+        to: options.to,
+      });
+      if (match === null) {
         return null;
       }
 
-      const span = identifierTokenSpan(node, context.source, options.from);
+      const { span } = match;
       if (span === null) {
         const location = offsetToLineColumn(context.source, node.start);
-        const caution = `Identifier "${options.from}" token span could not be verified; routed to review.`;
+        const caution = `Identifier "${match.from}" token span could not be verified; routed to review.`;
         return {
           detail: {
-            candidateReplacement: options.to,
-            expectedTarget: `Rename identifier "${options.from}" to "${options.to}".`,
+            candidateReplacement: match.to,
+            expectedTarget: `Rename identifier "${match.from}" to "${match.to}".`,
             judgment: 'unresolved',
-            matchedForm: options.from,
+            matchedForm: match.from,
             nodeKind: node.type,
             preserveCautions: [caution],
             reason: 'ast-identifier-token-span-unverified',
@@ -311,7 +477,7 @@ export const createAstIdentifierRenameClass = (
               start: node.start,
             },
             suggestedValidation: 'bun run typecheck',
-            symbol: options.from,
+            symbol: match.from,
           },
           kind: 'review',
           note: caution,
@@ -322,26 +488,26 @@ export const createAstIdentifierRenameClass = (
       if (
         options.shouldPreserve?.({
           end: span.end,
-          from: options.from,
+          from: match.from,
           path: context.path,
           source: context.source,
           start: span.start,
-          to: options.to,
+          to: match.to,
         }) === true
       ) {
         return null;
       }
 
-      const declaration = context.getDeclaration(options.from);
+      const declaration = context.getDeclaration(match.from);
       if (declaration && reviewDeclarationTypes.has(declaration.type)) {
         const location = offsetToLineColumn(context.source, span.start);
-        const caution = `Identifier "${options.from}" resolves to ${declaration.type}; routed to review.`;
+        const caution = `Identifier "${match.from}" resolves to ${declaration.type}; routed to review.`;
         return {
           detail: {
-            candidateReplacement: options.to,
-            expectedTarget: `Rename identifier "${options.from}" to "${options.to}".`,
+            candidateReplacement: match.to,
+            expectedTarget: `Rename identifier "${match.from}" to "${match.to}".`,
             judgment: 'unresolved',
-            matchedForm: options.from,
+            matchedForm: match.from,
             nodeKind: node.type,
             preserveCautions: [caution],
             reason: 'ast-identifier-review-declaration',
@@ -353,7 +519,7 @@ export const createAstIdentifierRenameClass = (
               start: span.start,
             },
             suggestedValidation: 'bun run typecheck',
-            symbol: options.from,
+            symbol: match.from,
           },
           kind: 'review',
           note: caution,
@@ -362,9 +528,9 @@ export const createAstIdentifierRenameClass = (
       }
 
       return {
-        edit: createSourceEdit(span.start, span.end, options.to),
+        edit: createSourceEdit(span.start, span.end, match.to),
         kind: 'edit',
-        note: `Renamed identifier "${options.from}" to "${options.to}".`,
+        note: `Renamed identifier "${match.from}" to "${match.to}".`,
       };
     },
   });
@@ -490,6 +656,7 @@ export const createGovernedAstIdentifierRenameClasses = (
       describe: `Rename governed symbol "${rename.from}" to "${rename.to}" for ${transition.id}.`,
       from: rename.from,
       id: `ast-symbol-rename:${transition.id}:${rename.from}->${rename.to}`,
+      match: rename.match,
       reviewDeclarationTypes: new Set(rename.reviewDeclarationTypes),
       ...(options.shouldPreserve === undefined
         ? {}

--- a/packages/warden/src/__tests__/retired-vocabulary.test.ts
+++ b/packages/warden/src/__tests__/retired-vocabulary.test.ts
@@ -5,6 +5,7 @@ import {
   formatGovernedVocabularyTransitionGuide,
   getGovernedVocabularyTransition,
   governedVocabularyRegistrySchema,
+  governedVocabularySymbolRenameSchema,
   governedVocabularyTransitions,
   listGovernedVocabularyTransitions,
 } from '../rules/retired-vocabulary.js';
@@ -52,6 +53,34 @@ describe('governed vocabulary registry', () => {
         },
       ])
     ).toThrow(ZodError);
+  });
+
+  test('defaults governed symbol rename matching to exact identifiers', () => {
+    expect(
+      governedVocabularySymbolRenameSchema.parse({
+        from: 'sourceTerm',
+        to: 'targetTerm',
+      })
+    ).toEqual({
+      from: 'sourceTerm',
+      match: 'exact',
+      reviewDeclarationTypes: [],
+      to: 'targetTerm',
+    });
+
+    expect(
+      governedVocabularySymbolRenameSchema.parse({
+        from: 'sourceTerm',
+        match: 'identifier-segment',
+        reviewDeclarationTypes: ['FunctionParam'],
+        to: 'targetTerm',
+      })
+    ).toEqual({
+      from: 'sourceTerm',
+      match: 'identifier-segment',
+      reviewDeclarationTypes: ['FunctionParam'],
+      to: 'targetTerm',
+    });
   });
 
   test('keeps v1 vocabulary transitions from rewriting the registry itself', () => {
@@ -123,6 +152,26 @@ describe('governed vocabulary registry', () => {
     expect(literalSources).not.toContain('blazing');
     expect(literalSources).not.toContain('blazed');
     expect(literalSources).not.toContain('trailblaze');
+  });
+
+  test('opts singular blaze symbols into segment matching without changing status', () => {
+    const blaze = getGovernedVocabularyTransition('v1-blaze-implementation');
+
+    expect(blaze?.status).toBe('planned');
+    expect(blaze?.symbolRenames).toEqual([
+      {
+        from: 'blaze',
+        match: 'identifier-segment',
+        reviewDeclarationTypes: ['FunctionParam'],
+        to: 'implementation',
+      },
+      {
+        from: 'blazes',
+        match: 'exact',
+        reviewDeclarationTypes: ['FunctionParam'],
+        to: 'implementations',
+      },
+    ]);
   });
 
   test('rejects duplicate ids and duplicate source terms', () => {

--- a/packages/warden/src/rules/retired-vocabulary.ts
+++ b/packages/warden/src/rules/retired-vocabulary.ts
@@ -42,8 +42,14 @@ export const governedVocabularyScopeSchema = z.object({
   include: z.array(z.string().min(1)).optional(),
 });
 
+export const governedVocabularySymbolRenameMatchModes = [
+  'exact',
+  'identifier-segment',
+] as const;
+
 export const governedVocabularySymbolRenameSchema = z.object({
   from: z.string().min(1),
+  match: z.enum(governedVocabularySymbolRenameMatchModes).default('exact'),
   reviewDeclarationTypes: z.array(z.string().min(1)).default([]),
   to: z.string().min(1),
 });
@@ -272,6 +278,7 @@ export const governedVocabularyTransitions =
         {
           ...reviewFunctionParamDeclarations,
           from: 'blaze',
+          match: 'identifier-segment',
           to: 'implementation',
         },
         {


### PR DESCRIPTION
## Context

Run-exposed prerequisite for [TRL-1018](https://linear.app/outfitter/issue/TRL-1018/): exact-name rewrites could not safely cover compound identifier segments without brittle enumeration.

## What changed

- Add governed identifier-segment renames for camel, Pascal, underscore, and screaming-snake forms.
- Avoid substring and inflection overreach.
- Add positive compound-shape and negative near-match tests.

## Verification

- Focused Regrade AST and registry tests.
- GPT-5.5 rereview reached 5/5 after adding the accepted composition coverage.
- Full final-stack check/test/build gates passed.

## Risk

The new mode is deliberately constrained to identifier segments and does not broaden prose rewriting.