### PR TITLE
fix(commander): support contiguous multiselect values

### DIFF
--- a/.changeset/commander-contiguous-multiselect.md
+++ b/.changeset/commander-contiguous-multiselect.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/cli': patch
+'@ontrails/commander': patch
+---
+
+Define bounded multiselect argv normalization in the framework CLI model and apply it automatically in the Commander adapter, accepting both contiguous and repeated forms while preserving child routes after the first explicit value.

--- a/adapters/commander/README.md
+++ b/adapters/commander/README.md
@@ -35,6 +35,17 @@ if (commands.isErr()) {
 const program = toCommander(commands.value, { name: 'myapp' });
 ```
 
+## Multiselect flags
+
+Schema fields such as `z.array(z.enum(['cli', 'mcp', 'http']))` derive a bounded multiselect flag. The shared CLI argv normalizer lets adapters accept both contiguous and repeated forms; Commander applies it automatically:
+
+```bash
+myapp create --surfaces cli mcp http
+myapp create --surfaces cli --surfaces mcp --surfaces http
+```
+
+The first matching token after the flag is its explicit value. After that first value, additional collection stops before known child routes or values outside the declared choices. Adopters do not need custom parsing or surface configuration for either form.
+
 ## Installation
 
 ```bash

--- a/adapters/commander/src/__tests__/to-commander.test.ts
+++ b/adapters/commander/src/__tests__/to-commander.test.ts
@@ -1799,6 +1799,72 @@ describe('toCommander validation', () => {
     });
   });
 
