### PR TITLE
fix(regrade): make history evidence completion-true

### DIFF
--- a/.changeset/trl-1251-regrade-history-evidence.md
+++ b/.changeset/trl-1251-regrade-history-evidence.md
@@ -1,0 +1,8 @@
+---
+'@ontrails/trails': patch
+---
+
+Make Regrade history hashes stable across report serialization and preserve
+pre-apply occurrence evidence alongside truthful completion counts and a
+freshly scanned post-apply completion report for replay detection. Existing
+plans and history stamped with the earlier hash serializer remain valid.

--- a/apps/trails/src/__tests__/regrade-history.test.ts
+++ b/apps/trails/src/__tests__/regrade-history.test.ts
@@ -18,9 +18,12 @@ import {
   verifyRegradeHistoryRuns,
 } from '../regrade/history.js';
 import {
+  legacyRegradeSourceHash,
   regradePlanContentHash,
   regradePlanSlugForBody,
   regradeSourceHash,
+  regradeSourceHashMatches,
+  regradeSourceHashes,
 } from '../regrade/plan-artifact.js';
 import type {
   RegradePlanArtifact,
@@ -75,6 +78,32 @@ const makeReport = (selectedClassIds: readonly string[]): RegradeReport => ({
   unknownClassIds: [],
 });
 
+const makeReportWithReviewDetail = (): RegradeReport => ({
+  ...makeReport(['term-rewrite:no-retired-cross-vocabulary']),
+  entries: [
+    {
+      classId: 'term-rewrite:no-retired-cross-vocabulary',
+      outcome: 'needs-review',
+      path: 'packages/example/src/trail.ts',
+      reason: 'term-review',
+      reviewDetails: [
+        {
+          classId: 'term-rewrite:no-retired-cross-vocabulary',
+          matchedForm: 'facet',
+          preserveCautions: ['ambiguous context', 'public docs'],
+          reason: 'ambiguous-term',
+          signals: ['term-rewrite', 'identifier'],
+          // oxlint-disable-next-line sort-keys -- non-canonical nested insertion order proves source hashing is order-stable
+          span: { start: 12, line: 2, end: 17, column: 13 },
+          symbol: 'facet',
+        },
+      ],
+    },
+  ],
+  matched: 1,
+  review: 1,
+});
+
 describe('regradePlanContentHash', () => {
   test('is stable for unchanged plans and changes on any edit', () => {
     const plan = makePlanBody();
@@ -101,6 +130,65 @@ describe('regradePlanContentHash', () => {
         preserve: [{ pattern: 'facet-flag', reason: 'External API name.' }],
       })
     ).not.toBe(first);
+  });
+});
+
+describe('regradeSourceHash', () => {
+  test('is stable across nested report key insertion order while preserving array order', () => {
+    const sourceReport = makeReportWithReviewDetail();
+    const reorderedReport: RegradeReport = {
+      ...sourceReport,
+      entries: [
+        {
+          classId: 'term-rewrite:no-retired-cross-vocabulary',
+          outcome: 'needs-review',
+          path: 'packages/example/src/trail.ts',
+          reason: 'term-review',
+          reviewDetails: [
+            // oxlint-disable-next-line sort-keys -- alternate nested insertion order is the subject under test
+            {
+              symbol: 'facet',
+              // oxlint-disable-next-line sort-keys -- alternate nested insertion order is the subject under test
+              span: { column: 13, end: 17, line: 2, start: 12 },
+              signals: ['term-rewrite', 'identifier'],
+              reason: 'ambiguous-term',
+              preserveCautions: ['ambiguous context', 'public docs'],
+              matchedForm: 'facet',
+              classId: 'term-rewrite:no-retired-cross-vocabulary',
+            },
+          ],
+        },
+      ],
+    };
+    const reorderedArrayReport: RegradeReport = {
+      ...sourceReport,
+      entries: [
+        {
+          ...sourceReport.entries[0],
+          reviewDetails: [
+            {
+              ...sourceReport.entries[0]?.reviewDetails?.[0],
+              preserveCautions: ['public docs', 'ambiguous context'],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(regradeSourceHash(reorderedReport)).toBe(
+      regradeSourceHash(sourceReport)
+    );
+    expect(regradeSourceHash(reorderedArrayReport)).not.toBe(
+      regradeSourceHash(sourceReport)
+    );
+
+    const compatibleHashes = regradeSourceHashes(sourceReport);
+    expect(compatibleHashes).toHaveLength(2);
+    expect(
+      compatibleHashes.every((hash) =>
+        regradeSourceHashMatches(hash, sourceReport)
+      )
+    ).toBe(true);
   });
 });
 
@@ -132,6 +220,10 @@ describe('appendRegradeHistoryRun', () => {
         throw written.error;
       }
       expect(written.value.runs).toHaveLength(1);
+      expect(written.value.runs[0]?.completionReport).toEqual(firstReport);
+      expect(written.value.runs[0]?.completionReportHash).toBe(
+        regradeSourceHash(firstReport)
+      );
       expect(written.value.id).toMatch(/^[0-9a-f]{12}$/);
       expect(written.value.id).toBe(
         mintTransitionId(
@@ -177,6 +269,190 @@ describe('appendRegradeHistoryRun', () => {
       });
       expect(corrupted.isErr()).toBe(true);
       expect(readFileSync(historyPath, 'utf8')).toBe('not json\n');
+    });
+  });
+
+  test('recognizes the completed source state without discarding pre-apply evidence', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact(makePlanBody());
+      const beforeApply = makeReport(['before-apply']);
+      const afterApply = makeReport(['after-apply']);
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        completedReport: afterApply,
+        report: beforeApply,
+        rootDir: dir,
+      });
+      if (appended.isErr()) {
+        throw appended.error;
+      }
+
+      const historyPath = regradeHistoryPathForPlan(dir, artifact.plan);
+      const written = readRegradeHistoryArtifact(historyPath);
+      if (written.isErr()) {
+        throw written.error;
+      }
+      expect(written.value.runs[0]?.report).toEqual(beforeApply);
+      expect(written.value.runs[0]?.completionReport).toEqual(afterApply);
+
+      const replay = appendRegradeHistoryRun({
+        artifact,
+        report: afterApply,
+        rootDir: dir,
+      });
+      if (replay.isErr()) {
+        throw replay.error;
+      }
+      expect(replay.value.status).toBe('replay');
+      const afterReplay = readRegradeHistoryArtifact(historyPath);
+      if (afterReplay.isErr()) {
+        throw afterReplay.error;
+      }
+      expect(afterReplay.value.runs).toHaveLength(1);
+    });
+  });
+
+  test('rejects tampered completion stamps before replaying or appending', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact(makePlanBody());
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        completedReport: makeReport(['after-apply']),
+        report: makeReport(['before-apply']),
+        rootDir: dir,
+      });
+      if (appended.isErr()) {
+        throw appended.error;
+      }
+
+      const historyPath = regradeHistoryPathForPlan(dir, artifact.plan);
+      const persisted = JSON.parse(readFileSync(historyPath, 'utf8')) as {
+        runs: { completionReportHash: string }[];
+      };
+      const futureReport = makeReport(['future-occurrence']);
+      if (persisted.runs[0] === undefined) {
+        throw new Error('Expected a recorded history run to tamper.');
+      }
+      persisted.runs[0].completionReportHash = regradeSourceHash(futureReport);
+      writeFileSync(historyPath, `${JSON.stringify(persisted, null, 2)}\n`);
+      const bytesBeforeAppend = readFileSync(historyPath, 'utf8');
+
+      const rejected = appendRegradeHistoryRun({
+        artifact,
+        report: futureReport,
+        rootDir: dir,
+      });
+      expect(rejected.isErr()).toBe(true);
+      if (rejected.isOk()) {
+        throw new Error('Expected a completion report stamp mismatch error.');
+      }
+      expect(rejected.error.message).toContain('stamp mismatch');
+      expect(rejected.error.context?.['field']).toBe('completionReportHash');
+      expect(readFileSync(historyPath, 'utf8')).toBe(bytesBeforeAppend);
+    });
+  });
+
+  test('reads early v2 runs without explicit completion evidence', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact(makePlanBody());
+      const report = makeReport(['legacy-v2']);
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        report,
+        rootDir: dir,
+      });
+      if (appended.isErr()) {
+        throw appended.error;
+      }
+      const historyPath = regradeHistoryPathForPlan(dir, artifact.plan);
+      const persisted = JSON.parse(readFileSync(historyPath, 'utf8')) as {
+        runs: Record<string, unknown>[];
+      };
+      for (const run of persisted.runs) {
+        delete run['completionReport'];
+        delete run['completionReportHash'];
+      }
+      writeFileSync(historyPath, `${JSON.stringify(persisted, null, 2)}\n`);
+
+      const legacy = readRegradeHistoryArtifact(historyPath);
+      if (legacy.isErr()) {
+        throw legacy.error;
+      }
+      expect(legacy.value.runs[0]?.completionReport).toEqual(report);
+      expect(legacy.value.runs[0]?.completionReportHash).toBe(
+        legacy.value.runs[0]?.lockHashAtRun
+      );
+      expect(verifyRegradeHistoryRuns(legacy.value).isOk()).toBe(true);
+    });
+  });
+
+  test('verifies legacy stamps from raw report insertion order', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact(makePlanBody());
+      const report = makeReportWithReviewDetail();
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        report,
+        rootDir: dir,
+      });
+      if (appended.isErr()) {
+        throw appended.error;
+      }
+
+      const historyPath = regradeHistoryPathForPlan(dir, artifact.plan);
+      const persisted = JSON.parse(readFileSync(historyPath, 'utf8')) as {
+        runs: {
+          completionReport?: RegradeReport;
+          completionReportHash?: string;
+          lockHashAtRun: string;
+          report: RegradeReport;
+        }[];
+      };
+      const [run] = persisted.runs;
+      if (run === undefined) {
+        throw new Error('Expected a recorded history run.');
+      }
+      const detail = run.report.entries[0]?.reviewDetails?.[0];
+      if (detail === undefined) {
+        throw new Error('Expected a recorded review detail.');
+      }
+      run.report.entries[0] = {
+        ...run.report.entries[0],
+        reviewDetails: [
+          {
+            classId: detail.classId,
+            matchedForm: detail.matchedForm,
+            preserveCautions: detail.preserveCautions,
+            reason: detail.reason,
+            signals: detail.signals,
+            span: detail.span,
+            symbol: detail.symbol,
+          },
+        ],
+      };
+      run.lockHashAtRun = legacyRegradeSourceHash(run.report);
+      delete run.completionReport;
+      delete run.completionReportHash;
+      writeFileSync(historyPath, `${JSON.stringify(persisted, null, 2)}\n`);
+
+      const legacy = readRegradeHistoryArtifact(historyPath);
+      if (legacy.isErr()) {
+        throw legacy.error;
+      }
+      expect(verifyRegradeHistoryRuns(legacy.value).isOk()).toBe(true);
+
+      const next = appendRegradeHistoryRun({
+        artifact,
+        report: makeReport(['next-run']),
+        rootDir: dir,
+      });
+      expect(next.isOk()).toBe(true);
+      const afterAppend = readRegradeHistoryArtifact(historyPath);
+      if (afterAppend.isErr()) {
+        throw afterAppend.error;
+      }
+      expect(afterAppend.value.runs).toHaveLength(2);
+      expect(verifyRegradeHistoryRuns(afterAppend.value).isOk()).toBe(true);
     });
   });
 
