### PR TITLE
feat(regrade): complete contour transition code facts

### DIFF
--- a/.changeset/trl-1252-contour-regrade-readiness.md
+++ b/.changeset/trl-1252-contour-regrade-readiness.md
@@ -1,0 +1,9 @@
+---
+"@ontrails/warden": patch
+"@ontrails/regrade": patch
+---
+
+Make the planned contour-to-entity Regrade transition code-fact complete for
+apply readiness while leaving the repository cutover status planned.
+Identifiers that already contain the target segment now stay in the review
+inventory instead of producing duplicated target names.

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -679,6 +679,173 @@ describe('Trails MCP surface shaping', () => {
     }
   });
 
+  test('executes contour plan code facts and review inventory through MCP', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/rewrite.ts',
+        [
+          "import { contour, contours } from './runtime';",
+          'export type ContourRecord = { contour: typeof contour };',
+          'export const contourSummarySchema = contour;',
+          'export const contoursSummarySchema = contours;',
+          'const label = "contourSummarySchema contoursList contoured";',
+          '',
+        ].join('\n')
+      );
+      writeFile(
+        dir,
+        'src/literal.ts',
+        "ctx.compose('wayfind.contours', { entities: [] });\n"
+      );
+      writeFile(
+        dir,
+        'src/review.ts',
+        [
+          "import { contour } from './runtime';",
+          'export function render(contour: () => void) {',
+          '  return contour();',
+          '}',
+          '',
+        ].join('\n')
+      );
+
+      const tools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
+      const planRegrade = requireTool(tools, 'trails_plan_regrade');
+      const previewRegrade = requireTool(tools, 'trails_preview_regrade');
+
+      const planResult = await planRegrade.handler(
+        {
+          from: 'contour',
+          rootDir: dir,
+          to: 'entity',
+        },
+        {}
+      );
+      expect(planResult.isError).toBeUndefined();
+      const result = await previewRegrade.handler(
+        {
+          includeEntries: 'all',
+          rootDir: dir,
+        },
+        {}
+      );
+
+      expect(result.isError).toBeUndefined();
+      const structured = result.structuredContent as {
+        readonly entries?: readonly {
+          readonly classId?: string;
+          readonly outcome?: string;
+          readonly path?: string;
+          readonly reason?: string;
+          readonly reviewDetails?: readonly {
+            readonly candidateReplacement?: string;
+            readonly classId?: string;
+            readonly matchedForm?: string;
+            readonly reason?: string;
+            readonly symbol?: string;
+          }[];
+        }[];
+        readonly run?: {
+          readonly plan?: {
+            readonly from?: string;
+            readonly id?: string;
+            readonly scope?: { readonly exclude?: readonly string[] };
+            readonly to?: string;
+          };
+          readonly report?: {
+            readonly gate?: {
+              readonly reasons?: readonly string[];
+              readonly status?: string;
+            };
+          };
+        };
+        readonly selectedClassIds?: readonly string[];
+      };
+
+      expect(structured.selectedClassIds).toEqual(
+        expect.arrayContaining([
+          'ast-string-literal-rename:v1-contour-entity:contour->entity',
+          'ast-string-literal-rename:v1-contour-entity:contours->entities',
+          'ast-string-literal-rename:v1-contour-entity:wayfind.contours->wayfind.entities',
+          'ast-symbol-rename:v1-contour-entity:contour->entity',
+          'ast-symbol-rename:v1-contour-entity:contours->entities',
+          'v1-contour-entity',
+        ])
+      );
+      expect(structured.run?.plan).toMatchObject({
+        from: 'contour',
+        id: 'v1-contour-entity',
+        scope: {
+          exclude: facetTrailheadRegistryExcludes,
+        },
+        to: 'entity',
+      });
+      expect(structured.run?.report?.gate).toMatchObject({
+        reasons: [
+          'deferred-forms-or-occurrences',
+          'safe-modifications-not-yet-applied',
+        ],
+        remaining: 3,
+        remainingByDisposition: {
+          'code-context-out-of-engine': 3,
+        },
+        status: 'open',
+      });
+      expect(structured.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            classId: expect.stringContaining(
+              'ast-string-literal-rename:v1-contour-entity:wayfind.contours->wayfind.entities'
+            ),
+            outcome: 'rewrite',
+            path: 'src/literal.ts',
+          }),
+          expect.objectContaining({
+            classId: 'ast-symbol-rename:v1-contour-entity:contour->entity',
+            outcome: 'needs-review',
+            path: 'src/rewrite.ts',
+            reason: 'ast-identifier-module-boundary',
+            reviewDetails: expect.arrayContaining([
+              expect.objectContaining({
+                reason: 'ast-identifier-module-boundary',
+                symbol: 'contour',
+              }),
+            ]),
+          }),
+          expect.objectContaining({
+            classId: 'ast-symbol-rename:v1-contour-entity:contour->entity',
+            outcome: 'needs-review',
+            path: 'src/review.ts',
+            reason: 'ast-identifier-module-boundary',
+            reviewDetails: expect.arrayContaining([
+              expect.objectContaining({
+                reason: 'ast-identifier-module-boundary',
+                symbol: 'contour',
+              }),
+              expect.objectContaining({
+                candidateReplacement: 'entity',
+                classId: 'ast-symbol-rename:v1-contour-entity:contour->entity',
+                matchedForm: 'contour',
+                reason: 'ast-identifier-review-declaration',
+                symbol: 'contour',
+              }),
+            ]),
+          }),
+        ])
+      );
+      expect(readFileSync(join(dir, 'src', 'rewrite.ts'), 'utf8')).toContain(
+        'contourSummarySchema contoursList contoured'
+      );
+      expect(readFileSync(join(dir, 'src', 'review.ts'), 'utf8')).toContain(
+        'render(contour: () => void)'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('executes registry-backed regrade review forms through MCP', async () => {
     const dir = makeTempDir();
     try {

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -2883,6 +2883,164 @@ describe('trails regrade', () => {
     }
   });
 
+  test('CLI exposes contour plan code facts and structured review inventory', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/rewrite.ts',
+        [
+          "import { contour, contours } from './runtime';",
+          'export { contour, contours };',
+          'export type ContourRecord = { contour: typeof contour };',
+          'export const contourSummarySchema = contour;',
+          'export const contoursSummarySchema = contours;',
+          'const label = "contourSummarySchema contoursList contoured";',
+          '',
+        ].join('\n')
+      );
+      writeFile(
+        dir,
+        'src/literal.ts',
+        "ctx.compose('wayfind.contours', { entities: [] });\n"
+      );
+      writeFile(
+        dir,
+        'src/review.ts',
+        [
+          "import { contour } from './runtime';",
+          'export function render(contour: () => void) {',
+          '  return contour();',
+          '}',
+          '',
+        ].join('\n')
+      );
+
+      const result = runRawCli([
+        'regrade',
+        'contour',
+        'entity',
+        '--root-dir',
+        dir,
+        '--include-entries',
+        'all',
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = JSON.parse(result.stdout) as {
+        readonly entries?: readonly {
+          readonly classId?: string;
+          readonly outcome?: string;
+          readonly path?: string;
+          readonly reason?: string;
+          readonly reviewDetails?: readonly {
+            readonly candidateReplacement?: string;
+            readonly classId?: string;
+            readonly matchedForm?: string;
+            readonly reason?: string;
+            readonly symbol?: string;
+          }[];
+        }[];
+        readonly run?: {
+          readonly plan?: {
+            readonly from?: string;
+            readonly id?: string;
+            readonly scope?: { readonly exclude?: readonly string[] };
+            readonly to?: string;
+          };
+          readonly report?: {
+            readonly gate?: {
+              readonly reasons?: readonly string[];
+              readonly status?: string;
+            };
+          };
+        };
+        readonly selectedClassIds?: readonly string[];
+      };
+
+      expect(parsed.selectedClassIds).toEqual(
+        expect.arrayContaining([
+          'ast-string-literal-rename:v1-contour-entity:contour->entity',
+          'ast-string-literal-rename:v1-contour-entity:contours->entities',
+          'ast-string-literal-rename:v1-contour-entity:wayfind.contours->wayfind.entities',
+          'ast-symbol-rename:v1-contour-entity:contour->entity',
+          'ast-symbol-rename:v1-contour-entity:contours->entities',
+          'v1-contour-entity',
+        ])
+      );
+      expect(parsed.run?.plan).toMatchObject({
+        from: 'contour',
+        id: 'v1-contour-entity',
+        scope: {
+          exclude: facetTrailheadRegistryExcludes,
+        },
+        to: 'entity',
+      });
+      expect(parsed.run?.report?.gate).toMatchObject({
+        reasons: [
+          'deferred-forms-or-occurrences',
+          'safe-modifications-not-yet-applied',
+        ],
+        remaining: 3,
+        remainingByDisposition: {
+          'code-context-out-of-engine': 3,
+        },
+        status: 'open',
+      });
+      expect(parsed.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            classId: expect.stringContaining(
+              'ast-string-literal-rename:v1-contour-entity:wayfind.contours->wayfind.entities'
+            ),
+            outcome: 'rewrite',
+            path: 'src/literal.ts',
+          }),
+          expect.objectContaining({
+            classId: 'ast-symbol-rename:v1-contour-entity:contour->entity',
+            outcome: 'needs-review',
+            path: 'src/rewrite.ts',
+            reason: 'ast-identifier-module-boundary',
+            reviewDetails: expect.arrayContaining([
+              expect.objectContaining({
+                reason: 'ast-identifier-module-boundary',
+                symbol: 'contour',
+              }),
+            ]),
+          }),
+          expect.objectContaining({
+            classId: 'ast-symbol-rename:v1-contour-entity:contour->entity',
+            outcome: 'needs-review',
+            path: 'src/review.ts',
+            reason: 'ast-identifier-module-boundary',
+            reviewDetails: expect.arrayContaining([
+              expect.objectContaining({
+                reason: 'ast-identifier-module-boundary',
+                symbol: 'contour',
+              }),
+              expect.objectContaining({
+                candidateReplacement: 'entity',
+                classId: 'ast-symbol-rename:v1-contour-entity:contour->entity',
+                matchedForm: 'contour',
+                reason: 'ast-identifier-review-declaration',
+                symbol: 'contour',
+              }),
+            ]),
+          }),
+        ])
+      );
+      expect(readFileSync(join(dir, 'src', 'rewrite.ts'), 'utf8')).toContain(
+        'contourSummarySchema contoursList contoured'
+      );
+      expect(readFileSync(join(dir, 'src', 'review.ts'), 'utf8')).toContain(
+        'render(contour: () => void)'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('CLI applies governed symbol include scope before rewriting', () => {
     const dir = makeTempDir();
     try {

--- a/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
+++ b/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
@@ -125,16 +125,16 @@ describe('createAstRewriteClass', () => {
 });
 
 describe('createAstIdentifierRenameClass', () => {
-  test('renames imports, exports, properties, and references by exact identifier', () => {
+  test('renames declarations, properties, and references by exact identifier', () => {
     const cls = createAstIdentifierRenameClass({
       from: 'sourceTerm',
       to: 'targetTerm',
     });
     const result = cls.apply(
       [
-        "import { sourceTerm } from './sourceTerms';",
+        'const sourceTermSeed = 1;',
         'export const sourceTerm = { sourceTerm, nested: { sourceTerm } };',
-        'const value = obj.sourceTerm + sourceTerm;',
+        'const value = obj.sourceTerm + sourceTerm + sourceTermSeed;',
         '',
       ].join('\n'),
       { path: 'src/sourceTerm.ts' }
@@ -143,9 +143,9 @@ describe('createAstIdentifierRenameClass', () => {
     expect(result.kind).toBe('rewrite');
     expect(result.nextSource).toBe(
       [
-        "import { targetTerm } from './sourceTerms';",
+        'const sourceTermSeed = 1;',
         'export const targetTerm = { targetTerm, nested: { targetTerm } };',
-        'const value = obj.targetTerm + targetTerm;',
+        'const value = obj.targetTerm + targetTerm + sourceTermSeed;',
         '',
       ].join('\n')
     );
@@ -408,8 +408,8 @@ describe('createAstIdentifierRenameClass', () => {
 
     const result = cls.apply(
       [
-        "import { sourceTerm } from './sourceTerms';",
-        'export const current = sourceTerm();',
+        "import { otherValue } from './sourceTerms';",
+        'export const current = otherValue();',
         'function local(sourceTerm: () => void) {',
         '  return sourceTerm();',
         '}',
@@ -468,8 +468,8 @@ describe('createAstIdentifierRenameClass', () => {
 
     const result = cls.apply(
       [
-        "import { blazeInput } from './runtime';",
-        'export const current = blazeInput();',
+        "import { otherInput } from './runtime';",
+        'export const current = otherInput();',
         'function local(blazeInput: () => void) {',
         '  return blazeInput();',
         '}',
@@ -737,6 +737,447 @@ describe('createAstIdentifierRenameClass', () => {
     );
   });
 
+  test('uses identifier-segment mode for governed contour symbols', () => {
+    const transition = getGovernedVocabularyTransition('v1-contour-entity');
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected contour vocabulary transition.');
+    }
+
+    const classes = createGovernedAstIdentifierRenameClasses(transition);
+    const entitySymbolClass = classes.find((cls) =>
+      cls.id.includes('ast-symbol-rename:v1-contour-entity:contour->entity')
+    );
+    expect(entitySymbolClass).toBeDefined();
+    if (entitySymbolClass === undefined) {
+      throw new Error('Expected contour symbol rename class.');
+    }
+
+    const result = entitySymbolClass.apply(
+      [
+        'const contour = createContour();',
+        'const createTableContour = (value: unknown) => value;',
+        'export type ContourRecord = { contour: typeof contour };',
+        'const contourSummarySchema = contour;',
+        'const contourToEntry = createTableContour(contourSummarySchema);',
+        'const CONTOUR_ID_METADATA = contourToEntry;',
+        'const countercontour = CONTOUR_ID_METADATA;',
+        'const contoured = countercontour;',
+        'const contouring = contoured;',
+        '',
+      ].join('\n'),
+      { path: 'src/contour.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        'const entity = createEntity();',
+        'const createTableEntity = (value: unknown) => value;',
+        'export type EntityRecord = { entity: typeof entity };',
+        'const entitySummarySchema = entity;',
+        'const entityToEntry = createTableEntity(entitySummarySchema);',
+        'const ENTITY_ID_METADATA = entityToEntry;',
+        'const countercontour = ENTITY_ID_METADATA;',
+        'const contoured = countercontour;',
+        'const contouring = contoured;',
+        '',
+      ].join('\n')
+    );
+  });
+
+  test('routes identifiers that already contain the contour target segment to review', () => {
+    const transition = getGovernedVocabularyTransition('v1-contour-entity');
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected contour vocabulary transition.');
+    }
+
+    const classes = createGovernedAstIdentifierRenameClasses(transition);
+    const entitySymbolClass = classes.find((cls) =>
+      cls.id.includes('ast-symbol-rename:v1-contour-entity:contour->entity')
+    );
+    expect(entitySymbolClass).toBeDefined();
+    if (entitySymbolClass === undefined) {
+      throw new Error('Expected contour symbol rename class.');
+    }
+
+    const source = [
+      'const entityContour = 1;',
+      'const ENTITY_CONTOUR = entityContour;',
+      '',
+    ].join('\n');
+    const result = entitySymbolClass.apply(source, {
+      path: 'src/entity-contour.ts',
+    });
+
+    expect(result.kind).toBe('needs-review');
+    expect(result.nextSource).toBeUndefined();
+    expect(result.reviewDetails).toEqual([
+      expect.objectContaining({
+        candidateReplacement: 'entityEntity',
+        reason: 'ast-identifier-target-segment-present',
+        symbol: 'entityContour',
+      }),
+      expect.objectContaining({
+        candidateReplacement: 'ENTITY_ENTITY',
+        reason: 'ast-identifier-target-segment-present',
+        symbol: 'ENTITY_CONTOUR',
+      }),
+      expect.objectContaining({
+        candidateReplacement: 'entityEntity',
+        reason: 'ast-identifier-target-segment-present',
+        symbol: 'entityContour',
+      }),
+    ]);
+  });
+
+  test('routes governed import and export names to review', () => {
+    const transition = getGovernedVocabularyTransition('v1-contour-entity');
+    if (transition === undefined) {
+      throw new Error('Expected contour vocabulary transition.');
+    }
+    const entitySymbolClass = createGovernedAstIdentifierRenameClasses(
+      transition
+    ).find((cls) =>
+      cls.id.includes('ast-symbol-rename:v1-contour-entity:contour->entity')
+    );
+    if (entitySymbolClass === undefined) {
+      throw new Error('Expected contour symbol rename class.');
+    }
+
+    for (const source of [
+      "import { contourId } from 'external';",
+      "import contourId from 'external';",
+      "import * as contourId from 'external';",
+      'export { localContourId as contourId };',
+    ]) {
+      const result = entitySymbolClass.apply(source, {
+        path: 'src/module-boundary.ts',
+      });
+      expect(result).toMatchObject({
+        kind: 'needs-review',
+        reason: 'ast-identifier-module-boundary',
+        reviewDetails: expect.arrayContaining([
+          expect.objectContaining({
+            reason: 'ast-identifier-module-boundary',
+          }),
+        ]),
+      });
+      expect(result.nextSource).toBeUndefined();
+    }
+  });
+
+  test('uses identifier-segment mode for governed contours symbols', () => {
+    const transition = getGovernedVocabularyTransition('v1-contour-entity');
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected contour vocabulary transition.');
+    }
+
+    const classes = createGovernedAstIdentifierRenameClasses(transition);
+    const entitiesSymbolClass = classes.find((cls) =>
+      cls.id.includes('ast-symbol-rename:v1-contour-entity:contours->entities')
+    );
+    expect(entitiesSymbolClass).toBeDefined();
+    if (entitiesSymbolClass === undefined) {
+      throw new Error('Expected contours symbol rename class.');
+    }
+
+    const result = entitiesSymbolClass.apply(
+      [
+        'const contours = listContoursSource();',
+        'const listContours = (value: unknown) => value;',
+        'export type ContoursRecord = { contours: typeof contours };',
+        'const contoursSummarySchema = contours;',
+        'const CONTOURS_ROUTE = listContours(contoursSummarySchema);',
+        'const countercontours = CONTOURS_ROUTE;',
+        '',
+      ].join('\n'),
+      { path: 'src/contours.ts' }
+    );
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        'const entities = listEntitiesSource();',
+        'const listEntities = (value: unknown) => value;',
+        'export type EntitiesRecord = { entities: typeof entities };',
+        'const entitiesSummarySchema = entities;',
+        'const ENTITIES_ROUTE = listEntities(entitiesSummarySchema);',
+        'const countercontours = ENTITIES_ROUTE;',
+        '',
+      ].join('\n')
+    );
+
+    const mixedTargetResult = entitiesSymbolClass.apply(
+      'const entityContours = 1;\n',
+      { path: 'src/entity-contours.ts' }
+    );
+    expect(mixedTargetResult.kind).toBe('needs-review');
+    expect(mixedTargetResult.nextSource).toBeUndefined();
+    expect(mixedTargetResult.reviewDetails).toEqual([
+      expect.objectContaining({
+        candidateReplacement: 'entityEntities',
+        reason: 'ast-identifier-target-segment-present',
+        symbol: 'entityContours',
+      }),
+    ]);
+  });
+
+  test('proves the public contour census replacements for the hard v1 cut', () => {
+    const transition = getGovernedVocabularyTransition('v1-contour-entity');
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected contour vocabulary transition.');
+    }
+
+    const classes = createGovernedAstIdentifierRenameClasses(transition);
+    const entitySymbolClass = classes.find((cls) =>
+      cls.id.includes('ast-symbol-rename:v1-contour-entity:contour->entity')
+    );
+    const entitiesSymbolClass = classes.find((cls) =>
+      cls.id.includes('ast-symbol-rename:v1-contour-entity:contours->entities')
+    );
+    expect(entitySymbolClass).toBeDefined();
+    expect(entitiesSymbolClass).toBeDefined();
+    if (entitySymbolClass === undefined || entitiesSymbolClass === undefined) {
+      throw new Error('Expected contour symbol rename classes.');
+    }
+
+    const source = [
+      'export interface ContourOptions {}',
+      'export type AnyContour = ContourOptions;',
+      'export type ContourReference = AnyContour;',
+      'export const getContourIdMetadata = () => undefined;',
+      'export interface TopoGraphContourReference {}',
+      'export interface TopoStoreContourRecord {}',
+      'export type TableContour = AnyContour;',
+      'export const wayfindContoursTrail = undefined;',
+      'export const getContour = () => undefined;',
+      'export const listContours = () => [];',
+      'export const contourIds = () => [];',
+      'export const contourCount = 0;',
+      '',
+    ].join('\n');
+
+    const singularResult = entitySymbolClass.apply(source, {
+      path: 'src/public-api.ts',
+    });
+    expect(singularResult.kind).toBe('rewrite');
+    const pluralResult = entitiesSymbolClass.apply(
+      singularResult.nextSource ?? '',
+      { path: 'src/public-api.ts' }
+    );
+
+    expect(pluralResult.kind).toBe('rewrite');
+    expect(pluralResult.nextSource).toBe(
+      [
+        'export interface EntityOptions {}',
+        'export type AnyEntity = EntityOptions;',
+        'export type EntityReference = AnyEntity;',
+        'export const getEntityIdMetadata = () => undefined;',
+        'export interface TopoGraphEntityReference {}',
+        'export interface TopoStoreEntityRecord {}',
+        'export type TableEntity = AnyEntity;',
+        'export const wayfindEntitiesTrail = undefined;',
+        'export const getEntity = () => undefined;',
+        'export const listEntities = () => [];',
+        'export const entityIds = () => [];',
+        'export const entityCount = 0;',
+        '',
+      ].join('\n')
+    );
+  });
+
+  test('routes governed contour FunctionParam shadows to review', () => {
+    const transition = getGovernedVocabularyTransition('v1-contour-entity');
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected contour vocabulary transition.');
+    }
+
+    const classes = createGovernedAstIdentifierRenameClasses(transition);
+    const entitySymbolClass = classes.find((cls) =>
+      cls.id.includes('ast-symbol-rename:v1-contour-entity:contour->entity')
+    );
+    expect(entitySymbolClass).toBeDefined();
+    if (entitySymbolClass === undefined) {
+      throw new Error('Expected contour symbol rename class.');
+    }
+
+    const result = entitySymbolClass.apply(
+      [
+        "import { subject } from './domain';",
+        'export const current = subject();',
+        'function local(contour: () => void) {',
+        '  return contour();',
+        '}',
+        '',
+      ].join('\n'),
+      { path: 'src/contour.ts' }
+    );
+
+    expect(result.kind).toBe('needs-review');
+    expect(result.reason).toBe('ast-identifier-review-declaration');
+    expect(result.nextSource).toBeUndefined();
+    expect(result.reviewDetails).toEqual([
+      expect.objectContaining({
+        candidateReplacement: 'entity',
+        classId: 'ast-symbol-rename:v1-contour-entity:contour->entity',
+        matchedForm: 'contour',
+        preserveCautions: [
+          'Identifier "contour" resolves to FunctionParam; routed to review.',
+        ],
+        reason: 'ast-identifier-review-declaration',
+        symbol: 'contour',
+      }),
+      expect.objectContaining({
+        candidateReplacement: 'entity',
+        classId: 'ast-symbol-rename:v1-contour-entity:contour->entity',
+        matchedForm: 'contour',
+        preserveCautions: [
+          'Identifier "contour" resolves to FunctionParam; routed to review.',
+        ],
+        reason: 'ast-identifier-review-declaration',
+        symbol: 'contour',
+      }),
+    ]);
+  });
+
+  test('rewrites governed contour string literals exactly', () => {
+    const transition = getGovernedVocabularyTransition('v1-contour-entity');
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected contour vocabulary transition.');
+    }
+
+    const classes = createGovernedAstIdentifierRenameClasses(transition);
+    const literalClasses = new Map(classes.map((cls) => [cls.id, cls]));
+    const contourLiteralClass = literalClasses.get(
+      'ast-string-literal-rename:v1-contour-entity:contour->entity'
+    );
+    const contoursLiteralClass = literalClasses.get(
+      'ast-string-literal-rename:v1-contour-entity:contours->entities'
+    );
+    const wayfindLiteralClass = literalClasses.get(
+      'ast-string-literal-rename:v1-contour-entity:wayfind.contours->wayfind.entities'
+    );
+    expect(contourLiteralClass).toBeDefined();
+    expect(contoursLiteralClass).toBeDefined();
+    expect(wayfindLiteralClass).toBeDefined();
+    if (
+      contourLiteralClass === undefined ||
+      contoursLiteralClass === undefined ||
+      wayfindLiteralClass === undefined
+    ) {
+      throw new Error('Expected contour literal rename classes.');
+    }
+
+    const source = [
+      'const singular = "contour";',
+      "const plural = 'contours';",
+      "ctx.compose('wayfind.contours', { contours });",
+      'const prose = "contourSummarySchema contoursList wayfind.contours.extra";',
+      'const idioms = ["counter-contour", "contoured", "contouring", "Contour"];',
+      '',
+    ].join('\n');
+
+    const singularResult = contourLiteralClass.apply(source, {
+      path: 'src/contour.ts',
+    });
+    expect(singularResult).toMatchObject({
+      kind: 'needs-review',
+      reason: 'ast-string-literal-review-position',
+    });
+    const pluralResult = contoursLiteralClass.apply(source, {
+      path: 'src/contour.ts',
+    });
+    expect(pluralResult).toMatchObject({
+      kind: 'needs-review',
+      reason: 'ast-string-literal-review-position',
+    });
+    const payloadResult = contourLiteralClass.apply(
+      'const apiPayload = { kind: "contour" };',
+      { path: 'src/api.ts' }
+    );
+    expect(payloadResult).toMatchObject({
+      kind: 'needs-review',
+      reason: 'ast-string-literal-review-position',
+    });
+    const wayfindResult = wayfindLiteralClass.apply(source, {
+      path: 'src/contour.ts',
+    });
+
+    expect(wayfindResult.kind).toBe('rewrite');
+    expect(wayfindResult.nextSource).toBe(
+      [
+        'const singular = "contour";',
+        "const plural = 'contours';",
+        "ctx.compose('wayfind.entities', { contours });",
+        'const prose = "contourSummarySchema contoursList wayfind.contours.extra";',
+        'const idioms = ["counter-contour", "contoured", "contouring", "Contour"];',
+        '',
+      ].join('\n')
+    );
+
+    expect(
+      wayfindLiteralClass.apply(
+        'const resolved = require.resolve("wayfind.contours");',
+        { path: 'src/module-route.ts' }
+      )
+    ).toMatchObject({
+      kind: 'needs-review',
+      reason: 'ast-string-literal-module-specifier',
+    });
+
+    for (const mockSource of [
+      'jest.createMockFromModule("wayfind.contours");',
+      'jest.doMock("wayfind.contours");',
+      'jest.genMockFromModule("wayfind.contours");',
+      'jest.mock("wayfind.contours");',
+      'jest.requireActual("wayfind.contours");',
+      'jest.requireMock("wayfind.contours");',
+      'jest.unmock("wayfind.contours");',
+      'vi.doMock("wayfind.contours");',
+      'vi.doUnmock("wayfind.contours");',
+      'vi.importActual("wayfind.contours");',
+      'vi.importMock("wayfind.contours");',
+      'vi.mock("wayfind.contours");',
+      'vi.unmock("wayfind.contours");',
+      'mock.module("wayfind.contours");',
+      'Bun.mock.module("wayfind.contours");',
+    ]) {
+      expect(
+        wayfindLiteralClass.apply(mockSource, {
+          path: 'src/module-mock.ts',
+        })
+      ).toMatchObject({
+        kind: 'needs-review',
+        reason: 'ast-string-literal-module-specifier',
+      });
+    }
+
+    for (const moduleSource of [
+      'import { contour } from "contour";',
+      'export { contour } from "contour";',
+      "type ContourModule = import('contour').Contour;",
+      "type ContourModule = typeof import('contour');",
+      'declare module "contour" {}',
+      'import contourModule = require("contour");',
+      'const contourModule = require("contour");',
+    ]) {
+      expect(
+        contourLiteralClass.apply(moduleSource, {
+          path: 'src/module-route.ts',
+        })
+      ).toMatchObject({
+        kind: 'needs-review',
+        reason: 'ast-string-literal-module-specifier',
+      });
+    }
+  });
+
   test('routes governed registry shadow declarations to review', () => {
     const transition = getGovernedVocabularyTransition('cross-compose');
     expect(transition).toBeDefined();
@@ -755,8 +1196,8 @@ describe('createAstIdentifierRenameClass', () => {
 
     const result = crossInputClass.apply(
       [
-        "import { crossInput } from './composition';",
-        'export const current = crossInput;',
+        "import { composeRef } from './composition';",
+        'export const current = composeRef;',
         'function local(crossInput: string) {',
         '  return crossInput;',
         '}',

--- a/packages/regrade/src/downstream/ast-rewrite.ts
+++ b/packages/regrade/src/downstream/ast-rewrite.ts
@@ -6,8 +6,10 @@ import type {
 import {
   applySourceEdits,
   createSourceEdit,
+  getNodeCallee,
   getStringValue,
   identifierName,
+  isMemberExpression,
   isStringLiteral,
   offsetToLineColumn,
   parseWithDiagnostics,
@@ -235,6 +237,7 @@ export interface AstIdentifierRenameClassOptions {
   readonly id?: string;
   readonly match?: AstIdentifierRenameMatchMode;
   readonly reviewDeclarationTypes?: ReadonlySet<string>;
+  readonly reviewExistingTargetSegments?: readonly string[];
   readonly shouldPreserve?: (
     occurrence: AstIdentifierRenameOccurrence
   ) => boolean;
@@ -253,18 +256,90 @@ export interface AstIdentifierRenameOccurrence {
 }
 
 export interface AstStringLiteralRenameClassOptions {
+  readonly allowModuleSpecifier?: boolean;
   readonly describe?: string;
   readonly from: string;
   readonly id?: string;
-  readonly match?: 'exact' | 'property-key';
+  readonly match?: 'exact' | 'property-key' | 'review';
   readonly shouldPreserve?: (
     occurrence: AstIdentifierRenameOccurrence
   ) => boolean;
   readonly to: string;
 }
 
+const isEsmModuleSpecifierPosition = (context: AstScopeContext): boolean =>
+  context.key === 'source' &&
+  (context.parent?.type === 'ImportDeclaration' ||
+    context.parent?.type === 'ExportAllDeclaration' ||
+    context.parent?.type === 'ExportNamedDeclaration' ||
+    context.parent?.type === 'ImportExpression' ||
+    context.parent?.type === 'TSImportType');
+
+const isTypeScriptModuleSpecifierPosition = (
+  context: AstScopeContext
+): boolean =>
+  (context.key === 'id' && context.parent?.type === 'TSModuleDeclaration') ||
+  (context.key === 'expression' &&
+    context.parent?.type === 'TSExternalModuleReference');
+
+const memberAccessPath = (node: AstNode | undefined): string | null => {
+  const name = identifierName(node);
+  if (name !== null) {
+    return name;
+  }
+  if (!isMemberExpression(node)) {
+    return null;
+  }
+  const object = memberAccessPath(node.object);
+  const property = identifierName(node.property);
+  return object === null || property === null ? null : `${object}.${property}`;
+};
+
+const MODULE_LOADER_CALLEES = new Set([
+  'Bun.mock.module',
+  'jest.createMockFromModule',
+  'jest.doMock',
+  'jest.genMockFromModule',
+  'jest.mock',
+  'jest.requireActual',
+  'jest.requireMock',
+  'jest.unmock',
+  'mock.module',
+  'require',
+  'require.resolve',
+  'vi.doMock',
+  'vi.doUnmock',
+  'vi.importActual',
+  'vi.importMock',
+  'vi.mock',
+  'vi.unmock',
+]);
+
+const isLoaderModuleSpecifierPosition = (context: AstScopeContext): boolean => {
+  if (
+    context.key !== 'arguments' ||
+    context.parent?.type !== 'CallExpression'
+  ) {
+    return false;
+  }
+
+  const callee = memberAccessPath(getNodeCallee(context.parent));
+  return callee !== null && MODULE_LOADER_CALLEES.has(callee);
+};
+
+const isModuleSpecifierPosition = (context: AstScopeContext): boolean =>
+  isEsmModuleSpecifierPosition(context) ||
+  isTypeScriptModuleSpecifierPosition(context) ||
+  isLoaderModuleSpecifierPosition(context);
+
 const isIdentifierNamed = (node: AstNode, name: string): boolean =>
   node.type === 'Identifier' && identifierName(node) === name;
+
+const stringLiteralNeedsReview = (
+  match: AstStringLiteralRenameClassOptions['match'],
+  contextKey: AstScopeContext['key']
+): boolean =>
+  match === 'review' || (match === 'property-key' && contextKey !== 'key');
 
 const identifierTokenSpan = (
   node: AstNode,
@@ -387,6 +462,9 @@ const deriveIdentifierSegmentTarget = (
     : `${leadingUnderscores}${camelOrPascalTarget}`;
 };
 
+const hasIdentifierSegment = (name: string, segment: string): boolean =>
+  deriveIdentifierSegmentTarget(name, segment, segment) !== null;
+
 interface AstIdentifierRenameMatch {
   readonly from: string;
   readonly span: { readonly end: number; readonly start: number } | null;
@@ -498,6 +576,40 @@ export const createAstIdentifierRenameClass = (
         return null;
       }
 
+      const existingTargetSegment = (
+        options.reviewExistingTargetSegments ?? [options.to]
+      ).find((segment) => hasIdentifierSegment(match.from, segment));
+      if (
+        matchMode === 'identifier-segment' &&
+        existingTargetSegment !== undefined
+      ) {
+        const location = offsetToLineColumn(context.source, span.start);
+        const caution = `Identifier "${match.from}" already contains target segment "${existingTargetSegment}"; routed to review.`;
+        return {
+          detail: {
+            candidateReplacement: match.to,
+            expectedTarget: `Review identifier "${match.from}" before replacing "${options.from}" with "${options.to}".`,
+            judgment: 'unresolved',
+            matchedForm: match.from,
+            nodeKind: node.type,
+            preserveCautions: [caution],
+            reason: 'ast-identifier-target-segment-present',
+            signals: ['ast:identifier-rename'],
+            span: {
+              column: location.column,
+              end: span.end,
+              line: location.line,
+              start: span.start,
+            },
+            suggestedValidation: 'bun run typecheck',
+            symbol: match.from,
+          },
+          kind: 'review',
+          note: caution,
+          reason: 'ast-identifier-target-segment-present',
+        };
+      }
+
       const declaration = context.getDeclaration(match.from);
       if (declaration && reviewDeclarationTypes.has(declaration.type)) {
         const location = offsetToLineColumn(context.source, span.start);
@@ -524,6 +636,39 @@ export const createAstIdentifierRenameClass = (
           kind: 'review',
           note: caution,
           reason: 'ast-identifier-review-declaration',
+        };
+      }
+
+      if (
+        context.parent?.type === 'ImportSpecifier' ||
+        context.parent?.type === 'ImportDefaultSpecifier' ||
+        context.parent?.type === 'ImportNamespaceSpecifier' ||
+        context.parent?.type === 'ExportSpecifier'
+      ) {
+        const location = offsetToLineColumn(context.source, span.start);
+        const caution = `Identifier "${match.from}" names an import or export boundary; routed to review.`;
+        return {
+          detail: {
+            candidateReplacement: match.to,
+            expectedTarget: `Review public or foreign identifier "${match.from}" before renaming it to "${match.to}".`,
+            judgment: 'unresolved',
+            matchedForm: match.from,
+            nodeKind: node.type,
+            preserveCautions: [caution],
+            reason: 'ast-identifier-module-boundary',
+            signals: ['ast:identifier-rename'],
+            span: {
+              column: location.column,
+              end: span.end,
+              line: location.line,
+              start: span.start,
+            },
+            suggestedValidation: 'bun run typecheck',
+            symbol: match.from,
+          },
+          kind: 'review',
+          note: caution,
+          reason: 'ast-identifier-module-boundary',
         };
       }
 
@@ -606,19 +751,22 @@ export const createAstStringLiteralRenameClass = (
         return null;
       }
 
-      if (options.match === 'property-key' && context.key !== 'key') {
+      if (
+        options.allowModuleSpecifier !== true &&
+        isModuleSpecifierPosition(context)
+      ) {
         const location = offsetToLineColumn(context.source, node.start);
-        const caution = `String literal "${options.from}" is not an authored property key; routed to review.`;
+        const caution = `String literal "${options.from}" is a module specifier; routed to review.`;
         return {
           detail: {
             candidateReplacement: options.to,
-            expectedTarget: `Review whether string literal "${options.from}" names the authored contract field before renaming it to "${options.to}".`,
+            expectedTarget: `Review module route "${options.from}" before renaming it to "${options.to}".`,
             judgment: 'unresolved',
             matchedForm: options.from,
             nodeKind: node.type,
             preserveCautions: [caution],
-            reason: 'ast-string-literal-review-position',
-            signals: ['ast:string-literal-rename', 'ast:property-key-required'],
+            reason: 'ast-string-literal-module-specifier',
+            signals: ['ast:string-literal-rename', 'ast:module-specifier'],
             span: {
               column: location.column,
               end: node.end,
@@ -626,7 +774,39 @@ export const createAstStringLiteralRenameClass = (
               start: node.start,
             },
             suggestedValidation:
-              'Confirm the literal is a trail contract field before changing it.',
+              'Confirm the module route is owned by this transition before changing it.',
+            symbol: options.from,
+          },
+          kind: 'review',
+          note: caution,
+          reason: 'ast-string-literal-module-specifier',
+        };
+      }
+
+      if (stringLiteralNeedsReview(options.match, context.key)) {
+        const location = offsetToLineColumn(context.source, node.start);
+        const caution = `String literal "${options.from}" is not proven framework-owned; routed to review.`;
+        return {
+          detail: {
+            candidateReplacement: options.to,
+            expectedTarget: `Review whether string literal "${options.from}" is framework-owned before renaming it to "${options.to}".`,
+            judgment: 'unresolved',
+            matchedForm: options.from,
+            nodeKind: node.type,
+            preserveCautions: [caution],
+            reason: 'ast-string-literal-review-position',
+            signals: [
+              'ast:string-literal-rename',
+              'ast:framework-position-required',
+            ],
+            span: {
+              column: location.column,
+              end: node.end,
+              line: location.line,
+              start: node.start,
+            },
+            suggestedValidation:
+              'Confirm the literal is owned by a Trails contract before changing it.',
             symbol: options.from,
           },
           kind: 'review',
@@ -650,30 +830,37 @@ export const createGovernedAstIdentifierRenameClasses = (
       occurrence: AstIdentifierRenameOccurrence
     ) => boolean;
   } = {}
-): readonly RegradeClass[] => [
-  ...transition.symbolRenames.map((rename) =>
-    createAstIdentifierRenameClass({
-      describe: `Rename governed symbol "${rename.from}" to "${rename.to}" for ${transition.id}.`,
-      from: rename.from,
-      id: `ast-symbol-rename:${transition.id}:${rename.from}->${rename.to}`,
-      match: rename.match,
-      reviewDeclarationTypes: new Set(rename.reviewDeclarationTypes),
-      ...(options.shouldPreserve === undefined
-        ? {}
-        : { shouldPreserve: options.shouldPreserve }),
-      to: rename.to,
-    })
-  ),
-  ...transition.stringLiteralRenames.map((rename) =>
-    createAstStringLiteralRenameClass({
-      describe: `Rename governed string literal "${rename.from}" to "${rename.to}" for ${transition.id}.`,
-      from: rename.from,
-      id: `ast-string-literal-rename:${transition.id}:${rename.from}->${rename.to}`,
-      ...(rename.match === undefined ? {} : { match: rename.match }),
-      ...(options.shouldPreserve === undefined
-        ? {}
-        : { shouldPreserve: options.shouldPreserve }),
-      to: rename.to,
-    })
-  ),
-];
+): readonly RegradeClass[] => {
+  const targetSegments = [
+    ...new Set(transition.symbolRenames.map((rename) => rename.to)),
+  ];
+
+  return [
+    ...transition.symbolRenames.map((rename) =>
+      createAstIdentifierRenameClass({
+        describe: `Rename governed symbol "${rename.from}" to "${rename.to}" for ${transition.id}.`,
+        from: rename.from,
+        id: `ast-symbol-rename:${transition.id}:${rename.from}->${rename.to}`,
+        match: rename.match,
+        reviewDeclarationTypes: new Set(rename.reviewDeclarationTypes),
+        reviewExistingTargetSegments: targetSegments,
+        ...(options.shouldPreserve === undefined
+          ? {}
+          : { shouldPreserve: options.shouldPreserve }),
+        to: rename.to,
+      })
+    ),
+    ...transition.stringLiteralRenames.map((rename) =>
+      createAstStringLiteralRenameClass({
+        describe: `Rename governed string literal "${rename.from}" to "${rename.to}" for ${transition.id}.`,
+        from: rename.from,
+        id: `ast-string-literal-rename:${transition.id}:${rename.from}->${rename.to}`,
+        ...(rename.match === undefined ? {} : { match: rename.match }),
+        ...(options.shouldPreserve === undefined
+          ? {}
+          : { shouldPreserve: options.shouldPreserve }),
+        to: rename.to,
+      })
+    ),
+  ];
+};

--- a/packages/warden/src/__tests__/retired-vocabulary.test.ts
+++ b/packages/warden/src/__tests__/retired-vocabulary.test.ts
@@ -187,6 +187,46 @@ describe('governed vocabulary registry', () => {
     ]);
   });
 
+  test('makes contour transition code-fact complete for apply readiness', () => {
+    const entity = getGovernedVocabularyTransition('v1-contour-entity');
+
+    expect(entity?.status).toBe('planned');
+    expect(entity?.codeIdentifiers).toEqual(
+      expect.arrayContaining(['contour', 'contours', 'wayfind.contours'])
+    );
+    expect(entity?.safeRewriteForms).toMatchObject({
+      contour: 'entity',
+      contours: 'entities',
+    });
+    expect(entity?.stringLiteralRenames).toEqual([
+      { from: 'contour', match: 'review', to: 'entity' },
+      { from: 'contours', match: 'review', to: 'entities' },
+      { from: 'wayfind.contours', to: 'wayfind.entities' },
+    ]);
+    expect(entity?.symbolRenames).toEqual([
+      {
+        from: 'contour',
+        match: 'identifier-segment',
+        reviewDeclarationTypes: ['FunctionParam'],
+        to: 'entity',
+      },
+      {
+        from: 'contours',
+        match: 'identifier-segment',
+        reviewDeclarationTypes: ['FunctionParam'],
+        to: 'entities',
+      },
+    ]);
+
+    const literalSources =
+      entity?.stringLiteralRenames.map((rename) => rename.from) ?? [];
+    expect(literalSources).not.toContain('Contour');
+    expect(literalSources).not.toContain('Contours');
+    expect(literalSources).not.toContain('contoured');
+    expect(literalSources).not.toContain('contouring');
+    expect(literalSources).not.toContain('counter-contour');
+  });
+
   test('rejects duplicate ids and duplicate source terms', () => {
     const [transition] = governedVocabularyTransitions;
     if (transition === undefined) {

--- a/packages/warden/src/rules/retired-vocabulary.ts
+++ b/packages/warden/src/rules/retired-vocabulary.ts
@@ -56,7 +56,7 @@ export const governedVocabularySymbolRenameSchema = z.object({
 
 export const governedVocabularyLiteralRenameSchema = z.object({
   from: z.string().min(1),
-  match: z.enum(['exact', 'property-key']).optional(),
+  match: z.enum(['exact', 'property-key', 'review']).optional(),
   to: z.string().min(1),
 });
 
@@ -290,10 +290,12 @@ export const governedVocabularyTransitions =
       target: { kind: 'single', to: 'implementation' },
     }),
     defineV1Transition({
-      codeIdentifiers: ['contour', 'contours'],
+      codeIdentifiers: ['contour', 'contours', 'wayfind.contours'],
       docs: {
         guidance: [
           'Keep domain-object semantics distinct from entities in app data until the occurrence is classified.',
+          'Treat contour code/API identifiers as governed symbols, with FunctionParam shadows routed to review.',
+          'Rewrite exact framework string literals only; prose, substrings, and inflections stay outside mechanical apply.',
         ],
         summary:
           'The domain object declaration term is moving from contour to entity.',
@@ -304,17 +306,28 @@ export const governedVocabularyTransitions =
         'Move the domain object declaration vocabulary from contour to entity for v1.',
       kind: 'vocabulary',
       oldForms: ['contour', 'contours', 'Contour'],
-      reviewForms: ['Contour'],
+      reviewForms: ['Contour', 'Contours', 'contoured', 'contouring'],
       safeRewriteForms: {
         contour: 'entity',
         contours: 'entities',
       },
       status: 'planned',
+      stringLiteralRenames: [
+        { from: 'contour', match: 'review', to: 'entity' },
+        { from: 'contours', match: 'review', to: 'entities' },
+        { from: 'wayfind.contours', to: 'wayfind.entities' },
+      ],
       symbolRenames: [
-        { ...reviewFunctionParamDeclarations, from: 'contour', to: 'entity' },
+        {
+          ...reviewFunctionParamDeclarations,
+          from: 'contour',
+          match: 'identifier-segment',
+          to: 'entity',
+        },
         {
           ...reviewFunctionParamDeclarations,
           from: 'contours',
+          match: 'identifier-segment',
           to: 'entities',
         },
       ],


### PR DESCRIPTION
## Context

Prepares the code-fact substrate required by [TRL-1129](https://linear.app/outfitter/issue/TRL-1129/) so the `contour` to `entity` reset can run through Regrade without blind spots.

## What changed

- Govern contour identifier segments and exact string facts.
- Preserve structured review for function-parameter and context-sensitive cases.
- Add CLI/MCP parity for the transition plan lifecycle.

## Verification

- 113 focused Warden, Regrade, CLI, and MCP tests.
- `bun run check`.
- GPT-5.5 rereview reached 5/5 with no remaining findings.

## Risk

This branch deliberately does not activate or apply the vocabulary cut; [#936](https://github.com/outfitter-dev/trails/pull/936) owns the hard cut.