+  test('accepts contiguous choice-array values without consuming the bare child token', async () => {
+    let received:
+      | {
+          readonly args: Record<string, unknown>;
+          readonly opts: Record<string, unknown>;
+        }
+      | undefined;
+    const commands = [
+      {
+        args: [{ name: 'target', required: false, variadic: false }],
+        execute: async (
+          args: Record<string, unknown>,
+          opts: Record<string, unknown>
+        ) => {
+          received = { args, opts };
+          return await Result.ok('wayfind');
+        },
+        flags: [
+          {
+            choices: ['errors', 'examples'],
+            default: [],
+            name: 'include',
+            required: false,
+            type: 'string[]' as const,
+            variadic: false,
+          },
+        ],
+        intent: 'read' as const,
+        path: ['wayfind'] as const,
+        trail: trail('wayfind.navigate', {
+          implementation: () => Result.ok('wayfind'),
+          input: z.object({}),
+        }),
+      },
+      {
+        args: [],
+        execute: async () => await Result.ok('search'),
+        flags: [],
+        intent: 'read' as const,
+        path: ['wayfind', 'search'] as const,
+        trail: trail('wayfind.search', {
+          implementation: () => Result.ok('search'),
+          input: z.object({}),
+        }),
+      },
+    ];
+
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+
+    await program.parseAsync([
+      'node',
+      'test',
+      'wayfind',
+      '--include',
+      'examples',
+      'errors',
+      'search',
+    ]);
+
+    expect(received).toEqual({
+      args: { target: 'search' },
+      opts: { include: ['examples', 'errors'] },
+    });
+  });
+
   test('routes matching trailing parent flags through parent fallback', async () => {
     const calls: string[] = [];
     const commands = [
@@ -2007,6 +2073,347 @@ describe('toCommander option wiring', () => {
     const formatOpt = opts.find((entry) => entry.long === '--format');
     expect(formatOpt).toBeDefined();
     expect(formatOpt?.argChoices).toEqual(['json', 'text']);
+  });
+
+  test('accepts contiguous and repeated values for derived multiselect flags', async () => {
+    const received: string[][] = [];
+    const configure = trail('configure', {
+      implementation: (input: { surfaces: string[] }) => {
+        received.push(input.surfaces);
+        return Result.ok('configured');
+      },
+      input: z.object({
+        surfaces: z.array(z.enum(['cli', 'mcp', 'http'])),
+      }),
+    });
+
+    const parse = async (argv: readonly string[]) => {
+      const commands = buildCommands(makeApp(configure), {
+        onResult: noopResult,
+      });
+      const program = toCommander(commands, { name: 'test' });
+      program.exitOverride();
+      await program.parseAsync(argv, { from: 'user' });
+    };
+
+    await parse(['configure', '--surfaces', 'cli', 'mcp', 'http']);
+    await parse([
+      'configure',
+      '--surfaces',
+      'cli',
+      '--surfaces',
+      'mcp',
+      '--surfaces',
+      'http',
+    ]);
+
+    expect(received).toEqual([
+      ['cli', 'mcp', 'http'],
+      ['cli', 'mcp', 'http'],
+    ]);
+  });
+
+  test('normalizes implicit eval argv for bounded multiselect flags', async () => {
+    const received: string[][] = [];
+    const configure = trail('configure', {
+      implementation: (input: { surfaces: string[] }) => {
+        received.push(input.surfaces);
+        return Result.ok('configured');
+      },
+      input: z.object({
+        surfaces: z.array(z.enum(['cli', 'mcp', 'http'])),
+      }),
+    });
+    const commands = buildCommands(makeApp(configure), {
+      onResult: noopResult,
+    });
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+    const originalArgv = [...process.argv];
+    const originalExecArgv = [...process.execArgv];
+
+    try {
+      process.argv.splice(
+        0,
+        process.argv.length,
+        'bun',
+        'configure',
+        '--surfaces',
+        'cli',
+        'mcp'
+      );
+      process.execArgv.splice(0, process.execArgv.length, '-e');
+      await program.parseAsync();
+    } finally {
+      process.argv.splice(0, process.argv.length, ...originalArgv);
+      process.execArgv.splice(0, process.execArgv.length, ...originalExecArgv);
+    }
+
+    expect(received).toEqual([['cli', 'mcp']]);
+  });
+
+  test('gives implicit eval argv precedence over Electron offsets', async () => {
+    const received: string[][] = [];
+    const configure = trail('configure', {
+      implementation: (input: { surfaces: string[] }) => {
+        received.push(input.surfaces);
+        return Result.ok('configured');
+      },
+      input: z.object({
+        surfaces: z.array(z.enum(['cli', 'mcp', 'http'])),
+      }),
+    });
+    const commands = buildCommands(makeApp(configure), {
+      onResult: noopResult,
+    });
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+    const originalArgv = [...process.argv];
+    const originalExecArgv = [...process.execArgv];
+
+    try {
+      Object.defineProperty(process.versions, 'electron', {
+        configurable: true,
+        value: 'test',
+      });
+      Object.defineProperty(process, 'defaultApp', {
+        configurable: true,
+        value: true,
+      });
+      process.argv.splice(
+        0,
+        process.argv.length,
+        'electron',
+        'configure',
+        '--surfaces',
+        'cli',
+        'mcp'
+      );
+      process.execArgv.splice(0, process.execArgv.length, '-e');
+      await program.parseAsync();
+    } finally {
+      process.argv.splice(0, process.argv.length, ...originalArgv);
+      process.execArgv.splice(0, process.execArgv.length, ...originalExecArgv);
+      Reflect.deleteProperty(process.versions, 'electron');
+      Reflect.deleteProperty(process, 'defaultApp');
+    }
+
+    expect(received).toEqual([['cli', 'mcp']]);
+  });
+
+  test('keeps a matching additional choice available as a child route', async () => {
+    const calls: string[] = [];
+    const includeFlag = {
+      choices: ['examples', 'search'],
+      name: 'include',
+      required: false,
+      type: 'string[]' as const,
+      variadic: false,
+    };
+    const commands: CliCommand[] = [
+      {
+        args: [],
+        execute: async () => {
+          calls.push('wayfind');
+          return await Result.ok();
+        },
+        flags: [includeFlag],
+        intent: 'read',
+        path: ['wayfind'],
+        trail: trail('wayfind', { implementation: () => Result.ok() }),
+      },
+      {
+        args: [],
+        execute: async () => {
+          calls.push('wayfind.search');
+          return await Result.ok();
+        },
+        flags: [includeFlag],
+        intent: 'read',
+        path: ['wayfind', 'search'],
+        trail: trail('wayfind.search', { implementation: () => Result.ok() }),
+      },
+    ];
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+
+    await program.parseAsync(['wayfind', '--include', 'examples', 'search'], {
+      from: 'user',
+    });
+
+    expect(calls).toEqual(['wayfind.search']);
+  });
+
+  test('preserves explicit provenance for equivalent inherited bounded flags', async () => {
+    let supplied: ReadonlySet<string> | undefined;
+    const modesFlag = {
+      choices: ['one', 'two'],
+      default: ['one'],
+      name: 'modes',
+      required: false,
+      type: 'string[]' as const,
+      variadic: false,
+    };
+    const commands: CliCommand[] = [
+      {
+        args: [],
+        execute: async () => await Result.ok(),
+        flags: [modesFlag],
+        intent: 'read',
+        path: ['alpha'],
+        trail: trail('alpha', { implementation: () => Result.ok() }),
+      },
+      {
+        args: [],
+        execute: async (_args, _flags, _ctx, options) => {
+          supplied = options?.userSuppliedFlagKeys;
+          return await Result.ok();
+        },
+        flags: [modesFlag],
+        intent: 'read',
+        path: ['alpha', 'child'],
+        trail: trail('alpha.child', { implementation: () => Result.ok() }),
+      },
+    ];
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+
+    await program.parseAsync(['alpha', 'child', '--modes', 'one'], {
+      from: 'user',
+    });
+
+    expect(supplied).toEqual(new Set(['modes']));
+  });
+
+  test('preserves required option values that look like bounded flags', async () => {
+    let received:
+      | {
+          readonly args: Record<string, unknown>;
+          readonly flags: Record<string, unknown>;
+        }
+      | undefined;
+    const commands: CliCommand[] = [
+      {
+        args: [
+          { name: 'first', required: false, variadic: false },
+          { name: 'second', required: false, variadic: false },
+        ],
+        execute: async (args, flags) => {
+          received = { args, flags };
+          return await Result.ok();
+        },
+        flags: [
+          {
+            name: 'label',
+            required: true,
+            type: 'string',
+            variadic: false,
+          },
+          {
+            choices: ['cli', 'mcp'],
+            name: 'surfaces',
+            required: false,
+            type: 'string[]',
+            variadic: false,
+          },
+        ],
+        intent: 'read',
+        path: ['configure'],
+        trail: trail('configure', { implementation: () => Result.ok() }),
+      },
+    ];
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+
+    await program.parseAsync(
+      ['configure', '--label', '--surfaces', 'cli', 'mcp'],
+      { from: 'user' }
+    );
+
+    expect(received).toEqual({
+      args: { first: 'cli', second: 'mcp' },
+      flags: { label: '--surfaces' },
+    });
+  });
+
+  test('normalizes a bounded flag after a required variadic flag', async () => {
+    let received: Record<string, unknown> | undefined;
+    const commands: CliCommand[] = [
+      {
+        args: [],
+        execute: async (_args, flags) => {
+          received = flags;
+          return await Result.ok();
+        },
+        flags: [
+          {
+            name: 'tags',
+            required: true,
+            type: 'string[]',
+            variadic: true,
+          },
+          {
+            choices: ['cli', 'mcp'],
+            name: 'surfaces',
+            required: true,
+            type: 'string[]',
+            variadic: false,
+          },
+        ],
+        intent: 'read',
+        path: ['configure'],
+        trail: trail('configure', { implementation: () => Result.ok() }),
+      },
+    ];
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+
+    await program.parseAsync(
+      ['configure', '--tags', 'a', '--surfaces', 'cli', 'mcp'],
+      { from: 'user' }
+    );
+
+    expect(received).toEqual({ surfaces: ['cli', 'mcp'], tags: ['a'] });
+  });
+
+  test('gives a declared digit short flag precedence over numeric inference', async () => {
+    let received: Record<string, unknown> | undefined;
+    const commands: CliCommand[] = [
+      {
+        args: [],
+        execute: async (_args, flags) => {
+          received = flags;
+          return await Result.ok();
+        },
+        flags: [
+          {
+            name: 'threshold',
+            required: false,
+            type: 'number',
+            variadic: false,
+          },
+          {
+            choices: ['a', 'b'],
+            name: 'modes',
+            required: false,
+            short: '1',
+            type: 'string[]',
+            variadic: false,
+          },
+        ],
+        intent: 'read',
+        path: ['run'],
+        trail: trail('run', { implementation: () => Result.ok() }),
+      },
+    ];
+    const program = toCommander(commands, { name: 'test' });
+    program.exitOverride();
+
+    await program.parseAsync(['run', '--threshold', '-1', 'a', 'b'], {
+      from: 'user',
+    });
+
+    expect(received).toEqual({ modes: ['a', 'b'], threshold: true });
   });
 
   test('value aliases parse as canonical enum flag values', async () => {

--- a/adapters/commander/src/multiselect-argv.ts
+++ b/adapters/commander/src/multiselect-argv.ts
@@ -1,0 +1,182 @@
+import { Command } from 'commander';
+import type { ParseOptions, Option } from 'commander';
+import { normalizeCliArgv } from '@ontrails/cli';
+import type { CliCommand } from '@ontrails/cli';
+
+type EffectiveParseOptions = Omit<ParseOptions, 'from'> & {
+  readonly from?: ParseOptions['from'] | 'eval' | undefined;
+};
+
+export const visibleOptionsFor = (command: Command): readonly Option[] => {
+  const commands: Command[] = [];
+  let current: Command | null = command;
+  while (current !== null) {
+    commands.push(current);
+    current = current.parent;
+  }
+  return commands.toReversed().flatMap((owner) => owner.options);
+};
+
+export interface InvocationOptionMatch {
+  readonly inlineValue: boolean;
+  readonly option: Option;
+}
+
+const findShortOption = (
+  options: readonly Option[],
+  short: string
+): Option | undefined => options.find((candidate) => candidate.short === short);
+
+export const invocationOptionMatches = (
+  options: readonly Option[],
+  token: string
+): readonly InvocationOptionMatch[] => {
+  const exact = options.filter(
+    (option) => token === option.long || token === option.short
+  );
+  if (exact.length > 0) {
+    return exact.map((option) => ({ inlineValue: false, option }));
+  }
+
+  const longWithValue = options.filter(
+    (option) =>
+      option.long !== undefined &&
+      (option.required || option.optional) &&
+      token.startsWith(`${option.long}=`)
+  );
+  if (longWithValue.length > 0) {
+    return longWithValue.map((option) => ({ inlineValue: true, option }));
+  }
+
+  if (token.length <= 2 || token[0] !== '-' || token[1] === '-') {
+    return [];
+  }
+
+  const matches: InvocationOptionMatch[] = [];
+  let group = token.slice(1);
+  while (group.length > 0) {
+    const option = findShortOption(options, `-${group[0]}`);
+    if (option === undefined) {
+      break;
+    }
+    const inlineValue =
+      (option.required || option.optional) && group.length > 1;
+    matches.push({ inlineValue, option });
+    if (option.required || option.optional) {
+      break;
+    }
+    group = group.slice(1);
+  }
+  return matches;
+};
+
+export const isNegativeNumberArg = (
+  command: Command,
+  token: string
+): boolean => {
+  if (!/^-(\d+|\d*\.\d+)(e[+-]?\d+)?$/.test(token)) {
+    return false;
+  }
+
+  for (
+    let current: Command | null = command;
+    current !== null;
+    current = current.parent
+  ) {
+    if (current.options.some((option) => /^-\d$/.test(option.short ?? ''))) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+export const optionConsumesFollowingValue = (
+  command: Command,
+  match: InvocationOptionMatch,
+  nextToken: string | undefined
+): boolean =>
+  !match.inlineValue &&
+  (match.option.required ||
+    (match.option.optional &&
+      nextToken !== undefined &&
+      (!nextToken.startsWith('-') || isNegativeNumberArg(command, nextToken))));
+
+const argvUserStart = (
+  parseOptions?: EffectiveParseOptions | undefined
+): number => {
+  if (parseOptions?.from === 'user') {
+    return 0;
+  }
+  if (parseOptions?.from === 'eval') {
+    return 1;
+  }
+  if (parseOptions?.from === 'electron') {
+    const electronProcess = process as NodeJS.Process & {
+      readonly defaultApp?: boolean | undefined;
+    };
+    return electronProcess.defaultApp ? 2 : 1;
+  }
+  return 2;
+};
+
+const effectiveParseOptions = (
+  argv: readonly string[] | undefined,
+  parseOptions: ParseOptions | undefined
+): EffectiveParseOptions | undefined => {
+  if (
+    argv === undefined &&
+    parseOptions?.from === undefined &&
+    process.execArgv.some((arg) =>
+      ['-e', '--eval', '-p', '--print'].includes(arg)
+    )
+  ) {
+    // Commander supports this origin internally but does not publish it in
+    // ParseOptions. Preserve its one-token offset while normalizing argv.
+    return { from: 'eval' };
+  }
+  if (
+    argv === undefined &&
+    parseOptions?.from === undefined &&
+    process.versions['electron'] !== undefined
+  ) {
+    return { from: 'electron' };
+  }
+  return parseOptions;
+};
+
+export class TrailsCommanderProgram extends Command {
+  readonly #commands: readonly CliCommand[];
+
+  constructor(commands: readonly CliCommand[]) {
+    super();
+    this.#commands = commands;
+  }
+
+  #normalizeArgv(
+    argv: readonly string[] | undefined,
+    parseOptions: EffectiveParseOptions | undefined
+  ): readonly string[] {
+    const input = argv ?? process.argv;
+    const start = argvUserStart(parseOptions);
+    return [
+      ...input.slice(0, start),
+      ...normalizeCliArgv(this.#commands, input.slice(start)),
+    ];
+  }
+
+  override parse(argv?: readonly string[], parseOptions?: ParseOptions): this {
+    const options = effectiveParseOptions(argv, parseOptions);
+    const normalized = this.#normalizeArgv(argv, options);
+    return super.parse(normalized, options as ParseOptions | undefined);
+  }
+
+  override parseAsync(
+    argv?: readonly string[],
+    parseOptions?: ParseOptions
+  ): Promise<this> {
+    const options = effectiveParseOptions(argv, parseOptions);
+    const normalized = this.#normalizeArgv(argv, options);
+    return super.parseAsync(normalized, options as ParseOptions | undefined);
+  }
+}

--- a/adapters/commander/src/to-commander.ts
+++ b/adapters/commander/src/to-commander.ts
@@ -18,6 +18,14 @@ import {
 } from '@ontrails/cli';
 import { Command, InvalidArgumentError, Option } from 'commander';
 
+import {
+  invocationOptionMatches,
+  isNegativeNumberArg,
+  optionConsumesFollowingValue,
+  TrailsCommanderProgram,
+  visibleOptionsFor,
+} from './multiselect-argv.js';
+
 // ---------------------------------------------------------------------------
 // Options
 // ---------------------------------------------------------------------------
@@ -224,87 +232,6 @@ const rootCommandFor = (command: Command): Command => {
 const invocationArgsFor = (command: Command): readonly string[] =>
   rootCommandFor(command).args;
 
-const visibleOptionsFor = (command: Command): readonly Option[] => {
-  const commands: Command[] = [];
-  let current: Command | null = command;
-  while (current !== null) {
-    commands.push(current);
-    current = current.parent;
-  }
-  return commands.toReversed().flatMap((owner) => owner.options);
-};
-
-interface InvocationOptionMatch {
-  readonly inlineValue: boolean;
-  readonly option: Option;
-}
-
-const findShortOption = (
-  options: readonly Option[],
-  short: string
-): Option | undefined => options.find((candidate) => candidate.short === short);
-
-const invocationOptionMatches = (
-  options: readonly Option[],
-  token: string
-): readonly InvocationOptionMatch[] => {
-  const exact = options.filter(
-    (option) => token === option.long || token === option.short
-  );
-  if (exact.length > 0) {
-    return exact.map((option) => ({ inlineValue: false, option }));
-  }
-
-  const longWithValue = options.filter(
-    (option) =>
-      option.long !== undefined &&
-      (option.required || option.optional) &&
-      token.startsWith(`${option.long}=`)
-  );
-  if (longWithValue.length > 0) {
-    return longWithValue.map((option) => ({ inlineValue: true, option }));
-  }
-
-  if (token.length <= 2 || token[0] !== '-' || token[1] === '-') {
-    return [];
-  }
-
-  const matches: InvocationOptionMatch[] = [];
-  let group = token.slice(1);
-  while (group.length > 0) {
-    const option = findShortOption(options, `-${group[0]}`);
-    if (option === undefined) {
-      break;
-    }
-    const inlineValue =
-      (option.required || option.optional) && group.length > 1;
-    matches.push({ inlineValue, option });
-    if (option.required || option.optional) {
-      break;
-    }
-    group = group.slice(1);
-  }
-  return matches;
-};
-
-const isNegativeNumberArg = (command: Command, token: string): boolean => {
-  if (!/^-(\d+|\d*\.\d+)(e[+-]?\d+)?$/.test(token)) {
-    return false;
-  }
-
-  for (
-    let current: Command | null = command;
-    current !== null;
-    current = current.parent
-  ) {
-    if (current.options.some((option) => /^-\d$/.test(option.short ?? ''))) {
-      return false;
-    }
-  }
-
-  return true;
-};
-
 const isVariadicOptionValue = (
   command: Command,
   option: Option | undefined,
@@ -312,17 +239,6 @@ const isVariadicOptionValue = (
 ): boolean =>
   option !== undefined &&
   (!token.startsWith('-') || isNegativeNumberArg(command, token));
-
-const optionConsumesFollowingValue = (
-  command: Command,
-  match: InvocationOptionMatch,
-  nextToken: string | undefined
-): boolean =>
-  !match.inlineValue &&
-  (match.option.required ||
-    (match.option.optional &&
-      nextToken !== undefined &&
-      (!nextToken.startsWith('-') || isNegativeNumberArg(command, nextToken))));
 
 interface InvocationScan {
   readonly pathEnd: number | undefined;
@@ -506,8 +422,13 @@ const getUserSuppliedFlagKeys = (
 ): ReadonlySet<string> => {
   const userSupplied = new Set<string>();
   for (const key of getFlagOptionKeys(flags)) {
-    if (isUserSuppliedOption(command, key)) {
-      userSupplied.add(key);
+    let owner: Command | null = command;
+    while (owner !== null) {
+      if (isUserSuppliedOption(owner, key)) {
+        userSupplied.add(key);
+        break;
+      }
+      owner = owner.parent;
     }
   }
   return userSupplied;
@@ -999,7 +920,7 @@ export const toCommander = (
   options?: ToCommanderOptions
 ): Command => {
   validateCliCommands(commands);
-  const program = new Command();
+  const program = new TrailsCommanderProgram(commands);
   applyOptions(program, options);
   const topoName = options?.topoName ?? options?.name ?? program.name();
   const nodes = new Map<string, CommandNodeState>();

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -170,6 +170,7 @@ Current shipped surface packages are `@ontrails/cli`, `@ontrails/commander`, `@o
 deriveCliCommands(graph, options?)     // projection: Result-returning command definitions
 validateCliCommands(commands)          // validate command tree shape and collisions
 deriveFlags(schema, overrides?)        // Zod → CLI flags
+normalizeCliArgv(commands, argv)        // normalize framework-owned argv grammar
 output(value, mode)                    // write to stdout in text/json/jsonl
 deriveOutputMode(flags, topoName)      // determine output format from flags/topo-derived env
 

--- a/docs/surfaces/cli.md
+++ b/docs/surfaces/cli.md
@@ -100,6 +100,7 @@ Flags are derived from the trail's Zod input schema when the shape can be repres
 | `z.number()` | `--count <value>` | Required number |
 | `z.boolean()` | `--verbose` | Boolean switch |
 | `z.enum(["a", "b"])` | `--format <value>` | With `.choices()` |
+| `z.array(z.enum(["a", "b"]))` | `--mode <value>` | `--mode a b` or `--mode a --mode b` |
 | `z.array(z.string())` | `--tag <values...>` | Repeatable: `--tag a --tag b` |
 | `z.optional(z.string())` | `--name [value]` | Optional |
 | `z.string().default("x")` | `--name [value]` | With default |
@@ -109,6 +110,10 @@ Flags are derived from the trail's Zod input schema when the shape can be repres
 **Descriptions:** `.describe("text")` on Zod fields becomes the flag help text.
 
 Nested objects and arrays of objects are intentionally omitted from automatic flag derivation. The CLI prefers fewer flags over dishonest flags.
+
+Bounded multiselects accept contiguous and repeated forms through the framework-owned `normalizeCliArgv()` grammar. The first matching token after a flag is its explicit value. After that first value, additional collection stops before a known child command or the first value outside the declared choices. CLI adapters validate the command model and apply this normalization before parsing.
+
+When a nested command repeats an inherited bounded multiselect flag, its parsing shape and choices must stay equivalent. Divergent nested definitions are rejected before adapter wiring instead of depending on parser-specific option shadowing.
 
 Versioned trails also get a surface-owned `--trail-version <version>` flag. The flag accepts a live version number or unambiguous marker prefix and is stripped before trail input validation, so version negotiation stays at the CLI boundary.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -52,6 +52,7 @@ program.parse();
 | `deriveCliCommands(graph)` | Framework-agnostic command builder, returns `Result<CliCommand[], Error>` |
 | `validateCliCommands(commands)` | Validate `CliCommand[]` shapes before wiring a CLI adapter |
 | `deriveFlags(schema)` | Extract honest CLI flags from a Zod schema |
+| `normalizeCliArgv(commands, argv)` | Normalize framework-owned CLI syntax before adapter parsing |
 | `output(data, mode)` | Format output as JSON, JSONL, or text |
 | `deriveOutputMode(flags, topoName)` | Derive output mode from flags and topo-derived env vars (`<TOPO>_JSON`, `<TOPO>_JSONL`) |
 
@@ -74,12 +75,15 @@ Flags come from the Zod schema automatically when the field shape can be represe
 | `z.string()` | `--name <value>` | Required |
 | `z.boolean()` | `--verbose` | Switch |
 | `z.enum(["a","b"])` | `--format <value>` | With choices |
+| `z.array(z.enum(["a","b"]))` | `--mode a b` or `--mode a --mode b` | Bounded multiselect |
 | `z.array(z.string())` | `--tag <values...>` | Repeatable |
 | `z.optional(...)` | `--name [value]` | Optional |
 
 `camelCase` fields become `--kebab-case` flags. `.describe()` becomes help text.
 
 Nested objects and arrays of objects are intentionally omitted from automatic flag derivation. The CLI prefers fewer flags over dishonest flags.
+
+CLI adapters should pass user argv through `normalizeCliArgv(commands, argv)` before parsing. This gives bounded multiselects one framework-owned grammar: contiguous and repeated values are both accepted. The first matching token after a flag is its explicit value; after that first value, additional collection stops before known child routes or values outside the declared choices.
 
 Enum flags can expose standalone boolean aliases when a surface wants pipe-friendly shortcuts without inventing parallel flags. The alias still normalizes to the canonical enum field before the trail input is validated:
 

--- a/packages/cli/src/__tests__/argv.test.ts
+++ b/packages/cli/src/__tests__/argv.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test } from 'bun:test';
+import { Result, trail } from '@ontrails/core';
+
+import type { CliCommand, CliFlag } from '../command.js';
+import { normalizeCliArgv } from '../argv.js';
+
+const command = (
+  path: readonly string[],
+  flags: readonly CliFlag[]
+): CliCommand => ({
+  args: [],
+  execute: async () => await Result.ok(),
+  flags: [...flags],
+  intent: 'read',
+  path,
+  trail: trail(path.join('.'), {
+    implementation: () => Result.ok(),
+  }),
+});
+
+const surfacesFlag: CliFlag = {
+  choices: ['cli', 'mcp', 'http'],
+  name: 'surfaces',
+  required: false,
+  type: 'string[]',
+  variadic: false,
+};
+
+const modesFlag = (choices: string[]): CliFlag => ({
+  choices,
+  name: 'modes',
+  required: false,
+  type: 'string[]',
+  variadic: false,
+});
+
+describe('normalizeCliArgv', () => {
+  test('normalizes contiguous bounded choices into repeated flags', () => {
+    expect(
+      normalizeCliArgv(
+        [command(['create'], [surfacesFlag])],
+        ['create', '--surfaces', 'cli', 'mcp', 'http']
+      )
+    ).toEqual([
+      'create',
+      '--surfaces',
+      'cli',
+      '--surfaces',
+      'mcp',
+      '--surfaces',
+      'http',
+    ]);
+  });
+
+  test('preserves the repeated form', () => {
+    const argv = ['create', '--surfaces', 'cli', '--surfaces', 'mcp'];
+    expect(
+      normalizeCliArgv([command(['create'], [surfacesFlag])], argv)
+    ).toEqual(argv);
+  });
+
+  test('stops bounded values before a child command', () => {
+    const include: CliFlag = {
+      choices: ['examples', 'errors'],
+      name: 'include',
+      required: false,
+      type: 'string[]',
+      variadic: false,
+    };
+    expect(
+      normalizeCliArgv(
+        [command(['wayfind'], [include]), command(['wayfind', 'search'], [])],
+        ['wayfind', '--include', 'examples', 'errors', 'search']
+      )
+    ).toEqual([
+      'wayfind',
+      '--include',
+      'examples',
+      '--include',
+      'errors',
+      'search',
+    ]);
+  });
+
+  test('gives a child route precedence over an additional choice value', () => {
+    const include: CliFlag = {
+      choices: ['examples', 'search'],
+      name: 'include',
+      required: false,
+      type: 'string[]',
+      variadic: false,
+    };
+    expect(
+      normalizeCliArgv(
+        [command(['wayfind'], [include]), command(['wayfind', 'search'], [])],
+        ['wayfind', '--include', 'examples', 'search']
+      )
+    ).toEqual(['wayfind', '--include', 'examples', 'search']);
+  });
+
+  test('preserves a required option value that looks like another flag', () => {
+    const label: CliFlag = {
+      name: 'label',
+      required: true,
+      type: 'string',
+      variadic: false,
+    };
+    const argv = ['configure', '--label', '--surfaces', 'cli', 'mcp'];
+    expect(
+      normalizeCliArgv([command(['configure'], [label, surfacesFlag])], argv)
+    ).toEqual(argv);
+  });
+
+  test('stops a required variadic flag before a following bounded flag', () => {
+    const tags: CliFlag = {
+      name: 'tags',
+      required: true,
+      type: 'string[]',
+      variadic: true,
+    };
+    expect(
+      normalizeCliArgv(
+        [command(['configure'], [tags, surfacesFlag])],
+        ['configure', '--tags', 'a', '--surfaces', 'cli', 'mcp']
+      )
+    ).toEqual([
+      'configure',
+      '--tags',
+      'a',
+      '--surfaces',
+      'cli',
+      '--surfaces',
+      'mcp',
+    ]);
+  });
+
+  test('uses the active command when flag names overlap', () => {
+    const commands = [
+      command(['alpha'], [modesFlag(['one', 'two'])]),
+      command(['beta'], [modesFlag(['three', 'four'])]),
+    ];
+    expect(
+      normalizeCliArgv(commands, ['beta', '--modes', 'three', 'four'])
+    ).toEqual(['beta', '--modes', 'three', '--modes', 'four']);
+  });
+
+  test('prefers child flag semantics over an inherited flag', () => {
+    const commands = [
+      command(['wayfind'], [modesFlag(['nearby', 'impact'])]),
+      command(['wayfind', 'query'], [modesFlag(['fuzzy', 'exact'])]),
+    ];
+    expect(
+      normalizeCliArgv(commands, [
+        'wayfind',
+        'query',
+        '--modes',
+        'fuzzy',
+        'exact',
+      ])
+    ).toEqual(['wayfind', 'query', '--modes', 'fuzzy', '--modes', 'exact']);
+  });
+
+  test('supports an inline first value', () => {
+    expect(
+      normalizeCliArgv(
+        [command(['create'], [surfacesFlag])],
+        ['create', '--surfaces=cli', 'mcp']
+      )
+    ).toEqual(['create', '--surfaces=cli', '--surfaces', 'mcp']);
+  });
+
+  test('supports compact short-option first values', () => {
+    expect(
+      normalizeCliArgv(
+        [command(['create'], [{ ...surfacesFlag, short: 's' }])],
+        ['create', '-scli', 'mcp']
+      )
+    ).toEqual(['create', '-scli', '--surfaces', 'mcp']);
+  });
+
+  test('finds a bounded value option after grouped boolean shorts', () => {
+    const quiet: CliFlag = {
+      name: 'quiet',
+      required: false,
+      short: 'q',
+      type: 'boolean',
+      variadic: false,
+    };
+    expect(
+      normalizeCliArgv(
+        [command(['create'], [quiet, { ...surfacesFlag, short: 's' }])],
+        ['create', '-qscli', 'mcp']
+      )
+    ).toEqual(['create', '-qscli', '--surfaces', 'mcp']);
+  });
+
+  test('gives a declared digit short flag precedence over a negative number', () => {
+    const threshold: CliFlag = {
+      name: 'threshold',
+      required: false,
+      type: 'number',
+      variadic: false,
+    };
+    const modes: CliFlag = {
+      choices: ['a', 'b'],
+      name: 'modes',
+      required: false,
+      short: '1',
+      type: 'string[]',
+      variadic: false,
+    };
+    expect(
+      normalizeCliArgv(
+        [command(['run'], [threshold, modes])],
+        ['run', '--threshold', '-1', 'a', 'b']
+      )
+    ).toEqual(['run', '--threshold', '-1', 'a', '--modes', 'b']);
+  });
+});

--- a/packages/cli/src/__tests__/flags.test.ts
+++ b/packages/cli/src/__tests__/flags.test.ts
@@ -198,7 +198,7 @@ describe('deriveFlags', () => {
       expect(flag.variadic).toBe(true);
     });
 
-    test('z.array(z.enum()) derives a repeatable multiselect flag', () => {
+    test('z.array(z.enum()) derives a bounded multiselect flag', () => {
       const flags = deriveFlags(
         z.object({ include: z.array(z.enum(['examples', 'errors'])) })
       );

--- a/packages/cli/src/__tests__/public-api.test.ts
+++ b/packages/cli/src/__tests__/public-api.test.ts
@@ -3,6 +3,10 @@ import { describe, expect, test } from 'bun:test';
 import * as cli from '@ontrails/cli';
 
 describe('@ontrails/cli public API', () => {
+  test('exports framework argv normalization for CLI adapters', () => {
+    expect(typeof cli.normalizeCliArgv).toBe('function');
+  });
+
   test('does not expose Commander runtime helpers from the root entrypoint', () => {
     expect('surface' in cli).toBe(false);
     expect('createProgram' in cli).toBe(false);

--- a/packages/cli/src/__tests__/validate.test.ts
+++ b/packages/cli/src/__tests__/validate.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { Result, trail } from '@ontrails/core';
+
+import type { CliCommand, CliFlag } from '../command.js';
+import { validateCliCommands } from '../validate.js';
+
+const command = (
+  path: readonly string[],
+  flags: readonly CliFlag[]
+): CliCommand => ({
+  args: [],
+  execute: async () => await Result.ok(),
+  flags: [...flags],
+  intent: 'read',
+  path,
+  trail: trail(path.join('.'), {
+    implementation: () => Result.ok(),
+  }),
+});
+
+const modes = (choices: string[], short?: string): CliFlag => ({
+  choices,
+  name: 'modes',
+  required: false,
+  short,
+  type: 'string[]',
+  variadic: false,
+});
+
+describe('validateCliCommands inherited flags', () => {
+  test('accepts equivalent parsing semantics on nested commands', () => {
+    expect(() =>
+      validateCliCommands([
+        command(['parent'], [modes(['one', 'two'], 'm')]),
+        command(['parent', 'child'], [modes(['one', 'two'], 'm')]),
+      ])
+    ).not.toThrow();
+  });
+
+  test('rejects divergent parsing semantics on nested commands', () => {
+    expect(() =>
+      validateCliCommands([
+        command(['parent'], [modes(['one', 'two'])]),
+        command(['parent', 'child'], [modes(['three', 'four'])]),
+      ])
+    ).toThrow(
+      'CLI flag --modes on command parent child conflicts with inherited parsing semantics from command parent'
+    );
+  });
+
+  test('rejects divergent short aliases on inherited bounded flags', () => {
+    expect(() =>
+      validateCliCommands([
+        command(['parent'], [modes(['one', 'two'], 'm')]),
+        command(['parent', 'child'], [modes(['one', 'two'], 'x')]),
+      ])
+    ).toThrow(
+      'CLI flag --modes on command parent child conflicts with inherited parsing semantics from command parent'
+    );
+  });
+});

--- a/packages/cli/src/argv.ts
+++ b/packages/cli/src/argv.ts
@@ -1,0 +1,245 @@
+/**
+ * Framework-owned argv normalization for CLI adapters.
+ *
+ * Adapters remain responsible for parsing argv. This module normalizes the
+ * small amount of syntax Trails promises across adapters before that parser
+ * runs.
+ */
+
+import type { CliCommand, CliFlag } from './command.js';
+
+interface CommandNode {
+  readonly children: Map<string, CommandNode>;
+  readonly parent?: CommandNode | undefined;
+  command?: CliCommand | undefined;
+}
+
+interface FlagMatch {
+  readonly flag: CliFlag;
+  readonly inlineValue: boolean;
+}
+
+const commandRoutes = (command: CliCommand): readonly (readonly string[])[] =>
+  command.routes?.map((route) => route.path) ?? [command.path];
+
+const buildCommandTree = (commands: readonly CliCommand[]): CommandNode => {
+  const root: CommandNode = { children: new Map() };
+  for (const command of commands) {
+    for (const route of commandRoutes(command)) {
+      let node = root;
+      for (const segment of route) {
+        let child = node.children.get(segment);
+        if (child === undefined) {
+          child = { children: new Map(), parent: node };
+          node.children.set(segment, child);
+        }
+        node = child;
+      }
+      node.command = command;
+    }
+  }
+  return root;
+};
+
+const visibleFlags = (node: CommandNode): readonly CliFlag[] => {
+  const commands: CliCommand[] = [];
+  let current: CommandNode | undefined = node;
+  while (current !== undefined) {
+    if (current.command !== undefined) {
+      commands.push(current.command);
+    }
+    current = current.parent;
+  }
+  return commands.toReversed().flatMap((command) => command.flags);
+};
+
+const matchFlag = (
+  flags: readonly CliFlag[],
+  token: string
+): FlagMatch | undefined => {
+  const nearestFlags = flags.toReversed();
+  for (const flag of nearestFlags) {
+    if (
+      token === `--${flag.name}` ||
+      (flag.short !== undefined && token === `-${flag.short}`)
+    ) {
+      return { flag, inlineValue: false };
+    }
+    if (token.startsWith(`--${flag.name}=`)) {
+      return { flag, inlineValue: true };
+    }
+    if (flag.valueAliases?.some((alias) => token === `--${alias.name}`)) {
+      return { flag: { ...flag, type: 'boolean' }, inlineValue: false };
+    }
+  }
+
+  if (token.length <= 2 || token[0] !== '-' || token[1] === '-') {
+    return undefined;
+  }
+
+  let group = token.slice(1);
+  while (group.length > 0) {
+    let flag: CliFlag | undefined;
+    for (const candidate of nearestFlags) {
+      if (candidate.short === group[0]) {
+        flag = candidate;
+        break;
+      }
+    }
+    if (flag === undefined) {
+      return undefined;
+    }
+    if (flag.type !== 'boolean') {
+      return { flag, inlineValue: group.length > 1 };
+    }
+    group = group.slice(1);
+  }
+  return undefined;
+};
+
+const isBoundedMultiselect = (flag: CliFlag): boolean =>
+  flag.type === 'string[]' &&
+  !flag.variadic &&
+  flag.choices !== undefined &&
+  flag.choices.length > 0;
+
+const isNegativeNumber = (token: string): boolean =>
+  /^-(\d+|\d*\.\d+)(e[+-]?\d+)?$/.test(token);
+
+const hasDigitShortFlag = (flags: readonly CliFlag[]): boolean =>
+  flags.some((flag) => /^\d$/.test(flag.short ?? ''));
+
+const consumesValue = (
+  flag: CliFlag,
+  token: string | undefined,
+  flags: readonly CliFlag[]
+): boolean =>
+  flag.type !== 'boolean' &&
+  token !== undefined &&
+  (flag.required ||
+    !token.startsWith('-') ||
+    ((flag.type === 'number' || flag.type === 'number[]') &&
+      isNegativeNumber(token) &&
+      !hasDigitShortFlag(flags)));
+
+const continuesVariadicValue = (
+  flag: CliFlag,
+  token: string | undefined,
+  flags: readonly CliFlag[]
+): boolean =>
+  token !== undefined &&
+  (!token.startsWith('-') ||
+    ((flag.type === 'number' || flag.type === 'number[]') &&
+      isNegativeNumber(token) &&
+      !hasDigitShortFlag(flags)));
+
+const appendBoundedValues = (
+  normalized: string[],
+  argv: readonly string[],
+  optionIndex: number,
+  match: FlagMatch,
+  activeNode: CommandNode
+): number => {
+  const choices = new Set(match.flag.choices);
+  let index = optionIndex;
+  if (!match.inlineValue) {
+    const firstValue = argv[index + 1];
+    if (firstValue !== undefined && choices.has(firstValue)) {
+      normalized.push(firstValue);
+      index += 1;
+    }
+  }
+
+  while (index + 1 < argv.length) {
+    const nextValue = argv[index + 1];
+    if (
+      nextValue === undefined ||
+      activeNode.children.has(nextValue) ||
+      !choices.has(nextValue)
+    ) {
+      break;
+    }
+    normalized.push(`--${match.flag.name}`, nextValue);
+    index += 1;
+  }
+  return index;
+};
+
+/**
+ * Normalize framework-owned CLI syntax before an adapter parses argv.
+ *
+ * Bounded multiselect flags accept both contiguous values and repeated flags.
+ * After the first option value, additional contiguous consumption stops at a
+ * known child route or the first token outside the declared choice set.
+ *
+ * @example
+ * ```ts
+ * import { normalizeCliArgv, type CliCommand } from '@ontrails/cli';
+ *
+ * const commands: CliCommand[] = [];
+ * const argv = normalizeCliArgv(commands, process.argv.slice(2));
+ * ```
+ */
+export const normalizeCliArgv = (
+  commands: readonly CliCommand[],
+  argv: readonly string[]
+): readonly string[] => {
+  const root = buildCommandTree(commands);
+  const normalized: string[] = [];
+  let activeNode = root;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === undefined) {
+      continue;
+    }
+    normalized.push(token);
+
+    if (token === '--') {
+      normalized.push(...argv.slice(index + 1));
+      break;
+    }
+
+    const flags = visibleFlags(activeNode);
+    const match = matchFlag(flags, token);
+    if (match !== undefined) {
+      if (isBoundedMultiselect(match.flag)) {
+        index = appendBoundedValues(normalized, argv, index, match, activeNode);
+        continue;
+      }
+
+      if (match.flag.variadic && !match.inlineValue) {
+        let consumedFirstValue = false;
+        while (
+          consumedFirstValue
+            ? continuesVariadicValue(match.flag, argv[index + 1], flags)
+            : consumesValue(match.flag, argv[index + 1], flags)
+        ) {
+          const value = argv[index + 1];
+          if (value !== undefined) {
+            normalized.push(value);
+          }
+          index += 1;
+          consumedFirstValue = true;
+        }
+      } else if (
+        !match.inlineValue &&
+        consumesValue(match.flag, argv[index + 1], flags)
+      ) {
+        const value = argv[index + 1];
+        if (value !== undefined) {
+          normalized.push(value);
+          index += 1;
+        }
+      }
+      continue;
+    }
+
+    const child = activeNode.children.get(token);
+    if (child !== undefined) {
+      activeNode = child;
+    }
+  }
+
+  return normalized;
+};

--- a/packages/cli/src/command.ts
+++ b/packages/cli/src/command.ts
@@ -40,6 +40,14 @@ export interface CliFlag {
   readonly default?: unknown | undefined;
   readonly choices?: string[] | undefined;
   readonly valueAliases?: readonly CliFlagValueAlias[] | undefined;
+  /**
+   * Whether one flag occurrence consumes an unbounded value sequence.
+   *
+   * Bounded multiselects remain non-variadic so a parser does not greedily
+   * consume every following token. CLI adapters should pass argv through
+   * `normalizeCliArgv` to support both contiguous and repeated bounded-choice
+   * syntax while preserving child routes after the first explicit value.
+   */
   readonly variadic: boolean;
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ export type {
   CliArg,
   CliFlagValueAlias,
 } from './command.js';
+export { normalizeCliArgv } from './argv.js';
 
 // Build
 export { deriveCliCommands } from './build.js';

--- a/packages/cli/src/validate.ts
+++ b/packages/cli/src/validate.ts
@@ -153,6 +153,89 @@ const validateCommandFlags = (command: CliCommand): void => {
   }
 };
 
+const isStrictPathPrefix = (
+  prefix: readonly string[],
+  path: readonly string[]
+): boolean =>
+  prefix.length < path.length &&
+  prefix.every((segment, index) => path[index] === segment);
+
+const sortedStrings = (values: readonly string[] | undefined): string[] =>
+  [...(values ?? [])].toSorted();
+
+const sortedAliases = (flag: CliFlag): readonly string[] =>
+  (flag.valueAliases ?? [])
+    .map((alias) => `${alias.name}\0${alias.value}`)
+    .toSorted();
+
+const sameParsingSemantics = (left: CliFlag, right: CliFlag): boolean =>
+  left.name === right.name &&
+  left.short === right.short &&
+  left.type === right.type &&
+  left.required === right.required &&
+  left.variadic === right.variadic &&
+  left.role === right.role &&
+  JSON.stringify(left.default) === JSON.stringify(right.default) &&
+  JSON.stringify(sortedStrings(left.choices)) ===
+    JSON.stringify(sortedStrings(right.choices)) &&
+  JSON.stringify(sortedAliases(left)) === JSON.stringify(sortedAliases(right));
+
+const isBoundedMultiselect = (flag: CliFlag): boolean =>
+  flag.type === 'string[]' &&
+  !flag.variadic &&
+  flag.choices !== undefined &&
+  flag.choices.length > 0;
+
+const findConflictingInheritedFlag = (
+  ancestor: CliCommand,
+  descendant: CliCommand
+):
+  | { readonly ancestorFlag: CliFlag; readonly descendantFlag: CliFlag }
+  | undefined => {
+  for (const descendantFlag of descendant.flags) {
+    for (const ancestorFlag of ancestor.flags) {
+      const sharesLong = ancestorFlag.name === descendantFlag.name;
+      const sharesShort =
+        ancestorFlag.short !== undefined &&
+        ancestorFlag.short === descendantFlag.short;
+      if (
+        (sharesLong || sharesShort) &&
+        (isBoundedMultiselect(ancestorFlag) ||
+          isBoundedMultiselect(descendantFlag)) &&
+        !sameParsingSemantics(ancestorFlag, descendantFlag)
+      ) {
+        return { ancestorFlag, descendantFlag };
+      }
+    }
+  }
+  return undefined;
+};
+
+const validateInheritedFlagSemantics = (
+  commands: readonly CliCommand[]
+): void => {
+  for (const descendant of commands) {
+    for (const descendantRoute of commandRoutes(descendant)) {
+      for (const ancestor of commands) {
+        if (ancestor === descendant) {
+          continue;
+        }
+        for (const ancestorRoute of commandRoutes(ancestor)) {
+          if (!isStrictPathPrefix(ancestorRoute.path, descendantRoute.path)) {
+            continue;
+          }
+          const conflict = findConflictingInheritedFlag(ancestor, descendant);
+          if (conflict !== undefined) {
+            throw new ValidationError(
+              `CLI flag --${conflict.descendantFlag.name} on command ${renderPath(descendantRoute.path)} conflicts with inherited parsing semantics from command ${renderPath(ancestorRoute.path)}`
+            );
+          }
+        }
+      }
+    }
+  }
+};
+
 /**
  * Validate command paths and flag collisions before wiring a CLI adapter.
  *
@@ -180,4 +263,5 @@ export const validateCliCommands = (commands: readonly CliCommand[]): void => {
   }
 
   validateUniquePaths(commands);
+  validateInheritedFlagSemantics(commands);
 };


### PR DESCRIPTION
## Context

Bounded multiselect fields derived from `z.array(z.enum(...))` accepted repeated options, but no longer accepted the natural contiguous form used by Trails examples such as `--surfaces cli mcp http`.

This grammar belongs to the framework CLI model so future adapters can inherit it instead of independently rebuilding Commander behavior.

## What changed

- Add public `normalizeCliArgv(commands, argv)` support to `@ontrails/cli`.
- Accept both contiguous and repeated bounded multiselect values.
- Preserve child routes after the first explicit bounded value and stop at values outside the declared choices.
- Preserve required and variadic option arity, negative-number and digit-short behavior, implicit eval/Electron argv origins, and explicit flag provenance across equivalent nested commands.
- Reject divergent inherited bounded-multiselect definitions before adapter wiring.
- Make the Commander adapter call the shared normalizer automatically before parsing.
- Document the framework contract and add patch changesets for `@ontrails/cli` and `@ontrails/commander`.

## Local review

- Full-stack and targeted local-review loops exercised the framework grammar and Commander integration.
- Findings fixed: required option arity, required variadic continuation, child-route collisions, nested flag provenance, implicit eval/Electron precedence, digit short flags, public API docs, and first-value ambiguity wording.
- Final targeted report: 5/5 clean, zero open P0/P1/P2 (`/tmp/agent-reviews/commander-multiselect/argv-targeted/round-3.json`).

## Verification

- `bun run check`
- `bun run test`
- `bun run build`
- `bun run changeset:check`
- `bun run publish:check`
- `bun test packages/cli/src/__tests__/argv.test.ts packages/cli/src/__tests__/validate.test.ts adapters/commander/src/__tests__/to-commander.test.ts` (85 pass / 0 fail)
- Direct smoke: `trails create proof --surfaces cli mcp http` generated CLI, MCP, and HTTP entry files
- Full pre-push hook: Warden, ADR checks, tests, typecheck, lint, AST grep, format, release-pack coherence, and dead-code all passed
- `git diff --check`

`bun run wayfinder:dogfood` was attempted twice but stalled in its isolated `trails compile` fixture; the second attempt was terminated after a four-minute timeout. This argv change does not alter Wayfinder, and it is covered by the shared CLI regression suite, full repo test suite, direct create smoke, lock round-trip, and package pack validation above.