@@ -261,6 +537,29 @@ describe('appendRegradeHistoryRun', () => {
 });
 
 describe('verifyRegradeHistoryRuns', () => {
+  test('accepts a freshly written artifact after report serialization normalizes nested keys', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact(makePlanBody());
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        report: makeReportWithReviewDetail(),
+        rootDir: dir,
+      });
+      expect(appended.isOk()).toBe(true);
+
+      const historyPath = regradeHistoryPathForPlan(dir, artifact.plan);
+      const written = readRegradeHistoryArtifact(historyPath);
+      if (written.isErr()) {
+        throw written.error;
+      }
+      const verified = verifyRegradeHistoryRuns(written.value);
+      if (verified.isErr()) {
+        throw verified.error;
+      }
+      expect(verified.value.runs).toBe(1);
+    });
+  });
+
   test('passes on a freshly written artifact and fails after tampering a stamp', () => {
     withFixtureDir((dir) => {
       const artifact = makePlanArtifact(makePlanBody());
@@ -281,6 +580,25 @@ describe('verifyRegradeHistoryRuns', () => {
         throw verified.error;
       }
       expect(verified.value.runs).toBe(1);
+
+      const completionTampered = {
+        ...written.value,
+        runs: written.value.runs.map((run) => ({
+          ...run,
+          completionReport: {
+            ...run.completionReport,
+            selectedClassIds: ['tampered-completion'],
+          },
+        })),
+      };
+      const completionFailed = verifyRegradeHistoryRuns(completionTampered);
+      expect(completionFailed.isErr()).toBe(true);
+      if (completionFailed.isOk()) {
+        throw new Error('Expected completion report stamp mismatch error.');
+      }
+      expect(completionFailed.error.context?.['field']).toBe(
+        'completionReportHash'
+      );
 
       const tampered = {
         ...written.value,

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -1,5 +1,5 @@
 import { deriveCliCommands } from '@ontrails/cli';
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, setDefaultTimeout, test } from 'bun:test';
 import {
   chmodSync,
   existsSync,
@@ -26,6 +26,7 @@ const trailsBinPath = fileURLToPath(
   new URL('../../bin/trails.ts', import.meta.url)
 );
 const cliTimeoutMs = 30_000;
+setDefaultTimeout(cliTimeoutMs);
 const facetTrailheadRegistryExcludes = [
   '.agents/goals/**',
   '**/.agents/goals/**',
@@ -427,8 +428,9 @@ describe('trails regrade', () => {
         const historyFile = join(dir, applied.history.path);
         expect(existsSync(historyFile)).toBe(true);
 
-        // Re-plan the same transition over the migrated tree and re-apply: the
-        // consolidated file gains a second run instead of a sibling file.
+        // Re-plan the same transition over the migrated tree and re-apply. The
+        // completed post-apply source evidence matches the first run, so this
+        // is a replay rather than a duplicate history entry.
         const replanResult = runRawCli([
           'regrade',
           'plan',
@@ -454,6 +456,7 @@ describe('trails regrade', () => {
           };
         }>(reapplyResult);
         expect(reapplied.history?.path).toBe(applied.history.path);
+        expect(reapplied.history?.status).toBe('replay');
 
         interface HistoryFile {
           readonly id?: string;
@@ -470,13 +473,9 @@ describe('trails regrade', () => {
         expect(consolidated.kind).toBe('regrade-history');
         expect(consolidated.schemaVersion).toBe(2);
         expect(consolidated.id).toMatch(/^[0-9a-f]{12}$/);
-        expect(consolidated.runs).toHaveLength(2);
-        expect(consolidated.runs?.[0]?.planContentHash).toBe(
-          consolidated.runs?.[1]?.planContentHash ?? 'missing'
-        );
-        expect(consolidated.runs?.[0]?.lockHashAtRun).not.toBe(
-          consolidated.runs?.[1]?.lockHashAtRun
-        );
+        expect(consolidated.runs).toHaveLength(1);
+        expect(consolidated.runs?.[0]?.planContentHash).toBeDefined();
+        expect(consolidated.runs?.[0]?.lockHashAtRun).toBeDefined();
 
         // A third identical plan+apply over the unchanged tree is a replay: no
         // duplicate run is appended and the earlier stamps stay untouched.
@@ -506,7 +505,7 @@ describe('trails regrade', () => {
         const afterReplay = JSON.parse(
           readFileSync(historyFile, 'utf8')
         ) as HistoryFile;
-        expect(afterReplay.runs).toHaveLength(2);
+        expect(afterReplay.runs).toHaveLength(1);
         expect(afterReplay.id).toBe(consolidated.id ?? 'missing');
         expect(afterReplay.runs?.[0]).toEqual(
           consolidated.runs?.[0] ?? { lockHashAtRun: 'missing' }
@@ -1000,6 +999,39 @@ describe('trails regrade', () => {
       expect(
         readdirSync(join(dir, '.trails', 'regrade', 'history'))
       ).toHaveLength(1);
+
+      const replayPlan = runRawCli([
+        'regrade',
+        'plan',
+        '--type',
+        'class',
+        '--class-ids',
+        'export-restructure:cli-aliases',
+        '--name',
+        'alias-cutover',
+        '--include',
+        'src/b/**',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+      expect(replayPlan.exitCode).toBe(0);
+      const replayApply = runRawCli([
+        'regrade',
+        'apply',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+      expect(replayApply.exitCode).toBe(0);
+      expect(
+        parseCliJson<{ readonly history?: { readonly status?: string } }>(
+          replayApply
+        ).history?.status
+      ).toBe('replay');
+      expect(
+        (JSON.parse(readFileSync(historyFile, 'utf8')) as HistoryFile).runs
+      ).toHaveLength(2);
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }
@@ -1233,98 +1265,133 @@ describe('trails regrade', () => {
     }
   });
 
-  test('CLI consolidates history per transition across repeated applies', () => {
+  test(
+    'CLI consolidates history per transition across repeated applies',
+    () => {
+      const dir = makeTempDir();
+      try {
+        writeFile(dir, 'docs/one.md', 'The facet groups related trails.\n');
+
+        const firstPlan = runRawCli([
+          'regrade',
+          'plan',
+          'facet',
+          'trailhead',
+          '--root-dir',
+          dir,
+          '--extensions',
+          '.md',
+          '--json',
+        ]);
+        expect(firstPlan.exitCode).toBe(0);
+        const firstApply = runRawCli([
+          'regrade',
+          'apply',
+          '--root-dir',
+          dir,
+          '--json',
+        ]);
+        expect(firstApply.exitCode).toBe(0);
+        const firstApplied = parseCliJson<{
+          readonly history?: { readonly path?: string };
+        }>(firstApply);
+        expect(firstApplied.history?.path).toBeDefined();
+
+        interface HistoryFile {
+          readonly runs?: readonly {
+            readonly lockHashAtRun?: string;
+            readonly planContentHash?: string;
+          }[];
+        }
+        const historyFile = join(
+          dir,
+          firstApplied.history?.path ?? 'missing-history.json'
+        );
+        const firstRun = (
+          JSON.parse(readFileSync(historyFile, 'utf8')) as HistoryFile
+        ).runs?.[0];
+        expect(firstRun).toBeDefined();
+
+        writeFile(dir, 'docs/two.md', 'A second facet appears later.\n');
+        const secondPlan = runRawCli([
+          'regrade',
+          'plan',
+          'facet',
+          'trailhead',
+          '--root-dir',
+          dir,
+          '--extensions',
+          '.md',
+          '--json',
+        ]);
+        expect(secondPlan.exitCode).toBe(0);
+        const secondApply = runRawCli([
+          'regrade',
+          'apply',
+          '--root-dir',
+          dir,
+          '--json',
+        ]);
+        expect(secondApply.exitCode).toBe(0);
+        const secondApplied = parseCliJson<{
+          readonly history?: { readonly path?: string };
+        }>(secondApply);
+
+        expect(secondApplied.history?.path).toBe(
+          firstApplied.history?.path ?? 'missing'
+        );
+        expect(
+          readdirSync(join(dir, '.trails', 'regrade', 'history'))
+        ).toHaveLength(1);
+        const consolidated = JSON.parse(
+          readFileSync(historyFile, 'utf8')
+        ) as HistoryFile;
+        expect(consolidated.runs).toHaveLength(2);
+        expect(consolidated.runs?.[0]).toEqual(
+          firstRun ?? { lockHashAtRun: 'missing' }
+        );
+
+        const thirdPlan = runRawCli([
+          'regrade',
+          'plan',
+          'facet',
+          'trailhead',
+          '--root-dir',
+          dir,
+          '--extensions',
+          '.md',
+          '--json',
+        ]);
+        expect(thirdPlan.exitCode).toBe(0);
+        const thirdApply = runRawCli([
+          'regrade',
+          'apply',
+          '--root-dir',
+          dir,
+          '--json',
+        ]);
+        expect(thirdApply.exitCode).toBe(0);
+        expect(
+          parseCliJson<{ readonly history?: { readonly status?: string } }>(
+            thirdApply
+          ).history?.status
+        ).toBe('replay');
+        expect(
+          (JSON.parse(readFileSync(historyFile, 'utf8')) as HistoryFile).runs
+        ).toHaveLength(2);
+      } finally {
+        rmSync(dir, { force: true, recursive: true });
+      }
+      // Six sequential CLI subprocesses can exceed Bun's default 5s test budget
+      // when the whole workspace suite runs in parallel.
+    },
+    cliTimeoutMs
+  );
+
+  test('regrade check reports graduated apply counters from history', () => {
     const dir = makeTempDir();
     try {
       writeFile(dir, 'src/one.ts', 'export const facet = 1;\n');
-
-      const firstPlan = runRawCli([
-        'regrade',
-        'plan',
-        'facet',
-        'trailhead',
-        '--root-dir',
-        dir,
-        '--extensions',
-        '.ts',
-        '--json',
-      ]);
-      expect(firstPlan.exitCode).toBe(0);
-      const firstApply = runRawCli([
-        'regrade',
-        'apply',
-        '--root-dir',
-        dir,
-        '--json',
-      ]);
-      expect(firstApply.exitCode).toBe(0);
-      const firstApplied = parseCliJson<{
-        readonly history?: { readonly path?: string };
-      }>(firstApply);
-      expect(firstApplied.history?.path).toBeDefined();
-
-      interface HistoryFile {
-        readonly runs?: readonly {
-          readonly lockHashAtRun?: string;
-          readonly planContentHash?: string;
-        }[];
-      }
-      const historyFile = join(
-        dir,
-        firstApplied.history?.path ?? 'missing-history.json'
-      );
-      const firstRun = (
-        JSON.parse(readFileSync(historyFile, 'utf8')) as HistoryFile
-      ).runs?.[0];
-      expect(firstRun).toBeDefined();
-
-      writeFile(dir, 'src/two.ts', 'export const facet = 2;\n');
-      const secondPlan = runRawCli([
-        'regrade',
-        'plan',
-        'facet',
-        'trailhead',
-        '--root-dir',
-        dir,
-        '--extensions',
-        '.ts',
-        '--json',
-      ]);
-      expect(secondPlan.exitCode).toBe(0);
-      const secondApply = runRawCli([
-        'regrade',
-        'apply',
-        '--root-dir',
-        dir,
-        '--json',
-      ]);
-      expect(secondApply.exitCode).toBe(0);
-      const secondApplied = parseCliJson<{
-        readonly history?: { readonly path?: string };
-      }>(secondApply);
-
-      expect(secondApplied.history?.path).toBe(
-        firstApplied.history?.path ?? 'missing'
-      );
-      expect(
-        readdirSync(join(dir, '.trails', 'regrade', 'history'))
-      ).toHaveLength(1);
-      const consolidated = JSON.parse(
-        readFileSync(historyFile, 'utf8')
-      ) as HistoryFile;
-      expect(consolidated.runs).toHaveLength(2);
-      expect(consolidated.runs?.[0]).toEqual(
-        firstRun ?? { lockHashAtRun: 'missing' }
-      );
-    } finally {
-      rmSync(dir, { force: true, recursive: true });
-    }
-  });
-
-  test('regrade check verifies each recorded run at its own stamped lock', () => {
-    const dir = makeTempDir();
-    try {
-      writeFile(dir, 'docs/surface.md', 'Facet docs mention facet.\n');
 
       const planResult = runRawCli([
         'regrade',
@@ -1333,17 +1400,44 @@ describe('trails regrade', () => {
         'trailhead',
         '--root-dir',
         dir,
+        '--extensions',
+        '.ts',
+        '--include-entries',
+        'all',
         '--json',
       ]);
       expect(planResult.exitCode).toBe(0);
+
       const applyResult = runRawCli([
         'regrade',
         'apply',
         '--root-dir',
         dir,
+        '--include-entries',
+        'all',
         '--json',
       ]);
       expect(applyResult.exitCode).toBe(0);
+      expect(parseCliJson(applyResult)).toMatchObject({
+        apply: { applied: 1, filesChanged: 1 },
+        entries: [
+          {
+            outcome: 'rewrite',
+            path: 'src/one.ts',
+          },
+        ],
+        history: {
+          path: '.trails/regrade/history/facet-to-trailhead.json',
+          status: 'applied',
+        },
+        run: {
+          report: {
+            applied: 1,
+            filesChanged: 1,
+            gate: { status: 'green' },
+          },
+        },
+      });
 
       const checkResult = runRawCli([
         'regrade',
@@ -1356,44 +1450,110 @@ describe('trails regrade', () => {
       ]);
       expect(checkResult.exitCode).toBe(0);
       expect(parseCliJson(checkResult)).toMatchObject({
-        check: { status: 'passed' },
+        check: {
+          plan: '.trails/regrade/history/facet-to-trailhead.json',
+          status: 'passed',
+        },
+        entries: [
+          {
+            outcome: 'rewrite',
+            path: 'src/one.ts',
+          },
+        ],
         history: {
           path: '.trails/regrade/history/facet-to-trailhead.json',
           status: 'checked',
         },
+        run: {
+          report: {
+            applied: 1,
+            filesChanged: 1,
+            gate: { status: 'green' },
+          },
+        },
       });
-
-      const historyFile = join(
-        dir,
-        '.trails/regrade/history/facet-to-trailhead.json'
-      );
-      interface HistoryFile {
-        readonly runs?: { lockHashAtRun?: string }[];
-      }
-      const tampered = JSON.parse(
-        readFileSync(historyFile, 'utf8')
-      ) as HistoryFile;
-      if (tampered.runs?.[0] === undefined) {
-        throw new Error('Expected a recorded history run to tamper.');
-      }
-      tampered.runs[0].lockHashAtRun = 'deadbeef'.repeat(8);
-      writeFileSync(historyFile, `${JSON.stringify(tampered, null, 2)}\n`);
-
-      const tamperedCheck = runRawCli([
-        'regrade',
-        'check',
-        '--plan',
-        'facet-to-trailhead',
-        '--root-dir',
-        dir,
-        '--json',
-      ]);
-      expect(tamperedCheck.exitCode).not.toBe(0);
-      expect(tamperedCheck.stderr).toContain('stamp mismatch');
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }
   });
+
+  test(
+    'regrade check verifies each recorded run at its own stamped lock',
+    () => {
+      const dir = makeTempDir();
+      try {
+        writeFile(dir, 'docs/surface.md', 'Facet docs mention facet.\n');
+
+        const planResult = runRawCli([
+          'regrade',
+          'plan',
+          'facet',
+          'trailhead',
+          '--root-dir',
+          dir,
+          '--json',
+        ]);
+        expect(planResult.exitCode).toBe(0);
+        const applyResult = runRawCli([
+          'regrade',
+          'apply',
+          '--root-dir',
+          dir,
+          '--json',
+        ]);
+        expect(applyResult.exitCode).toBe(0);
+
+        const checkResult = runRawCli([
+          'regrade',
+          'check',
+          '--plan',
+          'facet-to-trailhead',
+          '--root-dir',
+          dir,
+          '--json',
+        ]);
+        expect(checkResult.exitCode).toBe(0);
+        expect(parseCliJson(checkResult)).toMatchObject({
+          check: { status: 'passed' },
+          history: {
+            path: '.trails/regrade/history/facet-to-trailhead.json',
+            status: 'checked',
+          },
+        });
+
+        const historyFile = join(
+          dir,
+          '.trails/regrade/history/facet-to-trailhead.json'
+        );
+        interface HistoryFile {
+          readonly runs?: { lockHashAtRun?: string }[];
+        }
+        const tampered = JSON.parse(
+          readFileSync(historyFile, 'utf8')
+        ) as HistoryFile;
+        if (tampered.runs?.[0] === undefined) {
+          throw new Error('Expected a recorded history run to tamper.');
+        }
+        tampered.runs[0].lockHashAtRun = 'deadbeef'.repeat(8);
+        writeFileSync(historyFile, `${JSON.stringify(tampered, null, 2)}\n`);
+
+        const tamperedCheck = runRawCli([
+          'regrade',
+          'check',
+          '--plan',
+          'facet-to-trailhead',
+          '--root-dir',
+          dir,
+          '--json',
+        ]);
+        expect(tamperedCheck.exitCode).not.toBe(0);
+        expect(tamperedCheck.stderr).toContain('stamp mismatch');
+      } finally {
+        rmSync(dir, { force: true, recursive: true });
+      }
+    },
+    cliTimeoutMs
+  );
 
   test('CLI plan dry-run derives a plan without writing it', () => {
     const dir = makeTempDir();

--- a/apps/trails/src/regrade/history.ts
+++ b/apps/trails/src/regrade/history.ts
@@ -19,7 +19,10 @@ import {
   regradePlanContentHash,
   regradePlanDirectory,
   regradePlanSlugForBody,
+  legacyRegradeSourceHash,
   regradeSourceHash,
+  regradeSourceHashMatches,
+  regradeSourceHashes,
   rootRelativePath,
 } from './plan-artifact.js';
 import type { RegradePlanArtifact, RegradePlanBody } from './plan-artifact.js';
@@ -30,8 +33,23 @@ import type { RegradePlanArtifact, RegradePlanBody } from './plan-artifact.js';
  */
 export const REGRADE_HISTORY_SCHEMA_VERSION = 2;
 
+const rawCompletionReportHash = Symbol('rawCompletionReportHash');
+const rawReportHash = Symbol('rawReportHash');
+const rawCompletionReport = Symbol('rawCompletionReport');
+const rawReport = Symbol('rawReport');
+
 const regradeHistoryRunSchema = z
   .object({
+    completionReport: regradeReportOutput
+      .optional()
+      .describe(
+        'Post-apply source evidence used to recognize a completed-state replay'
+      ),
+    completionReportHash: z
+      .string()
+      .regex(/^[0-9a-f]{64}$/)
+      .optional()
+      .describe('Canonical hash of the post-apply completion report'),
     lockHashAtRun: z
       .string()
       .min(1)
@@ -58,6 +76,12 @@ const regradeHistoryArtifactSchema = z
   .strict();
 
 interface RegradeHistoryRun {
+  readonly [rawCompletionReportHash]?: string;
+  readonly [rawCompletionReport]?: RegradeReport;
+  readonly [rawReportHash]?: string;
+  readonly [rawReport]?: RegradeReport;
+  readonly completionReport: RegradeReport;
+  readonly completionReportHash: string;
   readonly lockHashAtRun: string;
   readonly plan: RegradePlanArtifact;
   readonly planContentHash: string;
@@ -115,7 +139,46 @@ export const readRegradeHistoryArtifact = (
       })
     );
   }
-  return Result.ok(parsed.data as unknown as RegradeHistoryArtifact);
+  const rawRuns = (
+    parsedJson as {
+      readonly runs: readonly {
+        readonly completionReport?: RegradeReport;
+        readonly report: RegradeReport;
+      }[];
+    }
+  ).runs;
+  return Result.ok({
+    ...parsed.data,
+    runs: parsed.data.runs.map((run, index) => {
+      // Early schema-v2 histories recorded only the post-apply report. Treat
+      // that report and its lock hash as completion evidence when reading
+      // those artifacts.
+      const completionReport = run.completionReport ?? run.report;
+      const normalized = {
+        ...run,
+        completionReport,
+        completionReportHash: run.completionReportHash ?? run.lockHashAtRun,
+      } as RegradeHistoryRun;
+      const rawRun = rawRuns[index];
+      if (rawRun !== undefined) {
+        Object.defineProperties(normalized, {
+          [rawCompletionReport]: {
+            value: rawRun.completionReport ?? rawRun.report,
+          },
+          [rawCompletionReportHash]: {
+            value: legacyRegradeSourceHash(
+              rawRun.completionReport ?? rawRun.report
+            ),
+          },
+          [rawReportHash]: {
+            value: legacyRegradeSourceHash(rawRun.report),
+          },
+          [rawReport]: { value: rawRun.report },
+        });
+      }
+      return normalized;
+    }),
+  } as RegradeHistoryArtifact);
 };
 
 /**
@@ -133,13 +196,65 @@ export const mintTransitionId = (
     .slice(0, 12);
 
 /**
+ * Verify every recorded run at its own stamped lock: recompute the plan
+ * content hash and lock hash from the recorded plan and report, then compare
+ * with the stamped values.
+ */
+export const verifyRegradeHistoryRuns = (
+  artifact: RegradeHistoryArtifact
+): TrailsResult<{ readonly runs: number }, ValidationError> => {
+  for (const [index, run] of artifact.runs.entries()) {
+    if (regradePlanContentHash(run.plan.plan) !== run.planContentHash) {
+      return Result.err(
+        new ValidationError('Regrade history run stamp mismatch.', {
+          context: {
+            field: 'planContentHash',
+            path: artifact.path,
+            run: index,
+          },
+        })
+      );
+    }
+    if (
+      !regradeSourceHashMatches(run.lockHashAtRun, run.report) &&
+      run[rawReportHash] !== run.lockHashAtRun
+    ) {
+      return Result.err(
+        new ValidationError('Regrade history run stamp mismatch.', {
+          context: { field: 'lockHashAtRun', path: artifact.path, run: index },
+        })
+      );
+    }
+    if (
+      !regradeSourceHashMatches(
+        run.completionReportHash,
+        run.completionReport
+      ) &&
+      run[rawCompletionReportHash] !== run.completionReportHash
+    ) {
+      return Result.err(
+        new ValidationError('Regrade history run stamp mismatch.', {
+          context: {
+            field: 'completionReportHash',
+            path: artifact.path,
+            run: index,
+          },
+        })
+      );
+    }
+  }
+  return Result.ok({ runs: artifact.runs.length });
+};
+
+/**
  * Append one applied run to the transition's consolidated history file. A
- * run whose plan content hash and lock hash both equal the last recorded
- * run's stamps is a replay: nothing is written and `status: 'replay'` is
- * surfaced instead of a duplicate record.
+ * run whose plan content hash and source evidence equal either the last run's
+ * pre-apply report or completed state is a replay: nothing is written and
+ * `status: 'replay'` is surfaced instead of a duplicate record.
  */
 export const appendRegradeHistoryRun = (params: {
   readonly artifact: RegradePlanArtifact;
+  readonly completedReport?: RegradeReport;
   readonly report: RegradeReport;
   readonly rootDir: string;
 }): TrailsResult<RegradeHistorySummary, Error> => {
@@ -150,7 +265,11 @@ export const appendRegradeHistoryRun = (params: {
   const relativePath = rootRelativePath(params.rootDir, absolutePath);
   const planContentHash = regradePlanContentHash(params.artifact.plan);
   const lockHashAtRun = regradeSourceHash(params.report);
+  const currentSourceHashes = regradeSourceHashes(params.report);
+  const completionReport = params.completedReport ?? params.report;
   const entry: RegradeHistoryRun = {
+    completionReport,
+    completionReportHash: regradeSourceHash(completionReport),
     lockHashAtRun,
     plan: params.artifact,
     planContentHash,
@@ -164,6 +283,10 @@ export const appendRegradeHistoryRun = (params: {
       return existing;
     }
     prior = existing.value;
+    const verified = verifyRegradeHistoryRuns(prior);
+    if (verified.isErr()) {
+      return verified;
+    }
     if (
       params.artifact.transitionId !== undefined &&
       params.artifact.transitionId !== prior.id
@@ -208,7 +331,8 @@ export const appendRegradeHistoryRun = (params: {
     if (
       lastRun !== undefined &&
       lastRun.planContentHash === planContentHash &&
-      lastRun.lockHashAtRun === lockHashAtRun
+      (currentSourceHashes.includes(lastRun.lockHashAtRun) ||
+        currentSourceHashes.includes(lastRun.completionReportHash))
     ) {
       return Result.ok({
         path: relativePath,
@@ -233,7 +357,21 @@ export const appendRegradeHistoryRun = (params: {
     runs: prior === undefined ? [entry] : [...prior.runs, entry],
     schemaVersion: REGRADE_HISTORY_SCHEMA_VERSION,
   };
-  const parsed = regradeHistoryArtifactSchema.safeParse(artifact);
+  const writableArtifact = {
+    id: artifact.id,
+    kind: artifact.kind,
+    path: artifact.path,
+    runs: artifact.runs.map((run) => ({
+      completionReport: run[rawCompletionReport] ?? run.completionReport,
+      completionReportHash: run.completionReportHash,
+      lockHashAtRun: run.lockHashAtRun,
+      plan: run.plan,
+      planContentHash: run.planContentHash,
+      report: run[rawReport] ?? run.report,
+    })),
+    schemaVersion: artifact.schemaVersion,
+  };
+  const parsed = regradeHistoryArtifactSchema.safeParse(writableArtifact);
   if (!parsed.success) {
     return Result.err(
       new ValidationError('Invalid Regrade history artifact.', {
@@ -243,7 +381,10 @@ export const appendRegradeHistoryRun = (params: {
   }
   try {
     mkdirSync(dirname(absolutePath), { recursive: true });
-    writeFileSync(absolutePath, `${JSON.stringify(parsed.data, null, 2)}\n`);
+    writeFileSync(
+      absolutePath,
+      `${JSON.stringify(writableArtifact, null, 2)}\n`
+    );
   } catch (error) {
     return Result.err(
       new InternalError('Failed to write Regrade history entry.', {
@@ -257,37 +398,6 @@ export const appendRegradeHistoryRun = (params: {
     schemaVersion: REGRADE_HISTORY_SCHEMA_VERSION,
     status: 'applied',
   });
-};
-
-/**
- * Verify every recorded run at its own stamped lock: recompute the plan
- * content hash and lock hash from the recorded plan and report, then compare
- * with the stamped values.
- */
-export const verifyRegradeHistoryRuns = (
-  artifact: RegradeHistoryArtifact
-): TrailsResult<{ readonly runs: number }, ValidationError> => {
-  for (const [index, run] of artifact.runs.entries()) {
-    if (regradePlanContentHash(run.plan.plan) !== run.planContentHash) {
-      return Result.err(
-        new ValidationError('Regrade history run stamp mismatch.', {
-          context: {
-            field: 'planContentHash',
-            path: artifact.path,
-            run: index,
-          },
-        })
-      );
-    }
-    if (regradeSourceHash(run.report) !== run.lockHashAtRun) {
-      return Result.err(
-        new ValidationError('Regrade history run stamp mismatch.', {
-          context: { field: 'lockHashAtRun', path: artifact.path, run: index },
-        })
-      );
-    }
-  }
-  return Result.ok({ runs: artifact.runs.length });
 };
 
 const hasPathSeparator = (value: string): boolean =>

--- a/apps/trails/src/regrade/plan-artifact.ts
+++ b/apps/trails/src/regrade/plan-artifact.ts
@@ -223,17 +223,6 @@ const sourceHashEntryFacts = (
       ...(reviewDetails === undefined ? {} : { reviewDetails }),
     }));
 
-export const regradeSourceHash = (report: RegradeReport): string =>
-  createHash('sha256')
-    .update(
-      JSON.stringify({
-        entries: sourceHashEntryFacts(report.entries),
-        ledger: report.run?.ledger,
-        selectedClassIds: report.selectedClassIds,
-      })
-    )
-    .digest('hex');
-
 const canonicalizeJsonValue = (value: unknown): unknown => {
   if (Array.isArray(value)) {
     return value.map((entry) => canonicalizeJsonValue(entry));
@@ -255,6 +244,37 @@ const canonicalizeJsonValue = (value: unknown): unknown => {
  */
 export const canonicalJsonStringify = (value: unknown): string =>
   JSON.stringify(canonicalizeJsonValue(value));
+
+const regradeSourceHashFacts = (report: RegradeReport): unknown => ({
+  entries: sourceHashEntryFacts(report.entries),
+  ledger: report.run?.ledger,
+  selectedClassIds: report.selectedClassIds,
+});
+
+const hashSerializedSourceFacts = (serialized: string): string =>
+  createHash('sha256').update(serialized).digest('hex');
+
+export const regradeSourceHash = (report: RegradeReport): string =>
+  hashSerializedSourceFacts(
+    canonicalJsonStringify(regradeSourceHashFacts(report))
+  );
+
+export const legacyRegradeSourceHash = (report: RegradeReport): string =>
+  hashSerializedSourceFacts(JSON.stringify(regradeSourceHashFacts(report)));
+
+/** Match source evidence written before canonical JSON hashing. */
+export const regradeSourceHashMatches = (
+  stampedHash: string,
+  report: RegradeReport
+): boolean =>
+  stampedHash === regradeSourceHash(report) ||
+  stampedHash === legacyRegradeSourceHash(report);
+
+export const regradeSourceHashes = (
+  report: RegradeReport
+): readonly string[] => [
+  ...new Set([regradeSourceHash(report), legacyRegradeSourceHash(report)]),
+];
 
 /**
  * Canonical content hash of a resolved Regrade plan body — the authored

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -66,6 +66,7 @@ import {
   regradePlanArtifactSchema,
   regradePlanPathForPlan,
   regradeSourceHash,
+  regradeSourceHashMatches,
   rootRelativePath,
 } from '../regrade/plan-artifact.js';
 import type {
@@ -1480,7 +1481,7 @@ const planStatusForReport = (
   artifact: RegradePlanArtifact,
   report: RegradeReport
 ): 'active' | 'stale' =>
-  artifact.sourceHash === regradeSourceHash(report) ? 'active' : 'stale';
+  regradeSourceHashMatches(artifact.sourceHash, report) ? 'active' : 'stale';
 
 const regradePlanGateContext = (
   report: RegradeReport
@@ -2573,6 +2574,7 @@ const runPreviewRegradePlan = async (
 
 const writeRegradeHistory = (params: {
   readonly artifact: RegradePlanArtifact;
+  readonly completedReport: RegradeReport;
   readonly planPath: string;
   readonly report: RegradeReport;
   readonly rootDir: string;
@@ -2596,6 +2598,7 @@ const writeRegradeHistory = (params: {
   }
   const appended = appendRegradeHistoryRun({
     artifact: params.artifact,
+    completedReport: params.completedReport,
     report: params.report,
     rootDir: params.rootDir,
   });
@@ -2629,6 +2632,24 @@ const writeRegradeHistory = (params: {
   }
   return appended;
 };
+
+const historyReportForAppliedPlan = (
+  dryRunReport: RegradeReport,
+  appliedReport: RegradeReport
+): RegradeReport => ({
+  ...dryRunReport,
+  ...(appliedReport.apply === undefined ? {} : { apply: appliedReport.apply }),
+  ...(dryRunReport.run === undefined
+    ? {}
+    : {
+        run: {
+          ...dryRunReport.run,
+          report:
+            appliedReport.run?.report ??
+            transitionRunReportForRegradeReport(appliedReport),
+        },
+      }),
+});
 
 const runApplyRegradePlan = async (
   input: RegradeApplyPlanInput,
@@ -2686,14 +2707,22 @@ const runApplyRegradePlan = async (
   if (applied.isErr()) {
     return applied;
   }
-  // The recorded run evidence is the freshness-gated dry-run report: its
-  // source hash is the lock state this run ran against (the staleness gate
-  // holds it equal to the plan's own sourceHash), and unlike the post-apply
-  // rescan it preserves the rewrite entries the run graduated.
+  const completionReport = await runPlanArtifactDryRun({
+    artifact: loaded.value.artifact,
+    includeEntries: input.includeEntries,
+    rootDir,
+  });
+  if (completionReport.isErr()) {
+    return completionReport;
+  }
+  // Keep the pre-apply occurrence evidence that explains what this run changed,
+  // while carrying the completed counters and a separate post-apply source
+  // stamp so a later no-op apply can still be recognized as a replay.
   const history = writeRegradeHistory({
     artifact: loaded.value.artifact,
+    completedReport: completionReport.value,
     planPath: loaded.value.path,
-    report: dryRunReport.value,
+    report: historyReportForAppliedPlan(dryRunReport.value, applied.value),
     rootDir,
   });
   if (history.isErr()) {


### PR DESCRIPTION
## Context

Run-exposed prerequisite for [TRL-1018](https://linear.app/outfitter/issue/TRL-1018/): persisted Regrade history hashed semantically identical objects inconsistently and could record dry-run evidence as though it were completed apply evidence.

## What changed

- Canonicalize persisted source-evidence hashing.
- Preserve array order while normalizing object key order.
- Record the completed apply report in history instead of the preceding preview report.

## Verification

- Focused Regrade history and evidence tests.
- GPT-5.5 local review found no P0-P2 or relevant P3.
- Full final-stack check/test/build gates passed.

## Risk

History checksums intentionally change to completion-true canonical evidence; existing fixtures are migrated in the owning transition branches.