### PR TITLE
fix(release): classify first scoped publications

### DIFF
--- a/.changeset/registry-first-publication-auth.md
+++ b/.changeset/registry-first-publication-auth.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': patch
+---
+
+Classify unauthenticated scoped-package dist-tag fallbacks as first publications after npm has already reported the package missing, and preserve registry probe details in release-policy blockers.

--- a/apps/trails/src/__tests__/release-policy.test.ts
+++ b/apps/trails/src/__tests__/release-policy.test.ts
@@ -260,6 +260,26 @@ describe('evaluateReleasePolicy', () => {
     );
   });
 
+  test('preserves registry probe errors in policy blockers', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        registryPackages: [
+          {
+            error: 'npm error 503 Service Unavailable',
+            name: '@ontrails/core',
+            status: 'inaccessible',
+            version: '1.0.0-beta.19',
+          },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe('block');
+    expect(report.blockers).toContain(
+      '@ontrails/core: registry state is inaccessible: npm error 503 Service Unavailable'
+    );
+  });
+
   test('blocks already-published versions when the release tag is stale', () => {
     const report = evaluateReleasePolicy(
       baseInput({

--- a/apps/trails/src/__tests__/release-registry-classifier.test.ts
+++ b/apps/trails/src/__tests__/release-registry-classifier.test.ts
@@ -163,6 +163,11 @@ const packumentLagView: RegistryView = async (name) => ({
 
 const targetAbsent: RegistryVersionView = async () => false;
 const targetPublished: RegistryVersionView = async () => true;
+const unauthorizedNpmRunner: NpmCommandRunner = async () => ({
+  exitCode: 1,
+  stderr: 'npm error code E401\nnpm error 401 Unauthorized',
+  stdout: '',
+});
 
 describe('registryPostureErrors — live beta.28 incident', () => {
   test('ready phase passes (publish pending); published phase fails', async () => {
@@ -342,6 +347,39 @@ describe('npm registry fallback wiring', () => {
       ['view', '@ontrails/regrade', 'name', 'version', 'dist-tags', '--json'],
       ['dist-tag', 'ls', '@ontrails/regrade'],
     ]);
+  });
+
+  test('treats scoped dist-tag E401 after package E404 as first publication', async () => {
+    const commands: string[][] = [];
+    const runNpm: NpmCommandRunner = async (args) => {
+      commands.push([...args]);
+      if (args[0] === 'view') {
+        return notFoundResult;
+      }
+      if (args.join(' ') === 'dist-tag ls @ontrails/source') {
+        return {
+          exitCode: 1,
+          stderr:
+            'npm error code E401\nnpm error 401 Unauthorized - GET https://registry.npmjs.org/-/package/@ontrails%2fsource/dist-tags',
+          stdout: '',
+        };
+      }
+      throw new Error(`unexpected npm command: ${args.join(' ')}`);
+    };
+
+    await expect(
+      createNpmRegistryView(runNpm)('@ontrails/source')
+    ).resolves.toBeNull();
+    expect(commands).toEqual([
+      ['view', '@ontrails/source', 'name', 'version', 'dist-tags', '--json'],
+      ['dist-tag', 'ls', '@ontrails/source'],
+    ]);
+  });
+
+  test('keeps package-view authorization failures inaccessible', async () => {
+    await expect(
+      createNpmRegistryView(unauthorizedNpmRunner)('@ontrails/source')
+    ).rejects.toThrow('401 Unauthorized');
   });
 
   test('falls back from npm view exact-version 404 to npm pack proof', async () => {

--- a/apps/trails/src/release/native-bun-registry.ts
+++ b/apps/trails/src/release/native-bun-registry.ts
@@ -339,6 +339,11 @@ const isNpmNotFoundOutput = (stdout: string, stderr: string): boolean => {
   return combined.includes('E404') || combined.includes('404 Not Found');
 };
 
+const isNpmUnauthorizedOutput = (stdout: string, stderr: string): boolean => {
+  const combined = `${stdout}\n${stderr}`;
+  return combined.includes('E401') || combined.includes('401 Unauthorized');
+};
+
 const isNpmExactVersionMissingOutput = (
   stdout: string,
   stderr: string
@@ -403,7 +408,13 @@ const npmDistTagRegistryView = async (
 ): Promise<NpmView | null> => {
   const { exitCode, stderr, stdout } = await runNpm(['dist-tag', 'ls', name]);
   if (exitCode !== 0) {
-    if (isNpmNotFoundOutput(stdout, stderr)) {
+    // npm returns E401 for the dist-tag endpoint of an unpublished scoped
+    // package, even though the preceding package view returned E404. At this
+    // fallback boundary both responses mean the package does not exist yet.
+    if (
+      isNpmNotFoundOutput(stdout, stderr) ||
+      isNpmUnauthorizedOutput(stdout, stderr)
+    ) {
       return null;
     }
     throw new Error(stderr.trim() || `npm dist-tag ls failed for ${name}`);

--- a/apps/trails/src/release/policy.ts
+++ b/apps/trails/src/release/policy.ts
@@ -59,6 +59,7 @@ export interface ReleasePolicySourcePullRequest {
 }
 
 export interface ReleasePolicyRegistryPackage {
+  readonly error?: string | undefined;
   readonly expectedTagVersion?: string | undefined;
   readonly name: string;
   readonly status: 'inaccessible' | 'missing' | 'published';
@@ -462,6 +463,7 @@ const readLabelFamily = <T extends string>(
 const factsFromPolicyPackage = (
   entry: ReleasePolicyRegistryPackage
 ): PackageRegistryFacts => ({
+  error: entry.error,
   expectedTagVersion: entry.expectedTagVersion,
   status: entry.status,
   targetVersion: entry.version,
@@ -485,7 +487,7 @@ const registryBlockers = (
   packages.flatMap((entry) => {
     const state = classifyPackageRegistryState(factsFromPolicyPackage(entry));
     if (state.kind === 'registry-inaccessible') {
-      return [`${entry.name}: registry state is inaccessible`];
+      return [`${entry.name}: registry state is inaccessible: ${state.error}`];
     }
     if (state.kind === 'tag-points-ahead') {
       return [
@@ -986,6 +988,7 @@ const registryPackagesFromResults = (
       };
     }
     return {
+      ...(result.status === 'inaccessible' ? { error: result.error } : {}),
       name: result.name,
       status: result.status,
       version: result.workspaceVersion,


### PR DESCRIPTION
## Context

The beta.40 Release workflow classified the new `@ontrails/source` and
`@ontrails/topography` packages as registry-inaccessible on an unauthenticated
GitHub runner. npm first returned the expected package-level `E404`, then its
scoped dist-tag fallback returned `E401 Unauthorized`. The local authenticated
checkout therefore disagreed with CI about the same first-publication state.

Closes [TRL-1220](https://linear.app/outfitter/issue/TRL-1220/).

## What Changed

- Treat scoped dist-tag `E401` as a missing package only inside the fallback
  reached after an explicit package-level `E404`.
- Keep initial authorization failures classified as registry-inaccessible.
- Preserve underlying registry probe errors through release-policy blockers.
- Add command-level regressions for the unauthenticated first-publication path
  and the authorization boundary.
- Add a patch changeset for `@ontrails/trails`.

## Verification

- Focused registry/policy tests: 56 passed, 0 failed.
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun run lock:roundtrip`
- Exact no-`.npmrc` beta.40 reproduction: `bun run publish:policy` resolves
  `manual` with `publish:manual` instead of blocking.
- Graphite pre-push hook passed.
- Independent local review: 5/5 confidence, no P0-P3 findings.

## Risk

The `E401` interpretation is intentionally narrow: it is accepted only after
npm has already returned package-level `E404`. General package-view auth
failures continue to block. No publish was run while testing this repair.
