### PR TITLE
feat(release): require governed package routes

### DIFF
--- a/.changeset/trl-1255-package-route-release-check.md
+++ b/.changeset/trl-1255-package-route-release-check.md
@@ -1,0 +1,7 @@
+---
+'@ontrails/trails': patch
+---
+
+Require release checks to prove an exact governed Regrade route, or an explicit
+classified multi-owner fold, whenever a public `@ontrails/*` package disappears
+from the publishable workspace inventory.

--- a/apps/trails/src/__tests__/release-check-trail.test.ts
+++ b/apps/trails/src/__tests__/release-check-trail.test.ts
@@ -1,5 +1,6 @@
 import { deriveCliCommands } from '@ontrails/cli';
 import { afterEach, describe, expect, test } from 'bun:test';
+import { execSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -87,6 +88,12 @@ const makeTempRoot = (): string => {
     name: '@ontrails/trails',
   });
   writeFile(root, 'apps/trails/src/app.ts', 'export {};\n');
+  execSync('git init', { cwd: root, stdio: 'ignore' });
+  execSync('git add .', { cwd: root, stdio: 'ignore' });
+  execSync(
+    'git -c user.email=test@example.com -c user.name=Test commit -m initial',
+    { cwd: root, stdio: 'ignore' }
+  );
   return root;
 };
 
@@ -133,7 +140,7 @@ describe('trails release check', () => {
     ]);
 
     const result = await releaseCheckTrail.implementation(
-      { changedFiles: changedFilesPath, rootDir: root },
+      { baseRef: 'HEAD', changedFiles: changedFilesPath, rootDir: root },
       { cwd: root, env: { TRAILS_ENV: 'test' } } as never
     );
 
