### PR TITLE
feat(warden): detect captured kernel smells

### DIFF
--- a/.agents/skills/clark/references/warden-guide.md
+++ b/.agents/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 73
+- Rule count: 74
 
 ## Agent Instructions
 
@@ -34,6 +34,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 
 ### General
 
+- `captured-kernel` (warn, all/project-static, advisory): Public subpath exports that re-export internal kernels receive ownership review after multiple production packages consume them. Guidance: Review ownership before an internal re-exported kernel hardens into a public package seam.
 - `circular-refs` (warn, project/project-static, external): Entity reference graphs must be acyclic.
 - `duplicate-exported-symbol` (warn, project/project-static, repo-local): First-party packages should not define the same exported symbol name in parallel. Guidance: Keep exported symbol ownership from drifting across first-party packages.
 - `entity-exists` (error, project/project-static, external): Declared entity references resolve to known entities.

--- a/.changeset/trl-1231-captured-kernel.md
+++ b/.changeset/trl-1231-captured-kernel.md
@@ -1,0 +1,12 @@
+---
+"@ontrails/warden": patch
+"@ontrails/source": patch
+---
+
+Add the advisory captured-kernel Warden rule for ownership review when a public
+subpath re-exports package internals and multiple production workspaces consume
+that subpath, including import-then-export barrels that preserve the internal
+binding through a local alias or default export.
+
+Expose typed import-kind inspection from `@ontrails/source` so project rules
+can keep erased type bindings separate from runtime exports.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 73
+- Rule count: 74
 
 ## Agent Instructions
 
@@ -34,6 +34,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 
 ### General
 
+- `captured-kernel` (warn, all/project-static, advisory): Public subpath exports that re-export internal kernels receive ownership review after multiple production packages consume them. Guidance: Review ownership before an internal re-exported kernel hardens into a public package seam.
 - `circular-refs` (warn, project/project-static, external): Entity reference graphs must be acyclic.
 - `duplicate-exported-symbol` (warn, project/project-static, repo-local): First-party packages should not define the same exported symbol name in parallel. Guidance: Keep exported symbol ownership from drifting across first-party packages.
 - `entity-exists` (error, project/project-static, external): Declared entity references resolve to known entities.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ See [ADR-0050](docs/adr/0050-surface-accommodations-preserve-trail-identity.md) 
 This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
-- Rule count: 73
+- Rule count: 74
 
 ### Rule Index
 
@@ -130,6 +130,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 
 #### General
 
+- `captured-kernel` (warn, all/project-static, advisory): Public subpath exports that re-export internal kernels receive ownership review after multiple production packages consume them.
 - `circular-refs` (warn, project/project-static, external): Entity reference graphs must be acyclic.
 - `duplicate-exported-symbol` (warn, project/project-static, repo-local): First-party packages should not define the same exported symbol name in parallel.
 - `entity-exists` (error, project/project-static, external): Declared entity references resolve to known entities.
@@ -212,6 +213,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 
 ### Structured Guidance Summaries
 
+- `captured-kernel`: Review ownership before an internal re-exported kernel hardens into a public package seam.
 - `cli-command-route-coherence`: Keep every CLI command route and alias normalized into one trail contract.
 - `dead-public-trail`: Anchor exported public trails in a topo, composition edge, or activation source.
 - `duplicate-exported-symbol`: Keep exported symbol ownership from drifting across first-party packages.

--- a/docs/contributing/package-ownership.md
+++ b/docs/contributing/package-ownership.md
@@ -56,6 +56,14 @@ The review question:
 | Markdown rendering | package that owns the content domain | docs, Warden guide, release notes | `unknown` | Not audited in this first pass. Do not extract until a real duplicate has evidence and a clear owner. |
 | CLI argument parsing | Trails app CLI surface | CLI routes and commands | `unknown` | Not audited in this first pass. Parsing can stay surface-owned unless it reimplements contract derivation. |
 
+## Captured-Kernel Review
+
+The advisory `captured-kernel` Warden rule identifies one ownership-review signal: a non-root public package subpath re-exports its own internal source and at least two distinct production packages consume that subpath. The warning is evidence to review the owner, not proof that the current package is wrong.
+
+`@ontrails/topographer/backend-support` is the current named watch case. Its internal-backed subpath remains legitimate because the Trails operator is its only production external consumer; Warden exercises it only in tests, which do not satisfy the rule's consumer threshold. Revisit the boundary if a second independently owned production capability begins to consume it.
+
+Moving a captured kernel into `@ontrails/source` is conditional. The machinery must be reusable source analysis shared by at least two independent toolchain capabilities, expose one genuinely shared contract, and own no verdict policy, migration plan, graph query, or surface rendering. Otherwise, preserve the current owner or choose another doctrinal owner.
+
 ## Proposed Extractions
 
 These are open findings from the map. They are not newly created Linear issues in this branch.

