### PR TITLE
feat(regrade): govern package route transitions

### DIFF
--- a/.changeset/trl-1254-warden-ast-source-route.md
+++ b/.changeset/trl-1254-warden-ast-source-route.md
@@ -1,0 +1,14 @@
+---
+"@ontrails/warden": patch
+"@ontrails/regrade": patch
+"@ontrails/trails": patch
+---
+
+Govern the exact `@ontrails/warden/ast` to `@ontrails/source` package route
+transition for Regrade string-literal and module-specifier rewrites exposed
+through the Trails CLI and MCP tools. Safe rewrites now require the owning
+manifest to already declare the target package; otherwise Regrade preserves the
+occurrence with dependency repair guidance. Invalid manifests remain unchanged
+and produce structured repair guidance that names the owning manifest. Explicit
+preserve rules remain no-ops before dependency validation, and dotted or
+subpath-like near routes remain deferred instead of becoming invented imports.

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -924,6 +924,147 @@ describe('Trails MCP surface shaping', () => {
     }
   });
 
+  test('executes governed package route rewrites and preserves through MCP', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'package.json',
+        `${JSON.stringify({ dependencies: { '@ontrails/source': '^1.0.0' }, name: 'consumer' })}\n`
+      );
+      writeFile(
+        dir,
+        'src/rewrite.ts',
+        [
+          "import { parse } from '@ontrails/warden/ast';",
+          'const route = "@ontrails/warden/ast";',
+          'const near = "@ontrails/warden/ast-extra";',
+          '',
+        ].join('\n')
+      );
+      writeFile(
+        dir,
+        'src/preserved.ts',
+        "import { walk } from '@ontrails/warden/ast';\n"
+      );
+      const tools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
+      const planRegrade = requireTool(tools, 'trails_plan_regrade');
+      const previewRegrade = requireTool(tools, 'trails_preview_regrade');
+      const applyRegrade = requireTool(tools, 'trails_apply_regrade');
+
+      const planResult = await planRegrade.handler(
+        {
+          from: '@ontrails/warden/ast',
+          include: ['src/**'],
+          preserve: [
+            {
+              forms: ['@ontrails/warden/ast'],
+              paths: ['src/preserved.ts'],
+              pattern: '@ontrails/warden/ast',
+              reason: 'intentional negative fixture',
+            },
+          ],
+          rootDir: dir,
+          to: '@ontrails/source',
+        },
+        {}
+      );
+      expect(planResult.isError).toBeUndefined();
+      expect(planResult.structuredContent).toMatchObject({
+        kind: 'regrade-plan',
+        path: '.trails/regrade/ontrails-warden-ast-to-ontrails-source.json',
+        plan: {
+          from: '@ontrails/warden/ast',
+          to: '@ontrails/source',
+        },
+      });
+
+      const previewResult = await previewRegrade.handler(
+        { includeEntries: 'all', rootDir: dir },
+        {}
+      );
+      expect(previewResult.isError).toBeUndefined();
+      const structured = previewResult.structuredContent as {
+        readonly entries?: readonly {
+          readonly classId?: string;
+          readonly outcome?: string;
+          readonly path?: string;
+        }[];
+        readonly run?: {
+          readonly plan?: {
+            readonly from?: string;
+            readonly preserve?: readonly {
+              readonly paths?: readonly string[];
+              readonly pattern?: string;
+              readonly reason?: string;
+            }[];
+            readonly to?: string;
+          };
+          readonly report?: {
+            readonly gate?: {
+              readonly reasons?: readonly string[];
+              readonly status?: string;
+            };
+          };
+        };
+        readonly selectedClassIds?: readonly string[];
+      };
+      expect(structured.selectedClassIds).toContain(
+        'ast-string-literal-rename:v1-warden-ast-source:@ontrails/warden/ast->@ontrails/source'
+      );
+      expect(structured.run?.plan).toMatchObject({
+        from: '@ontrails/warden/ast',
+        id: 'v1-warden-ast-source',
+        to: '@ontrails/source',
+      });
+      expect(structured.run?.plan?.preserve).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            paths: ['src/preserved.ts'],
+            pattern: '@ontrails/warden/ast',
+            reason: 'intentional negative fixture',
+          }),
+        ])
+      );
+      expect(structured.run?.report?.gate).toMatchObject({
+        reasons: ['safe-modifications-not-yet-applied'],
+        status: 'open',
+      });
+      expect(structured.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            classId: expect.stringContaining(
+              'ast-string-literal-rename:v1-warden-ast-source:@ontrails/warden/ast->@ontrails/source'
+            ),
+            outcome: 'rewrite',
+            path: 'src/rewrite.ts',
+          }),
+          expect.objectContaining({
+            outcome: 'no-op',
+            path: 'src/preserved.ts',
+          }),
+        ])
+      );
+
+      const applyResult = await applyRegrade.handler({ rootDir: dir }, {});
+      expect(applyResult.isError).toBeUndefined();
+      expect(applyResult.structuredContent).toMatchObject({
+        history: {
+          status: 'applied',
+        },
+      });
+      const applied = readFileSync(join(dir, 'src', 'rewrite.ts'), 'utf8');
+      expect(applied).toContain("from '@ontrails/source'");
+      expect(applied).toContain('const route = "@ontrails/source";');
+      expect(applied).toContain('const near = "@ontrails/warden/ast-extra";');
+      expect(readFileSync(join(dir, 'src', 'preserved.ts'), 'utf8')).toBe(
+        "import { walk } from '@ontrails/warden/ast';\n"
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('keeps app-authored trailhead selectors explicit enough for review', () => {
     expect(trailsMcpTrailheads.inspect.trails).toContain('survey');
     expect(trailsMcpTrailheads.inspect.trails).not.toContain('survey.*');

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -4050,10 +4050,249 @@ describe('trails regrade', () => {
         }>(result);
         expect(parsed.plan).toMatchObject({
           from: '@ontrails/warden/ast',
-          id: 'vocabulary:@ontrails/warden/ast->@ontrails/source',
+          id: 'v1-warden-ast-source',
           to: '@ontrails/source',
         });
       }
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI regrade observes and applies governed package route source strings', () => {
+    const dir = makeTempDir();
+    const input = {
+      from: '@ontrails/warden/ast',
+      include: ['src/**'],
+      to: '@ontrails/source',
+    };
+    try {
+      writeFile(
+        dir,
+        'package.json',
+        `${JSON.stringify({ dependencies: { '@ontrails/source': '^1.0.0' }, name: 'consumer' })}\n`
+      );
+      writeFile(
+        dir,
+        'src/rewrite.ts',
+        [
+          "import { parse } from '@ontrails/warden/ast';",
+          'const route = "@ontrails/warden/ast";',
+          'const near = "@ontrails/warden/ast-extra";',
+          'const larger = "use @ontrails/warden/ast here";',
+          '',
+        ].join('\n')
+      );
+      writeFile(
+        dir,
+        'src/preserved.ts',
+        "import { walk } from '@ontrails/warden/ast';\n"
+      );
+
+      const dryRun = runRawCli([
+        'regrade',
+        '--root-dir',
+        dir,
+        '--dry-run',
+        '--include-entries',
+        'all',
+        '--input-json',
+        JSON.stringify(input),
+        '--json',
+      ]);
+
+      expect(dryRun.exitCode).toBe(0);
+      const dryRunParsed = parseCliJson<{
+        readonly entries?: readonly {
+          readonly classId?: string;
+          readonly outcome?: string;
+          readonly path?: string;
+        }[];
+        readonly run?: {
+          readonly plan?: {
+            readonly from?: string;
+            readonly id?: string;
+            readonly to?: string;
+          };
+          readonly report?: {
+            readonly gate?: {
+              readonly reasons?: readonly string[];
+              readonly status?: string;
+            };
+          };
+        };
+        readonly selectedClassIds?: readonly string[];
+      }>(dryRun);
+      expect(dryRunParsed.selectedClassIds).toContain(
+        'ast-string-literal-rename:v1-warden-ast-source:@ontrails/warden/ast->@ontrails/source'
+      );
+      expect(dryRunParsed.run?.plan).toMatchObject({
+        from: '@ontrails/warden/ast',
+        id: 'v1-warden-ast-source',
+        to: '@ontrails/source',
+      });
+      expect(dryRunParsed.run?.report?.gate).toMatchObject({
+        reasons: ['safe-modifications-not-yet-applied'],
+        status: 'open',
+      });
+      expect(dryRunParsed.entries).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            classId: expect.stringContaining(
+              'ast-string-literal-rename:v1-warden-ast-source:@ontrails/warden/ast->@ontrails/source'
+            ),
+            outcome: 'rewrite',
+            path: 'src/rewrite.ts',
+          }),
+          expect.objectContaining({
+            classId:
+              'ast-string-literal-rename:v1-warden-ast-source:@ontrails/warden/ast->@ontrails/source',
+            outcome: 'rewrite',
+            path: 'src/preserved.ts',
+          }),
+        ])
+      );
+
+      const recordPath = writeVocabularyTransitionRecord([
+        '--root-dir',
+        dir,
+        '--input-json',
+        JSON.stringify({
+          ...input,
+          preserve: [
+            {
+              forms: ['@ontrails/warden/ast'],
+              paths: ['src/preserved.ts'],
+              pattern: '@ontrails/warden/ast',
+              reason: 'intentional negative fixture',
+            },
+          ],
+        }),
+      ]);
+      const apply = runRawCli([
+        'regrade',
+        '--root-dir',
+        dir,
+        '--include-entries',
+        'all',
+        '--input-json',
+        JSON.stringify({
+          apply: true,
+          planRecord: recordPath,
+        }),
+        '--json',
+      ]);
+
+      expect(apply.exitCode).toBe(0);
+      const applied = readFileSync(join(dir, 'src', 'rewrite.ts'), 'utf8');
+      expect(applied).toContain("from '@ontrails/source'");
+      expect(applied).toContain('const route = "@ontrails/source";');
+      expect(applied).toContain('const near = "@ontrails/warden/ast-extra";');
+      expect(applied).toContain(
+        'const larger = "use @ontrails/warden/ast here";'
+      );
+      expect(readFileSync(join(dir, 'src', 'preserved.ts'), 'utf8')).toBe(
+        "import { walk } from '@ontrails/warden/ast';\n"
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI regrade preserves package routes until the target dependency is declared', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'package.json',
+        `${JSON.stringify({ dependencies: { '@ontrails/warden': '^1.0.0' }, name: 'consumer' })}\n`
+      );
+      writeFile(
+        dir,
+        'src/consumer.ts',
+        "import { parse } from '@ontrails/warden/ast';\n"
+      );
+
+      const result = runRawCli([
+        'regrade',
+        '--root-dir',
+        dir,
+        '--dry-run',
+        '--include-entries',
+        'all',
+        '--input-json',
+        JSON.stringify({
+          from: '@ontrails/warden/ast',
+          include: ['src/**'],
+          to: '@ontrails/source',
+        }),
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      const parsed = parseCliJson<{
+        readonly entries?: readonly {
+          readonly outcome?: string;
+          readonly reason?: string;
+          readonly reviewDetails?: readonly {
+            readonly expectedTarget?: string;
+          }[];
+        }[];
+      }>(result);
+      expect(parsed.entries).toContainEqual(
+        expect.objectContaining({
+          outcome: 'needs-review',
+          reason: 'package-route-target-dependency-unverified',
+          reviewDetails: expect.arrayContaining([
+            expect.objectContaining({
+              expectedTarget: expect.stringContaining(
+                'Declare "@ontrails/source" in package.json'
+              ),
+            }),
+          ]),
+        })
+      );
+      expect(readFileSync(join(dir, 'src', 'consumer.ts'), 'utf8')).toContain(
+        "from '@ontrails/warden/ast'"
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI regrade names invalid package manifests before preserving routes', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'package.json', '{ invalid json\n');
+      writeFile(
+        dir,
+        'src/consumer.ts',
+        "import { parse } from '@ontrails/warden/ast';\n"
+      );
+
+      const result = runRawCli([
+        'regrade',
+        '--root-dir',
+        dir,
+        '--dry-run',
+        '--include-entries',
+        'all',
+        '--input-json',
+        JSON.stringify({
+          from: '@ontrails/warden/ast',
+          include: ['src/**'],
+          to: '@ontrails/source',
+        }),
+        '--json',
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(
+        'Fix invalid package manifest package.json'
+      );
+      expect(readFileSync(join(dir, 'src', 'consumer.ts'), 'utf8')).toContain(
+        "from '@ontrails/warden/ast'"
+      );
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
+++ b/packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test';
 import { createSourceEdit, getNodeName } from '@ontrails/source';
-import { getGovernedVocabularyTransition } from '@ontrails/warden';
+import {
+  getGovernedVocabularyTransition,
+  governedVocabularyTransitionSchema,
+} from '@ontrails/warden';
 
 import {
   createAstIdentifierRenameClass,
@@ -1176,6 +1179,337 @@ describe('createAstIdentifierRenameClass', () => {
         reason: 'ast-string-literal-module-specifier',
       });
     }
+  });
+
+  test('rewrites governed package route import specifiers and exact strings only', () => {
+    const transition = getGovernedVocabularyTransition('v1-warden-ast-source');
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected warden ast package route transition.');
+    }
+
+    const classes = createGovernedAstIdentifierRenameClasses(transition);
+    const routeLiteralClass = classes.find((cls) =>
+      cls.id.includes(
+        'ast-string-literal-rename:v1-warden-ast-source:@ontrails/warden/ast->@ontrails/source'
+      )
+    );
+    expect(routeLiteralClass).toBeDefined();
+    if (routeLiteralClass === undefined) {
+      throw new Error('Expected warden ast route literal rename class.');
+    }
+
+    const source = [
+      "import { parse } from '@ontrails/warden/ast';",
+      "export { walk } from '@ontrails/warden/ast';",
+      'const route = "@ontrails/warden/ast";',
+      'const near = "@ontrails/warden/ast-extra";',
+      'const larger = "use @ontrails/warden/ast here";',
+      "import { parse as parseSource } from '@ontrails/source';",
+      '',
+    ].join('\n');
+
+    const result = routeLiteralClass.apply(source, {
+      package: {
+        dependencies: ['@ontrails/source'],
+        name: 'consumer',
+        path: 'package.json',
+      },
+      path: 'src/source.ts',
+    });
+
+    expect(result.kind).toBe('rewrite');
+    expect(result.nextSource).toBe(
+      [
+        "import { parse } from '@ontrails/source';",
+        "export { walk } from '@ontrails/source';",
+        'const route = "@ontrails/source";',
+        'const near = "@ontrails/warden/ast-extra";',
+        'const larger = "use @ontrails/warden/ast here";',
+        "import { parse as parseSource } from '@ontrails/source';",
+        '',
+      ].join('\n')
+    );
+
+    const templateResult = routeLiteralClass.apply(
+      [
+        'const route = `@ontrails/warden/ast`;',
+        'const loaded = import(`@ontrails/warden/ast`);',
+        '',
+      ].join('\n'),
+      {
+        package: {
+          dependencies: ['@ontrails/source'],
+          name: 'consumer',
+          path: 'package.json',
+          runtimeDependencies: ['@ontrails/source'],
+        },
+        path: 'src/templates.ts',
+      }
+    );
+    expect(templateResult.kind).toBe('rewrite');
+    expect(templateResult.nextSource).toBe(
+      [
+        'const route = `@ontrails/source`;',
+        'const loaded = import(`@ontrails/source`);',
+        '',
+      ].join('\n')
+    );
+
+    for (const adjacentRoute of [
+      '@ontrails/warden/ast/utils',
+      '@ontrails/warden/ast.js',
+      '@ontrails/warden/ast.utils',
+    ]) {
+      const adjacentResult = routeLiteralClass.apply(
+        `import value from '${adjacentRoute}';`,
+        {
+          package: {
+            dependencies: ['@ontrails/source'],
+            name: 'consumer',
+            path: 'package.json',
+          },
+          path: 'src/source.ts',
+        }
+      );
+      expect(adjacentResult).toMatchObject({
+        kind: 'needs-review',
+        reason: 'ast-string-literal-adjacent-module-route',
+      });
+      expect(adjacentResult.reviewDetails?.[0]).toMatchObject({
+        matchedForm: adjacentRoute,
+      });
+    }
+
+    for (const helperSource of [
+      "require.resolve('@ontrails/warden/ast/utils');",
+      "jest.mock('@ontrails/warden/ast/utils');",
+      "vi.mock('@ontrails/warden/ast/utils');",
+    ]) {
+      expect(
+        routeLiteralClass.apply(helperSource, {
+          package: {
+            dependencies: ['@ontrails/source'],
+            name: 'consumer',
+            path: 'package.json',
+          },
+          path: 'src/source.ts',
+        })
+      ).toMatchObject({
+        kind: 'needs-review',
+        reason: 'ast-string-literal-adjacent-module-route',
+      });
+    }
+
+    const inventedPlural = routeLiteralClass.apply(
+      "import value from '@ontrails/warden/asts';",
+      {
+        package: {
+          dependencies: ['@ontrails/source'],
+          name: 'consumer',
+          path: 'package.json',
+        },
+        path: 'src/source.ts',
+      }
+    );
+    expect(inventedPlural.kind).toBe('no-op');
+
+    const missingDependency = routeLiteralClass.apply(source, {
+      package: {
+        dependencies: ['@ontrails/warden'],
+        name: 'consumer',
+        path: 'package.json',
+      },
+      path: 'src/source.ts',
+    });
+    expect(missingDependency).toMatchObject({
+      kind: 'needs-review',
+      reason: 'package-route-target-dependency-unverified',
+    });
+    expect(missingDependency.reviewDetails?.[0]).toMatchObject({
+      candidateReplacement: '@ontrails/source',
+      expectedTarget: expect.stringContaining(
+        'Declare "@ontrails/source" in package.json'
+      ),
+    });
+
+    const devOnlyDependency = routeLiteralClass.apply(
+      "import { parse } from '@ontrails/warden/ast';",
+      {
+        package: {
+          dependencies: ['@ontrails/source'],
+          name: 'consumer',
+          path: 'package.json',
+          runtimeDependencies: [],
+        },
+        path: 'src/source.ts',
+      }
+    );
+    expect(devOnlyDependency).toMatchObject({
+      kind: 'needs-review',
+      reason: 'package-route-target-dependency-unverified',
+    });
+
+    const testOnlyDependency = routeLiteralClass.apply(
+      "import { parse } from '@ontrails/warden/ast';",
+      {
+        package: {
+          dependencies: ['@ontrails/source'],
+          name: 'consumer',
+          path: 'package.json',
+          runtimeDependencies: [],
+        },
+        path: 'src/__tests__/source.test.ts',
+      }
+    );
+    expect(testOnlyDependency.kind).toBe('rewrite');
+
+    const preservingClasses = createGovernedAstIdentifierRenameClasses(
+      transition,
+      {
+        shouldPreserve: (occurrence) =>
+          occurrence.path === 'src/preserved.ts' &&
+          occurrence.from === '@ontrails/warden/ast',
+      }
+    );
+    const preservingRouteClass = preservingClasses.find((cls) =>
+      cls.id.includes(
+        'ast-string-literal-rename:v1-warden-ast-source:@ontrails/warden/ast->@ontrails/source'
+      )
+    );
+    expect(preservingRouteClass).toBeDefined();
+    if (preservingRouteClass === undefined) {
+      throw new Error('Expected preserving package route rename class.');
+    }
+    const preservedMissingDependency = preservingRouteClass.apply(
+      "import { parse } from '@ontrails/warden/ast';",
+      {
+        package: {
+          dependencies: ['@ontrails/warden'],
+          name: 'consumer',
+          path: 'package.json',
+        },
+        path: 'src/preserved.ts',
+      }
+    );
+    expect(preservedMissingDependency.kind).toBe('no-op');
+
+    const adjacentInPreservedPath = preservingRouteClass.apply(
+      "import value from '@ontrails/warden/ast/utils';",
+      {
+        package: {
+          dependencies: ['@ontrails/source'],
+          name: 'consumer',
+          path: 'package.json',
+        },
+        path: 'src/preserved.ts',
+      }
+    );
+    expect(adjacentInPreservedPath).toMatchObject({
+      kind: 'needs-review',
+      reason: 'ast-string-literal-adjacent-module-route',
+    });
+    expect(adjacentInPreservedPath.reviewDetails?.[0]).toMatchObject({
+      matchedForm: '@ontrails/warden/ast/utils',
+    });
+
+    const invalidManifest = routeLiteralClass.apply(
+      "import { parse } from '@ontrails/warden/ast';",
+      {
+        package: {
+          dependencies: [],
+          manifestState: 'invalid',
+          path: 'package.json',
+        },
+        path: 'src/source.ts',
+      }
+    );
+    expect(invalidManifest).toMatchObject({
+      kind: 'needs-review',
+      reason: 'package-route-target-dependency-unverified',
+    });
+    expect(invalidManifest.reviewDetails?.[0]).toMatchObject({
+      expectedTarget: expect.stringContaining(
+        'Fix invalid package manifest package.json'
+      ),
+      signals: expect.arrayContaining(['package:manifest-invalid']),
+    });
+  });
+
+  test('requires explicit governed package route intent for scoped literals', () => {
+    const transition = governedVocabularyTransitionSchema.parse({
+      docs: {
+        summary: 'A scoped label changes without owning a package route.',
+      },
+      from: '@example/internal-label',
+      id: 'scoped-label-transition',
+      intent: 'Rename a scoped label without changing module routes.',
+      kind: 'vocabulary',
+      oldForms: ['@example/internal-label'],
+      status: 'active',
+      stringLiteralRenames: [
+        { from: '@example/internal-label', to: '@example/new-label' },
+      ],
+      target: { kind: 'single', to: '@example/new-label' },
+    });
+    const literalClass = createGovernedAstIdentifierRenameClasses(
+      transition
+    ).find((cls) => cls.id.startsWith('ast-string-literal-rename:'));
+
+    expect(literalClass).toBeDefined();
+    expect(
+      literalClass?.apply("import value from '@example/internal-label';", {
+        path: 'src/label.ts',
+      })
+    ).toMatchObject({
+      kind: 'needs-review',
+      reason: 'ast-string-literal-module-specifier',
+    });
+  });
+
+  test('orders exact package subpath rewrites before package roots', () => {
+    const transition = governedVocabularyTransitionSchema.parse({
+      docs: { summary: 'Move one package and its public subpath.' },
+      from: '@example/old',
+      id: 'package-route-order',
+      intent: 'Move exact package routes without losing subpath rewrites.',
+      kind: 'vocabulary',
+      oldForms: ['@example/old', '@example/old/support'],
+      status: 'active',
+      stringLiteralRenames: [
+        {
+          from: '@example/old',
+          moduleSpecifier: { targetPackage: '@example/new' },
+          to: '@example/new',
+        },
+        {
+          from: '@example/old/support',
+          moduleSpecifier: { targetPackage: '@example/new' },
+          to: '@example/new/support',
+        },
+      ],
+      target: { kind: 'single', to: '@example/new' },
+    });
+    const literalClasses = createGovernedAstIdentifierRenameClasses(
+      transition
+    ).filter((cls) => cls.id.startsWith('ast-string-literal-rename:'));
+
+    expect(literalClasses.map((cls) => cls.id)).toEqual([
+      'ast-string-literal-rename:package-route-order:@example/old/support->@example/new/support',
+      'ast-string-literal-rename:package-route-order:@example/old->@example/new',
+    ]);
+    expect(
+      literalClasses[0]?.apply("import value from '@example/old/support';", {
+        package: {
+          dependencies: ['@example/new'],
+          path: 'package.json',
+        },
+        path: 'src/source.ts',
+      })
+    ).toMatchObject({
+      kind: 'rewrite',
+      nextSource: "import value from '@example/new/support';",
+    });
   });
 
   test('routes governed registry shadow declarations to review', () => {

--- a/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
+++ b/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
@@ -119,6 +119,210 @@ describe('runVocabularyRegrade', () => {
     }
   });
 
+  test('keeps non-word governed sources exact instead of inventing plural forms', () => {
+    const transition = getGovernedVocabularyTransition('v1-warden-ast-source');
+    expect(transition).toBeDefined();
+    if (transition === undefined) {
+      throw new Error('Expected Warden AST package route transition.');
+    }
+
+    const plan = vocabularyRegradePlanFromTransition(transition);
+    expect(plan).toMatchObject({
+      from: '@ontrails/warden/ast',
+      id: 'v1-warden-ast-source',
+      kind: 'vocabulary',
+      overrides: {
+        '@ontrails/warden/ast': '@ontrails/source',
+      },
+      scope: {
+        exclude: expect.arrayContaining([
+          '.changeset/**',
+          'packages/warden/src/rules/retired-vocabulary.ts',
+        ]),
+      },
+      to: '@ontrails/source',
+    });
+    expect(plan?.overrides).not.toHaveProperty('@ontrails/warden/asts');
+    if (plan === null) {
+      throw new Error('Expected package route transition to produce a plan.');
+    }
+
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'docs/route.md',
+        'Use @ontrails/warden/ast for the shared source helpers. Then use @ontrails/warden/ast.\n'
+      );
+      writeFile(dir, 'docs/root-route.md', '@ontrails/warden/ast');
+      writeFile(
+        dir,
+        'docs/api-reference.md',
+        'The @ontrails/warden/ast compatibility facade remains live.\n'
+      );
+      writeFile(
+        dir,
+        'docs/invented.md',
+        'The invented @ontrails/warden/asts route must stay untouched.\n'
+      );
+      writeFile(
+        dir,
+        'scripts/verify-oxc-resolver-published.ts',
+        "assertResolved(check, '@ontrails/warden/ast');\n"
+      );
+      writeFile(
+        dir,
+        'docs/suffixed.md',
+        'Use @ontrails/warden/ast/utils for private helpers.\n'
+      );
+      writeFile(
+        dir,
+        'docs/dotted.md',
+        'Keep @ontrails/warden/ast.js and @ontrails/warden/ast.utils untouched.\n'
+      );
+      writeFile(
+        dir,
+        'src/source.ts',
+        "import { parse } from '@ontrails/warden/ast';\n"
+      );
+      writeFile(
+        dir,
+        'apps/trails/src/__tests__/regrade.test.ts',
+        "const legacyRoute = '@ontrails/warden/ast';\n"
+      );
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          ...plan,
+          scope: {
+            include: ['apps/**', 'docs/**', 'scripts/**', 'src/**'],
+          },
+        },
+        root: dir,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+      expect(result.value.run.ledger.forms).toMatchObject({
+        '@ontrails/warden/ast.js': 'deferred',
+        '@ontrails/warden/ast.utils': 'deferred',
+        '@ontrails/warden/ast/utils': 'deferred',
+        '@ontrails/warden/asts': 'deferred',
+      });
+      expect(readFileSync(join(dir, 'docs', 'route.md'), 'utf8')).toBe(
+        'Use @ontrails/source for the shared source helpers. Then use @ontrails/source.\n'
+      );
+      expect(readFileSync(join(dir, 'docs', 'root-route.md'), 'utf8')).toBe(
+        '@ontrails/source'
+      );
+      expect(readFileSync(join(dir, 'docs', 'api-reference.md'), 'utf8')).toBe(
+        'The @ontrails/warden/ast compatibility facade remains live.\n'
+      );
+      expect(
+        readFileSync(
+          join(dir, 'scripts', 'verify-oxc-resolver-published.ts'),
+          'utf8'
+        )
+      ).toBe("assertResolved(check, '@ontrails/warden/ast');\n");
+      expect(readFileSync(join(dir, 'docs', 'invented.md'), 'utf8')).toBe(
+        'The invented @ontrails/warden/asts route must stay untouched.\n'
+      );
+      expect(readFileSync(join(dir, 'docs', 'suffixed.md'), 'utf8')).toBe(
+        'Use @ontrails/warden/ast/utils for private helpers.\n'
+      );
+      expect(readFileSync(join(dir, 'docs', 'dotted.md'), 'utf8')).toBe(
+        'Keep @ontrails/warden/ast.js and @ontrails/warden/ast.utils untouched.\n'
+      );
+      expect(readFileSync(join(dir, 'src', 'source.ts'), 'utf8')).toBe(
+        "import { parse } from '@ontrails/warden/ast';\n"
+      );
+      expect(result.value.entries).toContainEqual(
+        expect.objectContaining({
+          outcome: 'needs-review',
+          path: 'src/source.ts',
+          reviewDetails: expect.arrayContaining([
+            expect.objectContaining({
+              reason: 'package-route-ast-required',
+              symbol: '@ontrails/warden/ast',
+            }),
+          ]),
+        })
+      );
+      expect(result.value.run.ledger.occurrences).toContainEqual(
+        expect.objectContaining({
+          disposition: 'explicit-preserve',
+          path: 'apps/trails/src/__tests__/regrade.test.ts',
+          verdict: 'skipped',
+        })
+      );
+      expect(result.value.entries).not.toContainEqual(
+        expect.objectContaining({
+          path: 'apps/trails/src/__tests__/regrade.test.ts',
+        })
+      );
+      expect(
+        readFileSync(
+          join(dir, 'apps/trails/src/__tests__/regrade.test.ts'),
+          'utf8'
+        )
+      ).toBe("const legacyRoute = '@ontrails/warden/ast';\n");
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('defers package routes across the full JS and TS extension family', () => {
+    const transition = getGovernedVocabularyTransition('v1-warden-ast-source');
+    const plan =
+      transition === undefined
+        ? null
+        : vocabularyRegradePlanFromTransition(transition);
+    if (plan === null) {
+      throw new Error('Expected package route transition to produce a plan.');
+    }
+
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/config.cts',
+        "const source = require('@ontrails/warden/ast');\n"
+      );
+
+      const result = runVocabularyRegrade({
+        apply: true,
+        plan: {
+          ...plan,
+          scope: { extensions: ['.cts'], include: ['src/**'] },
+        },
+        root: dir,
+      });
+      expect(result.isOk()).toBe(true);
+      if (result.isErr()) {
+        throw result.error;
+      }
+
+      expect(result.value.entries).toContainEqual(
+        expect.objectContaining({
+          outcome: 'needs-review',
+          path: 'src/config.cts',
+          reviewDetails: expect.arrayContaining([
+            expect.objectContaining({
+              reason: 'package-route-ast-required',
+              symbol: '@ontrails/warden/ast',
+            }),
+          ]),
+        })
+      );
+      expect(readFileSync(join(dir, 'src/config.cts'), 'utf8')).toBe(
+        "const source = require('@ontrails/warden/ast');\n"
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('does not turn classified vocabulary transitions into unsafe plans', () => {
     const transition = getGovernedVocabularyTransition(
       'v1-projection-derive-render'

--- a/packages/regrade/src/downstream/ast-rewrite.ts
+++ b/packages/regrade/src/downstream/ast-rewrite.ts
@@ -2,6 +2,7 @@ import type { AstNode, AstScopeContext, SourceEdit } from '@ontrails/source';
 import {
   applySourceEdits,
   createSourceEdit,
+  extractPlainTemplateLiteral,
   getNodeCallee,
   getStringValue,
   identifierName,
@@ -21,8 +22,8 @@ import type {
   RegradeReviewDetail,
 } from './report.js';
 
-export interface AstRewriteContext extends AstScopeContext {
-  readonly path: string;
+export interface AstRewriteContext
+  extends AstScopeContext, RegradeClassContext {
   readonly source: string;
 }
 
@@ -177,7 +178,7 @@ export const createAstRewriteClass = (
           ...toArray(
             options.visit(node, {
               ...scopeContext,
-              path: context.path,
+              ...context,
               source,
             })
           )
@@ -260,6 +261,8 @@ export interface AstStringLiteralRenameClassOptions {
   readonly shouldPreserve?: (
     occurrence: AstIdentifierRenameOccurrence
   ) => boolean;
+  /** Require the owning manifest to already admit this package route. */
+  readonly targetPackage?: string;
   readonly to: string;
 }
 
@@ -327,6 +330,24 @@ const isModuleSpecifierPosition = (context: AstScopeContext): boolean =>
   isEsmModuleSpecifierPosition(context) ||
   isTypeScriptModuleSpecifierPosition(context) ||
   isLoaderModuleSpecifierPosition(context);
+
+const isTargetPackageMissing = (
+  context: AstRewriteContext,
+  targetPackage: string | undefined
+): boolean => {
+  if (targetPackage === undefined || context.package?.name === targetPackage) {
+    return false;
+  }
+  const testSource =
+    context.path.split('/').includes('__tests__') ||
+    /(?:^|\.)(?:test|spec)\.[cm]?[jt]sx?$/.test(
+      context.path.split('/').at(-1) ?? ''
+    );
+  const dependencies = testSource
+    ? context.package?.dependencies
+    : (context.package?.runtimeDependencies ?? context.package?.dependencies);
+  return !dependencies?.includes(targetPackage);
+};
 
 const isIdentifierNamed = (node: AstNode, name: string): boolean =>
   node.type === 'Identifier' && identifierName(node) === name;
@@ -691,6 +712,35 @@ const stringLiteralValueSpan = (
   return { end: start + value.length, start };
 };
 
+const isAdjacentModuleRoute = (value: string, route: string): boolean =>
+  value.startsWith(`${route}/`) || value.startsWith(`${route}.`);
+
+interface AstStringLiteralMatch {
+  readonly adjacentModuleRoute: boolean;
+  readonly value: string;
+}
+
+const matchAstStringLiteral = (
+  node: AstNode,
+  options: AstStringLiteralRenameClassOptions
+): AstStringLiteralMatch | null => {
+  if (!isStringLiteral(node) && node.type !== 'TemplateLiteral') {
+    return null;
+  }
+  const value = isStringLiteral(node)
+    ? getStringValue(node)
+    : extractPlainTemplateLiteral(node);
+  if (value === null) {
+    return null;
+  }
+  const adjacentModuleRoute =
+    options.allowModuleSpecifier === true &&
+    isAdjacentModuleRoute(value, options.from);
+  return value === options.from || adjacentModuleRoute
+    ? { adjacentModuleRoute, value }
+    : null;
+};
+
 export const createAstStringLiteralRenameClass = (
   options: AstStringLiteralRenameClassOptions
 ): RegradeClass =>
@@ -701,11 +751,13 @@ export const createAstStringLiteralRenameClass = (
     id:
       options.id ?? `ast-string-literal-rename:${options.from}->${options.to}`,
     visit: (node, context) => {
-      if (!isStringLiteral(node) || getStringValue(node) !== options.from) {
+      const match = matchAstStringLiteral(node, options);
+      if (match === null) {
         return null;
       }
+      const { adjacentModuleRoute, value } = match;
 
-      const span = stringLiteralValueSpan(node, context.source, options.from);
+      const span = stringLiteralValueSpan(node, context.source, value);
       if (span === null) {
         const location = offsetToLineColumn(context.source, node.start);
         const caution = `String literal "${options.from}" token span could not be verified; routed to review.`;
@@ -737,7 +789,7 @@ export const createAstStringLiteralRenameClass = (
       if (
         options.shouldPreserve?.({
           end: span.end,
-          from: options.from,
+          from: value,
           path: context.path,
           source: context.source,
           start: span.start,
@@ -745,6 +797,35 @@ export const createAstStringLiteralRenameClass = (
         }) === true
       ) {
         return null;
+      }
+
+      if (adjacentModuleRoute) {
+        const location = offsetToLineColumn(context.source, node.start);
+        const caution = `Module route "${value}" is adjacent to governed route "${options.from}"; routed to review.`;
+        return {
+          detail: {
+            candidateReplacement: `${options.to}${value.slice(options.from.length)}`,
+            expectedTarget: `Review whether module route "${value}" moves with governed route "${options.from}".`,
+            judgment: 'unresolved',
+            matchedForm: value,
+            nodeKind: node.type,
+            preserveCautions: [caution],
+            reason: 'ast-string-literal-adjacent-module-route',
+            signals: ['ast:string-literal-rename', 'ast:module-specifier'],
+            span: {
+              column: location.column,
+              end: node.end,
+              line: location.line,
+              start: node.start,
+            },
+            suggestedValidation:
+              'Confirm whether the adjacent module route is public, private, or intentionally preserved.',
+            symbol: value,
+          },
+          kind: 'review',
+          note: caution,
+          reason: 'ast-string-literal-adjacent-module-route',
+        };
       }
 
       if (
@@ -776,6 +857,46 @@ export const createAstStringLiteralRenameClass = (
           kind: 'review',
           note: caution,
           reason: 'ast-string-literal-module-specifier',
+        };
+      }
+
+      if (isTargetPackageMissing(context, options.targetPackage)) {
+        const location = offsetToLineColumn(context.source, node.start);
+        const manifest = context.package?.path ?? 'the owning package.json';
+        const invalidManifest = context.package?.manifestState === 'invalid';
+        const caution = invalidManifest
+          ? `Package manifest ${manifest} is invalid; routed to review before rewriting package route "${options.to}".`
+          : `Package route "${options.to}" is not declared by ${manifest}; routed to review before rewriting source.`;
+        return {
+          detail: {
+            candidateReplacement: options.to,
+            expectedTarget: invalidManifest
+              ? `Fix invalid package manifest ${manifest}, declare "${options.targetPackage}", install dependencies, then rename "${options.from}" to "${options.to}".`
+              : `Declare "${options.targetPackage}" in ${manifest}, install dependencies, then rename "${options.from}" to "${options.to}".`,
+            judgment: 'unresolved',
+            matchedForm: options.from,
+            nodeKind: node.type,
+            preserveCautions: [caution],
+            reason: 'package-route-target-dependency-unverified',
+            signals: [
+              'ast:string-literal-rename',
+              'package:dependency',
+              ...(invalidManifest ? ['package:manifest-invalid'] : []),
+            ],
+            span: {
+              column: location.column,
+              end: node.end,
+              line: location.line,
+              start: node.start,
+            },
+            suggestedValidation: invalidManifest
+              ? 'Repair the package manifest, install dependencies, and run the package typecheck.'
+              : 'Install dependencies and run the package typecheck.',
+            symbol: options.from,
+          },
+          kind: 'review',
+          note: caution,
+          reason: 'package-route-target-dependency-unverified',
         };
       }
 
@@ -830,6 +951,11 @@ export const createGovernedAstIdentifierRenameClasses = (
   const targetSegments = [
     ...new Set(transition.symbolRenames.map((rename) => rename.to)),
   ];
+  const orderedLiteralRenames = [...transition.stringLiteralRenames].toSorted(
+    (left, right) =>
+      right.from.length - left.from.length ||
+      left.from.localeCompare(right.from)
+  );
 
   return [
     ...transition.symbolRenames.map((rename) =>
@@ -846,7 +972,7 @@ export const createGovernedAstIdentifierRenameClasses = (
         to: rename.to,
       })
     ),
-    ...transition.stringLiteralRenames.map((rename) =>
+    ...orderedLiteralRenames.map((rename) =>
       createAstStringLiteralRenameClass({
         describe: `Rename governed string literal "${rename.from}" to "${rename.to}" for ${transition.id}.`,
         from: rename.from,
@@ -855,6 +981,12 @@ export const createGovernedAstIdentifierRenameClasses = (
         ...(options.shouldPreserve === undefined
           ? {}
           : { shouldPreserve: options.shouldPreserve }),
+        ...(rename.moduleSpecifier === undefined
+          ? {}
+          : {
+              allowModuleSpecifier: true,
+              targetPackage: rename.moduleSpecifier.targetPackage,
+            }),
         to: rename.to,
       })
     ),

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -17,7 +17,8 @@ import {
   loadProjectWardenRules,
   wardenRules,
 } from '@ontrails/warden';
-import { readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
 import { z } from 'zod';
 
 import {
@@ -79,6 +80,16 @@ export interface RegradeClassContext {
   readonly path: string;
   /** Absolute path on disk, when the caller has one. */
   readonly absolutePath?: string;
+  /** Nearest owning package facts, when filesystem collection found a manifest. */
+  readonly package?: {
+    readonly dependencies: readonly string[];
+    /** Runtime-visible dependency declarations (dependencies, optional, peer). */
+    readonly runtimeDependencies?: readonly string[];
+    readonly manifestState?: 'invalid' | 'valid';
+    readonly name?: string;
+    /** Root-relative POSIX manifest path. */
+    readonly path: string;
+  };
 }
 
 /** Files a regrade class knows how to inspect. */
@@ -966,6 +977,7 @@ const buildRegradeEvaluation = (params: {
     readonly path: string;
     readonly source: string;
     readonly absolutePath?: string;
+    readonly package?: RegradeClassContext['package'];
   }[];
   readonly skipped: readonly SkippedSource[];
   readonly classes: readonly RegradeClass[];
@@ -987,6 +999,7 @@ const buildRegradeEvaluation = (params: {
         ...(file.absolutePath === undefined
           ? {}
           : { absolutePath: file.absolutePath }),
+        ...(file.package === undefined ? {} : { package: file.package }),
         path: file.path,
       },
       selected,
@@ -1055,6 +1068,7 @@ export const buildRegradeReport = (params: {
     readonly path: string;
     readonly source: string;
     readonly absolutePath?: string;
+    readonly package?: RegradeClassContext['package'];
   }[];
   readonly skipped: readonly SkippedSource[];
   readonly classes: readonly RegradeClass[];
@@ -1127,6 +1141,121 @@ const canReadDownstreamRoot = (root: string): boolean => {
   }
 };
 
+const PACKAGE_DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
+
+const RUNTIME_PACKAGE_DEPENDENCY_FIELDS = [
+  'dependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
+
+const dependencyNames = (
+  manifest: Readonly<Record<string, unknown>>,
+  fields: readonly (typeof PACKAGE_DEPENDENCY_FIELDS)[number][]
+): readonly string[] =>
+  fields.flatMap((field) => {
+    const value = manifest[field];
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? Object.keys(value)
+      : [];
+  });
+
+const packageContextFor = (
+  root: string,
+  absolutePath: string,
+  cache: Map<string, RegradeClassContext['package'] | undefined>
+): RegradeClassContext['package'] | undefined => {
+  const absoluteRoot = resolve(root);
+  let current = dirname(absolutePath);
+  const visited: string[] = [];
+  while (true) {
+    if (cache.has(current)) {
+      const cached = cache.get(current);
+      for (const directory of visited) {
+        cache.set(directory, cached);
+      }
+      return cached;
+    }
+    visited.push(current);
+    const fromRoot = relative(absoluteRoot, current);
+    if (fromRoot.startsWith('..') || resolve(current) !== current) {
+      break;
+    }
+    const manifestPath = join(current, 'package.json');
+    if (existsSync(manifestPath)) {
+      const manifestRelativePath = relative(
+        absoluteRoot,
+        manifestPath
+      ).replaceAll('\\', '/');
+      try {
+        const parsed = JSON.parse(
+          readFileSync(manifestPath, 'utf8')
+        ) as unknown;
+        if (
+          typeof parsed !== 'object' ||
+          parsed === null ||
+          Array.isArray(parsed)
+        ) {
+          const invalidContext = {
+            dependencies: [],
+            manifestState: 'invalid' as const,
+            path: manifestRelativePath,
+          };
+          for (const directory of visited) {
+            cache.set(directory, invalidContext);
+          }
+          return invalidContext;
+        }
+        const manifest = parsed as Record<string, unknown>;
+        const dependencies = dependencyNames(
+          manifest,
+          PACKAGE_DEPENDENCY_FIELDS
+        );
+        const runtimeDependencies = dependencyNames(
+          manifest,
+          RUNTIME_PACKAGE_DEPENDENCY_FIELDS
+        );
+        const packageContext = {
+          dependencies: [...new Set(dependencies)].toSorted(),
+          manifestState: 'valid' as const,
+          ...(typeof manifest['name'] === 'string'
+            ? { name: manifest['name'] }
+            : {}),
+          path: manifestRelativePath,
+          runtimeDependencies: [...new Set(runtimeDependencies)].toSorted(),
+        };
+        for (const directory of visited) {
+          cache.set(directory, packageContext);
+        }
+        return packageContext;
+      } catch {
+        const invalidContext = {
+          dependencies: [],
+          manifestState: 'invalid' as const,
+          path: manifestRelativePath,
+        };
+        for (const directory of visited) {
+          cache.set(directory, invalidContext);
+        }
+        return invalidContext;
+      }
+    }
+    if (current === absoluteRoot) {
+      break;
+    }
+    current = dirname(current);
+  }
+  for (const directory of visited) {
+    cache.set(directory, undefined);
+  }
+  return undefined;
+};
+
 const runRegradeEvaluation = (params: {
   readonly root: string;
   readonly classes: readonly RegradeClass[];
@@ -1169,10 +1298,20 @@ const runRegradeEvaluation = (params: {
 
   const files: { absolutePath: string; path: string; source: string }[] = [];
   const skipped: SkippedSource[] = [...collected.skipped];
+  const packageContextCache = new Map<
+    string,
+    RegradeClassContext['package'] | undefined
+  >();
   for (const file of collected.files) {
     try {
+      const packageContext = packageContextFor(
+        params.root,
+        file.absolutePath,
+        packageContextCache
+      );
       files.push({
         absolutePath: file.absolutePath,
+        ...(packageContext === undefined ? {} : { package: packageContext }),
         path: file.path,
         source: readFileSync(file.absolutePath, 'utf8'),
       });

--- a/packages/regrade/src/downstream/vocabulary-registry.ts
+++ b/packages/regrade/src/downstream/vocabulary-registry.ts
@@ -11,6 +11,9 @@ const pluralizeVocabularyForm = (value: string): string =>
     ? `${value}es`
     : `${value}s`;
 
+const defaultSourceForms = (value: string): readonly string[] =>
+  /^[A-Za-z]+$/.test(value) ? [value, pluralizeVocabularyForm(value)] : [value];
+
 const preserveRulesFromTransition = (
   transition: GovernedVocabularyTransition
 ): readonly VocabularyPreserveRule[] =>
@@ -44,12 +47,7 @@ const defaultFormsAreRegistrySafe = (
     return false;
   }
 
-  const defaultForms = [
-    transition.from,
-    pluralizeVocabularyForm(transition.from),
-  ];
-
-  return defaultForms.every((form) => {
+  return defaultSourceForms(transition.from).every((form) => {
     const replacement = transition.safeRewriteForms[form];
     return replacement !== undefined && !transition.reviewForms.includes(form);
   });

--- a/packages/regrade/src/downstream/vocabulary.ts
+++ b/packages/regrade/src/downstream/vocabulary.ts
@@ -6,7 +6,14 @@ import {
   matchesAnyPathGlob,
 } from '@ontrails/core';
 import { createHash } from 'node:crypto';
-import { dirname, isAbsolute, join, normalize, relative } from 'node:path';
+import {
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  normalize,
+  relative,
+} from 'node:path';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { z } from 'zod';
 
@@ -213,30 +220,56 @@ const vocabularyDispositionCounts = (
   );
 };
 
-const isVocabularyTokenCharacter = (value: string): boolean =>
-  /[A-Za-z0-9_$-]/.test(value);
+const isVocabularyTokenCharacter = (
+  value: string,
+  routeLike: boolean
+): boolean => /[A-Za-z0-9_$-]/.test(value) || (routeLike && value === '/');
+
+const isVocabularyTokenCharacterAt = (
+  source: string,
+  index: number,
+  routeLike: boolean
+): boolean => {
+  if (index < 0 || index >= source.length) {
+    return false;
+  }
+  const value = source.at(index) ?? '';
+  if (isVocabularyTokenCharacter(value, routeLike)) {
+    return true;
+  }
+  if (!routeLike || value !== '.') {
+    return false;
+  }
+  return (
+    isVocabularyTokenCharacter(source.at(index - 1) ?? '', false) &&
+    isVocabularyTokenCharacter(source.at(index + 1) ?? '', false)
+  );
+};
 
 const hasWordBoundary = (
   source: string,
   start: number,
-  end: number
+  end: number,
+  form: string
 ): boolean => {
-  const before = start === 0 ? '' : (source.at(start - 1) ?? '');
-  const after = end >= source.length ? '' : (source.at(end) ?? '');
+  const routeLike = form.includes('/');
   return (
-    !isVocabularyTokenCharacter(before) && !isVocabularyTokenCharacter(after)
+    !isVocabularyTokenCharacterAt(source, start - 1, routeLike) &&
+    !isVocabularyTokenCharacterAt(source, end, routeLike)
   );
 };
 
 const expandVocabularyNeighborSpan = (
   source: string,
   start: number,
-  end: number
+  end: number,
+  form: string
 ): { readonly end: number; readonly start: number } => {
+  const routeLike = form.includes('/');
   let expandedStart = start;
   while (
     expandedStart > 0 &&
-    isVocabularyTokenCharacter(source.at(expandedStart - 1) ?? '')
+    isVocabularyTokenCharacterAt(source, expandedStart - 1, routeLike)
   ) {
     expandedStart -= 1;
   }
@@ -244,7 +277,7 @@ const expandVocabularyNeighborSpan = (
   let expandedEnd = end;
   while (
     expandedEnd < source.length &&
-    isVocabularyTokenCharacter(source.at(expandedEnd) ?? '')
+    isVocabularyTokenCharacterAt(source, expandedEnd, routeLike)
   ) {
     expandedEnd += 1;
   }
@@ -287,6 +320,21 @@ const contextDetailsForOffset = (
 
 const isMarkdownPath = (path: string): boolean =>
   path.endsWith('.md') || path.endsWith('.mdx');
+
+const packageRouteCodeExtensions = new Set([
+  '.cjs',
+  '.cts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.mts',
+  '.ts',
+  '.tsx',
+]);
+
+const isPackageRouteCodeOccurrence = (path: string, form: string): boolean =>
+  packageRouteCodeExtensions.has(extname(path)) &&
+  /^@[^/]+\/[^/]+(?:\/.*)?$/.test(form);
 
 const sourceLineBoundsForOffset = (
   source: string,
@@ -478,11 +526,13 @@ const defaultDeferredVocabularyForms = (from: string): readonly string[] => {
   ]).filter((form) => form !== from && form !== pluralize(from));
 };
 
-const defaultVocabularyForms = (from: string, to: string) =>
-  new Map<string, string>([
-    [from, to],
-    [pluralize(from), pluralize(to)],
-  ]);
+const defaultVocabularyForms = (from: string, to: string) => {
+  const forms = new Map<string, string>([[from, to]]);
+  if (isSimpleVocabularyWord(from) && isSimpleVocabularyWord(to)) {
+    forms.set(pluralize(from), pluralize(to));
+  }
+  return forms;
+};
 
 const normalizedOverrideEntries = (
   overrides: Readonly<Record<string, string>> | undefined
@@ -806,7 +856,7 @@ const exactDeferredFormOccurrencesForFile = (
         formIdentityForPlan(plan, form)
       );
       if (
-        !hasWordBoundary(file.source, start, end) ||
+        !hasWordBoundary(file.source, start, end, form) ||
         occurrenceOverlaps(occurrences, start, end) ||
         (!isAuthoredDefer && occurrenceOverlaps(targetFormSpans, start, end))
       ) {
@@ -840,7 +890,7 @@ const targetFormSpansForFile = (
       const start = match.index ?? 0;
       const end = start + match[0].length;
       if (
-        !hasWordBoundary(file.source, start, end) ||
+        !hasWordBoundary(file.source, start, end, form) ||
         occurrenceOverlaps(spans, start, end)
       ) {
         continue;
@@ -869,7 +919,7 @@ const occurrencesForFile = (
       const start = match.index ?? 0;
       const end = start + match[0].length;
       if (
-        !hasWordBoundary(file.source, start, end) ||
+        !hasWordBoundary(file.source, start, end, form) ||
         occurrenceOverlaps(deferredOccurrences, start, end)
       ) {
         continue;
@@ -889,10 +939,17 @@ const occurrencesForFile = (
       };
       const preserveRule = preserveRuleForOccurrence(baseOccurrence, plan);
       const markdownCodeContext = isMarkdownCodeContext(file, start, end);
-      const verdict = capturedVocabularyVerdict(
+      const packageRouteCodeContext = isPackageRouteCodeOccurrence(
+        file.path,
+        form
+      );
+      let verdict = capturedVocabularyVerdict(
         preserveRule,
         markdownCodeContext
       );
+      if (preserveRule === undefined && packageRouteCodeContext) {
+        verdict = 'deferred';
+      }
       candidates.push({
         absolutePath: baseOccurrence.absolutePath,
         column: baseOccurrence.column,
@@ -909,9 +966,13 @@ const occurrencesForFile = (
         reason: vocabularyOccurrenceReason(
           preserveRule,
           markdownCodeContext,
-          'captured-form'
+          packageRouteCodeContext
+            ? 'package-route-ast-required'
+            : 'captured-form'
         ),
-        ...(preserveRule === undefined && !markdownCodeContext
+        ...(preserveRule === undefined &&
+        !markdownCodeContext &&
+        !packageRouteCodeContext
           ? { replacement: preserveCase(match[0], replacement) }
           : {}),
         start: baseOccurrence.start,
@@ -972,13 +1033,14 @@ const deferredOccurrencesForFile = (
     for (const match of file.source.matchAll(pattern)) {
       const matchStart = match.index ?? 0;
       const matchEnd = matchStart + match[0].length;
-      if (hasWordBoundary(file.source, matchStart, matchEnd)) {
+      if (hasWordBoundary(file.source, matchStart, matchEnd, form)) {
         continue;
       }
       const { end, start } = expandVocabularyNeighborSpan(
         file.source,
         matchStart,
-        matchEnd
+        matchEnd,
+        form
       );
       const matchedForm = file.source.slice(start, end);
       const lowerMatchedForm = matchedForm.toLowerCase();

--- a/packages/warden/src/__tests__/retired-vocabulary.test.ts
+++ b/packages/warden/src/__tests__/retired-vocabulary.test.ts
@@ -19,6 +19,7 @@ describe('governed vocabulary registry', () => {
       'v1-blaze-implementation',
       'v1-contour-entity',
       'v1-facet-trailhead',
+      'v1-warden-ast-source',
       'v1-projection-derive-render',
     ]);
     expect(transitions.map((transition) => transition.from)).toEqual([
@@ -26,6 +27,7 @@ describe('governed vocabulary registry', () => {
       'blaze',
       'contour',
       'facet',
+      '@ontrails/warden/ast',
       'projection',
     ]);
 
@@ -225,6 +227,47 @@ describe('governed vocabulary registry', () => {
     expect(literalSources).not.toContain('contoured');
     expect(literalSources).not.toContain('contouring');
     expect(literalSources).not.toContain('counter-contour');
+  });
+
+  test('governs the warden ast package route as an exact code string only', () => {
+    const source = getGovernedVocabularyTransition('v1-warden-ast-source');
+
+    expect(source).toMatchObject({
+      codeIdentifiers: ['@ontrails/warden/ast'],
+      from: '@ontrails/warden/ast',
+      status: 'complete',
+      target: { kind: 'single', to: '@ontrails/source' },
+    });
+    expect(source?.safeRewriteForms).toEqual({
+      '@ontrails/warden/ast': '@ontrails/source',
+    });
+    expect(source?.preserve).toContainEqual(
+      expect.objectContaining({
+        paths: expect.arrayContaining([
+          'adapters/commander/src/__tests__/to-commander.test.ts',
+          'apps/trails/src/__tests__/mcp.test.ts',
+          'apps/trails/src/__tests__/regrade.test.ts',
+          'docs/api-reference.md',
+          'packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts',
+          'packages/regrade/src/downstream/__tests__/vocabulary.test.ts',
+          'packages/warden/README.md',
+          'packages/warden/src/__tests__/ast-export-contract.test.ts',
+          'packages/warden/src/__tests__/public-api.test.ts',
+          'packages/warden/src/__tests__/retired-vocabulary.test.ts',
+          'scripts/verify-oxc-resolver-published.ts',
+        ]),
+        pattern: '^@ontrails/warden/ast$',
+      })
+    );
+    expect(source?.stringLiteralRenames).toEqual([
+      {
+        from: '@ontrails/warden/ast',
+        moduleSpecifier: { targetPackage: '@ontrails/source' },
+        to: '@ontrails/source',
+      },
+    ]);
+    expect(source?.symbolRenames).toEqual([]);
+    expect(source?.reviewForms).toEqual([]);
   });
 
   test('rejects duplicate ids and duplicate source terms', () => {

--- a/packages/warden/src/rules/retired-vocabulary.ts
+++ b/packages/warden/src/rules/retired-vocabulary.ts
@@ -57,6 +57,11 @@ export const governedVocabularySymbolRenameSchema = z.object({
 export const governedVocabularyLiteralRenameSchema = z.object({
   from: z.string().min(1),
   match: z.enum(['exact', 'property-key', 'review']).optional(),
+  moduleSpecifier: z
+    .object({
+      targetPackage: z.string().min(1),
+    })
+    .optional(),
   to: z.string().min(1),
 });
 
@@ -384,6 +389,56 @@ export const governedVocabularyTransitions =
         },
       ],
       target: { kind: 'single', to: 'trailhead' },
+    }),
+    defineV1Transition({
+      codeIdentifiers: ['@ontrails/warden/ast'],
+      docs: {
+        guidance: [
+          'Treat the package route as an exact code string and module specifier, not as vocabulary prose or an identifier segment.',
+          'Rewrite only exact string literal/module-specifier occurrences; near routes and larger strings stay untouched.',
+        ],
+        summary:
+          'The reusable AST helper route moved from @ontrails/warden/ast to @ontrails/source.',
+      },
+      from: '@ontrails/warden/ast',
+      id: 'v1-warden-ast-source',
+      intent:
+        'Move reusable AST helper imports from @ontrails/warden/ast to @ontrails/source for v1.',
+      kind: 'vocabulary',
+      oldForms: ['@ontrails/warden/ast'],
+      preserve: [
+        {
+          paths: [
+            'adapters/commander/src/__tests__/to-commander.test.ts',
+            'apps/trails/src/__tests__/mcp.test.ts',
+            'apps/trails/src/__tests__/regrade.test.ts',
+            'docs/api-reference.md',
+            'packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts',
+            'packages/regrade/src/downstream/__tests__/vocabulary.test.ts',
+            'packages/warden/README.md',
+            'packages/warden/src/__tests__/ast-export-contract.test.ts',
+            'packages/warden/src/__tests__/public-api.test.ts',
+            'packages/warden/src/__tests__/retired-vocabulary.test.ts',
+            'scripts/verify-oxc-resolver-published.ts',
+          ],
+          pattern: '^@ontrails/warden/ast$',
+          reason:
+            'Preserve current-live facade guidance and contract coverage until the following hard-cut branch retires the route.',
+        },
+      ],
+      reviewForms: [],
+      safeRewriteForms: {
+        '@ontrails/warden/ast': '@ontrails/source',
+      },
+      status: 'complete',
+      stringLiteralRenames: [
+        {
+          from: '@ontrails/warden/ast',
+          moduleSpecifier: { targetPackage: '@ontrails/source' },
+          to: '@ontrails/source',
+        },
+      ],
+      target: { kind: 'single', to: '@ontrails/source' },
     }),
     defineV1Transition({
       codeIdentifiers: [],


### PR DESCRIPTION
## Context

Run-exposed Regrade gap tracked by [TRL-1254](https://linear.app/outfitter/issue/TRL-1254/): package-route transitions such as `@ontrails/warden/ast` were not observable as governed code facts and generic inflection invented unsafe plurals.

## What changed

- Add Warden-owned exact string/module-specifier transition metadata.
- Bridge non-word registry plans through Regrade.
- Limit automatic inflection to simple alphabetic vocabulary.
- Route near package forms to review instead of inventing rewrites.
- Add CLI/MCP lifecycle proof.

## Verification

- Focused Warden/Regrade/CLI/MCP tests and full check/test/build/publish-pack/dogfood gates passed.
- Engine and acceptance reviews reached 5/5 after clearing the invented-plural finding.

## Risk

Package-route handling is exact by design; it does not generalize arbitrary path rewriting.