@@ -169,7 +176,7 @@ describe('trails release check', () => {
     );
 
     const result = await releaseCheckTrail.implementation(
-      { changedFiles: changedFilesPath, rootDir: root },
+      { baseRef: 'HEAD', changedFiles: changedFilesPath, rootDir: root },
       { cwd: root, env: { TRAILS_ENV: 'test' } } as never
     );
 
@@ -179,7 +186,7 @@ describe('trails release check', () => {
     }
     expect(result.value.passed).toBe(true);
     expect(result.value.configPath).toBe(join(root, 'trails.config.ts'));
-  });
+  }, 30_000);
 
   test('loads release rules from trails.config.json', async () => {
     const root = makeTempRoot();
@@ -199,7 +206,7 @@ describe('trails release check', () => {
     });
 
     const result = await releaseCheckTrail.implementation(
-      { changedFiles: changedFilesPath, rootDir: root },
+      { baseRef: 'HEAD', changedFiles: changedFilesPath, rootDir: root },
       { cwd: root, env: { TRAILS_ENV: 'test' } } as never
     );
 
@@ -222,6 +229,8 @@ describe('trails release check', () => {
       root,
       '--changed-files',
       changedFilesPath,
+      '--base-ref',
+      'HEAD',
       '--json',
     ]);
 

--- a/apps/trails/src/__tests__/release-check.test.ts
+++ b/apps/trails/src/__tests__/release-check.test.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import {
   checkReleaseRules,
   discoverWorkspaces,
+  runReleaseCheck,
   runReleaseCheckCli,
 } from '../release/check.js';
 import type { WorkspaceInfo } from '../release/check.js';
@@ -48,6 +49,12 @@ const contractFact = (
   workspacePath: 'packages/core',
 });
 
+const basePackage = (name: string): WorkspaceInfo => ({
+  isPrivate: false,
+  name,
+  relativePath: `packages/${name.slice('@ontrails/'.length)}`,
+});
+
 const withTempRepo = <T>(
   setup: (repoRoot: string) => T
 ): { readonly repoRoot: string; readonly value: T } => {
@@ -66,6 +73,247 @@ const withTempRepo = <T>(
 };
 
 describe('checkReleaseRules', () => {
+  test('fails a removed public package without an exact governed route', () => {
+    const { repoRoot } = withTempRepo(() => {});
+
+    try {
+      const result = checkReleaseRules({
+        baseWorkspaces: [basePackage('@ontrails/not-governed')],
+        changedFiles: [],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Public package removal '@ontrails/not-governed' requires an exact governed Regrade route. Add the route to the governed transition registry, then run trails regrade plan/check.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('does not let release:none bypass an ungoverned public package removal', () => {
+    const { repoRoot } = withTempRepo(() => {});
+
+    try {
+      const result = checkReleaseRules({
+        baseWorkspaces: [basePackage('@ontrails/not-governed')],
+        changedFiles: [],
+        releaseNone: true,
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Public package removal '@ontrails/not-governed' requires an exact governed Regrade route. Add the route to the governed transition registry, then run trails regrade plan/check.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('accepts an exact governed package rename with a present target', () => {
+    const { repoRoot } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'observe-rename.md'),
+        "---\n'@ontrails/observability': major\n---\n\nRename observability owner.\n"
+      );
+    });
+
+    try {
+      const result = checkReleaseRules({
+        baseWorkspaces: [basePackage('@ontrails/observe')],
+        changedFiles: ['.changeset/observe-rename.md'],
+        repoRoot,
+        workspaces: [...workspaces, basePackage('@ontrails/observability')],
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.packageRouteFacts).toEqual([
+        {
+          kind: 'single',
+          sourcePackage: '@ontrails/observe',
+          targetPackage: '@ontrails/observability',
+          transitionId: 'v1-observe-observability',
+        },
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('fails an exact governed route when its target package is absent', () => {
+    const { repoRoot } = withTempRepo(() => {});
+
+    try {
+      const result = checkReleaseRules({
+        baseWorkspaces: [basePackage('@ontrails/observe')],
+        changedFiles: [],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Governed Regrade route 'v1-observe-observability' maps '@ontrails/observe' to '@ontrails/observability', but that publishable target package is absent. Add the target package before applying the route, or use a classified transition with an explicit non-migratable reason for a multi-owner fold.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('accepts a classified governed fold without inventing a root target', () => {
+    const { repoRoot } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'tracing-fold.md'),
+        "---\n'@ontrails/core': patch\n---\n\nFold tracing ownership.\n"
+      );
+    });
+
+    try {
+      const result = checkReleaseRules({
+        baseWorkspaces: [basePackage('@ontrails/tracing')],
+        changedFiles: ['.changeset/tracing-fold.md'],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.packageRouteFacts).toEqual([
+        {
+          kind: 'classified',
+          sourcePackage: '@ontrails/tracing',
+          transitionId: 'v1-tracing-owner-fold',
+        },
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('requires a branch-local changeset for a governed public package route', () => {
+    const { repoRoot } = withTempRepo(() => {});
+
+    try {
+      const result = checkReleaseRules({
+        baseWorkspaces: [basePackage('@ontrails/tracing')],
+        changedFiles: [],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        'Public package route changesets must cover a surviving owner: @ontrails/tracing',
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects an unrelated changeset for a single package route', () => {
+    const { repoRoot } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'unrelated.md'),
+        "---\n'@ontrails/core': patch\n---\n\nUnrelated.\n"
+      );
+    });
+
+    try {
+      const result = checkReleaseRules({
+        baseWorkspaces: [basePackage('@ontrails/observe')],
+        changedFiles: ['.changeset/unrelated.md'],
+        repoRoot,
+        workspaces: [...workspaces, basePackage('@ontrails/observability')],
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        'Public package route changesets must cover a surviving owner: @ontrails/observe',
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('accepts an exact governed module-specifier package route', () => {
+    const { repoRoot } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'topography-rename.md'),
+        "---\n'@ontrails/topography': major\n---\n\nRename topography owner.\n"
+      );
+    });
+
+    try {
+      const result = checkReleaseRules({
+        baseWorkspaces: [basePackage('@ontrails/topographer')],
+        changedFiles: ['.changeset/topography-rename.md'],
+        repoRoot,
+        workspaces: [...workspaces, basePackage('@ontrails/topography')],
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.packageRouteFacts).toEqual([
+        {
+          kind: 'single',
+          sourcePackage: '@ontrails/topographer',
+          targetPackage: '@ontrails/topography',
+          transitionId: 'v1-topographer-topography',
+        },
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('counts a package route as evidence for an active changeset', () => {
+    const { repoRoot } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'tracing-fold.md'),
+        "---\n'@ontrails/core': patch\n---\n\nFold tracing ownership.\n"
+      );
+    });
+
+    try {
+      const result = checkReleaseRules({
+        baseWorkspaces: [basePackage('@ontrails/tracing')],
+        changedFiles: ['.changeset/tracing-fold.md'],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.activePackageChangesetsWithoutReleaseFacts).toEqual([]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('ignores private, added, and subpath-only package changes', () => {
+    const { repoRoot } = withTempRepo(() => {});
+
+    try {
+      const result = checkReleaseRules({
+        baseWorkspaces: [
+          {
+            isPrivate: true,
+            name: '@ontrails/private-old',
+            relativePath: 'tools/private-old',
+          },
+        ],
+        changedFiles: [],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.packageRouteFacts).toEqual([]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
   test('fails package-affecting publishable workspace changes without a covering changeset', () => {
     const { repoRoot } = withTempRepo(() => {});
 
@@ -511,6 +759,465 @@ export const userCreate = trail('user.create', {
     }
   });
 
+  test('fails when an explicit base ref cannot provide the workspace inventory', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-base-'));
+
+    try {
+      mkdirSync(join(repoRoot, 'packages', 'core'), { recursive: true });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ workspaces: ['packages/*'] })
+      );
+      writeFileSync(
+        join(repoRoot, 'packages', 'core', 'package.json'),
+        JSON.stringify({ name: '@ontrails/core' })
+      );
+      writeFileSync(join(repoRoot, 'changed-files.txt'), '');
+
+      const result = await runReleaseCheck({
+        baseRef: 'missing-base-ref',
+        changedFilesPath: join(repoRoot, 'changed-files.txt'),
+        repoRoot,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Release check could not read the base workspace inventory from 'missing-base-ref'. Fetch or provide a valid --base-ref before checking package routes.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('requires a base ref for changed-file release checks', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-base-'));
+
+    try {
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'app' })
+      );
+      writeFileSync(join(repoRoot, 'changed-files.txt'), '');
+
+      const result = await runReleaseCheck({
+        changedFilesPath: join(repoRoot, 'changed-files.txt'),
+        repoRoot,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        'Release check requires --base-ref when --changed-files is used.',
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('derives removed packages from base workspace patterns with a leading dot', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-base-'));
+
+    try {
+      mkdirSync(join(repoRoot, 'packages', 'core'), { recursive: true });
+      mkdirSync(join(repoRoot, 'packages', 'retired'), { recursive: true });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ workspaces: ['./packages/*'] })
+      );
+      writeFileSync(
+        join(repoRoot, 'packages', 'core', 'package.json'),
+        JSON.stringify({ name: '@ontrails/core' })
+      );
+      writeFileSync(
+        join(repoRoot, 'packages', 'retired', 'package.json'),
+        JSON.stringify({ name: '@ontrails/not-governed' })
+      );
+      execSync('git init', { cwd: repoRoot, stdio: 'ignore' });
+      execSync('git add .', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m initial',
+        { cwd: repoRoot, stdio: 'ignore' }
+      );
+      rmSync(join(repoRoot, 'packages', 'retired'), {
+        force: true,
+        recursive: true,
+      });
+      writeFileSync(join(repoRoot, 'changed-files.txt'), '');
+
+      const result = await runReleaseCheck({
+        baseRef: 'HEAD',
+        changedFilesPath: join(repoRoot, 'changed-files.txt'),
+        repoRoot,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Public package removal '@ontrails/not-governed' requires an exact governed Regrade route. Add the route to the governed transition registry, then run trails regrade plan/check.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('derives package routes for direct checks with a base ref', () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-base-'));
+
+    try {
+      mkdirSync(join(repoRoot, 'packages', 'retired'), { recursive: true });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ workspaces: ['packages/*'] })
+      );
+      writeFileSync(
+        join(repoRoot, 'packages', 'retired', 'package.json'),
+        JSON.stringify({ name: '@ontrails/not-governed' })
+      );
+      execSync('git init', { cwd: repoRoot, stdio: 'ignore' });
+      execSync('git add .', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m initial',
+        { cwd: repoRoot, stdio: 'ignore' }
+      );
+      rmSync(join(repoRoot, 'packages', 'retired'), {
+        force: true,
+        recursive: true,
+      });
+
+      const result = checkReleaseRules({
+        baseRef: 'HEAD',
+        changedFiles: [],
+        repoRoot,
+        workspaces: [],
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Public package removal '@ontrails/not-governed' requires an exact governed Regrade route. Add the route to the governed transition registry, then run trails regrade plan/check.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('derives removals from a trailing-slash base workspace selector', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-base-'));
+
+    try {
+      mkdirSync(join(repoRoot, 'packages', 'retired'), { recursive: true });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ workspaces: ['packages/retired/'] })
+      );
+      writeFileSync(
+        join(repoRoot, 'packages', 'retired', 'package.json'),
+        JSON.stringify({ name: '@ontrails/not-governed' })
+      );
+      execSync('git init', { cwd: repoRoot, stdio: 'ignore' });
+      execSync('git add .', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m initial',
+        { cwd: repoRoot, stdio: 'ignore' }
+      );
+      rmSync(join(repoRoot, 'packages', 'retired'), {
+        force: true,
+        recursive: true,
+      });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'app' })
+      );
+      writeFileSync(join(repoRoot, 'changed-files.txt'), '');
+
+      const result = await runReleaseCheck({
+        baseRef: 'HEAD',
+        changedFilesPath: join(repoRoot, 'changed-files.txt'),
+        repoRoot,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Public package removal '@ontrails/not-governed' requires an exact governed Regrade route. Add the route to the governed transition registry, then run trails regrade plan/check.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('derives removed packages from an exact root workspace in the base', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-base-'));
+
+    try {
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: '@ontrails/not-governed', workspaces: ['.'] })
+      );
+      execSync('git init', { cwd: repoRoot, stdio: 'ignore' });
+      execSync('git add .', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m initial',
+        { cwd: repoRoot, stdio: 'ignore' }
+      );
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'app' })
+      );
+      writeFileSync(join(repoRoot, 'changed-files.txt'), '');
+
+      const result = await runReleaseCheck({
+        baseRef: 'HEAD',
+        changedFilesPath: join(repoRoot, 'changed-files.txt'),
+        repoRoot,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Public package removal '@ontrails/not-governed' requires an exact governed Regrade route. Add the route to the governed transition registry, then run trails regrade plan/check.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('derives removals from a dot-slash root workspace selector', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-base-'));
+
+    try {
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: '@ontrails/not-governed', workspaces: ['./'] })
+      );
+      execSync('git init', { cwd: repoRoot, stdio: 'ignore' });
+      execSync('git add .', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m initial',
+        { cwd: repoRoot, stdio: 'ignore' }
+      );
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'app' })
+      );
+      writeFileSync(join(repoRoot, 'changed-files.txt'), '');
+
+      const result = await runReleaseCheck({
+        baseRef: 'HEAD',
+        changedFilesPath: join(repoRoot, 'changed-files.txt'),
+        repoRoot,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Public package removal '@ontrails/not-governed' requires an exact governed Regrade route. Add the route to the governed transition registry, then run trails regrade plan/check.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('derives removals from an explicit base when current workspaces are absent', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-base-'));
+
+    try {
+      mkdirSync(join(repoRoot, 'packages', 'retired'), { recursive: true });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ workspaces: ['packages/*'] })
+      );
+      writeFileSync(
+        join(repoRoot, 'packages', 'retired', 'package.json'),
+        JSON.stringify({ name: '@ontrails/not-governed' })
+      );
+      execSync('git init', { cwd: repoRoot, stdio: 'ignore' });
+      execSync('git add .', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m initial',
+        { cwd: repoRoot, stdio: 'ignore' }
+      );
+      rmSync(join(repoRoot, 'packages', 'retired'), {
+        force: true,
+        recursive: true,
+      });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'app' })
+      );
+      writeFileSync(join(repoRoot, 'changed-files.txt'), '');
+
+      const result = await runReleaseCheck({
+        baseRef: 'HEAD',
+        changedFilesPath: join(repoRoot, 'changed-files.txt'),
+        repoRoot,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Public package removal '@ontrails/not-governed' requires an exact governed Regrade route. Add the route to the governed transition registry, then run trails regrade plan/check.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('defaults local checks to origin main when current workspaces are absent', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-base-'));
+
+    try {
+      mkdirSync(join(repoRoot, 'packages', 'retired'), { recursive: true });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ workspaces: ['packages/*'] })
+      );
+      writeFileSync(
+        join(repoRoot, 'packages', 'retired', 'package.json'),
+        JSON.stringify({ name: '@ontrails/not-governed' })
+      );
+      execSync('git init --initial-branch=main', {
+        cwd: repoRoot,
+        stdio: 'ignore',
+      });
+      execSync('git add .', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m initial',
+        { cwd: repoRoot, stdio: 'ignore' }
+      );
+      execSync('git update-ref refs/remotes/origin/main HEAD', {
+        cwd: repoRoot,
+        stdio: 'ignore',
+      });
+      rmSync(join(repoRoot, 'packages', 'retired'), {
+        force: true,
+        recursive: true,
+      });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'app' })
+      );
+      execSync('git add -A', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m retire',
+        { cwd: repoRoot, stdio: 'ignore' }
+      );
+
+      const result = await runReleaseCheck({ repoRoot });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Public package removal '@ontrails/not-governed' requires an exact governed Regrade route. Add the route to the governed transition registry, then run trails regrade plan/check.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects unsupported base workspace patterns', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-base-'));
+
+    try {
+      mkdirSync(join(repoRoot, 'packages', 'retired'), { recursive: true });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ workspaces: ['packages/**'] })
+      );
+      writeFileSync(
+        join(repoRoot, 'packages', 'retired', 'package.json'),
+        JSON.stringify({ name: '@ontrails/not-governed' })
+      );
+      execSync('git init --initial-branch=main', {
+        cwd: repoRoot,
+        stdio: 'ignore',
+      });
+      execSync('git add .', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m initial',
+        { cwd: repoRoot, stdio: 'ignore' }
+      );
+      execSync('git update-ref refs/remotes/origin/main HEAD', {
+        cwd: repoRoot,
+        stdio: 'ignore',
+      });
+      rmSync(join(repoRoot, 'packages', 'retired'), {
+        force: true,
+        recursive: true,
+      });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'app' })
+      );
+      execSync('git add -A', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m retire',
+        { cwd: repoRoot, stdio: 'ignore' }
+      );
+
+      const result = await runReleaseCheck({ repoRoot });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Unsupported workspace pattern 'packages/**'. The release check supports exact workspace paths and one-level '/*' globs.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects base workspace patterns with a nested glob', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-base-'));
+
+    try {
+      mkdirSync(join(repoRoot, 'packages', 'core', 'plugins', 'retired'), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ workspaces: ['packages/*/plugins/*'] })
+      );
+      writeFileSync(
+        join(
+          repoRoot,
+          'packages',
+          'core',
+          'plugins',
+          'retired',
+          'package.json'
+        ),
+        JSON.stringify({ name: '@ontrails/not-governed' })
+      );
+      execSync('git init --initial-branch=main', {
+        cwd: repoRoot,
+        stdio: 'ignore',
+      });
+      execSync('git add .', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m initial',
+        { cwd: repoRoot, stdio: 'ignore' }
+      );
+      execSync('git update-ref refs/remotes/origin/main HEAD', {
+        cwd: repoRoot,
+        stdio: 'ignore',
+      });
+      rmSync(join(repoRoot, 'packages', 'core', 'plugins', 'retired'), {
+        force: true,
+        recursive: true,
+      });
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'app' })
+      );
+      execSync('git add -A', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m retire',
+        { cwd: repoRoot, stdio: 'ignore' }
+      );
+
+      const result = await runReleaseCheck({ repoRoot });
+
+      expect(result.passed).toBe(false);
+      expect(result.errors).toEqual([
+        "Unsupported workspace pattern 'packages/*/plugins/*'. The release check supports exact workspace paths and one-level '/*' globs.",
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
   test('passes as a no-op in non-workspace generated apps', async () => {
     const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-app-'));
 
@@ -518,6 +1225,29 @@ export const userCreate = trail('user.create', {
       writeFileSync(
         join(repoRoot, 'package.json'),
         JSON.stringify({ name: 'fresh-app' })
+      );
+
+      await expect(runReleaseCheckCli(['--repo-root', repoRoot])).resolves.toBe(
+        0
+      );
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('passes as a no-op in a git generated app without origin main', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-release-rules-app-'));
+
+    try {
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ name: 'fresh-app' })
+      );
+      execSync('git init', { cwd: repoRoot, stdio: 'ignore' });
+      execSync('git add .', { cwd: repoRoot, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m initial',
+        { cwd: repoRoot, stdio: 'ignore' }
       );
 
       await expect(runReleaseCheckCli(['--repo-root', repoRoot])).resolves.toBe(
@@ -594,6 +1324,23 @@ describe('discoverWorkspaces', () => {
 
       await expect(discoverWorkspaces(repoRoot)).rejects.toThrow(
         "Unsupported workspace pattern 'packages/**'"
+      );
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects workspace patterns with a nested glob', async () => {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'trails-workspaces-'));
+
+    try {
+      writeFileSync(
+        join(repoRoot, 'package.json'),
+        JSON.stringify({ workspaces: ['packages/*/plugins/*'] })
+      );
+
+      await expect(discoverWorkspaces(repoRoot)).rejects.toThrow(
+        "Unsupported workspace pattern 'packages/*/plugins/*'"
       );
     } finally {
       rmSync(repoRoot, { force: true, recursive: true });

--- a/apps/trails/src/__tests__/release-config.test.ts
+++ b/apps/trails/src/__tests__/release-config.test.ts
@@ -7,15 +7,18 @@ import {
 } from '../release/index.js';
 
 describe('release config schema', () => {
-  test('defaults to package and public contract release rules', () => {
+  test('defaults to package, package-route, and public contract release rules', () => {
     expect(defaultReleaseConfig.rules.map((rule) => rule.id)).toEqual([
+      'public-package-route-requires-regrade',
       'package-content-requires-intent',
       'public-trail-contract-requires-intent',
     ]);
     expect(defaultReleaseConfig.rules.map((rule) => rule.facts)).toEqual([
+      ['public-package-route'],
       ['package-content'],
       ['public-trail-contract'],
     ]);
+    expect(defaultReleaseConfig.rules[0]?.intent).toEqual(['changeset']);
   });
 
   test('accepts project-defined release rules', () => {
@@ -44,6 +47,7 @@ describe('release config schema', () => {
   test('keeps fact type vocabulary tight', () => {
     expect(releaseFactTypeValues).toEqual([
       'package-content',
+      'public-package-route',
       'public-trail-contract',
     ]);
   });

--- a/apps/trails/src/release/check.ts
+++ b/apps/trails/src/release/check.ts
@@ -8,6 +8,8 @@ import { defaultReleaseConfig, releaseConfigSchema } from './config.js';
 import type { ReleaseConfigInput, ReleaseFactType } from './config.js';
 import { findPublicTrailContractChangeFacts } from './contract-facts.js';
 import type { ContractReleaseFact } from './contract-facts.js';
+import { findPackageRouteReleaseFacts } from './package-route-facts.js';
+import type { PackageRouteReleaseFact } from './package-route-facts.js';
 
 interface PackageJson {
   readonly name?: string;
@@ -23,6 +25,8 @@ export interface WorkspaceInfo {
 
 export interface ReleaseCheckInput {
   readonly baseRef?: string;
+  readonly baseWorkspaceError?: string;
+  readonly baseWorkspaces?: readonly WorkspaceInfo[];
   readonly changedFiles: readonly string[];
   readonly contractFacts?: readonly ContractReleaseFact[];
   readonly noReleaseOverride?: boolean;
@@ -42,6 +46,7 @@ export interface ReleaseCheckResult {
   readonly errors: readonly string[];
   readonly matchedRuleIds: readonly string[];
   readonly noReleaseOverride: boolean;
+  readonly packageRouteFacts: readonly PackageRouteReleaseFact[];
   readonly passed: boolean;
   /** Compatibility alias for the existing GitHub label and package script. */
   readonly releaseNone: boolean;
@@ -97,10 +102,20 @@ const VERSION_RELEASE_WORKSPACE_FILES = new Set([
   'package.json',
 ]);
 const normalizePath = (path: string): string =>
-  path.replaceAll('\\', '/').replace(/^\.\//u, '');
+  path.replaceAll('\\', '/').replace(/^\.\//u, '').replace(/\/+$/u, '');
+
+const normalizeWorkspacePattern = (pattern: string): string =>
+  normalizePath(pattern) || '.';
 
 const hasWorkspaceGlobSyntax = (pattern: string): boolean =>
   WORKSPACE_GLOB_SYNTAX_PATTERN.test(pattern);
+
+const isSupportedWorkspacePattern = (pattern: string): boolean =>
+  !hasWorkspaceGlobSyntax(pattern) ||
+  (pattern.endsWith('/*') && !hasWorkspaceGlobSyntax(pattern.slice(0, -2)));
+
+const unsupportedWorkspacePatternError = (pattern: string): string =>
+  `Unsupported workspace pattern '${pattern}'. The release check supports exact workspace paths and one-level '/*' globs.`;
 
 const readJson = async <T>(path: string): Promise<T> =>
   (await Bun.file(path).json()) as T;
@@ -112,6 +127,10 @@ const discoverWorkspaceDirs = async (
   const dirs: string[] = [];
 
   for (const pattern of patterns) {
+    if (!isSupportedWorkspacePattern(pattern)) {
+      throw new Error(unsupportedWorkspacePatternError(pattern));
+    }
+
     if (pattern.endsWith('/*')) {
       const parent = join(repoRoot, pattern.slice(0, -2));
       let names: string[] = [];
@@ -143,12 +162,6 @@ const discoverWorkspaceDirs = async (
     if (await Bun.file(join(dir, 'package.json')).exists()) {
       dirs.push(dir);
       continue;
-    }
-
-    if (hasWorkspaceGlobSyntax(pattern)) {
-      throw new Error(
-        `Unsupported workspace pattern '${pattern}'. The release check supports exact workspace paths and one-level '/*' globs.`
-      );
     }
 
     throw new Error(
@@ -188,6 +201,126 @@ export const discoverWorkspaces = async (
   return workspaces.toSorted((left, right) =>
     left.relativePath.localeCompare(right.relativePath)
   );
+};
+
+interface BaseWorkspaceDiscovery {
+  readonly error?: string;
+  readonly workspaces: readonly WorkspaceInfo[];
+}
+
+const baseWorkspaceReadError = (baseRef: string): string =>
+  `Release check could not read the base workspace inventory from '${baseRef}'. Fetch or provide a valid --base-ref before checking package routes.`;
+
+const discoverBaseWorkspaces = (
+  repoRoot: string,
+  baseRef: string | undefined
+): BaseWorkspaceDiscovery => {
+  if (baseRef === undefined) {
+    return { workspaces: [] };
+  }
+
+  const root = Bun.spawnSync({
+    cmd: ['git', 'show', `${baseRef}:package.json`],
+    cwd: repoRoot,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  if (root.exitCode !== 0) {
+    return { error: baseWorkspaceReadError(baseRef), workspaces: [] };
+  }
+  const workspacePatterns = (
+    JSON.parse(root.stdout.toString()) as PackageJson
+  ).workspaces?.map(normalizeWorkspacePattern);
+  if (!workspacePatterns || workspacePatterns.length === 0) {
+    return { workspaces: [] };
+  }
+  const unsupportedPattern = workspacePatterns.find(
+    (pattern) => !isSupportedWorkspacePattern(pattern)
+  );
+  if (unsupportedPattern) {
+    return {
+      error: unsupportedWorkspacePatternError(unsupportedPattern),
+      workspaces: [],
+    };
+  }
+
+  const listed = Bun.spawnSync({
+    cmd: ['git', 'ls-tree', '-r', '--name-only', baseRef],
+    cwd: repoRoot,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  if (listed.exitCode !== 0) {
+    return { error: baseWorkspaceReadError(baseRef), workspaces: [] };
+  }
+
+  const workspaces: WorkspaceInfo[] = [];
+  for (const relativePath of listed.stdout.toString().split(/\r?\n/u)) {
+    if (
+      !relativePath.endsWith('/package.json') &&
+      relativePath !== 'package.json'
+    ) {
+      continue;
+    }
+    const workspacePath =
+      relativePath === 'package.json'
+        ? '.'
+        : normalizePath(relativePath.replace(/\/package\.json$/u, ''));
+    const isWorkspace = workspacePatterns.some(
+      (pattern) =>
+        pattern === workspacePath ||
+        (pattern.endsWith('/*') &&
+          workspacePath.startsWith(pattern.slice(0, -1)) &&
+          !workspacePath.slice(pattern.length - 1).includes('/'))
+    );
+    if (!isWorkspace) {
+      continue;
+    }
+    const shown = Bun.spawnSync({
+      cmd: ['git', 'show', `${baseRef}:${relativePath}`],
+      cwd: repoRoot,
+      stderr: 'pipe',
+      stdout: 'pipe',
+    });
+    if (shown.exitCode !== 0) {
+      return { error: baseWorkspaceReadError(baseRef), workspaces: [] };
+    }
+    const pkg = JSON.parse(shown.stdout.toString()) as PackageJson;
+    if (!pkg.name) {
+      continue;
+    }
+    workspaces.push({
+      isPrivate: pkg.private === true,
+      name: pkg.name,
+      relativePath: workspacePath,
+    });
+  }
+  return {
+    workspaces: workspaces.toSorted((left, right) =>
+      left.name.localeCompare(right.name)
+    ),
+  };
+};
+
+const resolveBaseWorkspaceInput = (
+  input: ReleaseCheckInput
+): BaseWorkspaceDiscovery => {
+  if (input.baseWorkspaces !== undefined) {
+    return {
+      ...(input.baseWorkspaceError === undefined
+        ? {}
+        : { error: input.baseWorkspaceError }),
+      workspaces: input.baseWorkspaces,
+    };
+  }
+
+  const discovered = discoverBaseWorkspaces(input.repoRoot, input.baseRef);
+  const error = input.baseWorkspaceError ?? discovered.error;
+
+  return {
+    ...(error === undefined ? {} : { error }),
+    workspaces: discovered.workspaces,
+  };
 };
 
 const isPublishableOnTrailsWorkspace = (workspace: WorkspaceInfo): boolean =>
@@ -380,9 +513,45 @@ const findMatchedRuleIds = (input: ReleaseCheckInput): readonly string[] => {
     .toSorted();
 };
 
+const findPackageRouteRuleErrors = ({
+  coveredPackages,
+  packageRoute,
+  requiresPackageRoute,
+}: {
+  readonly coveredPackages: readonly string[];
+  readonly packageRoute: ReturnType<typeof findPackageRouteReleaseFacts>;
+  readonly requiresPackageRoute: boolean;
+}): readonly string[] => {
+  if (!requiresPackageRoute) {
+    return [];
+  }
+
+  const errors = packageRoute.diagnostics.map(
+    (diagnostic) => diagnostic.message
+  );
+
+  const uncoveredIntents = packageRoute.intents.filter(
+    (intent) =>
+      !intent.eligiblePackages.some((packageName) =>
+        coveredPackages.includes(packageName)
+      )
+  );
+
+  if (uncoveredIntents.length > 0) {
+    errors.push(
+      `Public package route changesets must cover a surviving owner: ${uncoveredIntents
+        .map((intent) => intent.sourcePackage)
+        .join(', ')}`
+    );
+  }
+
+  return errors;
+};
+
 export const checkReleaseRules = (
   input: ReleaseCheckInput
 ): ReleaseCheckResult => {
+  const baseWorkspaceInput = resolveBaseWorkspaceInput(input);
   const noReleaseOverride =
     input.noReleaseOverride === true || input.releaseNone === true;
   const affectedPackages = findAffectedPackages(
@@ -399,6 +568,10 @@ export const checkReleaseRules = (
     ...new Set(changesets.flatMap((changeset) => changeset.packages)),
   ].toSorted();
   const contractFacts = findGateContractFacts(input);
+  const packageRoute = findPackageRouteReleaseFacts({
+    baseWorkspaces: baseWorkspaceInput.workspaces,
+    workspaces: input.workspaces,
+  });
   const versionRelease = isVersionReleaseChangeSet(
     input.changedFiles,
     input.workspaces,
@@ -411,7 +584,10 @@ export const checkReleaseRules = (
     (fact) => !isContractFactCovered(fact, coveredPackages)
   );
   const hasReleaseFacts =
-    affectedPackages.length > 0 || contractFacts.length > 0 || versionRelease;
+    affectedPackages.length > 0 ||
+    contractFacts.length > 0 ||
+    packageRoute.facts.length > 0 ||
+    versionRelease;
   const activePackageChangesetsWithoutReleaseFacts =
     activeChangedChangesets.length > 0 && !hasReleaseFacts
       ? activeChangedChangesets
@@ -422,7 +598,15 @@ export const checkReleaseRules = (
     input,
     'public-trail-contract'
   );
+  const requiresPackageRoute = ruleMatchesFactType(
+    input,
+    'public-package-route'
+  );
   const errors: string[] = [];
+
+  if (baseWorkspaceInput.error) {
+    errors.push(baseWorkspaceInput.error);
+  }
 
   if (noReleaseOverride && changedChangesets.length > 0) {
     errors.push(
@@ -447,6 +631,14 @@ export const checkReleaseRules = (
     );
   }
 
+  errors.push(
+    ...findPackageRouteRuleErrors({
+      coveredPackages,
+      packageRoute,
+      requiresPackageRoute,
+    })
+  );
+
   if (
     !noReleaseOverride &&
     !versionRelease &&
@@ -469,6 +661,7 @@ export const checkReleaseRules = (
     errors,
     matchedRuleIds,
     noReleaseOverride,
+    packageRouteFacts: packageRoute.facts,
     passed: errors.length === 0,
     releaseNone: noReleaseOverride,
     uncoveredContractFacts,
@@ -514,6 +707,17 @@ const readLocalChangedFiles = (
   }
 
   return parseChangedFilesOutput(result.stdout.toString());
+};
+
+const hasGitRef = (repoRoot: string, ref: string): boolean => {
+  const result = Bun.spawnSync({
+    cmd: ['git', 'rev-parse', '--verify', '--quiet', `${ref}^{commit}`],
+    cwd: repoRoot,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  return result.exitCode === 0;
 };
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -769,9 +973,16 @@ export const runReleaseCheck = async (
   options: RunReleaseCheckOptions
 ): Promise<ReleaseCheckReport> => {
   const workspaces = await discoverWorkspaces(options.repoRoot);
+  const changedFilesBaseError =
+    options.changedFilesPath !== undefined && options.baseRef === undefined
+      ? 'Release check requires --base-ref when --changed-files is used.'
+      : undefined;
   const baseRef =
     options.baseRef ??
-    (options.changedFilesPath === undefined ? 'origin/main' : undefined);
+    (options.changedFilesPath === undefined &&
+    (workspaces.length > 0 || hasGitRef(options.repoRoot, 'origin/main'))
+      ? 'origin/main'
+      : undefined);
   let changedFiles: readonly string[];
 
   if (options.changedFilesPath !== undefined) {
@@ -792,8 +1003,16 @@ export const runReleaseCheck = async (
     env: options.env,
     repoRoot: options.repoRoot,
   });
+  const baseWorkspaceDiscovery = discoverBaseWorkspaces(
+    options.repoRoot,
+    baseRef
+  );
+  const baseWorkspaceError =
+    changedFilesBaseError ?? baseWorkspaceDiscovery.error;
   const result = checkReleaseRules({
     ...(baseRef === undefined ? {} : { baseRef }),
+    ...(baseWorkspaceError === undefined ? {} : { baseWorkspaceError }),
+    baseWorkspaces: baseWorkspaceDiscovery.workspaces,
     changedFiles,
     ...(loadedConfig.config === undefined
       ? {}

--- a/apps/trails/src/release/config.ts
+++ b/apps/trails/src/release/config.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export const releaseFactTypeValues = [
   'package-content',
+  'public-package-route',
   'public-trail-contract',
 ] as const;
 
@@ -31,6 +32,15 @@ export type ReleaseRule = z.output<typeof releaseRuleSchema>;
 export type ReleaseRuleInput = z.input<typeof releaseRuleSchema>;
 
 export const defaultReleaseRules = [
+  {
+    description:
+      'Public package removals require an exact governed Regrade route or classified multi-owner fold plus branch-local release intent.',
+    enabled: true,
+    facts: ['public-package-route'],
+    id: 'public-package-route-requires-regrade',
+    intent: ['changeset'],
+    severity: 'error',
+  },
   {
     description:
       'Publishable package content changes require positive release intent.',

--- a/apps/trails/src/release/index.ts
+++ b/apps/trails/src/release/index.ts
@@ -32,6 +32,11 @@ export {
   type ContractSourceSnapshot,
 } from './contract-facts.js';
 export {
+  findPackageRouteReleaseFacts,
+  type PackageRouteReleaseDiagnostic,
+  type PackageRouteReleaseFact,
+} from './package-route-facts.js';
+export {
   defaultReleaseConfig,
   defaultReleaseRules,
   releaseConfigSchema,

--- a/apps/trails/src/release/package-route-facts.ts
+++ b/apps/trails/src/release/package-route-facts.ts
@@ -1,0 +1,146 @@
+import { listGovernedVocabularyTransitions } from '@ontrails/warden';
+
+import type { WorkspaceInfo } from './check.js';
+
+export interface PackageRouteReleaseFact {
+  readonly kind: 'classified' | 'single';
+  readonly sourcePackage: string;
+  readonly targetPackage?: string;
+  readonly transitionId: string;
+}
+
+export interface PackageRouteReleaseDiagnostic {
+  readonly code:
+    | 'missing-governed-package-route'
+    | 'missing-governed-package-route-target';
+  readonly message: string;
+  readonly sourcePackage: string;
+}
+
+export interface PackageRouteReleaseIntent {
+  readonly eligiblePackages: readonly string[];
+  readonly sourcePackage: string;
+}
+
+const isPublishableTrailsPackage = (workspace: WorkspaceInfo): boolean =>
+  !workspace.isPrivate && workspace.name.startsWith('@ontrails/');
+
+const findPackageRouteTransition = (
+  transitions: ReturnType<typeof listGovernedVocabularyTransitions>,
+  sourcePackage: string
+) => {
+  const direct = transitions.find(
+    (transition) => transition.from === sourcePackage
+  );
+
+  if (direct) {
+    return { target: direct.target, transition: direct };
+  }
+
+  for (const transition of transitions) {
+    const moduleSpecifierRoute = transition.stringLiteralRenames.find(
+      (route) =>
+        route.from === sourcePackage &&
+        route.moduleSpecifier?.targetPackage !== undefined
+    );
+
+    if (moduleSpecifierRoute?.moduleSpecifier?.targetPackage) {
+      return {
+        target: {
+          kind: 'single' as const,
+          to: moduleSpecifierRoute.moduleSpecifier.targetPackage,
+        },
+        transition,
+      };
+    }
+  }
+
+  return null;
+};
+
+export const findPackageRouteReleaseFacts = ({
+  baseWorkspaces,
+  workspaces,
+}: {
+  readonly baseWorkspaces: readonly WorkspaceInfo[];
+  readonly workspaces: readonly WorkspaceInfo[];
+}): {
+  readonly diagnostics: readonly PackageRouteReleaseDiagnostic[];
+  readonly facts: readonly PackageRouteReleaseFact[];
+  readonly intents: readonly PackageRouteReleaseIntent[];
+} => {
+  const currentPackages = new Set(
+    workspaces
+      .filter(isPublishableTrailsPackage)
+      .map((workspace) => workspace.name)
+  );
+  const removedPackages = baseWorkspaces
+    .filter(isPublishableTrailsPackage)
+    .map((workspace) => workspace.name)
+    .filter((name) => !currentPackages.has(name))
+    .toSorted();
+  const transitions = listGovernedVocabularyTransitions();
+  const diagnostics: PackageRouteReleaseDiagnostic[] = [];
+  const facts: PackageRouteReleaseFact[] = [];
+  const intents: PackageRouteReleaseIntent[] = [];
+
+  for (const sourcePackage of removedPackages) {
+    const resolvedRoute = findPackageRouteTransition(
+      transitions,
+      sourcePackage
+    );
+
+    if (!resolvedRoute) {
+      diagnostics.push({
+        code: 'missing-governed-package-route',
+        message: `Public package removal '${sourcePackage}' requires an exact governed Regrade route. Add the route to the governed transition registry, then run trails regrade plan/check.`,
+        sourcePackage,
+      });
+      continue;
+    }
+
+    const { target, transition } = resolvedRoute;
+
+    if (target.kind === 'classified') {
+      const classifiedTarget = target;
+      const eligiblePackages = [...currentPackages]
+        .filter((packageName) =>
+          classifiedTarget.options.some(
+            (option) =>
+              option.to === packageName ||
+              option.to.startsWith(`${packageName}/`)
+          )
+        )
+        .toSorted();
+      facts.push({
+        kind: 'classified',
+        sourcePackage,
+        transitionId: transition.id,
+      });
+      intents.push({ eligiblePackages, sourcePackage });
+      continue;
+    }
+
+    if (!currentPackages.has(target.to)) {
+      diagnostics.push({
+        code: 'missing-governed-package-route-target',
+        message: `Governed Regrade route '${transition.id}' maps '${sourcePackage}' to '${target.to}', but that publishable target package is absent. Add the target package before applying the route, or use a classified transition with an explicit non-migratable reason for a multi-owner fold.`,
+        sourcePackage,
+      });
+      continue;
+    }
+
+    facts.push({
+      kind: 'single',
+      sourcePackage,
+      targetPackage: target.to,
+      transitionId: transition.id,
+    });
+    intents.push({
+      eligiblePackages: [target.to],
+      sourcePackage,
+    });
+  }
+
+  return { diagnostics, facts, intents };
+};

--- a/apps/trails/src/trails/release-check.ts
+++ b/apps/trails/src/trails/release-check.ts
@@ -44,6 +44,13 @@ const contractReleaseFactSchema = z.object({
   workspacePath: z.string().optional(),
 });
 
+const packageRouteReleaseFactSchema = z.object({
+  kind: z.enum(['classified', 'single']),
+  sourcePackage: z.string(),
+  targetPackage: z.string().optional(),
+  transitionId: z.string(),
+});
+
 const releaseCheckOutputSchema = z.object({
   activePackageChangesetsWithoutReleaseFacts: z.array(z.string()).readonly(),
   affectedPackages: z.array(z.string()).readonly(),
@@ -55,6 +62,7 @@ const releaseCheckOutputSchema = z.object({
   formatted: z.string(),
   matchedRuleIds: z.array(z.string()).readonly(),
   noReleaseOverride: z.boolean(),
+  packageRouteFacts: z.array(packageRouteReleaseFactSchema).readonly(),
   passed: z.boolean(),
   releaseNone: z.boolean(),
   uncoveredContractFacts: z.array(contractReleaseFactSchema).readonly(),

--- a/docs/releases/release-rules-check.md
+++ b/docs/releases/release-rules-check.md
@@ -32,9 +32,10 @@ In this repo, `bun run dogfood:packed` and `bun run wayfinder:dogfood` remain pa
 
 ## Facts
 
-The current default rules inspect two fact families:
+The current default rules inspect three fact families:
 
 - `package-content`: changed shipping files inside non-private publishable `@ontrails/*` workspaces.
+- `public-package-route`: a non-private publishable package present at the base ref but absent now. The release check requires an exact governed Regrade transition. Its single target must be a current publishable package; a classified transition is the explicit non-migratable reason for a truthful multi-owner fold.
 - `public-trail-contract`: changed public trail additions/removals, visibility transitions, input schemas, output schemas, or surface exposure.
 
 The public contract detector is intentionally source-static for this first slice. It reports trail id, changed aspect, source path, affected package, and base/current source hashes when available. Future release facts can graduate to Topography or Wayfinder graph diffs once baseline/current artifact handling is settled.
@@ -55,20 +56,21 @@ export default defineConfig({
 });
 ```
 
-The default config includes two error rules:
+The default config includes three error rules:
 
 - `package-content-requires-intent`
+- `public-package-route-requires-regrade`
 - `public-trail-contract-requires-intent`
 
-Rules are project policy, not branch paperwork. A branch satisfies a matching rule by carrying positive release intent.
+Rules are project policy, not branch paperwork. A branch satisfies package-content and public-trail-contract rules by carrying positive release intent. A public-package-route fact additionally requires the exact governed route and a branch-local changeset covering its surviving single target or one current classified owner; this keeps a package retirement from degrading into a module-not-found error plus prose. The transition registry is the Regrade owner, while `release.check` owns the before/after package-inventory verdict.
 
 ## Intent
 
 A branch-local `.changeset/*.md` entry is the normal intent source. It says the branch changes user-visible package content and should flow into Changesets, package changelogs, and the next version plan.
 
-`release:none` remains a compatibility no-release override. It is a claim, not the primitive. Use it only when the branch touches package files but does not ship user-visible package content, and record the reason in the PR, issue, or handoff. A branch with both `release:none` and changed changeset files fails.
+`release:none` remains a compatibility no-release override. It is a claim, not the primitive. Use it only when the branch touches package files but does not ship user-visible package content, and record the reason in the PR, issue, or handoff. It never bypasses a public-package-route requirement: package retirement is user-visible even when no other package-content fact remains. A branch with both `release:none` and changed changeset files fails.
 
-An active package changeset is also release intent. If a branch adds or modifies `.changeset/*.md` without any matching package-content, generated version release, or public trail contract fact, the check fails. Deleted changesets are ignored for this inverse guard so cleanup branches can remove mistaken release intent without adding package noise.
+An active package changeset is also release intent. If a branch adds or modifies `.changeset/*.md` without any matching package-content, public-package-route, generated version release, or public trail contract fact, the check fails. Deleted changesets are ignored for this inverse guard so cleanup branches can remove mistaken release intent without adding package noise.
 
 ## Graphite Stacks
 


### PR DESCRIPTION
## Context

[TRL-1255](https://linear.app/outfitter/issue/TRL-1255) makes `trails release check` the single lifecycle-governance owner for public `@ontrails/*` package removals and renames. The check needs both the base and current package inventories, so this is intentionally not a Warden rule.

## What changed

- derive public-package route facts from the selected base ref and current publishable workspaces
- require an exact governed Regrade transition for a removed public package and verify a single target still exists
- accept an explicit classified transition for a truthful multi-owner fold, without fabricating a root redirect
- expose the facts through `trails release check`, cover the observability rename and tracing fold, and document the release-rule boundary
- add a branch-local patch changeset for `@ontrails/trails`

## Verification

- focused release-check/config/trail tests (33 cases)
- `bun apps/trails/bin/trails.ts release check --json` reports `@ontrails/observe` -> `@ontrails/observability` and classified `@ontrails/tracing` fold with no errors
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run changeset:check`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun run plugin:metadata:check`
- `bun scripts/adr.ts check`
- `git diff --check`

## Release and migration notes

This changes release validation only; it publishes no package and introduces no compatibility package. A package-level removal now needs either an exact declared Regrade route to a live public target or an explicit classified multi-owner fold. Private, additive, unchanged, and subpath-only changes are excluded.