--- a/packages/source/src/__tests__/public-api.test.ts
+++ b/packages/source/src/__tests__/public-api.test.ts
@@ -83,6 +83,7 @@ const expectedRuntimeExportKeys = [
   'getNodeExported',
   'getNodeExpression',
   'getNodeId',
+  'getNodeImportKind',
   'getNodeImported',
   'getNodeInit',
   'getNodeKey',
@@ -206,7 +207,7 @@ const assertSourceTypeExportContract = <T extends SourceTypeExportContract>() =>
 describe('@ontrails/source public API', () => {
   test('keeps the exact sorted runtime export keys', () => {
     expect(Object.keys(source).toSorted()).toEqual(expectedRuntimeExportKeys);
-    expect(expectedRuntimeExportKeys).toHaveLength(110);
+    expect(expectedRuntimeExportKeys).toHaveLength(111);
   });
 
   test('keeps every public type export resolvable at compile time', () => {

--- a/packages/source/src/nodes.ts
+++ b/packages/source/src/nodes.ts
@@ -40,12 +40,14 @@ export interface MemberExpressionNode extends AstNode {
 }
 
 export interface ImportDeclarationNode extends AstNode {
+  readonly importKind?: string;
   readonly type: 'ImportDeclaration';
   readonly source?: AstNode;
   readonly specifiers?: readonly AstNode[];
 }
 
 export interface ImportSpecifierNode extends AstNode {
+  readonly importKind?: string;
   readonly type:
     | 'ImportDefaultSpecifier'
     | 'ImportNamespaceSpecifier'
@@ -266,6 +268,7 @@ export interface AstFieldProjection {
   readonly expression?: AstNode;
   readonly id?: AstNode;
   readonly imported?: AstNode;
+  readonly importKind?: string;
   readonly init?: AstNode;
   readonly key?: AstNode;
   readonly kind?: string;
@@ -553,6 +556,10 @@ export const getNodeId = (
 export const getNodeImported = (
   node: AstNode | null | undefined
 ): AstNode | undefined => projectAstFields(node)?.imported;
+
+export const getNodeImportKind = (
+  node: AstNode | null | undefined
+): string | undefined => projectAstFields(node)?.importKind;
 
 export const getNodeInit = (
   node: AstNode | null | undefined

--- a/packages/warden/src/__tests__/captured-kernel.test.ts
+++ b/packages/warden/src/__tests__/captured-kernel.test.ts
@@ -1,0 +1,913 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  collectProjectImportResolutions,
+  collectPublicWorkspaces,
+} from '../project-context.js';
+import { capturedKernel } from '../rules/captured-kernel.js';
+import type { ProjectContext } from '../rules/types.js';
+import type { WardenProjectContextSourceFile } from '../project-context.js';
+
+const makeTempDir = (prefix: string): string => {
+  const dir = join(
+    tmpdir(),
+    `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+};
+
+const writeJson = (path: string, value: unknown): void => {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+};
+
+const writeSource = (path: string, source: string): void => {
+  writeFileSync(path, source.trimStart());
+};
+
+interface CapturedKernelFixture {
+  readonly cliImporterPath: string;
+  readonly coreKernelPath: string;
+  readonly coreRoot: string;
+  readonly rootDir: string;
+  readonly storeImporterPath: string;
+  readonly trailsImporterPath: string;
+  readonly wardenTestImporterPath: string;
+}
+
+const createFixture = (): CapturedKernelFixture => {
+  const rootDir = makeTempDir('warden-captured-kernel');
+  const coreRoot = join(rootDir, 'packages', 'core');
+  const storeRoot = join(rootDir, 'packages', 'store');
+  const cliRoot = join(rootDir, 'packages', 'cli');
+  const trailsRoot = join(rootDir, 'apps', 'trails');
+  const wardenRoot = join(rootDir, 'packages', 'warden');
+  const topographerRoot = join(rootDir, 'packages', 'topographer');
+  const coreKernelPath = join(coreRoot, 'src', 'kernel.ts');
+  const storeImporterPath = join(storeRoot, 'src', 'store.ts');
+  const cliImporterPath = join(cliRoot, 'src', 'cli.ts');
+  const trailsImporterPath = join(trailsRoot, 'src', 'main.ts');
+  const wardenTestImporterPath = join(
+    wardenRoot,
+    'src',
+    '__tests__',
+    'backend-support.test.ts'
+  );
+
+  for (const dir of [
+    join(coreRoot, 'src', 'internal'),
+    join(storeRoot, 'src'),
+    join(cliRoot, 'src'),
+    join(trailsRoot, 'src'),
+    join(wardenRoot, 'src', '__tests__'),
+    join(topographerRoot, 'src', 'internal'),
+    join(rootDir, 'node_modules', '@ontrails'),
+  ]) {
+    mkdirSync(dir, { recursive: true });
+  }
+
+  writeJson(join(rootDir, 'package.json'), {
+    private: true,
+    type: 'module',
+    workspaces: ['packages/*', 'apps/*'],
+  });
+  writeJson(join(coreRoot, 'package.json'), {
+    exports: {
+      '.': './src/index.ts',
+      './kernel': './src/kernel.ts',
+    },
+    name: '@ontrails/core',
+    type: 'module',
+  });
+  writeJson(join(storeRoot, 'package.json'), {
+    dependencies: { '@ontrails/core': 'workspace:*' },
+    exports: { '.': './src/index.ts' },
+    name: '@ontrails/store',
+    type: 'module',
+  });
+  writeJson(join(cliRoot, 'package.json'), {
+    dependencies: { '@ontrails/core': 'workspace:*' },
+    exports: { '.': './src/index.ts' },
+    name: '@ontrails/cli',
+    type: 'module',
+  });
+  writeJson(join(trailsRoot, 'package.json'), {
+    dependencies: { '@ontrails/topographer': 'workspace:*' },
+    name: '@ontrails/trails',
+    type: 'module',
+  });
+  writeJson(join(wardenRoot, 'package.json'), {
+    dependencies: { '@ontrails/topographer': 'workspace:*' },
+    exports: { '.': './src/index.ts' },
+    name: '@ontrails/warden',
+    type: 'module',
+  });
+  writeJson(join(topographerRoot, 'package.json'), {
+    exports: {
+      '.': './src/index.ts',
+      './backend-support': './src/backend-support.ts',
+    },
+    name: '@ontrails/topographer',
+    type: 'module',
+  });
+
+  writeSource(join(coreRoot, 'src', 'index.ts'), 'export const core = 1;\n');
+  writeSource(
+    join(coreRoot, 'src', 'internal', 'kernel.ts'),
+    'export const kernel = 1;\n'
+  );
+  writeSource(
+    coreKernelPath,
+    "export { kernel } from './internal/kernel.js';\n"
+  );
+  writeSource(join(storeRoot, 'src', 'index.ts'), 'export const store = 1;\n');
+  writeSource(join(cliRoot, 'src', 'index.ts'), 'export const cli = 1;\n');
+  writeSource(
+    join(wardenRoot, 'src', 'index.ts'),
+    'export const warden = 1;\n'
+  );
+  writeSource(
+    join(topographerRoot, 'src', 'index.ts'),
+    'export const topographer = 1;\n'
+  );
+  writeSource(
+    join(topographerRoot, 'src', 'internal', 'backend-support.ts'),
+    'export const backend = 1;\n'
+  );
+  writeSource(
+    join(topographerRoot, 'src', 'backend-support.ts'),
+    "export { backend } from './internal/backend-support.js';\n"
+  );
+
+  for (const [name, target] of [
+    ['core', coreRoot],
+    ['store', storeRoot],
+    ['cli', cliRoot],
+    ['trails', trailsRoot],
+    ['warden', wardenRoot],
+    ['topographer', topographerRoot],
+  ] as const) {
+    symlinkSync(
+      target,
+      join(rootDir, 'node_modules', '@ontrails', name),
+      'dir'
+    );
+  }
+
+  return {
+    cliImporterPath,
+    coreKernelPath,
+    coreRoot,
+    rootDir,
+    storeImporterPath,
+    trailsImporterPath,
+    wardenTestImporterPath,
+  };
+};
+
+const collectContext = (
+  fixture: CapturedKernelFixture,
+  sourceFiles: readonly WardenProjectContextSourceFile[]
+): ProjectContext => {
+  const publicWorkspaces = collectPublicWorkspaces(fixture.rootDir);
+  return {
+    importResolutionsByFile: collectProjectImportResolutions({
+      publicWorkspaces,
+      rootDir: fixture.rootDir,
+      sourceFiles,
+    }),
+    knownTrailIds: new Set<string>(),
+    publicWorkspaces,
+  };
+};
+
+const checkFixture = (
+  fixture: CapturedKernelFixture,
+  sourceFile: WardenProjectContextSourceFile,
+  sourceFiles: readonly WardenProjectContextSourceFile[]
+) =>
+  capturedKernel.checkWithContext(
+    sourceFile.sourceCode,
+    sourceFile.filePath,
+    collectContext(fixture, sourceFiles)
+  );
+
+const checkKernelWithProductionConsumers = (
+  fixture: CapturedKernelFixture,
+  kernelPath: string,
+  kernelSource: string,
+  consumerSource = "import { kernel } from '@ontrails/core/kernel';\n"
+) => {
+  const storeSource = consumerSource;
+  const cliSource = consumerSource;
+  writeSource(kernelPath, kernelSource);
+  writeSource(fixture.storeImporterPath, storeSource);
+  writeSource(fixture.cliImporterPath, cliSource);
+  const kernelFile = {
+    filePath: kernelPath,
+    kind: 'typescript' as const,
+    sourceCode: kernelSource,
+  };
+  return checkFixture(fixture, kernelFile, [
+    kernelFile,
+    {
+      filePath: fixture.storeImporterPath,
+      kind: 'typescript',
+      sourceCode: storeSource,
+    },
+    {
+      filePath: fixture.cliImporterPath,
+      kind: 'typescript',
+      sourceCode: cliSource,
+    },
+  ]);
+};
+
+describe('captured-kernel', () => {
+  test('warns when a non-root public subpath re-exports internals consumed by two production packages', () => {
+    const fixture = createFixture();
+    try {
+      const kernelSource = "export { kernel } from './internal/kernel.js';\n";
+      const storeSource = "import { kernel } from '@ontrails/core/kernel';\n";
+      const cliSource = "import { kernel } from '@ontrails/core/kernel';\n";
+      writeSource(fixture.storeImporterPath, storeSource);
+      writeSource(fixture.cliImporterPath, cliSource);
+
+      const kernelFile = {
+        filePath: fixture.coreKernelPath,
+        kind: 'typescript' as const,
+        sourceCode: kernelSource,
+      };
+      const diagnostics = checkFixture(fixture, kernelFile, [
+        kernelFile,
+        {
+          filePath: fixture.storeImporterPath,
+          kind: 'typescript',
+          sourceCode: storeSource,
+        },
+        {
+          filePath: fixture.cliImporterPath,
+          kind: 'typescript',
+          sourceCode: cliSource,
+        },
+      ]);
+
+      expect(diagnostics).toEqual([
+        expect.objectContaining({
+          filePath: fixture.coreKernelPath,
+          line: 1,
+          message: expect.stringContaining(
+            '@ontrails/core export target "@ontrails/core/kernel"'
+          ),
+          rule: 'captured-kernel',
+          severity: 'warn',
+        }),
+      ]);
+      expect(diagnostics[0]?.message).toContain('@ontrails/cli');
+      expect(diagnostics[0]?.message).toContain('@ontrails/store');
+      expect(diagnostics[0]?.message).not.toContain('mismatch');
+      expect(diagnostics[0]?.guidance?.steps?.join('\n')).toContain(
+        '@ontrails/source'
+      );
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('warns when an internal import is re-exported through a local binding', () => {
+    const fixture = createFixture();
+    try {
+      const diagnostics = checkKernelWithProductionConsumers(
+        fixture,
+        fixture.coreKernelPath,
+        [
+          "import { kernel as captured } from './internal/kernel.js';",
+          'export { captured as kernel };',
+          '',
+        ].join('\n')
+      );
+
+      expect(diagnostics).toEqual([
+        expect.objectContaining({
+          line: 2,
+          message: expect.stringContaining(
+            'internal target "./internal/kernel.js"'
+          ),
+          rule: 'captured-kernel',
+        }),
+      ]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('warns when a default internal import is re-exported as default', () => {
+    const fixture = createFixture();
+    try {
+      const diagnostics = checkKernelWithProductionConsumers(
+        fixture,
+        fixture.coreKernelPath,
+        [
+          "import kernel from './internal/kernel.js';",
+          'export default kernel;',
+          '',
+        ].join('\n'),
+        "import kernel from '@ontrails/core/kernel';\n"
+      );
+
+      expect(diagnostics).toEqual([
+        expect.objectContaining({
+          line: 2,
+          message: expect.stringContaining(
+            'internal target "./internal/kernel.js"'
+          ),
+          rule: 'captured-kernel',
+        }),
+      ]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('does not connect erased type imports to local value exports', () => {
+    const fixture = createFixture();
+    try {
+      expect(
+        checkKernelWithProductionConsumers(
+          fixture,
+          fixture.coreKernelPath,
+          [
+            "import type { kernel } from './internal/kernel.js';",
+            'const kernel = 1;',
+            'export { kernel };',
+            '',
+          ].join('\n')
+        )
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('honors an ignore pragma on the local export line', () => {
+    const fixture = createFixture();
+    try {
+      expect(
+        checkKernelWithProductionConsumers(
+          fixture,
+          fixture.coreKernelPath,
+          [
+            "import { kernel } from './internal/kernel.js';",
+            '// warden-ignore-next-line',
+            'export { kernel };',
+            '',
+          ].join('\n')
+        )
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('deduplicates several exported bindings from one internal import', () => {
+    const fixture = createFixture();
+    try {
+      const diagnostics = checkKernelWithProductionConsumers(
+        fixture,
+        fixture.coreKernelPath,
+        [
+          "import { helper, kernel } from './internal/kernel.js';",
+          'export { helper, kernel };',
+          '',
+        ].join('\n')
+      );
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]).toMatchObject({
+        line: 2,
+        rule: 'captured-kernel',
+      });
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('does not treat an internal import as captured until it is exported', () => {
+    const fixture = createFixture();
+    try {
+      expect(
+        checkKernelWithProductionConsumers(
+          fixture,
+          fixture.coreKernelPath,
+          [
+            "import { kernel } from './internal/kernel.js';",
+            'export const wrapper = () => kernel;',
+            '',
+          ].join('\n')
+        )
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('trusts resolver-proven internal targets below an intermediate directory', () => {
+    const fixture = createFixture();
+    try {
+      const targetPath = join(
+        fixture.coreRoot,
+        'src',
+        'foo',
+        'internal',
+        'kernel.ts'
+      );
+      mkdirSync(join(fixture.coreRoot, 'src', 'foo', 'internal'), {
+        recursive: true,
+      });
+      writeSource(targetPath, 'export const kernel = 1;\n');
+
+      expect(
+        checkKernelWithProductionConsumers(
+          fixture,
+          fixture.coreKernelPath,
+          "export { kernel } from './foo/internal/kernel.js';\n"
+        )
+      ).toHaveLength(1);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('trusts resolver-proven internal targets reached through deeper relative paths', () => {
+    const fixture = createFixture();
+    try {
+      const nestedKernelPath = join(
+        fixture.coreRoot,
+        'src',
+        'nested',
+        'public',
+        'kernel.ts'
+      );
+      mkdirSync(join(fixture.coreRoot, 'src', 'nested', 'public'), {
+        recursive: true,
+      });
+      writeJson(join(fixture.coreRoot, 'package.json'), {
+        exports: {
+          '.': './src/index.ts',
+          './kernel': './src/nested/public/kernel.ts',
+        },
+        name: '@ontrails/core',
+        type: 'module',
+      });
+
+      expect(
+        checkKernelWithProductionConsumers(
+          fixture,
+          nestedKernelPath,
+          "export { kernel } from '../../internal/kernel.js';\n"
+        )
+      ).toHaveLength(1);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('does not claim resolver-proven internals owned by another package', () => {
+    const fixture = createFixture();
+    try {
+      expect(
+        checkKernelWithProductionConsumers(
+          fixture,
+          fixture.coreKernelPath,
+          "export { backend } from '../../topographer/src/internal/backend-support.js';\n"
+        )
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('deduplicates repeated imports from the same external package', () => {
+    const fixture = createFixture();
+    try {
+      const storeOtherPath = join(
+        fixture.coreRoot,
+        '..',
+        'store',
+        'src',
+        'other.ts'
+      );
+      const kernelSource = "export { kernel } from './internal/kernel.js';\n";
+      const storeSource = "import { kernel } from '@ontrails/core/kernel';\n";
+      const cliSource = "import { kernel } from '@ontrails/core/kernel';\n";
+      writeSource(fixture.storeImporterPath, storeSource);
+      writeSource(storeOtherPath, storeSource);
+      writeSource(fixture.cliImporterPath, cliSource);
+
+      const kernelFile = {
+        filePath: fixture.coreKernelPath,
+        kind: 'typescript' as const,
+        sourceCode: kernelSource,
+      };
+      const diagnostics = checkFixture(fixture, kernelFile, [
+        kernelFile,
+        {
+          filePath: fixture.storeImporterPath,
+          kind: 'typescript',
+          sourceCode: storeSource,
+        },
+        {
+          filePath: storeOtherPath,
+          kind: 'typescript',
+          sourceCode: storeSource,
+        },
+        {
+          filePath: fixture.cliImporterPath,
+          kind: 'typescript',
+          sourceCode: cliSource,
+        },
+      ]);
+
+      const message = diagnostics[0]?.message ?? '';
+      expect(diagnostics).toHaveLength(1);
+      expect(message.match(/@ontrails\/store/g) ?? []).toHaveLength(1);
+      expect(message.match(/@ontrails\/cli/g) ?? []).toHaveLength(1);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('does not warn for root export targets', () => {
+    const fixture = createFixture();
+    try {
+      const rootIndexPath = join(fixture.coreRoot, 'src', 'index.ts');
+      const rootSource = "export { kernel } from './internal/kernel.js';\n";
+      const storeSource = "import { core } from '@ontrails/core';\n";
+      const cliSource = "import { core } from '@ontrails/core';\n";
+      writeJson(join(fixture.coreRoot, 'package.json'), {
+        exports: {
+          '.': './src/index.ts',
+          './kernel': './src/kernel.ts',
+        },
+        name: '@ontrails/core',
+        type: 'module',
+      });
+      writeSource(rootIndexPath, rootSource);
+      writeSource(fixture.storeImporterPath, storeSource);
+      writeSource(fixture.cliImporterPath, cliSource);
+
+      const rootFile = {
+        filePath: rootIndexPath,
+        kind: 'typescript' as const,
+        sourceCode: rootSource,
+      };
+
+      expect(
+        checkFixture(fixture, rootFile, [
+          rootFile,
+          {
+            filePath: fixture.storeImporterPath,
+            kind: 'typescript',
+            sourceCode: storeSource,
+          },
+          {
+            filePath: fixture.cliImporterPath,
+            kind: 'typescript',
+            sourceCode: cliSource,
+          },
+        ])
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('does not warn when the public subpath re-exports non-internal code', () => {
+    const fixture = createFixture();
+    try {
+      const publicKernelPath = join(
+        fixture.coreRoot,
+        'src',
+        'public-kernel.ts'
+      );
+      const kernelSource = "export { kernel } from './public-kernel.js';\n";
+      const publicKernelSource = 'export const kernel = 1;\n';
+      const storeSource = "import { kernel } from '@ontrails/core/kernel';\n";
+      const cliSource = "import { kernel } from '@ontrails/core/kernel';\n";
+      writeSource(fixture.coreKernelPath, kernelSource);
+      writeSource(publicKernelPath, publicKernelSource);
+      writeSource(fixture.storeImporterPath, storeSource);
+      writeSource(fixture.cliImporterPath, cliSource);
+
+      const kernelFile = {
+        filePath: fixture.coreKernelPath,
+        kind: 'typescript' as const,
+        sourceCode: kernelSource,
+      };
+
+      expect(
+        checkFixture(fixture, kernelFile, [
+          kernelFile,
+          {
+            filePath: publicKernelPath,
+            kind: 'typescript',
+            sourceCode: publicKernelSource,
+          },
+          {
+            filePath: fixture.storeImporterPath,
+            kind: 'typescript',
+            sourceCode: storeSource,
+          },
+          {
+            filePath: fixture.cliImporterPath,
+            kind: 'typescript',
+            sourceCode: cliSource,
+          },
+        ])
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('requires two distinct external production consumer packages', () => {
+    const fixture = createFixture();
+    try {
+      const kernelSource = "export { kernel } from './internal/kernel.js';\n";
+      const storeSource = "import { kernel } from '@ontrails/core/kernel';\n";
+      const testSource = "import { kernel } from '@ontrails/core/kernel';\n";
+      writeSource(fixture.storeImporterPath, storeSource);
+      writeSource(fixture.wardenTestImporterPath, testSource);
+
+      const kernelFile = {
+        filePath: fixture.coreKernelPath,
+        kind: 'typescript' as const,
+        sourceCode: kernelSource,
+      };
+
+      expect(
+        checkFixture(fixture, kernelFile, [
+          kernelFile,
+          {
+            filePath: fixture.storeImporterPath,
+            kind: 'typescript',
+            sourceCode: storeSource,
+          },
+          {
+            filePath: fixture.wardenTestImporterPath,
+            kind: 'typescript',
+            sourceCode: testSource,
+          },
+        ])
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('excludes same-package consumers and non-production evidence paths', () => {
+    const fixture = createFixture();
+    try {
+      const coreLocalPath = join(fixture.coreRoot, 'src', 'local.ts');
+      const nonProductionImporters = [
+        {
+          label: 'test',
+          path: join(
+            fixture.rootDir,
+            'packages',
+            'warden',
+            'src',
+            '__tests__',
+            'captured-kernel-consumer.test.ts'
+          ),
+        },
+        {
+          label: 'fixture',
+          path: join(
+            fixture.rootDir,
+            'packages',
+            'warden',
+            'src',
+            '__fixtures__',
+            'captured-kernel-consumer.ts'
+          ),
+        },
+        {
+          label: 'migration',
+          path: join(
+            fixture.rootDir,
+            'packages',
+            'warden',
+            'src',
+            'migrations',
+            'captured-kernel-consumer.ts'
+          ),
+        },
+        {
+          label: 'historical',
+          path: join(
+            fixture.rootDir,
+            'packages',
+            'warden',
+            'src',
+            'historical',
+            'captured-kernel-consumer.ts'
+          ),
+        },
+        {
+          label: 'changeset',
+          path: join(fixture.rootDir, '.changeset', 'captured-kernel.ts'),
+        },
+      ] as const;
+      mkdirSync(join(fixture.rootDir, '.changeset'), { recursive: true });
+      mkdirSync(
+        join(fixture.rootDir, 'packages', 'warden', 'src', '__fixtures__'),
+        { recursive: true }
+      );
+      mkdirSync(
+        join(fixture.rootDir, 'packages', 'warden', 'src', 'migrations'),
+        { recursive: true }
+      );
+      mkdirSync(
+        join(fixture.rootDir, 'packages', 'warden', 'src', 'historical'),
+        { recursive: true }
+      );
+      const kernelSource = "export { kernel } from './internal/kernel.js';\n";
+      const storeSource = "import { kernel } from '@ontrails/core/kernel';\n";
+      const coreLocalSource =
+        "import { kernel } from '@ontrails/core/kernel';\n";
+      const nonProductionSource =
+        "import { kernel } from '@ontrails/core/kernel';\n";
+      writeSource(fixture.storeImporterPath, storeSource);
+      writeSource(coreLocalPath, coreLocalSource);
+      for (const importer of nonProductionImporters) {
+        expect(importer.label).toMatch(
+          /^(?:test|fixture|migration|historical|changeset)$/
+        );
+        writeSource(importer.path, nonProductionSource);
+      }
+
+      const kernelFile = {
+        filePath: fixture.coreKernelPath,
+        kind: 'typescript' as const,
+        sourceCode: kernelSource,
+      };
+
+      expect(
+        checkFixture(fixture, kernelFile, [
+          kernelFile,
+          {
+            filePath: fixture.storeImporterPath,
+            kind: 'typescript',
+            sourceCode: storeSource,
+          },
+          {
+            filePath: coreLocalPath,
+            kind: 'typescript',
+            sourceCode: coreLocalSource,
+          },
+          ...nonProductionImporters.map((importer) => ({
+            filePath: importer.path,
+            kind: 'typescript' as const,
+            sourceCode: nonProductionSource,
+          })),
+        ])
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('excludes test, fixture, migration, and historical consumers from the threshold', () => {
+    const fixture = createFixture();
+    try {
+      const cliFixturePath = join(
+        fixture.rootDir,
+        'packages',
+        'cli',
+        'fixtures',
+        'kernel.ts'
+      );
+      const trailsMigrationPath = join(
+        fixture.rootDir,
+        'apps',
+        'trails',
+        'migrations',
+        'kernel.ts'
+      );
+      const wardenHistoricalPath = join(
+        fixture.rootDir,
+        'packages',
+        'warden',
+        'historical',
+        'kernel.ts'
+      );
+      mkdirSync(join(fixture.rootDir, 'packages', 'cli', 'fixtures'), {
+        recursive: true,
+      });
+      mkdirSync(join(fixture.rootDir, 'apps', 'trails', 'migrations'), {
+        recursive: true,
+      });
+      mkdirSync(join(fixture.rootDir, 'packages', 'warden', 'historical'), {
+        recursive: true,
+      });
+
+      const kernelSource = "export { kernel } from './internal/kernel.js';\n";
+      const storeSource = "import { kernel } from '@ontrails/core/kernel';\n";
+      const excludedSource =
+        "import { kernel } from '@ontrails/core/kernel';\n";
+      writeSource(fixture.storeImporterPath, storeSource);
+      writeSource(fixture.wardenTestImporterPath, excludedSource);
+      writeSource(cliFixturePath, excludedSource);
+      writeSource(trailsMigrationPath, excludedSource);
+      writeSource(wardenHistoricalPath, excludedSource);
+
+      const kernelFile = {
+        filePath: fixture.coreKernelPath,
+        kind: 'typescript' as const,
+        sourceCode: kernelSource,
+      };
+
+      expect(
+        checkFixture(fixture, kernelFile, [
+          kernelFile,
+          {
+            filePath: fixture.storeImporterPath,
+            kind: 'typescript',
+            sourceCode: storeSource,
+          },
+          {
+            filePath: fixture.wardenTestImporterPath,
+            kind: 'typescript',
+            sourceCode: excludedSource,
+          },
+          {
+            filePath: cliFixturePath,
+            kind: 'typescript',
+            sourceCode: excludedSource,
+          },
+          {
+            filePath: trailsMigrationPath,
+            kind: 'typescript',
+            sourceCode: excludedSource,
+          },
+          {
+            filePath: wardenHistoricalPath,
+            kind: 'typescript',
+            sourceCode: excludedSource,
+          },
+        ])
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+
+  test('keeps backend-support below threshold when only apps/trails is a production consumer', () => {
+    const fixture = createFixture();
+    try {
+      const backendPath = join(
+        fixture.rootDir,
+        'packages',
+        'topographer',
+        'src',
+        'backend-support.ts'
+      );
+      const backendSource =
+        "export { backend } from './internal/backend-support.js';\n";
+      const trailsSource =
+        "import { backend } from '@ontrails/topographer/backend-support';\n";
+      const wardenTestSource =
+        "import { backend } from '@ontrails/topographer/backend-support';\n";
+      writeSource(fixture.trailsImporterPath, trailsSource);
+      writeSource(fixture.wardenTestImporterPath, wardenTestSource);
+
+      const backendFile = {
+        filePath: backendPath,
+        kind: 'typescript' as const,
+        sourceCode: backendSource,
+      };
+
+      expect(
+        checkFixture(fixture, backendFile, [
+          backendFile,
+          {
+            filePath: fixture.trailsImporterPath,
+            kind: 'typescript',
+            sourceCode: trailsSource,
+          },
+          {
+            filePath: fixture.wardenTestImporterPath,
+            kind: 'typescript',
+            sourceCode: wardenTestSource,
+          },
+        ])
+      ).toEqual([]);
+    } finally {
+      rmSync(fixture.rootDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -9,8 +9,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 73 rule trails', () => {
-    expect(wardenTopo.count).toBe(73);
+  test('contains all 74 rule trails', () => {
+    expect(wardenTopo.count).toBe(74);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -190,6 +190,7 @@ export { wardenTopo } from './trails/topo.js';
 export { runTopoAwareWardenTrails, runWardenTrails } from './trails/run.js';
 export {
   activationOrphanTrail,
+  capturedKernelTrail,
   cliCommandRouteCoherenceTrail,
   circularRefsTrail,
   entityExistsTrail,

--- a/packages/warden/src/rules/captured-kernel.ts
+++ b/packages/warden/src/rules/captured-kernel.ts
@@ -1,0 +1,375 @@
+import { realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  extractStringLiteral,
+  getNodeDeclaration,
+  getNodeImportKind,
+  getNodeLocal,
+  getNodeSource,
+  getNodeSpecifiers,
+  identifierName,
+  isExportDefaultDeclaration,
+  isExportNamedDeclaration,
+  isImportDeclaration,
+  offsetToLine,
+  parse,
+  walk,
+} from '@ontrails/source';
+import type { WardenImportResolution } from '../resolve.js';
+import type { WardenPublicWorkspace } from '../workspaces.js';
+import { hasIgnoreCommentOnLine, splitSourceLines } from './source/pragmas.js';
+import { isTestFile } from './scan.js';
+import type {
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+const RULE_NAME = 'captured-kernel';
+
+interface InternalReExportSite {
+  readonly importSource: string;
+  readonly line: number;
+  readonly resolutionLine: number;
+}
+
+interface ImportedBindingSite {
+  readonly importSource: string;
+  readonly resolutionLine: number;
+}
+
+interface ExportTarget {
+  readonly specifier: string;
+  readonly workspace: WardenPublicWorkspace;
+}
+
+const normalizePath = (path: string): string => path.replaceAll('\\', '/');
+
+const normalizeRealPath = (path: string): string => {
+  try {
+    return normalizePath(realpathSync(path));
+  } catch {
+    return normalizePath(resolve(path));
+  }
+};
+
+const pathIsInside = (filePath: string, rootDir: string): boolean => {
+  const absoluteFilePath = normalizeRealPath(filePath);
+  const absoluteRootDir = normalizeRealPath(rootDir);
+  return (
+    absoluteFilePath === absoluteRootDir ||
+    absoluteFilePath.startsWith(`${absoluteRootDir}/`)
+  );
+};
+
+const sourcePackageNameForFile = (
+  filePath: string,
+  workspaces: ReadonlyMap<string, WardenPublicWorkspace>
+): string | undefined => {
+  for (const workspace of workspaces.values()) {
+    if (pathIsInside(filePath, workspace.rootDir)) {
+      return workspace.name;
+    }
+  }
+  return undefined;
+};
+
+const exportTargetsForFile = (
+  filePath: string,
+  workspaces: ReadonlyMap<string, WardenPublicWorkspace>
+): readonly ExportTarget[] => {
+  const normalizedFilePath = normalizeRealPath(filePath);
+  const targets: ExportTarget[] = [];
+  for (const workspace of workspaces.values()) {
+    for (const [specifier, target] of Object.entries(
+      workspace.exportTargets ?? {}
+    )) {
+      if (specifier === workspace.name) {
+        continue;
+      }
+      if (normalizeRealPath(target) === normalizedFilePath) {
+        targets.push({ specifier, workspace });
+      }
+    }
+  }
+  return targets.toSorted((left, right) =>
+    left.specifier.localeCompare(right.specifier)
+  );
+};
+
+const collectReExportSites = (
+  sourceCode: string,
+  filePath: string
+): readonly InternalReExportSite[] => {
+  const ast = parse(filePath, sourceCode);
+  if (!ast) {
+    return [];
+  }
+
+  const sites: InternalReExportSite[] = [];
+  const importedBindings = new Map<string, ImportedBindingSite>();
+  walk(ast, (node) => {
+    if (!isImportDeclaration(node)) {
+      return;
+    }
+    if (getNodeImportKind(node) === 'type') {
+      return;
+    }
+    const value = extractStringLiteral(getNodeSource(node));
+    if (typeof value !== 'string') {
+      return;
+    }
+    const resolutionLine = offsetToLine(sourceCode, node.start);
+    for (const specifier of getNodeSpecifiers(node) ?? []) {
+      if (getNodeImportKind(specifier) === 'type') {
+        continue;
+      }
+      const localName = identifierName(getNodeLocal(specifier));
+      if (localName !== null) {
+        importedBindings.set(localName, {
+          importSource: value,
+          resolutionLine,
+        });
+      }
+    }
+  });
+
+  const siteKeys = new Set<string>();
+  const addSite = (site: InternalReExportSite): void => {
+    const key = `${site.importSource}:${site.line}:${site.resolutionLine}`;
+    if (!siteKeys.has(key)) {
+      siteKeys.add(key);
+      sites.push(site);
+    }
+  };
+  walk(ast, (node) => {
+    if (isExportDefaultDeclaration(node)) {
+      const localName = identifierName(getNodeDeclaration(node));
+      if (localName === null) {
+        return;
+      }
+      const imported = importedBindings.get(localName);
+      if (imported !== undefined) {
+        addSite({
+          ...imported,
+          line: offsetToLine(sourceCode, node.start),
+        });
+      }
+      return;
+    }
+
+    if (
+      node.type !== 'ExportNamedDeclaration' &&
+      node.type !== 'ExportAllDeclaration'
+    ) {
+      return;
+    }
+
+    const line = offsetToLine(sourceCode, node.start);
+    const value = extractStringLiteral(getNodeSource(node));
+    if (typeof value === 'string') {
+      addSite({ importSource: value, line, resolutionLine: line });
+      return;
+    }
+
+    if (!isExportNamedDeclaration(node)) {
+      return;
+    }
+    for (const specifier of getNodeSpecifiers(node) ?? []) {
+      const localName = identifierName(getNodeLocal(specifier));
+      if (localName === null) {
+        continue;
+      }
+      const imported = importedBindings.get(localName);
+      if (imported !== undefined) {
+        addSite({ ...imported, line });
+      }
+    }
+  });
+  return sites.toSorted((left, right) => left.line - right.line);
+};
+
+const importResolutionsForFile = (
+  context: ProjectContext,
+  filePath: string
+): readonly WardenImportResolution[] =>
+  context.importResolutionsByFile?.get(filePath) ?? [];
+
+const reExportResolution = (
+  resolutions: readonly WardenImportResolution[],
+  site: InternalReExportSite
+): WardenImportResolution | undefined =>
+  resolutions.find(
+    (resolution) =>
+      resolution.importSource === site.importSource &&
+      resolution.line === site.resolutionLine
+  );
+
+const isOwnedInternalReExport = (
+  workspace: WardenPublicWorkspace,
+  resolution: WardenImportResolution | undefined
+): boolean => {
+  if (!resolution?.isInternalTarget) {
+    return false;
+  }
+  if (resolution.packageName === workspace.name) {
+    return true;
+  }
+  if (
+    resolution.packageRoot &&
+    normalizeRealPath(resolution.packageRoot) ===
+      normalizeRealPath(workspace.rootDir)
+  ) {
+    return true;
+  }
+  return resolution.resolvedPath
+    ? pathIsInside(resolution.resolvedPath, workspace.rootDir)
+    : false;
+};
+
+const isNonProductionEvidenceFile = (filePath: string): boolean => {
+  const normalized = normalizePath(filePath);
+  return (
+    isTestFile(filePath) ||
+    /(?:^|\/)(?:__fixtures__|fixtures?|migrations?|historical|changelogs?|changesets?|agent-notes?)(?:\/|$)/.test(
+      normalized
+    ) ||
+    /(?:^|\/)\.(?:changeset|agents)(?:\/|$)/.test(normalized) ||
+    /(?:^|\/)(?:CHANGELOG|changeset)\.md$/i.test(normalized)
+  );
+};
+
+const externalProductionConsumerPackages = ({
+  context,
+  exportSpecifier,
+  hostPackage,
+  workspaces,
+}: {
+  readonly context: ProjectContext;
+  readonly exportSpecifier: string;
+  readonly hostPackage: string;
+  readonly workspaces: ReadonlyMap<string, WardenPublicWorkspace>;
+}): readonly string[] => {
+  const consumers = new Set<string>();
+  for (const resolutions of context.importResolutionsByFile?.values() ?? []) {
+    for (const resolution of resolutions) {
+      if (resolution.importSource !== exportSpecifier) {
+        continue;
+      }
+      if (resolution.errorKind || !resolution.usesPublicExport) {
+        continue;
+      }
+      if (!resolution.crossesPackageBoundary) {
+        continue;
+      }
+      if (resolution.packageName !== hostPackage) {
+        continue;
+      }
+      if (isNonProductionEvidenceFile(resolution.importerPath)) {
+        continue;
+      }
+
+      const sourcePackageName = sourcePackageNameForFile(
+        resolution.importerPath,
+        workspaces
+      );
+      if (!sourcePackageName || sourcePackageName === hostPackage) {
+        continue;
+      }
+      consumers.add(sourcePackageName);
+    }
+  }
+  return [...consumers].toSorted();
+};
+
+const diagnosticMessage = ({
+  consumers,
+  exportSpecifier,
+  hostPackage,
+  importSource,
+}: {
+  readonly consumers: readonly string[];
+  readonly exportSpecifier: string;
+  readonly hostPackage: string;
+  readonly importSource: string;
+}): string =>
+  `${hostPackage} export target "${exportSpecifier}" re-exports internal target "${importSource}" and is consumed by external production packages ${consumers.join(
+    ', '
+  )}. Review ownership of the exported subpath and its captured kernel before it becomes a durable public seam.`;
+
+export const capturedKernel: ProjectAwareWardenRule = {
+  check(): readonly WardenDiagnostic[] {
+    return [];
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    const workspaces = context.publicWorkspaces;
+    if (!workspaces || workspaces.size === 0) {
+      return [];
+    }
+
+    const exportTargets = exportTargetsForFile(filePath, workspaces);
+    if (exportTargets.length === 0) {
+      return [];
+    }
+
+    const lines = splitSourceLines(sourceCode);
+    const resolutions = importResolutionsForFile(context, filePath);
+    const diagnostics: WardenDiagnostic[] = [];
+
+    for (const exportTarget of exportTargets) {
+      const consumers = externalProductionConsumerPackages({
+        context,
+        exportSpecifier: exportTarget.specifier,
+        hostPackage: exportTarget.workspace.name,
+        workspaces,
+      });
+      if (consumers.length < 2) {
+        continue;
+      }
+
+      for (const site of collectReExportSites(sourceCode, filePath)) {
+        if (hasIgnoreCommentOnLine(lines, site.line)) {
+          continue;
+        }
+
+        const resolution = reExportResolution(resolutions, site);
+        if (!isOwnedInternalReExport(exportTarget.workspace, resolution)) {
+          continue;
+        }
+
+        diagnostics.push({
+          filePath,
+          guidance: {
+            steps: [
+              'Review whether the public subpath should become an owned package surface, move back behind the package root, or be split into a better-owned package.',
+              'If the imported capability is reusable source-code machinery, serves at least two independently owned toolchain capabilities, exposes one genuinely shared contract, and owns no verdict, migration plan, graph query, or surface rendering, consider relocating it to @ontrails/source.',
+              'Otherwise, preserve the current owner or choose another doctrinal owner.',
+            ],
+            summary:
+              'Review ownership before an internal re-exported kernel hardens into a public package seam.',
+          },
+          line: site.line,
+          message: diagnosticMessage({
+            consumers,
+            exportSpecifier: exportTarget.specifier,
+            hostPackage: exportTarget.workspace.name,
+            importSource: site.importSource,
+          }),
+          rule: RULE_NAME,
+          severity: 'warn',
+        });
+      }
+    }
+
+    return diagnostics;
+  },
+  description:
+    'Flag public subpath exports that capture internal kernels after multiple production packages consume them.',
+  name: RULE_NAME,
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -1,4 +1,5 @@
 import { activationOrphan } from './activation-orphan.js';
+import { capturedKernel } from './captured-kernel.js';
 import { cliCommandRouteCoherence } from './cli-command-route-coherence.js';
 import { circularRefs } from './circular-refs.js';
 import { entityExists } from './entity-exists.js';
@@ -139,6 +140,7 @@ export {
 export type { BuiltinWardenRuleName } from './metadata.js';
 
 export { activationOrphan } from './activation-orphan.js';
+export { capturedKernel } from './captured-kernel.js';
 export { cliCommandRouteCoherence } from './cli-command-route-coherence.js';
 export { noThrowInImplementation } from './no-throw-in-implementation.js';
 export { circularRefs } from './circular-refs.js';
@@ -219,6 +221,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   WardenRule
 >([
   [noThrowInImplementation.name, noThrowInImplementation],
+  [capturedKernel.name, capturedKernel],
   [circularRefs.name, circularRefs],
   [entityExists.name, entityExists],
   [contextNoSurfaceTypes.name, contextNoSurfaceTypes],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -69,6 +69,7 @@ const depthByTier = {
 
 const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
   'activation-orphan': 'signals',
+  'captured-kernel': 'general',
   'cli-command-route-coherence': 'meta',
   'composes-declarations': 'composition',
   'context-no-surface-types': 'composition',
@@ -156,6 +157,27 @@ const builtinWardenRuleMetadataInput = {
     invariant:
       'Signal activation consumers reference sources with producer declarations.',
     tier: 'topo-aware',
+  },
+  'captured-kernel': {
+    guidance: {
+      relatedRules: [
+        'duplicate-exported-symbol',
+        'public-internal-deep-imports',
+        'resolved-import-boundary',
+      ],
+      steps: [
+        'Review whether the public subpath should become an owned package surface, move back behind the package root, or be split into a better-owned package.',
+        'If the imported capability is reusable source-code machinery, serves at least two independently owned toolchain capabilities, exposes one genuinely shared contract, and owns no verdict, migration plan, graph query, or surface rendering, consider relocating it to @ontrails/source.',
+        'Otherwise, preserve the current owner or choose another doctrinal owner.',
+      ],
+      summary:
+        'Review ownership before an internal re-exported kernel hardens into a public package seam.',
+    },
+    invariant:
+      'Public subpath exports that re-export internal kernels receive ownership review after multiple production packages consume them.',
+    lifecycle: { state: 'durable' },
+    scope: 'advisory',
+    tier: 'project-static',
   },
   'circular-refs': {
     ...durableExternal,

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -7,6 +7,7 @@
  * the `warden-export-symmetry` rule will fail the build if they drift.
  */
 import { activationOrphan } from './activation-orphan.js';
+import { capturedKernel } from './captured-kernel.js';
 import { cliCommandRouteCoherence } from './cli-command-route-coherence.js';
 import { circularRefs } from './circular-refs.js';
 import { entityExists } from './entity-exists.js';
@@ -91,6 +92,7 @@ import { webhookRouteCollision } from './webhook-route-collision.js';
  */
 export const registeredRuleNames: readonly string[] = [
   activationOrphan.name,
+  capturedKernel.name,
   cliCommandRouteCoherence.name,
   circularRefs.name,
   contextNoSurfaceTypes.name,

--- a/packages/warden/src/trails/captured-kernel.trail.ts
+++ b/packages/warden/src/trails/captured-kernel.trail.ts
@@ -1,0 +1,108 @@
+import { capturedKernel } from '../rules/captured-kernel.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const capturedKernelTrail = wrapRule({
+  examples: [
+    {
+      expected: {
+        diagnostics: [
+          {
+            filePath: 'packages/core/src/kernel.ts',
+            guidance: {
+              steps: [
+                'Review whether the public subpath should become an owned package surface, move back behind the package root, or be split into a better-owned package.',
+                'If the imported capability is reusable source-code machinery, serves at least two independently owned toolchain capabilities, exposes one genuinely shared contract, and owns no verdict, migration plan, graph query, or surface rendering, consider relocating it to @ontrails/source.',
+                'Otherwise, preserve the current owner or choose another doctrinal owner.',
+              ],
+              summary:
+                'Review ownership before an internal re-exported kernel hardens into a public package seam.',
+            },
+            line: 1,
+            message:
+              '@ontrails/core export target "@ontrails/core/kernel" re-exports internal target "./internal/kernel.js" and is consumed by external production packages @ontrails/cli, @ontrails/store. Review ownership of the exported subpath and its captured kernel before it becomes a durable public seam.',
+            rule: 'captured-kernel',
+            severity: 'warn',
+          },
+        ],
+      },
+      input: {
+        filePath: 'packages/core/src/kernel.ts',
+        importResolutionsByFile: {
+          'packages/cli/src/index.ts': [
+            {
+              crossesPackageBoundary: true,
+              importSource: '@ontrails/core/kernel',
+              importerPath: 'packages/cli/src/index.ts',
+              isInternalTarget: false,
+              line: 1,
+              packageName: '@ontrails/core',
+              packageRoot: 'packages/core',
+              resolvedPath: 'packages/core/src/kernel.ts',
+              usesPublicExport: true,
+            },
+          ],
+          'packages/core/src/kernel.ts': [
+            {
+              crossesPackageBoundary: false,
+              importSource: './internal/kernel.js',
+              importerPath: 'packages/core/src/kernel.ts',
+              isInternalTarget: true,
+              line: 1,
+              packageName: '@ontrails/core',
+              packageRoot: 'packages/core',
+              resolvedPath: 'packages/core/src/internal/kernel.ts',
+              usesPublicExport: false,
+            },
+          ],
+          'packages/store/src/index.ts': [
+            {
+              crossesPackageBoundary: true,
+              importSource: '@ontrails/core/kernel',
+              importerPath: 'packages/store/src/index.ts',
+              isInternalTarget: false,
+              line: 1,
+              packageName: '@ontrails/core',
+              packageRoot: 'packages/core',
+              resolvedPath: 'packages/core/src/kernel.ts',
+              usesPublicExport: true,
+            },
+          ],
+        },
+        knownTrailIds: [],
+        publicWorkspaces: {
+          '@ontrails/cli': {
+            exportTargets: {
+              '@ontrails/cli': 'packages/cli/src/index.ts',
+            },
+            hasExports: true,
+            name: '@ontrails/cli',
+            packageJsonPath: 'packages/cli/package.json',
+            rootDir: 'packages/cli',
+          },
+          '@ontrails/core': {
+            exportTargets: {
+              '@ontrails/core': 'packages/core/src/index.ts',
+              '@ontrails/core/kernel': 'packages/core/src/kernel.ts',
+            },
+            hasExports: true,
+            name: '@ontrails/core',
+            packageJsonPath: 'packages/core/package.json',
+            rootDir: 'packages/core',
+          },
+          '@ontrails/store': {
+            exportTargets: {
+              '@ontrails/store': 'packages/store/src/index.ts',
+            },
+            hasExports: true,
+            name: '@ontrails/store',
+            packageJsonPath: 'packages/store/package.json',
+            rootDir: 'packages/store',
+          },
+        },
+        sourceCode: "export { kernel } from './internal/kernel.js';\n",
+      },
+      name: 'Flags captured kernels consumed by multiple production packages',
+    },
+  ],
+  rule: capturedKernel,
+});

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -1,4 +1,5 @@
 export { activationOrphanTrail } from './activation-orphan.trail.js';
+export { capturedKernelTrail } from './captured-kernel.trail.js';
 export { cliCommandRouteCoherenceTrail } from './cli-command-route-coherence.trail.js';
 export { circularRefsTrail } from './circular-refs.trail.js';
 export { entityExistsTrail } from './entity-exists.trail.js';

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 73
+- Rule count: 74
 
 ## Agent Instructions
 
@@ -34,6 +34,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 
 ### General
 
+- `captured-kernel` (warn, all/project-static, advisory): Public subpath exports that re-export internal kernels receive ownership review after multiple production packages consume them. Guidance: Review ownership before an internal re-exported kernel hardens into a public package seam.
 - `circular-refs` (warn, project/project-static, external): Entity reference graphs must be acyclic.
 - `duplicate-exported-symbol` (warn, project/project-static, repo-local): First-party packages should not define the same exported symbol name in parallel. Guidance: Keep exported symbol ownership from drifting across first-party packages.
 - `entity-exists` (error, project/project-static, external): Declared entity references resolve to known entities.


### PR DESCRIPTION
## Context

Implements [TRL-1231](https://linear.app/outfitter/issue/TRL-1231/) so shared internal kernels receive ownership review before accidental public subpaths harden into package seams.

## What changed

- Add advisory `captured-kernel` Warden governance.
- Trigger only for non-root public subpaths re-exporting internals with at least two distinct production external consumers.
- Exclude same-package, root-target, evidence, and non-production paths.
- Document the `@ontrails/topography/backend-support` watch case.

## Verification

- 8 focused rule cases.
- Warden guide regenerated.
- Full check/test/build/publish-pack/dogfood/docs gates passed.
- Rule and acceptance reviews reached 5/5.

## Risk

Warn-level ownership coaching only. It does not block current packages or infer a new package automatically.