### PR TITLE
feat(governance): require Regrade transition provenance

### DIFF
--- a/.agents/skills/clark/references/warden-guide.md
+++ b/.agents/skills/clark/references/warden-guide.md
@@ -62,7 +62,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `draft-file-marking` (error, source/source-static, external): Draft-authored state is visibly marked in filenames.
 - `draft-visible-debt` (warn, source/source-static, external): Draft-authored IDs remain visible debt.
 - `fork-without-preserved-implementation` (error, source/source-static, external): Fork version entries preserve their historical implementation.
-- `governed-symbol-residue` (error, source/source-static, external): Active governed vocabulary symbol renames do not leave retired identifiers in source.
+- `governed-symbol-residue` (error, source/source-static, external): Governed vocabulary transitions carry committed Regrade provenance and do not leave or reintroduce retired identifiers. Guidance: Require committed Regrade evidence before completing a governed vocabulary migration.
 - `marker-schema-unsupported` (error, source/source-static, external): Versioned schemas stay inside the supported marker projection subset.
 - `pending-force` (warn, topo/topo-aware, external): Forced topo break audit events do not remain pending indefinitely.
 - `scheduled-destroy-intent` (warn, topo/topo-aware, external): Schedule-activated destroy trails make unattended destructive work visible for review.

--- a/.changeset/warm-rivers-prove.md
+++ b/.changeset/warm-rivers-prove.md
@@ -1,0 +1,16 @@
+---
+'@ontrails/regrade': minor
+'@ontrails/trails': minor
+'@ontrails/warden': minor
+---
+
+Require committed Regrade provenance for governed vocabulary transitions.
+
+Applied governed plans now expose deterministic transition, plan, source,
+safe-apply, and review-follow-up evidence through history results. Warden loads
+committed history into project context, cites it for reintroduced symbols, and
+rejects invalid or missing provenance for transitions that require Regrade in
+the workspace that owns the governed registry, without making downstream apps
+prove the framework's own migrations.
+Portable validation accepts the authoritative numeric file-rename counters
+persisted by Regrade history.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -62,7 +62,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `draft-file-marking` (error, source/source-static, external): Draft-authored state is visibly marked in filenames.
 - `draft-visible-debt` (warn, source/source-static, external): Draft-authored IDs remain visible debt.
 - `fork-without-preserved-implementation` (error, source/source-static, external): Fork version entries preserve their historical implementation.
-- `governed-symbol-residue` (error, source/source-static, external): Active governed vocabulary symbol renames do not leave retired identifiers in source.
+- `governed-symbol-residue` (error, source/source-static, external): Governed vocabulary transitions carry committed Regrade provenance and do not leave or reintroduce retired identifiers. Guidance: Require committed Regrade evidence before completing a governed vocabulary migration.
 - `marker-schema-unsupported` (error, source/source-static, external): Versioned schemas stay inside the supported marker projection subset.
 - `pending-force` (warn, topo/topo-aware, external): Forced topo break audit events do not remain pending indefinitely.
 - `scheduled-destroy-intent` (warn, topo/topo-aware, external): Schedule-activated destroy trails make unattended destructive work visible for review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,7 +158,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `draft-file-marking` (error, source/source-static, external): Draft-authored state is visibly marked in filenames.
 - `draft-visible-debt` (warn, source/source-static, external): Draft-authored IDs remain visible debt.
 - `fork-without-preserved-implementation` (error, source/source-static, external): Fork version entries preserve their historical implementation.
-- `governed-symbol-residue` (error, source/source-static, external): Active governed vocabulary symbol renames do not leave retired identifiers in source.
+- `governed-symbol-residue` (error, source/source-static, external): Governed vocabulary transitions carry committed Regrade provenance and do not leave or reintroduce retired identifiers.
 - `marker-schema-unsupported` (error, source/source-static, external): Versioned schemas stay inside the supported marker projection subset.
 - `pending-force` (warn, topo/topo-aware, external): Forced topo break audit events do not remain pending indefinitely.
 - `scheduled-destroy-intent` (warn, topo/topo-aware, external): Schedule-activated destroy trails make unattended destructive work visible for review.
@@ -219,6 +219,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `duplicate-exported-symbol`: Keep exported symbol ownership from drifting across first-party packages.
 - `duplicate-public-contract`: Keep duplicate public contract facts from drifting into separate capabilities.
 - `example-valid`: Keep trail examples synchronized with their authored schemas.
+- `governed-symbol-residue`: Require committed Regrade evidence before completing a governed vocabulary migration.
 - `library-projection-coherence`: Keep resolved library projection exports collision-free and attached to one trail contract.
 - `no-throw-in-implementation`: Convert thrown failures in implementations into explicit Result.err() outcomes.
 - `no-top-level-surface`: Keep topo entry modules side-effect-free for survey, guide, compile, and lock generation.

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -610,6 +610,11 @@ describe('Trails MCP surface shaping', () => {
       expect(applied.isError).toBeUndefined();
       expect(applied.structuredContent).toMatchObject({
         history: {
+          id: expect.stringMatching(/^[0-9a-f]{12}$/),
+          provenance: {
+            kind: 'governed-vocabulary',
+            transitionId: 'v1-facet-trailhead',
+          },
           status: 'applied',
         },
       });
@@ -636,6 +641,26 @@ describe('Trails MCP surface shaping', () => {
       expect(
         readFileSync(join(dir, 'scripts', 'vocab-cutover-fixture.ts'), 'utf8')
       ).toBe('export const facet = "facet";\n');
+
+      const absoluteHistoryPath = join(dir, historyPath ?? 'missing');
+      const tampered = JSON.parse(
+        readFileSync(absoluteHistoryPath, 'utf8')
+      ) as {
+        runs?: { provenance?: { transitionId?: string } }[];
+      };
+      if (tampered.runs?.[0]?.provenance === undefined) {
+        throw new Error('Expected governed MCP history provenance.');
+      }
+      tampered.runs[0].provenance.transitionId = 'v1-contour-entity';
+      writeFileSync(
+        absoluteHistoryPath,
+        `${JSON.stringify(tampered, null, 2)}\n`
+      );
+      const tamperedCheck = await checkRegrade.handler(
+        { plan: 'facet-to-trailhead', rootDir: dir },
+        {}
+      );
+      expect(tamperedCheck.isError).toBe(true);
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }

--- a/apps/trails/src/__tests__/regrade-history.test.ts
+++ b/apps/trails/src/__tests__/regrade-history.test.ts
@@ -18,6 +18,7 @@ import {
   verifyRegradeHistoryRuns,
 } from '../regrade/history.js';
 import {
+  currentRegradeSourceHashMatches,
   legacyRegradeSourceHash,
   regradePlanContentHash,
   regradePlanSlugForBody,
@@ -102,6 +103,47 @@ const makeReportWithReviewDetail = (): RegradeReport => ({
   ],
   matched: 1,
   review: 1,
+});
+
+const makeReportWithFileRenameEvidence = (): RegradeReport => ({
+  ...makeReportWithReviewDetail(),
+  run: {
+    ledger: { cycle: 1, forms: {}, occurrences: [] },
+    plan: {
+      fileRenames: [{ from: 'docs/old.md', to: 'docs/new.md' }],
+      from: 'old',
+      kind: 'vocabulary',
+      to: 'new',
+    },
+    report: {
+      applied: 0,
+      deferred: 0,
+      dispositions: {},
+      fileRenames: [
+        {
+          deferred: 0,
+          from: 'docs/old.md',
+          historical: 1,
+          preserved: 0,
+          rewritten: 0,
+          skipped: 1,
+          to: 'docs/new.md',
+        },
+      ],
+      filesChanged: 0,
+      gate: {
+        reasons: [],
+        remaining: 0,
+        remainingByDisposition: {},
+        status: 'green',
+      },
+      modified: 0,
+      open: 0,
+      scopeTiers: { 'in-scope': 0, 'policy-classified': 0 },
+      skipped: 1,
+      teachingSurfaces: { expected: [], missing: [], touched: [] },
+    },
+  },
 });
 
 describe('regradePlanContentHash', () => {
@@ -189,6 +231,19 @@ describe('regradeSourceHash', () => {
         regradeSourceHashMatches(hash, sourceReport)
       )
     ).toBe(true);
+    expect(
+      currentRegradeSourceHashMatches(
+        regradeSourceHash(sourceReport),
+        sourceReport
+      )
+    ).toBe(true);
+    const compatibilityHash = compatibleHashes.find(
+      (hash) => hash !== regradeSourceHash(sourceReport)
+    );
+    expect(compatibilityHash).toBeDefined();
+    expect(
+      currentRegradeSourceHashMatches(compatibilityHash ?? '', sourceReport)
+    ).toBe(false);
   });
 
   test('changes when protected file-reference evidence changes', () => {
@@ -250,10 +305,135 @@ describe('regradeSourceHash', () => {
     expect(regradeSourceHash(changedReport)).not.toBe(
       regradeSourceHash(sourceReport)
     );
+    const compatibleHashes = regradeSourceHashes(sourceReport);
+    expect(
+      compatibleHashes.every((hash) =>
+        regradeSourceHashMatches(hash, sourceReport)
+      )
+    ).toBe(true);
   });
 });
 
 describe('appendRegradeHistoryRun', () => {
+  test('persists deterministic governed provenance for safe apply and review follow-up', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact({
+        ...makePlanBody(),
+        id: 'v1-facet-trailhead',
+      });
+      const report = {
+        ...makeReportWithReviewDetail(),
+        apply: {
+          applied: 2,
+          filesChanged: 2,
+          review: 1,
+          skipped: 0,
+          unknown: 0,
+        },
+      };
+      const completedReport = makeReport([
+        'term-rewrite:no-retired-cross-vocabulary',
+      ]);
+
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        completedReport,
+        report,
+        rootDir: dir,
+      });
+      if (appended.isErr()) {
+        throw appended.error;
+      }
+      expect(appended.value.id).toMatch(/^[0-9a-f]{12}$/);
+      expect(appended.value.provenance).toEqual({
+        disposition: 'review-follow-up',
+        kind: 'governed-vocabulary',
+        planContentHash: regradePlanContentHash(artifact.plan),
+        reviewPending: 1,
+        safeApplied: 2,
+        sourceHashAfter: regradeSourceHash(completedReport),
+        sourceHashBefore: regradeSourceHash(report),
+        transitionId: 'v1-facet-trailhead',
+      });
+
+      const history = readRegradeHistoryArtifact(
+        regradeHistoryPathForPlan(dir, artifact.plan)
+      );
+      if (history.isErr()) {
+        throw history.error;
+      }
+      expect(history.value.runs[0]?.provenance).toEqual(
+        appended.value.provenance
+      );
+      expect(verifyRegradeHistoryRuns(history.value).isOk()).toBe(true);
+    });
+  });
+
+  test('resolves governed provenance from an id-less plan pair', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact(makePlanBody());
+      const report = makeReport(['term-rewrite:no-retired-cross-vocabulary']);
+
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        report,
+        rootDir: dir,
+      });
+      if (appended.isErr()) {
+        throw appended.error;
+      }
+
+      expect(appended.value.provenance?.transitionId).toBe(
+        'v1-facet-trailhead'
+      );
+    });
+  });
+
+  test('resolves governed provenance from a plan pair with a custom id', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact({
+        ...makePlanBody(),
+        id: 'local-plan',
+      });
+      const report = makeReport(['term-rewrite:no-retired-cross-vocabulary']);
+
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        report,
+        rootDir: dir,
+      });
+      if (appended.isErr()) {
+        throw appended.error;
+      }
+
+      expect(appended.value.provenance?.transitionId).toBe(
+        'v1-facet-trailhead'
+      );
+    });
+  });
+
+  test('rejects an id-less plan with a governed source and unknown target', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact({
+        ...makePlanBody(),
+        to: 'unknown-target',
+      });
+
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        report: makeReport([]),
+        rootDir: dir,
+      });
+
+      expect(appended.isErr()).toBe(true);
+      if (appended.isErr()) {
+        expect(appended.error.message).toContain(
+          'does not match its registry transition'
+        );
+      }
+    });
+  });
+
   test('appends runs per transition, recognizes replays, and never overwrites unrecognized files', () => {
     withFixtureDir((dir) => {
       const artifact = makePlanArtifact(makePlanBody());
@@ -517,6 +697,150 @@ describe('appendRegradeHistoryRun', () => {
     });
   });
 
+  test('verifies governed provenance stamped with legacy report hashes', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact({
+        ...makePlanBody(),
+        id: 'v1-facet-trailhead',
+      });
+      const report = makeReportWithReviewDetail();
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        completedReport: report,
+        report,
+        rootDir: dir,
+      });
+      if (appended.isErr()) {
+        throw appended.error;
+      }
+
+      const historyPath = regradeHistoryPathForPlan(dir, artifact.plan);
+      const persisted = JSON.parse(readFileSync(historyPath, 'utf8')) as {
+        runs: {
+          completionReport: RegradeReport;
+          completionReportHash: string;
+          lockHashAtRun: string;
+          provenance: {
+            sourceHashAfter: string;
+            sourceHashBefore: string;
+          };
+          report: RegradeReport;
+        }[];
+      };
+      const [run] = persisted.runs;
+      if (run === undefined) {
+        throw new Error('Expected a recorded history run.');
+      }
+      for (const source of [run.report, run.completionReport]) {
+        const detail = source.entries[0]?.reviewDetails?.[0];
+        if (detail === undefined) {
+          throw new Error('Expected a recorded review detail.');
+        }
+        source.entries[0] = {
+          ...source.entries[0],
+          reviewDetails: [
+            {
+              classId: detail.classId,
+              matchedForm: detail.matchedForm,
+              preserveCautions: detail.preserveCautions,
+              reason: detail.reason,
+              signals: detail.signals,
+              span: detail.span,
+              symbol: detail.symbol,
+            },
+          ],
+        };
+      }
+      run.lockHashAtRun = legacyRegradeSourceHash(run.report);
+      run.completionReportHash = legacyRegradeSourceHash(run.completionReport);
+      run.provenance.sourceHashBefore = run.lockHashAtRun;
+      run.provenance.sourceHashAfter = run.completionReportHash;
+      writeFileSync(historyPath, `${JSON.stringify(persisted, null, 2)}\n`);
+
+      const legacy = readRegradeHistoryArtifact(historyPath);
+      if (legacy.isErr()) {
+        throw legacy.error;
+      }
+      expect(verifyRegradeHistoryRuns(legacy.value).isOk()).toBe(true);
+
+      run.provenance.sourceHashBefore = '0'.repeat(64);
+      writeFileSync(historyPath, `${JSON.stringify(persisted, null, 2)}\n`);
+      const tampered = readRegradeHistoryArtifact(historyPath);
+      if (tampered.isErr()) {
+        throw tampered.error;
+      }
+      const failed = verifyRegradeHistoryRuns(tampered.value);
+      expect(failed.isErr()).toBe(true);
+      if (failed.isErr()) {
+        expect(failed.error.message).toBe(
+          'Regrade history run provenance mismatch.'
+        );
+      }
+    });
+  });
+
+  test('verifies governed provenance stamped with legacy file evidence hashes', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact({
+        ...makePlanBody(),
+        id: 'v1-facet-trailhead',
+      });
+      const report = makeReportWithFileRenameEvidence();
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        completedReport: report,
+        report,
+        rootDir: dir,
+      });
+      if (appended.isErr()) {
+        throw appended.error;
+      }
+
+      const historyPath = regradeHistoryPathForPlan(dir, artifact.plan);
+      const persisted = JSON.parse(readFileSync(historyPath, 'utf8')) as {
+        runs: {
+          completionReport: RegradeReport;
+          completionReportHash: string;
+          lockHashAtRun: string;
+          provenance: {
+            sourceHashAfter: string;
+            sourceHashBefore: string;
+          };
+          report: RegradeReport;
+        }[];
+      };
+      const [run] = persisted.runs;
+      if (run === undefined) {
+        throw new Error('Expected a recorded history run.');
+      }
+      expect(regradeSourceHashes(run.report).length).toBeGreaterThan(2);
+      const sourceHash = regradeSourceHashes(run.report).find(
+        (hash) =>
+          hash !== regradeSourceHash(run.report) &&
+          hash !== legacyRegradeSourceHash(run.report)
+      );
+      const completionHash = regradeSourceHashes(run.completionReport).find(
+        (hash) =>
+          hash !== regradeSourceHash(run.completionReport) &&
+          hash !== legacyRegradeSourceHash(run.completionReport)
+      );
+      if (sourceHash === undefined || completionHash === undefined) {
+        throw new Error('Expected legacy file-evidence source hashes.');
+      }
+      run.lockHashAtRun = sourceHash;
+      run.completionReportHash = completionHash;
+      run.provenance.sourceHashBefore = sourceHash;
+      run.provenance.sourceHashAfter = completionHash;
+      writeFileSync(historyPath, `${JSON.stringify(persisted, null, 2)}\n`);
+
+      const legacy = readRegradeHistoryArtifact(historyPath);
+      if (legacy.isErr()) {
+        throw legacy.error;
+      }
+      expect(verifyRegradeHistoryRuns(legacy.value).isOk()).toBe(true);
+    });
+  });
+
   test('refuses to fork a consolidated history when the plan pins a different transition id', () => {
     withFixtureDir((dir) => {
       const artifact = makePlanArtifact(makePlanBody());
@@ -598,6 +922,40 @@ describe('appendRegradeHistoryRun', () => {
 });
 
 describe('verifyRegradeHistoryRuns', () => {
+  test('requires provenance for id-less governed plans', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact({
+        ...makePlanBody(),
+        from: 'projection',
+        to: 'derive',
+      });
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        report: makeReport(['first-class']),
+        rootDir: dir,
+      });
+      expect(appended.isOk()).toBe(true);
+
+      const historyPath = regradeHistoryPathForPlan(dir, artifact.plan);
+      const written = readRegradeHistoryArtifact(historyPath);
+      if (written.isErr()) {
+        throw written.error;
+      }
+      const withoutProvenance = {
+        ...written.value,
+        runs: written.value.runs.map(
+          ({ provenance: _provenance, ...run }) => run
+        ),
+      };
+      const verified = verifyRegradeHistoryRuns(withoutProvenance);
+
+      expect(verified.isErr()).toBe(true);
+      if (verified.isErr()) {
+        expect(verified.error.message).toContain('lacks governed provenance');
+      }
+    });
+  });
+
   test('accepts a freshly written artifact after report serialization normalizes nested keys', () => {
     withFixtureDir((dir) => {
       const artifact = makePlanArtifact(makePlanBody());

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -390,12 +390,21 @@ describe('trails regrade', () => {
         expect(applyResult.exitCode).toBe(0);
         const applied = parseCliJson<{
           readonly history?: {
+            readonly id?: string;
             readonly path?: string;
+            readonly provenance?: {
+              readonly safeApplied?: number;
+              readonly transitionId?: string;
+            };
             readonly status?: string;
           };
         }>(applyResult);
         expect(applied.history).toMatchObject({
           path: '.trails/regrade/history/facet-to-trailhead.json',
+          provenance: {
+            safeApplied: 1,
+            transitionId: 'v1-facet-trailhead',
+          },
           status: 'applied',
         });
         expect(readFileSync(join(dir, 'docs', 'surface.md'), 'utf8')).toContain(
@@ -444,6 +453,7 @@ describe('trails regrade', () => {
           readonly runs?: readonly {
             readonly lockHashAtRun?: string;
             readonly planContentHash?: string;
+            readonly provenance?: { readonly transitionId?: string };
           }[];
           readonly schemaVersion?: number;
         }
@@ -456,6 +466,9 @@ describe('trails regrade', () => {
         expect(consolidated.runs).toHaveLength(1);
         expect(consolidated.runs?.[0]?.planContentHash).toBeDefined();
         expect(consolidated.runs?.[0]?.lockHashAtRun).toBeDefined();
+        expect(consolidated.runs?.[0]?.provenance?.transitionId).toBe(
+          'v1-facet-trailhead'
+        );
 
         // A third identical plan+apply over the unchanged tree is a replay: no
         // duplicate run is appended and the earlier stamps stay untouched.
@@ -719,6 +732,53 @@ describe('trails regrade', () => {
         '`fileRenames` is not supported for class-mode plans'
       );
       expect(existsSync(join(dir, '.trails', 'regrade'))).toBe(false);
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI rejects mismatched governed plans before applying source edits', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'docs/current.md', 'Replace alpha here.\n');
+      const planned = runRawCli([
+        'regrade',
+        'plan',
+        'alpha',
+        'omega',
+        '--root-dir',
+        dir,
+        '--extensions',
+        '.md',
+        '--json',
+      ]);
+      expect(planned.exitCode).toBe(0);
+      const planPath = parseCliJson<{ readonly path?: string }>(planned).path;
+      if (planPath === undefined) {
+        throw new Error('Expected a saved Regrade plan path.');
+      }
+      const absolutePlanPath = join(dir, planPath);
+      const artifact = JSON.parse(readFileSync(absolutePlanPath, 'utf8')) as {
+        plan: { id?: string };
+      };
+      artifact.plan.id = 'v1-facet-trailhead';
+      writeFileSync(absolutePlanPath, `${JSON.stringify(artifact, null, 2)}\n`);
+
+      const applied = runRawCli([
+        'regrade',
+        'apply',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+
+      expect(applied.exitCode).toBe(1);
+      expect(applied.stderr).toContain(
+        'Governed Regrade plan does not match its registry transition.'
+      );
+      expect(readFileSync(join(dir, 'docs/current.md'), 'utf8')).toBe(
+        'Replace alpha here.\n'
+      );
     } finally {
       rmSync(dir, { force: true, recursive: true });
     }
@@ -1551,7 +1611,9 @@ describe('trails regrade', () => {
           '.trails/regrade/history/facet-to-trailhead.json'
         );
         interface HistoryFile {
-          readonly runs?: { lockHashAtRun?: string }[];
+          readonly runs?: {
+            provenance?: { transitionId?: string };
+          }[];
         }
         const tampered = JSON.parse(
           readFileSync(historyFile, 'utf8')
@@ -1559,7 +1621,10 @@ describe('trails regrade', () => {
         if (tampered.runs?.[0] === undefined) {
           throw new Error('Expected a recorded history run to tamper.');
         }
-        tampered.runs[0].lockHashAtRun = 'deadbeef'.repeat(8);
+        if (tampered.runs[0].provenance === undefined) {
+          throw new Error('Expected governed provenance to tamper.');
+        }
+        tampered.runs[0].provenance.transitionId = 'v1-contour-entity';
         writeFileSync(historyFile, `${JSON.stringify(tampered, null, 2)}\n`);
 
         const tamperedCheck = runRawCli([
@@ -1572,7 +1637,7 @@ describe('trails regrade', () => {
           '--json',
         ]);
         expect(tamperedCheck.exitCode).not.toBe(0);
-        expect(tamperedCheck.stderr).toContain('stamp mismatch');
+        expect(tamperedCheck.stderr).toContain('provenance mismatch');
       } finally {
         rmSync(dir, { force: true, recursive: true });
       }

--- a/apps/trails/src/regrade/history.ts
+++ b/apps/trails/src/regrade/history.ts
@@ -9,6 +9,12 @@ import { InternalError, Result, ValidationError } from '@ontrails/core';
 import type { Result as TrailsResult } from '@ontrails/core';
 import { regradeReportOutput } from '@ontrails/regrade';
 import type { RegradeReport } from '@ontrails/regrade';
+import {
+  getGovernedVocabularyTransition,
+  governedVocabularyHistoryProvenanceSchema,
+  listGovernedVocabularyTransitions,
+} from '@ontrails/warden';
+import type { GovernedVocabularyHistoryProvenance } from '@ontrails/warden';
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, isAbsolute, join } from 'node:path';
@@ -61,6 +67,7 @@ const regradeHistoryRunSchema = z
       .string()
       .min(1)
       .describe('Canonical content hash of the resolved plan body'),
+    provenance: governedVocabularyHistoryProvenanceSchema.optional(),
     report: regradeReportOutput.describe('Applied report recorded by the run'),
   })
   .strict();
@@ -85,6 +92,7 @@ interface RegradeHistoryRun {
   readonly lockHashAtRun: string;
   readonly plan: RegradePlanArtifact;
   readonly planContentHash: string;
+  readonly provenance?: GovernedVocabularyHistoryProvenance;
   readonly report: RegradeReport;
 }
 
@@ -97,7 +105,9 @@ export interface RegradeHistoryArtifact {
 }
 
 export interface RegradeHistorySummary {
+  readonly id: string;
   readonly path: string;
+  readonly provenance?: GovernedVocabularyHistoryProvenance;
   readonly schemaVersion: number;
   readonly status: 'applied' | 'replay';
 }
@@ -195,6 +205,117 @@ export const mintTransitionId = (
     .digest('hex')
     .slice(0, 12);
 
+const targetIncludesPlanTarget = (
+  transition: NonNullable<ReturnType<typeof getGovernedVocabularyTransition>>,
+  to: string
+): boolean =>
+  transition.target.kind === 'single'
+    ? transition.target.to === to
+    : transition.target.options.some((option) => option.to === to);
+
+const governedTransitionForPlan = (
+  plan: Extract<RegradePlanBody, { kind: 'vocabulary' }>
+) => {
+  const idTransition =
+    plan.id === undefined
+      ? undefined
+      : getGovernedVocabularyTransition(plan.id);
+  return (
+    idTransition ??
+    listGovernedVocabularyTransitions().find(
+      (transition) => transition.from === plan.from
+    )
+  );
+};
+
+export const validateGovernedRegradePlan = (
+  artifact: RegradePlanArtifact
+): TrailsResult<void, ValidationError> => {
+  const { plan } = artifact;
+  if (plan.kind !== 'vocabulary') {
+    return Result.ok();
+  }
+  const transition = governedTransitionForPlan(plan);
+  if (transition === undefined) {
+    return Result.ok();
+  }
+  if (
+    transition.from === plan.from &&
+    targetIncludesPlanTarget(transition, plan.to)
+  ) {
+    return Result.ok();
+  }
+  return Result.err(
+    new ValidationError(
+      'Governed Regrade plan does not match its registry transition.',
+      {
+        context: {
+          plan: { from: plan.from, id: plan.id, to: plan.to },
+          registry: { from: transition.from, id: transition.id },
+        },
+      }
+    )
+  );
+};
+
+const governedProvenanceForRun = (params: {
+  readonly artifact: RegradePlanArtifact;
+  readonly completionReport: RegradeReport;
+  readonly planContentHash: string;
+  readonly report: RegradeReport;
+}): TrailsResult<
+  GovernedVocabularyHistoryProvenance | undefined,
+  ValidationError
+> => {
+  const { plan } = params.artifact;
+  const validation = validateGovernedRegradePlan(params.artifact);
+  if (validation.isErr()) {
+    return validation;
+  }
+  if (plan.kind !== 'vocabulary') {
+    return Result.ok();
+  }
+  const transition = governedTransitionForPlan(plan);
+  if (transition === undefined) {
+    return Result.ok();
+  }
+
+  const reviewPending = params.report.review;
+  return Result.ok({
+    disposition: reviewPending > 0 ? 'review-follow-up' : 'applied-clean',
+    kind: 'governed-vocabulary',
+    planContentHash: params.planContentHash,
+    reviewPending,
+    safeApplied: params.report.apply?.applied ?? params.report.rewritten,
+    sourceHashAfter: regradeSourceHash(params.completionReport),
+    sourceHashBefore: regradeSourceHash(params.report),
+    transitionId: transition.id,
+  });
+};
+
+const governedProvenanceMatchesRun = (params: {
+  readonly expected: GovernedVocabularyHistoryProvenance | undefined;
+  readonly run: RegradeHistoryRun;
+}): boolean => {
+  const { expected, run } = params;
+  const actual = run.provenance;
+  if (actual === undefined || expected === undefined) {
+    return actual === expected;
+  }
+  return (
+    actual.disposition === expected.disposition &&
+    actual.kind === expected.kind &&
+    actual.planContentHash === expected.planContentHash &&
+    actual.reviewPending === expected.reviewPending &&
+    actual.safeApplied === expected.safeApplied &&
+    (regradeSourceHashMatches(actual.sourceHashBefore, run.report) ||
+      run[rawReportHash] === actual.sourceHashBefore) &&
+    (regradeSourceHashMatches(actual.sourceHashAfter, run.completionReport) ||
+      run[rawCompletionReportHash] === actual.sourceHashAfter) &&
+    actual.transitionId === expected.transitionId
+  );
+};
+
 /**
  * Verify every recorded run at its own stamped lock: recompute the plan
  * content hash and lock hash from the recorded plan and report, then compare
@@ -242,9 +363,120 @@ export const verifyRegradeHistoryRuns = (
         })
       );
     }
+    const expectedProvenance = governedProvenanceForRun({
+      artifact: run.plan,
+      completionReport: run.completionReport,
+      planContentHash: run.planContentHash,
+      report: run.report,
+    });
+    if (expectedProvenance.isErr()) {
+      return expectedProvenance;
+    }
+    const transition =
+      run.plan.plan.kind === 'vocabulary'
+        ? governedTransitionForPlan(run.plan.plan)
+        : undefined;
+    if (
+      transition?.provenance.mode === 'regrade-history' &&
+      run.provenance === undefined
+    ) {
+      return Result.err(
+        new ValidationError('Regrade history run lacks governed provenance.', {
+          context: { path: artifact.path, run: index },
+        })
+      );
+    }
+    if (
+      run.provenance !== undefined &&
+      !governedProvenanceMatchesRun({
+        expected: expectedProvenance.value,
+        run,
+      })
+    ) {
+      return Result.err(
+        new ValidationError('Regrade history run provenance mismatch.', {
+          context: { path: artifact.path, run: index },
+        })
+      );
+    }
   }
   return Result.ok({ runs: artifact.runs.length });
 };
+
+const historyEntryFor = (params: {
+  readonly artifact: RegradePlanArtifact;
+  readonly completionReport: RegradeReport;
+  readonly lockHashAtRun: string;
+  readonly planContentHash: string;
+  readonly report: RegradeReport;
+}): TrailsResult<RegradeHistoryRun, ValidationError> => {
+  const provenance = governedProvenanceForRun(params);
+  if (provenance.isErr()) {
+    return provenance;
+  }
+  return Result.ok({
+    completionReport: params.completionReport,
+    completionReportHash: regradeSourceHash(params.completionReport),
+    lockHashAtRun: params.lockHashAtRun,
+    plan: params.artifact,
+    planContentHash: params.planContentHash,
+    ...(provenance.value === undefined ? {} : { provenance: provenance.value }),
+    report: params.report,
+  });
+};
+
+const historySummaryFor = (
+  artifact: Pick<RegradeHistoryArtifact, 'id' | 'path' | 'schemaVersion'>,
+  status: RegradeHistorySummary['status'],
+  provenance?: GovernedVocabularyHistoryProvenance
+): RegradeHistorySummary => ({
+  id: artifact.id,
+  path: artifact.path,
+  ...(provenance === undefined ? {} : { provenance }),
+  schemaVersion: artifact.schemaVersion,
+  status,
+});
+
+const writableHistoryArtifact = (artifact: RegradeHistoryArtifact) => ({
+  id: artifact.id,
+  kind: artifact.kind,
+  path: artifact.path,
+  runs: artifact.runs.map((run) => ({
+    completionReport: run[rawCompletionReport] ?? run.completionReport,
+    completionReportHash: run.completionReportHash,
+    lockHashAtRun: run.lockHashAtRun,
+    plan: run.plan,
+    planContentHash: run.planContentHash,
+    ...(run.provenance === undefined ? {} : { provenance: run.provenance }),
+    report: run[rawReport] ?? run.report,
+  })),
+  schemaVersion: artifact.schemaVersion,
+});
+
+const nextHistoryArtifact = (params: {
+  readonly entry: RegradeHistoryRun;
+  readonly lockHashAtRun: string;
+  readonly path: string;
+  readonly plan: RegradePlanArtifact;
+  readonly planContentHash: string;
+  readonly prior: RegradeHistoryArtifact | undefined;
+}): RegradeHistoryArtifact => ({
+  id:
+    params.prior?.id ??
+    params.plan.transitionId ??
+    mintTransitionId(
+      regradePlanSlugForBody(params.plan.plan),
+      params.planContentHash,
+      params.lockHashAtRun
+    ),
+  kind: 'regrade-history',
+  path: params.path,
+  runs:
+    params.prior === undefined
+      ? [params.entry]
+      : [...params.prior.runs, params.entry],
+  schemaVersion: REGRADE_HISTORY_SCHEMA_VERSION,
+});
 
 /**
  * Append one applied run to the transition's consolidated history file. A
@@ -267,14 +499,16 @@ export const appendRegradeHistoryRun = (params: {
   const lockHashAtRun = regradeSourceHash(params.report);
   const currentSourceHashes = regradeSourceHashes(params.report);
   const completionReport = params.completedReport ?? params.report;
-  const entry: RegradeHistoryRun = {
+  const entry = historyEntryFor({
+    artifact: params.artifact,
     completionReport,
-    completionReportHash: regradeSourceHash(completionReport),
     lockHashAtRun,
-    plan: params.artifact,
     planContentHash,
     report: params.report,
-  };
+  });
+  if (entry.isErr()) {
+    return entry;
+  }
 
   let prior: RegradeHistoryArtifact | undefined;
   if (existsSync(absolutePath)) {
@@ -334,43 +568,19 @@ export const appendRegradeHistoryRun = (params: {
       (currentSourceHashes.includes(lastRun.lockHashAtRun) ||
         currentSourceHashes.includes(lastRun.completionReportHash))
     ) {
-      return Result.ok({
-        path: relativePath,
-        schemaVersion: REGRADE_HISTORY_SCHEMA_VERSION,
-        status: 'replay',
-      });
+      return Result.ok(historySummaryFor(prior, 'replay', lastRun.provenance));
     }
   }
 
-  const artifact: RegradeHistoryArtifact = {
-    id:
-      prior === undefined
-        ? (params.artifact.transitionId ??
-          mintTransitionId(
-            regradePlanSlugForBody(params.artifact.plan),
-            planContentHash,
-            lockHashAtRun
-          ))
-        : prior.id,
-    kind: 'regrade-history',
+  const artifact = nextHistoryArtifact({
+    entry: entry.value,
+    lockHashAtRun,
     path: relativePath,
-    runs: prior === undefined ? [entry] : [...prior.runs, entry],
-    schemaVersion: REGRADE_HISTORY_SCHEMA_VERSION,
-  };
-  const writableArtifact = {
-    id: artifact.id,
-    kind: artifact.kind,
-    path: artifact.path,
-    runs: artifact.runs.map((run) => ({
-      completionReport: run[rawCompletionReport] ?? run.completionReport,
-      completionReportHash: run.completionReportHash,
-      lockHashAtRun: run.lockHashAtRun,
-      plan: run.plan,
-      planContentHash: run.planContentHash,
-      report: run[rawReport] ?? run.report,
-    })),
-    schemaVersion: artifact.schemaVersion,
-  };
+    plan: params.artifact,
+    planContentHash,
+    prior,
+  });
+  const writableArtifact = writableHistoryArtifact(artifact);
   const parsed = regradeHistoryArtifactSchema.safeParse(writableArtifact);
   if (!parsed.success) {
     return Result.err(
@@ -393,11 +603,9 @@ export const appendRegradeHistoryRun = (params: {
       })
     );
   }
-  return Result.ok({
-    path: relativePath,
-    schemaVersion: REGRADE_HISTORY_SCHEMA_VERSION,
-    status: 'applied',
-  });
+  return Result.ok(
+    historySummaryFor(artifact, 'applied', entry.value.provenance)
+  );
 };
 
 const hasPathSeparator = (value: string): boolean =>

--- a/apps/trails/src/regrade/plan-artifact.ts
+++ b/apps/trails/src/regrade/plan-artifact.ts
@@ -368,7 +368,10 @@ export const canonicalJsonStringify = (value: unknown): string =>
 export const isGeneratedRegradeArtifactPath = (path: string): boolean =>
   /(?:^|\/)\.trails\/regrade\/.+\.json$/u.test(path);
 
-const sourceHashLedgerFacts = (report: RegradeReport): unknown => {
+const sourceHashLedgerFacts = (
+  report: RegradeReport,
+  policyMode: 'current' | 'legacy'
+): unknown => {
   const ledger = report.run?.ledger;
   if (ledger === undefined) {
     return undefined;
@@ -377,7 +380,8 @@ const sourceHashLedgerFacts = (report: RegradeReport): unknown => {
   const occurrences = ledger.occurrences.filter(
     (occurrence) =>
       occurrence.scopeTier !== 'policy-classified' ||
-      !isGeneratedRegradeArtifactPath(occurrence.path)
+      (policyMode === 'current' &&
+        !isGeneratedRegradeArtifactPath(occurrence.path))
   );
   const forms = new Set(occurrences.map((occurrence) => occurrence.form));
   return {
@@ -389,20 +393,23 @@ const sourceHashLedgerFacts = (report: RegradeReport): unknown => {
   };
 };
 
-const regradeSourceHashFacts = (report: RegradeReport): unknown => ({
+const regradeSourceHashFacts = (
+  report: RegradeReport,
+  policyMode: 'current' | 'legacy' = 'current',
+  fileEvidenceMode: 'current' | 'legacy' = 'current'
+): unknown => ({
   entries: sourceHashEntryFacts(report.entries),
   fileRenames: report.run?.report.fileRenames?.map(
     ({ deferred, from, historical, preserved, rewritten, skipped, to }) => ({
       deferred,
       from,
-      historical,
-      preserved,
+      ...(fileEvidenceMode === 'current' ? { historical, preserved } : {}),
       rewritten,
-      skipped,
+      ...(fileEvidenceMode === 'current' ? { skipped } : {}),
       to,
     })
   ),
-  ledger: sourceHashLedgerFacts(report),
+  ledger: sourceHashLedgerFacts(report, policyMode),
   selectedClassIds: report.selectedClassIds,
 });
 
@@ -414,22 +421,39 @@ export const regradeSourceHash = (report: RegradeReport): string =>
     canonicalJsonStringify(regradeSourceHashFacts(report))
   );
 
+/** Match only the complete current source-evidence shape used by active plans. */
+export const currentRegradeSourceHashMatches = (
+  stampedHash: string,
+  report: RegradeReport
+): boolean => stampedHash === regradeSourceHash(report);
+
 export const legacyRegradeSourceHash = (report: RegradeReport): string =>
   hashSerializedSourceFacts(JSON.stringify(regradeSourceHashFacts(report)));
 
-/** Match source evidence written before canonical JSON hashing. */
+export const regradeSourceHashes = (
+  report: RegradeReport
+): readonly string[] => {
+  const facts = [
+    regradeSourceHashFacts(report),
+    regradeSourceHashFacts(report, 'current', 'legacy'),
+    regradeSourceHashFacts(report, 'legacy'),
+    regradeSourceHashFacts(report, 'legacy', 'legacy'),
+  ];
+  return [
+    ...new Set(
+      facts.flatMap((value) => [
+        hashSerializedSourceFacts(canonicalJsonStringify(value)),
+        hashSerializedSourceFacts(JSON.stringify(value)),
+      ])
+    ),
+  ];
+};
+
+/** Match source evidence written by any supported historical hash shape. */
 export const regradeSourceHashMatches = (
   stampedHash: string,
   report: RegradeReport
-): boolean =>
-  stampedHash === regradeSourceHash(report) ||
-  stampedHash === legacyRegradeSourceHash(report);
-
-export const regradeSourceHashes = (
-  report: RegradeReport
-): readonly string[] => [
-  ...new Set([regradeSourceHash(report), legacyRegradeSourceHash(report)]),
-];
+): boolean => regradeSourceHashes(report).includes(stampedHash);
 
 /**
  * Canonical content hash of a resolved Regrade plan body — the authored

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -60,6 +60,7 @@ import {
   readRegradeHistoryArtifact,
   regradeHistoryPathForPlan,
   resolveRegradeHistoryPath,
+  validateGovernedRegradePlan,
   verifyRegradeHistoryRuns,
 } from '../regrade/history.js';
 import type { RegradeHistorySummary } from '../regrade/history.js';
@@ -72,11 +73,11 @@ import {
 import {
   REGRADE_PLAN_SCHEMA_VERSION,
   canonicalJsonStringify,
+  currentRegradeSourceHashMatches,
   isGeneratedRegradeArtifactPath,
   regradePlanArtifactSchema,
   regradePlanPathForPlan,
   regradeSourceHash,
-  regradeSourceHashMatches,
   rootRelativePath,
 } from '../regrade/plan-artifact.js';
 import type {
@@ -1416,7 +1417,11 @@ const reportWithHistorySummary = (
 ): RegradeReport => ({
   ...report,
   history: {
+    id: params.id,
     path: params.path,
+    ...(params.provenance === undefined
+      ? {}
+      : { provenance: params.provenance }),
     schemaVersion: params.schemaVersion,
     status: params.status,
   },
@@ -1750,7 +1755,7 @@ const planStatusForReport = (
   report: RegradeReport,
   rootDir: string
 ): 'active' | 'stale' => {
-  if (!regradeSourceHashMatches(artifact.sourceHash, report)) {
+  if (!currentRegradeSourceHashMatches(artifact.sourceHash, report)) {
     return 'stale';
   }
   if (artifact.plan.kind === 'class' || artifact.derivation === undefined) {
@@ -3241,6 +3246,12 @@ const runApplyRegradePlan = async (
   const loaded = await loadPlanForInput(input, rootDir);
   if (loaded.isErr()) {
     return loaded;
+  }
+  const governedPlanValidation = validateGovernedRegradePlan(
+    loaded.value.artifact
+  );
+  if (governedPlanValidation.isErr()) {
+    return governedPlanValidation;
   }
   const dryRunReport = await runPlanArtifactDryRun({
     artifact: loaded.value.artifact,

--- a/docs/releases/v1-vocabulary-transition-workflow.md
+++ b/docs/releases/v1-vocabulary-transition-workflow.md
@@ -97,6 +97,8 @@ bun apps/trails/bin/trails.ts regrade apply \
 
 Regrade is the primary migration engine. Apply consumes an active plan artifact and appends the evidence as a run entry in the transition's consolidated history file at `.trails/regrade/history/<slug>.json`. Manual edits are reviewed follow-up after Regrade exhausts the safe slice, not a substitute for running the transition.
 
+For a registry-governed transition, apply also stamps the history run and the CLI/MCP result with governed provenance: transition identity, plan and source hashes, safely applied count, and remaining review count. Warden loads that committed evidence once per project run. A completed transition that requires Regrade provenance cannot be satisfied by an equivalent hand migration with no history entry.
+
 Use `trails regrade check --root-dir . --plan "$PLAN_PATH"` when a family should prove the saved plan gate without writing. The check succeeds only when the plan is fresh and its completion gate is green. Use `trails regrade plans --root-dir .` when more than one active plan may exist, because commands without `--plan <path-or-name>` intentionally fail on ambiguity.
 
 Safe follow-up edits usually include:

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -6,6 +6,7 @@ import {
 } from '@ontrails/core';
 import type { ScanTargets } from '@ontrails/core';
 import type {
+  GovernedVocabularyHistoryProvenance,
   WardenDiagnostic,
   WardenFixEdit,
   WardenGuidance,
@@ -13,6 +14,7 @@ import type {
 } from '@ontrails/warden';
 import {
   getWardenRuleMetadata,
+  governedVocabularyHistoryProvenanceSchema,
   isWardenSourceScanTarget,
   loadProjectWardenRules,
   wardenRules,
@@ -756,7 +758,9 @@ export interface RegradeReport {
   };
   /** Saved applied Regrade history evidence for vocabulary regrades. */
   readonly history?: {
+    readonly id?: string;
     readonly path: string;
+    readonly provenance?: GovernedVocabularyHistoryProvenance;
     readonly schemaVersion: number;
     readonly status: 'applied' | 'checked' | 'replay';
   };
@@ -1464,7 +1468,14 @@ export const regradeReportOutput = z.object({
     ),
   history: z
     .object({
+      id: z
+        .string()
+        .optional()
+        .describe('Stable consolidated Regrade history identity'),
       path: z.string().describe('Root-relative applied history entry path'),
+      provenance: governedVocabularyHistoryProvenanceSchema
+        .optional()
+        .describe('Governed transition evidence attached to the applied run'),
       schemaVersion: z.number().describe('Regrade history schema version'),
       status: z
         .enum(['applied', 'checked', 'replay'])

--- a/packages/warden/src/__tests__/cli.test.ts
+++ b/packages/warden/src/__tests__/cli.test.ts
@@ -883,6 +883,78 @@ export const second = entity('second', {
 });
 
 describe('runWarden project context', () => {
+  test('keeps governed residue detection in source-only runs', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFileSync(join(dir, 'residue.ts'), 'export const facet = true;\n');
+
+      const report = await runWarden({ depth: 'source', rootDir: dir });
+
+      expect(report.diagnostics).toContainEqual(
+        expect.objectContaining({
+          filePath: join(dir, 'residue.ts'),
+          rule: 'governed-symbol-residue',
+        })
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('skips governed history validation in source-only runs', async () => {
+    const dir = makeTempDir();
+    try {
+      const historyDirectory = join(dir, '.trails', 'regrade', 'history');
+      mkdirSync(historyDirectory, { recursive: true });
+      writeFileSync(join(historyDirectory, 'invalid.json'), '{not-json}\n');
+      writeFileSync(join(dir, 'index.ts'), 'export const clean = true;\n');
+
+      const reports = await Promise.all([
+        runWarden({ depth: 'source', rootDir: dir }),
+        runWarden({ rootDir: dir, tier: 'source-static' }),
+      ]);
+
+      for (const report of reports) {
+        expect(report.diagnostics).not.toContainEqual(
+          expect.objectContaining({
+            filePath: '.trails/regrade/history/invalid.json',
+            rule: 'governed-symbol-residue',
+          })
+        );
+      }
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('runs governed history validation once for project-capable selectors', async () => {
+    const dir = makeTempDir();
+    try {
+      const historyDirectory = join(dir, '.trails', 'regrade', 'history');
+      mkdirSync(historyDirectory, { recursive: true });
+      writeFileSync(join(historyDirectory, 'invalid.json'), '{not-json}\n');
+      writeFileSync(join(dir, 'index.ts'), 'export const clean = true;\n');
+
+      const reports = await Promise.all([
+        runWarden({ rootDir: dir }),
+        runWarden({ rootDir: dir, tier: 'project-static' }),
+      ]);
+      for (const report of reports) {
+        const diagnostics = report.diagnostics.filter(
+          (diagnostic) => diagnostic.rule === 'governed-symbol-residue'
+        );
+        expect(diagnostics).toEqual([
+          expect.objectContaining({
+            filePath: '.trails/regrade/history/invalid.json',
+            message: 'Committed Regrade history is not valid JSON.',
+          }),
+        ]);
+      }
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('reports throw inside detour recover functions', async () => {
     const dir = makeTempDir();
     try {

--- a/packages/warden/src/__tests__/governed-symbol-residue.test.ts
+++ b/packages/warden/src/__tests__/governed-symbol-residue.test.ts
@@ -1,11 +1,73 @@
 import { describe, expect, test } from 'bun:test';
 
 import { governedSymbolResidue } from '../rules/governed-symbol-residue.js';
+import type { ProjectContext } from '../rules/types.js';
 
 const check = (sourceCode: string) =>
   governedSymbolResidue.check(sourceCode, '/repo/src/example.ts');
 
+const projectContext = (
+  overrides: Partial<ProjectContext> = {}
+): ProjectContext => ({
+  knownTrailIds: new Set(),
+  ...overrides,
+});
+
 describe('governed-symbol-residue', () => {
+  test('cites committed history when a governed symbol is reintroduced', () => {
+    const diagnostics = governedSymbolResidue.checkWithContext(
+      'const contourId = "invoice";\n',
+      '/repo/src/example.ts',
+      projectContext({
+        governedVocabularyHistoryByTransitionId: new Map([
+          [
+            'v1-contour-entity',
+            {
+              id: 'history-id',
+              path: '.trails/regrade/history/contour-to-entity.json',
+              runCount: 2,
+              transitionId: 'v1-contour-entity',
+            },
+          ],
+        ]),
+      })
+    );
+
+    expect(diagnostics[0]?.message).toContain(
+      "governed transition 'v1-contour-entity'"
+    );
+    expect(diagnostics[0]?.message).toContain(
+      '.trails/regrade/history/contour-to-entity.json'
+    );
+    expect(diagnostics[0]?.message).toContain('history-id');
+  });
+
+  test('fails invalid committed provenance once at the project boundary', () => {
+    const diagnostics = governedSymbolResidue.checkProject?.(
+      projectContext({
+        governedVocabularyHistoryIssues: [
+          {
+            message:
+              'Committed Regrade history lacks required governed provenance.',
+            path: '.trails/regrade/history/projection-to-derive.json',
+            transitionId: 'v1-projection-derive-render',
+          },
+        ],
+      })
+    );
+
+    expect(diagnostics).toEqual([
+      {
+        filePath: '.trails/regrade/history/projection-to-derive.json',
+        line: 1,
+        message:
+          'Committed Regrade history lacks required governed provenance.',
+        rule: 'governed-symbol-residue',
+        severity: 'error',
+      },
+    ]);
+  });
+
   test('does not duplicate cross-compose fixes owned by the beta.19 rule', () => {
     const diagnostics = check(
       [

--- a/packages/warden/src/__tests__/guide.test.ts
+++ b/packages/warden/src/__tests__/guide.test.ts
@@ -44,6 +44,23 @@ describe('warden guide manifest', () => {
     expect(markdown).toContain('- Docs: [Trail Rules](AGENTS.md#trail-rules)');
   });
 
+  test('projects Regrade-first governed transition guidance', () => {
+    const rule = buildWardenGuideManifest().rules.find(
+      (candidate) => candidate.id === 'governed-symbol-residue'
+    );
+
+    expect(rule).toMatchObject({
+      guidance: {
+        summary:
+          'Require committed Regrade evidence before completing a governed vocabulary migration.',
+      },
+      tier: 'source-static',
+    });
+    expect(rule?.guidance?.steps).toContain(
+      'Use manual edits only for review or cleanup after Regrade exhausts the safe slice.'
+    );
+  });
+
   test('agent-json rendering is stable and parseable', () => {
     const manifest = buildWardenGuideManifest();
     const agentGuide = buildWardenAgentGuide(manifest);

--- a/packages/warden/src/__tests__/regrade-history.test.ts
+++ b/packages/warden/src/__tests__/regrade-history.test.ts
@@ -1,0 +1,559 @@
+import { describe, expect, test } from 'bun:test';
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { loadGovernedVocabularyHistory } from '../regrade-history.js';
+
+const canonicalize = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (typeof value === 'object' && value !== null) {
+    return Object.fromEntries(
+      Object.entries(value)
+        .toSorted(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalize(entry)])
+    );
+  }
+  return value;
+};
+
+const hash = (value: unknown): string =>
+  createHash('sha256')
+    .update(JSON.stringify(canonicalize(value)))
+    .digest('hex');
+
+const rawHash = (value: unknown): string =>
+  createHash('sha256').update(JSON.stringify(value)).digest('hex');
+
+const plan = {
+  from: 'projection',
+  id: 'v1-projection-derive-render',
+  kind: 'vocabulary',
+  to: 'derive',
+} as const;
+
+const report = {
+  entries: [1, 2, 3].map((index) => ({
+    outcome: 'rewrite',
+    path: `src/example-${index}.ts`,
+  })),
+  matched: 3,
+  review: 0,
+  rewritten: 3,
+  root: '.',
+  scan: {
+    byDirectory: [],
+    byExtension: [],
+    files: { matched: 3, scanned: 3, skipped: 0 },
+    skippedByReason: {},
+  },
+  scanned: 3,
+  selectedClassIds: [],
+  skipped: 0,
+  skipsByReason: {},
+  unknownClassIds: [],
+};
+
+const completionReport = {
+  entries: [],
+  matched: 0,
+  review: 0,
+  rewritten: 0,
+  root: '.',
+  scan: {
+    byDirectory: [],
+    byExtension: [],
+    files: { matched: 0, scanned: 0, skipped: 0 },
+    skippedByReason: {},
+  },
+  scanned: 0,
+  selectedClassIds: [],
+  skipped: 0,
+  skipsByReason: {},
+  unknownClassIds: [],
+};
+
+const withNumericFileRenameEvidence = (
+  value: typeof report | typeof completionReport
+) => ({
+  ...value,
+  run: {
+    ledger: { cycle: 1, forms: {}, occurrences: [] },
+    report: {
+      fileRenames: [
+        {
+          deferred: 0,
+          from: 'src/projection.ts',
+          historical: 2,
+          preserved: 1,
+          rewritten: 1,
+          skipped: 1,
+          to: 'src/derivation.ts',
+        },
+      ],
+    },
+  },
+});
+
+const numericEvidenceSourceHash = (
+  value: ReturnType<typeof withNumericFileRenameEvidence>
+): string =>
+  hash({
+    entries: value.entries,
+    fileRenames: value.run.report.fileRenames,
+    ledger: value.run.ledger,
+    selectedClassIds: value.selectedClassIds,
+  });
+
+const legacyNumericEvidenceSourceHash = (
+  value: ReturnType<typeof withNumericFileRenameEvidence>
+): string =>
+  hash({
+    entries: value.entries,
+    fileRenames: value.run.report.fileRenames.map(
+      ({ deferred, from, rewritten, to }) => ({
+        deferred,
+        from,
+        rewritten,
+        to,
+      })
+    ),
+    ledger: value.run.ledger,
+    selectedClassIds: value.selectedClassIds,
+  });
+
+const policyOccurrence = {
+  disposition: 'historical-by-policy',
+  form: 'projection',
+  line: 1,
+  path: 'docs/adr/0050.md',
+  reason: 'Published decisions remain immutable.',
+  scopeTier: 'policy-classified',
+  verdict: 'skipped',
+} as const;
+
+const unrelatedNestedJsonPolicyOccurrence = {
+  ...policyOccurrence,
+  path: 'examples/app/evidence/policy.json',
+} as const;
+
+const withPolicyEvidence = (
+  value: typeof report | typeof completionReport
+) => ({
+  ...value,
+  run: {
+    ledger: {
+      cycle: 1,
+      forms: { projection: 'skipped' },
+      occurrences: [
+        policyOccurrence,
+        {
+          ...policyOccurrence,
+          path: '.trails/regrade/projection-to-derive.json',
+        },
+        {
+          ...policyOccurrence,
+          path: 'examples/app/.trails/regrade/projection-to-derive.json',
+        },
+        unrelatedNestedJsonPolicyOccurrence,
+      ],
+    },
+    report: {},
+  },
+});
+
+const policyEvidenceSourceHash = (
+  value: ReturnType<typeof withPolicyEvidence>
+): string =>
+  hash({
+    entries: value.entries,
+    fileRenames: undefined,
+    ledger: {
+      cycle: value.run.ledger.cycle,
+      forms: value.run.ledger.forms,
+      occurrences: [policyOccurrence, unrelatedNestedJsonPolicyOccurrence],
+    },
+    selectedClassIds: value.selectedClassIds,
+  });
+
+const rawPolicyEvidenceSourceHash = (
+  value: ReturnType<typeof withPolicyEvidence>
+): string =>
+  rawHash({
+    entries: value.entries,
+    fileRenames: undefined,
+    ledger: {
+      cycle: value.run.ledger.cycle,
+      forms: value.run.ledger.forms,
+      occurrences: [policyOccurrence, unrelatedNestedJsonPolicyOccurrence],
+    },
+    selectedClassIds: value.selectedClassIds,
+  });
+
+const legacyPolicyEvidenceSourceHash = (
+  value: ReturnType<typeof withPolicyEvidence>
+): string =>
+  hash({
+    entries: value.entries,
+    fileRenames: undefined,
+    ledger: {
+      cycle: value.run.ledger.cycle,
+      forms: {},
+      occurrences: [],
+    },
+    selectedClassIds: value.selectedClassIds,
+  });
+
+const sourceHash = (value: typeof report | typeof completionReport): string =>
+  hash({
+    entries: value.entries,
+    fileRenames: undefined,
+    ledger: undefined,
+    selectedClassIds: value.selectedClassIds,
+  });
+
+const withHistory = (
+  run: Record<string, unknown> | readonly Record<string, unknown>[],
+  exercise: (rootDir: string) => void,
+  overrides: Record<string, unknown> = {}
+): void => {
+  const rootDir = mkdtempSync(join(tmpdir(), 'warden-regrade-history-'));
+  const directory = join(rootDir, '.trails', 'regrade', 'history');
+  mkdirSync(directory, { recursive: true });
+  writeFileSync(
+    join(directory, 'projection-to-derive.json'),
+    `${JSON.stringify(
+      {
+        id: 'history-id',
+        kind: 'regrade-history',
+        path: '.trails/regrade/history/projection-to-derive.json',
+        runs: Array.isArray(run) ? run : [run],
+        schemaVersion: 2,
+        ...overrides,
+      },
+      null,
+      2
+    )}\n`
+  );
+  try {
+    exercise(rootDir);
+  } finally {
+    rmSync(rootDir, { force: true, recursive: true });
+  }
+};
+
+const run = (provenance = true): Record<string, unknown> => ({
+  completionReport,
+  completionReportHash: sourceHash(completionReport),
+  lockHashAtRun: sourceHash(report),
+  plan: {
+    kind: 'regrade-plan',
+    path: '.trails/regrade/projection-to-derive.json',
+    plan,
+    provenance: { fields: {} },
+    schemaVersion: 1,
+    sourceHash: sourceHash(report),
+    transitionId: 'v1-projection-derive-render',
+  },
+  planContentHash: hash(plan),
+  ...(provenance
+    ? {
+        provenance: {
+          disposition: 'applied-clean',
+          kind: 'governed-vocabulary',
+          planContentHash: hash(plan),
+          reviewPending: 0,
+          safeApplied: 3,
+          sourceHashAfter: sourceHash(completionReport),
+          sourceHashBefore: sourceHash(report),
+          transitionId: 'v1-projection-derive-render',
+        },
+      }
+    : {}),
+  report,
+});
+
+const runWithNumericFileRenameEvidence = (
+  sourceHashFor = numericEvidenceSourceHash
+): Record<string, unknown> => {
+  const before = withNumericFileRenameEvidence(report);
+  const after = withNumericFileRenameEvidence(completionReport);
+  return {
+    ...run(),
+    completionReport: after,
+    completionReportHash: sourceHashFor(after),
+    lockHashAtRun: sourceHashFor(before),
+    provenance: {
+      disposition: 'applied-clean',
+      kind: 'governed-vocabulary',
+      planContentHash: hash(plan),
+      reviewPending: 0,
+      safeApplied: 3,
+      sourceHashAfter: sourceHashFor(after),
+      sourceHashBefore: sourceHashFor(before),
+      transitionId: 'v1-projection-derive-render',
+    },
+    report: before,
+  };
+};
+
+const runWithPolicyEvidence = (
+  sourceHashFor = policyEvidenceSourceHash
+): Record<string, unknown> => {
+  const before = withPolicyEvidence(report);
+  const after = withPolicyEvidence(completionReport);
+  return {
+    ...run(),
+    completionReport: after,
+    completionReportHash: sourceHashFor(after),
+    lockHashAtRun: sourceHashFor(before),
+    provenance: {
+      disposition: 'applied-clean',
+      kind: 'governed-vocabulary',
+      planContentHash: hash(plan),
+      reviewPending: 0,
+      safeApplied: 3,
+      sourceHashAfter: sourceHashFor(after),
+      sourceHashBefore: sourceHashFor(before),
+      transitionId: 'v1-projection-derive-render',
+    },
+    report: before,
+  };
+};
+
+describe('loadGovernedVocabularyHistory', () => {
+  test('indexes validated committed provenance once per transition', () => {
+    withHistory(run(), (rootDir) => {
+      const index = loadGovernedVocabularyHistory(rootDir);
+
+      expect(index.issues).toEqual([]);
+      expect(
+        index.byTransitionId.get('v1-projection-derive-render')
+      ).toMatchObject({
+        id: 'history-id',
+        path: '.trails/regrade/history/projection-to-derive.json',
+        runCount: 1,
+        transitionId: 'v1-projection-derive-render',
+      });
+    });
+  });
+
+  test('indexes id-less governed plans from stamped provenance', () => {
+    const idlessRun = run();
+    const artifact = idlessRun.plan as {
+      plan: Record<string, unknown>;
+    };
+    const idlessPlan = {
+      from: plan.from,
+      kind: plan.kind,
+      to: plan.to,
+    };
+    artifact.plan = idlessPlan;
+    idlessRun.planContentHash = hash(idlessPlan);
+    const provenance = idlessRun.provenance as Record<string, unknown>;
+    provenance.planContentHash = hash(idlessPlan);
+
+    withHistory(idlessRun, (rootDir) => {
+      const index = loadGovernedVocabularyHistory(rootDir);
+
+      expect(index.issues).toEqual([]);
+      expect(
+        index.byTransitionId.get('v1-projection-derive-render')
+      ).toMatchObject({
+        id: 'history-id',
+        transitionId: 'v1-projection-derive-render',
+      });
+    });
+  });
+
+  test('indexes custom-id governed plans from stamped provenance', () => {
+    const customRun = run();
+    const artifact = customRun.plan as {
+      plan: Record<string, unknown>;
+    };
+    const customPlan = { ...plan, id: 'local-plan' };
+    artifact.plan = customPlan;
+    customRun.planContentHash = hash(customPlan);
+    const provenance = customRun.provenance as Record<string, unknown>;
+    provenance.planContentHash = hash(customPlan);
+
+    withHistory(customRun, (rootDir) => {
+      const index = loadGovernedVocabularyHistory(rootDir);
+
+      expect(index.issues).toEqual([]);
+      expect(
+        index.byTransitionId.get('v1-projection-derive-render')
+      ).toMatchObject({
+        id: 'history-id',
+        transitionId: 'v1-projection-derive-render',
+      });
+    });
+  });
+
+  test('accepts authoritative numeric file-rename evidence', () => {
+    withHistory(runWithNumericFileRenameEvidence(), (rootDir) => {
+      const index = loadGovernedVocabularyHistory(rootDir);
+
+      expect(index.issues).toEqual([]);
+      expect(
+        index.byTransitionId.get('v1-projection-derive-render')
+      ).toBeDefined();
+    });
+  });
+
+  test('accepts immutable histories stamped before complete file evidence hashing', () => {
+    withHistory(
+      runWithNumericFileRenameEvidence(legacyNumericEvidenceSourceHash),
+      (rootDir) => {
+        const index = loadGovernedVocabularyHistory(rootDir);
+
+        expect(index.issues).toEqual([]);
+        expect(
+          index.byTransitionId.get('v1-projection-derive-render')
+        ).toBeDefined();
+      }
+    );
+  });
+
+  test('accepts external policy evidence while excluding generated Regrade artifacts', () => {
+    withHistory(runWithPolicyEvidence(), (rootDir) => {
+      const index = loadGovernedVocabularyHistory(rootDir);
+
+      expect(index.issues).toEqual([]);
+      expect(
+        index.byTransitionId.get('v1-projection-derive-render')
+      ).toBeDefined();
+    });
+  });
+
+  test('accepts immutable histories stamped before policy evidence hashing', () => {
+    withHistory(
+      runWithPolicyEvidence(legacyPolicyEvidenceSourceHash),
+      (rootDir) => {
+        const index = loadGovernedVocabularyHistory(rootDir);
+
+        expect(index.issues).toEqual([]);
+        expect(
+          index.byTransitionId.get('v1-projection-derive-render')
+        ).toBeDefined();
+      }
+    );
+  });
+
+  test('accepts raw legacy hashes before passthrough occurrences are parsed', () => {
+    withHistory(
+      runWithPolicyEvidence(rawPolicyEvidenceSourceHash),
+      (rootDir) => {
+        const index = loadGovernedVocabularyHistory(rootDir);
+
+        expect(index.issues).toEqual([]);
+        expect(
+          index.byTransitionId.get('v1-projection-derive-render')
+        ).toBeDefined();
+      }
+    );
+  });
+
+  test('rejects required histories without governed provenance', () => {
+    withHistory(run(false), (rootDir) => {
+      const index = loadGovernedVocabularyHistory(rootDir);
+
+      expect(index.byTransitionId.size).toBe(0);
+      expect(index.issues).toEqual([
+        {
+          message:
+            'Committed Regrade history lacks required governed provenance.',
+          path: '.trails/regrade/history/projection-to-derive.json',
+          transitionId: 'v1-projection-derive-render',
+        },
+      ]);
+    });
+  });
+
+  test('rejects required histories when any recorded run lacks provenance', () => {
+    withHistory([run(false), run()], (rootDir) => {
+      const index = loadGovernedVocabularyHistory(rootDir);
+
+      expect(index.byTransitionId.size).toBe(0);
+      expect(index.issues[0]?.message).toBe(
+        'Committed Regrade history lacks required governed provenance.'
+      );
+    });
+  });
+
+  test('rejects provenance whose deterministic counts were hand-authored', () => {
+    const tampered = run();
+    const provenance = tampered.provenance as Record<string, unknown>;
+    provenance.safeApplied = 99;
+
+    withHistory(tampered, (rootDir) => {
+      const index = loadGovernedVocabularyHistory(rootDir);
+
+      expect(index.byTransitionId.size).toBe(0);
+      expect(index.issues[0]?.message).toBe(
+        'Committed Regrade history has invalid deterministic run evidence.'
+      );
+    });
+  });
+
+  test('rejects source and plan stamps that do not match recorded evidence', () => {
+    const tampered = run();
+    tampered.planContentHash = 'a'.repeat(64);
+
+    withHistory(tampered, (rootDir) => {
+      const index = loadGovernedVocabularyHistory(rootDir);
+
+      expect(index.byTransitionId.size).toBe(0);
+      expect(index.issues[0]?.message).toBe(
+        'Committed Regrade history has invalid deterministic run evidence.'
+      );
+    });
+  });
+
+  test('rejects history artifacts without the authoritative schema version', () => {
+    withHistory(
+      run(),
+      (rootDir) => {
+        const index = loadGovernedVocabularyHistory(rootDir);
+
+        expect(index.byTransitionId.size).toBe(0);
+        expect(index.issues[0]?.message).toBe(
+          'Committed Regrade history has an invalid evidence shape.'
+        );
+      },
+      { schemaVersion: undefined }
+    );
+  });
+
+  test('rejects partial plan artifacts that Regrade cannot read', () => {
+    const partial = run();
+    partial.plan = { plan };
+
+    withHistory(partial, (rootDir) => {
+      const index = loadGovernedVocabularyHistory(rootDir);
+
+      expect(index.byTransitionId.size).toBe(0);
+      expect(index.issues[0]?.message).toBe(
+        'Committed Regrade history has an invalid evidence shape.'
+      );
+    });
+  });
+
+  test('rejects history whose embedded path differs from the observed file', () => {
+    withHistory(
+      run(),
+      (rootDir) => {
+        const index = loadGovernedVocabularyHistory(rootDir);
+
+        expect(index.byTransitionId.size).toBe(0);
+        expect(index.issues[0]?.message).toBe(
+          'Committed Regrade history path does not match its observed file.'
+        );
+      },
+      { path: '.trails/regrade/history/other.json' }
+    );
+  });
+});

--- a/packages/warden/src/__tests__/retired-vocabulary.test.ts
+++ b/packages/warden/src/__tests__/retired-vocabulary.test.ts
@@ -50,10 +50,12 @@ describe('governed vocabulary registry', () => {
       'v1-projection-derive-render'
     );
     expect(projection?.oldForms).toContain('project');
+    expect(projection?.provenance).toEqual({ mode: 'regrade-history' });
     expect(projection?.target.kind).toBe('classified');
 
     const facet = getGovernedVocabularyTransition('v1-facet-trailhead');
     expect(facet?.status).toBe('complete');
+    expect(facet?.provenance.mode).toBe('legacy');
 
     const implementation = getGovernedVocabularyTransition(
       'v1-blaze-implementation'
@@ -539,5 +541,6 @@ describe('governed vocabulary registry', () => {
     expect(guide).toContain('v1-facet-trailhead: facet -> trailhead');
     expect(guide).toContain('v1-projection-derive-render: projection ->');
     expect(guide).toContain('Status: planned');
+    expect(guide).toContain('Provenance: committed Regrade history required');
   });
 });

--- a/packages/warden/src/cli.ts
+++ b/packages/warden/src/cli.ts
@@ -39,6 +39,7 @@ import type { DriftResult } from './drift.js';
 import { checkDrift, staleDriftMessage } from './drift.js';
 import { loadProjectWardenRules } from './project-rules.js';
 import type { ProjectWardenRules } from './project-rules.js';
+import { loadGovernedVocabularyHistory } from './regrade-history.js';
 import {
   collectProjectDocumentationImportResolutions,
   collectProjectExportedSymbolDefinitions,
@@ -393,6 +394,9 @@ interface MutableProjectContext {
     string,
     readonly WardenExportedSymbolDefinition[]
   >;
+  governedVocabularyHistoryByTransitionId: ProjectContext['governedVocabularyHistoryByTransitionId'];
+  governedVocabularyHistoryIssues: ProjectContext['governedVocabularyHistoryIssues'];
+  governedVocabularyHistoryRequired: ProjectContext['governedVocabularyHistoryRequired'];
   documentedImportResolutionsByFile: Map<
     string,
     readonly WardenImportResolution[]
@@ -414,6 +418,9 @@ const createMutableProjectContext = (): MutableProjectContext => ({
   >(),
   entityReferencesByName: new Map<string, Set<string>>(),
   exportedSymbolDefinitionsByName: new Map(),
+  governedVocabularyHistoryByTransitionId: undefined,
+  governedVocabularyHistoryIssues: undefined,
+  governedVocabularyHistoryRequired: undefined,
   importResolutionsByFile: new Map<string, readonly WardenImportResolution[]>(),
   knownEntityIds: new Set<string>(),
   knownResourceIds: new Set<string>(),
@@ -471,6 +478,24 @@ const toProjectContext = (context: MutableProjectContext): ProjectContext => ({
       }
     : {}),
   composeTargetTrailIds: context.composeTargetTrailIds,
+  ...(context.governedVocabularyHistoryByTransitionId === undefined
+    ? {}
+    : {
+        governedVocabularyHistoryByTransitionId:
+          context.governedVocabularyHistoryByTransitionId,
+      }),
+  ...(context.governedVocabularyHistoryIssues === undefined
+    ? {}
+    : {
+        governedVocabularyHistoryIssues:
+          context.governedVocabularyHistoryIssues,
+      }),
+  ...(context.governedVocabularyHistoryRequired === undefined
+    ? {}
+    : {
+        governedVocabularyHistoryRequired:
+          context.governedVocabularyHistoryRequired,
+      }),
   knownEntityIds: context.knownEntityIds,
   knownResourceIds: context.knownResourceIds,
   knownSignalIds: context.knownSignalIds,
@@ -951,6 +976,10 @@ const buildProjectContext = (
     | undefined = undefined
 ): ProjectContext => {
   const context = createMutableProjectContext();
+  const governedHistory = loadGovernedVocabularyHistory(rootDir);
+  context.governedVocabularyHistoryByTransitionId =
+    governedHistory.byTransitionId;
+  context.governedVocabularyHistoryIssues = governedHistory.issues;
   context.authoredMcpSurfaceBindingSets = authoredMcpSurfaceBindingSets;
   const typeScriptSourceFiles = sourceFiles.filter(
     (sourceFile) => sourceFile.kind === 'typescript'
@@ -961,6 +990,8 @@ const buildProjectContext = (
   context.publicWorkspaces = collectPublicWorkspaces(rootDir, {
     exclude: scope.exclude,
   });
+  context.governedVocabularyHistoryRequired =
+    context.publicWorkspaces.has('@ontrails/warden');
 
   if (appTopos.length > 0) {
     for (const appTopo of appTopos) {
@@ -1095,6 +1126,25 @@ const isSelectedRule = (
     : ruleMatchesDepth(metadata, selector.depth);
 };
 
+const selectorIncludesProjectChecks = (
+  selector: WardenRuleSelector
+): boolean => {
+  if (selector.tier !== undefined) {
+    return selector.tier !== 'source-static';
+  }
+  return (
+    selector.depth === undefined ||
+    depthIncludesTier(selector.depth, 'project-static')
+  );
+};
+
+const isSelectedProjectRule = (
+  rule: WardenRule,
+  selector: WardenRuleSelector
+): boolean =>
+  selectorIncludesProjectChecks(selector) &&
+  (selector.tier === 'project-static' || isSelectedRule(rule, selector));
+
 const isSelectedTopoRule = (
   rule: TopoAwareWardenRule,
   selector: WardenRuleSelector
@@ -1182,6 +1232,15 @@ const lintSourceFiles = (
 ): readonly WardenDiagnostic[] => {
   const diagnostics: WardenDiagnostic[] = [];
   const rules = [...wardenRules.values(), ...extraSourceRules];
+  for (const rule of rules) {
+    if (
+      isSelectedProjectRule(rule, selector) &&
+      isProjectAwareRule(rule) &&
+      rule.checkProject !== undefined
+    ) {
+      diagnostics.push(...rule.checkProject(context));
+    }
+  }
   for (const sourceFile of sourceFiles) {
     for (const rule of rules) {
       if (

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -10,6 +10,8 @@
 // Rule types
 export type {
   BuiltinWardenRuleName,
+  GovernedVocabularyHistoryEvidence,
+  GovernedVocabularyHistoryIssue,
   ProjectAwareWardenRule,
   ProjectContext,
   TopoAwareWardenRule,
@@ -40,7 +42,9 @@ export {
   getGovernedVocabularyTransition,
   governedVocabularyLiteralRenameSchema,
   governedVocabularyFileRenameSchema,
+  governedVocabularyHistoryProvenanceSchema,
   governedVocabularyPreserveRuleSchema,
+  governedVocabularyProvenancePolicySchema,
   governedVocabularyRegistrySchema,
   governedVocabularyScopeSchema,
   governedVocabularySymbolRenameSchema,
@@ -63,7 +67,9 @@ export {
 } from './rules/index.js';
 export type {
   GovernedVocabularyLiteralRename,
+  GovernedVocabularyHistoryProvenance,
   GovernedVocabularyPreserveRule,
+  GovernedVocabularyProvenancePolicy,
   GovernedVocabularyScope,
   GovernedVocabularySymbolRename,
   GovernedVocabularyTarget,

--- a/packages/warden/src/regrade-history.ts
+++ b/packages/warden/src/regrade-history.ts
@@ -1,0 +1,506 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { createHash } from 'node:crypto';
+import { z } from 'zod';
+
+import {
+  getGovernedVocabularyTransition,
+  governedVocabularyHistoryProvenanceSchema,
+  listGovernedVocabularyTransitions,
+} from './rules/retired-vocabulary.js';
+import type {
+  GovernedVocabularyHistoryEvidence,
+  GovernedVocabularyHistoryIssue,
+} from './rules/types.js';
+
+const planBodySchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      from: z.string().min(1),
+      id: z.string().optional(),
+      kind: z.literal('vocabulary'),
+      to: z.string().min(1),
+    })
+    .passthrough(),
+  z
+    .object({
+      classIds: z.array(z.string().min(1)).min(1),
+      id: z.string().min(1),
+      kind: z.literal('class'),
+    })
+    .passthrough(),
+]);
+
+const planArtifactSchema = z
+  .object({
+    derivation: z.unknown().optional(),
+    expansion: z.unknown().optional(),
+    kind: z.literal('regrade-plan'),
+    path: z.string().min(1),
+    plan: planBodySchema,
+    provenance: z.object({
+      fields: z.record(z.string(), z.enum(['authored', 'derived'])),
+    }),
+    schemaVersion: z.literal(1),
+    sourceHash: z.string().min(1),
+    transitionId: z.string().min(1).optional(),
+  })
+  .strict();
+
+const historyRunSchema = z
+  .object({
+    completionReport: z.unknown().optional(),
+    completionReportHash: z.string().optional(),
+    lockHashAtRun: z.string().min(1),
+    plan: planArtifactSchema,
+    planContentHash: z.string().min(1),
+    provenance: governedVocabularyHistoryProvenanceSchema.optional(),
+    report: z.unknown(),
+  })
+  .strict();
+
+const historyArtifactSchema = z
+  .object({
+    id: z.string().min(1),
+    kind: z.literal('regrade-history'),
+    path: z.string().min(1),
+    runs: z.array(historyRunSchema).min(1),
+    schemaVersion: z.literal(2),
+  })
+  .strict();
+
+const reportEntrySchema = z
+  .object({
+    classId: z.string().optional(),
+    notes: z.array(z.string()).optional(),
+    outcome: z.enum(['needs-review', 'no-op', 'rewrite', 'skip']),
+    path: z.string(),
+    reason: z.string().optional(),
+    reviewDetails: z.unknown().optional(),
+  })
+  .passthrough();
+
+const reportSchema = z
+  .object({
+    apply: z.object({ applied: z.number() }).passthrough().optional(),
+    entries: z.array(reportEntrySchema),
+    matched: z.number(),
+    review: z.number(),
+    rewritten: z.number(),
+    root: z.string(),
+    run: z
+      .object({
+        ledger: z
+          .object({
+            cycle: z.unknown(),
+            forms: z.record(z.string(), z.unknown()),
+            occurrences: z.array(
+              z
+                .object({
+                  form: z.string(),
+                  path: z.string(),
+                  scopeTier: z.string().optional(),
+                })
+                .passthrough()
+            ),
+          })
+          .passthrough(),
+        report: z
+          .object({
+            fileRenames: z
+              .array(
+                z
+                  .object({
+                    deferred: z.number(),
+                    from: z.string(),
+                    historical: z.number().optional(),
+                    preserved: z.number().optional(),
+                    rewritten: z.number(),
+                    skipped: z.number().optional(),
+                    to: z.string(),
+                  })
+                  .passthrough()
+              )
+              .optional(),
+          })
+          .passthrough(),
+      })
+      .passthrough()
+      .optional(),
+    scan: z.object({
+      byDirectory: z.array(z.unknown()),
+      byExtension: z.array(z.unknown()),
+      files: z.object({
+        matched: z.number(),
+        scanned: z.number(),
+        skipped: z.number(),
+      }),
+      skippedByReason: z.record(z.string(), z.number()),
+    }),
+    scanned: z.number(),
+    selectedClassIds: z.array(z.string()),
+    skipped: z.number(),
+    skipsByReason: z.record(z.string(), z.number()),
+    unknownClassIds: z.array(z.string()),
+  })
+  .passthrough();
+
+const governedHistoryRunSchema = historyRunSchema.extend({
+  completionReport: reportSchema,
+  completionReportHash: z.string().regex(/^[0-9a-f]{64}$/),
+  lockHashAtRun: z.string().regex(/^[0-9a-f]{64}$/),
+  planContentHash: z.string().regex(/^[0-9a-f]{64}$/),
+  report: reportSchema,
+});
+
+type GovernedHistoryRun = z.infer<typeof governedHistoryRunSchema>;
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const canonicalizeJsonValue = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(canonicalizeJsonValue);
+  }
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .toSorted()
+        .map((key) => [key, canonicalizeJsonValue(value[key])])
+    );
+  }
+  return value;
+};
+
+const hash = (value: string): string =>
+  createHash('sha256').update(value).digest('hex');
+
+const isGeneratedRegradeArtifact = (path: string): boolean =>
+  /(?:^|\/)\.trails\/regrade\/.+\.json$/u.test(path);
+
+const sourceHashFacts = (
+  report: z.infer<typeof reportSchema>,
+  policyMode: 'current' | 'legacy' = 'current',
+  fileEvidenceMode: 'current' | 'legacy' = 'current'
+): unknown => {
+  const ledger = report.run?.ledger;
+  const occurrences = ledger?.occurrences.filter(
+    (occurrence) =>
+      occurrence.scopeTier !== 'policy-classified' ||
+      (policyMode === 'current' && !isGeneratedRegradeArtifact(occurrence.path))
+  );
+  const forms = new Set(occurrences?.map((occurrence) => occurrence.form));
+  return {
+    entries: report.entries
+      .filter(
+        (entry) =>
+          entry.outcome === 'rewrite' || entry.outcome === 'needs-review'
+      )
+      .map(({ classId, notes, outcome, path, reason, reviewDetails }) => ({
+        ...(classId === undefined ? {} : { classId }),
+        ...(notes === undefined ? {} : { notes }),
+        outcome,
+        path,
+        ...(reason === undefined ? {} : { reason }),
+        ...(reviewDetails === undefined ? {} : { reviewDetails }),
+      })),
+    fileRenames: report.run?.report.fileRenames?.map((rename) => ({
+      deferred: rename.deferred,
+      from: rename.from,
+      ...(fileEvidenceMode === 'current'
+        ? {
+            historical: rename.historical ?? 0,
+            preserved: rename.preserved ?? 0,
+          }
+        : {}),
+      rewritten: rename.rewritten,
+      ...(fileEvidenceMode === 'current'
+        ? { skipped: rename.skipped ?? 0 }
+        : {}),
+      to: rename.to,
+    })),
+    ledger:
+      ledger === undefined || occurrences === undefined || forms === undefined
+        ? undefined
+        : {
+            cycle: ledger.cycle,
+            forms: Object.fromEntries(
+              Object.entries(ledger.forms).filter(([form]) => forms.has(form))
+            ),
+            occurrences,
+          },
+    selectedClassIds: report.selectedClassIds,
+  };
+};
+
+const sourceHashes = (report: z.infer<typeof reportSchema>): Set<string> => {
+  const facts = [
+    sourceHashFacts(report),
+    sourceHashFacts(report, 'current', 'legacy'),
+    sourceHashFacts(report, 'legacy'),
+    sourceHashFacts(report, 'legacy', 'legacy'),
+  ];
+  return new Set(
+    facts.flatMap((value) => [
+      hash(JSON.stringify(canonicalizeJsonValue(value))),
+      hash(JSON.stringify(value)),
+    ])
+  );
+};
+
+interface RawGovernedHistoryRun {
+  readonly completionReport?: z.infer<typeof reportSchema>;
+  readonly report: z.infer<typeof reportSchema>;
+}
+
+const rawEvidenceReports = (
+  run: GovernedHistoryRun,
+  rawRun: RawGovernedHistoryRun | undefined
+): {
+  readonly completionReport: z.infer<typeof reportSchema>;
+  readonly report: z.infer<typeof reportSchema>;
+} => ({
+  completionReport:
+    rawRun?.completionReport ?? rawRun?.report ?? run.completionReport,
+  report: rawRun?.report ?? run.report,
+});
+
+const validatesDeterministicEvidence = (
+  run: GovernedHistoryRun,
+  rawRun: RawGovernedHistoryRun | undefined,
+  transitionId: string
+): boolean => {
+  const { provenance } = run;
+  const { completionReport, report } = rawEvidenceReports(run, rawRun);
+  const provenanceValid =
+    provenance === undefined ||
+    (provenance.disposition ===
+      (run.report.review > 0 ? 'review-follow-up' : 'applied-clean') &&
+      provenance.kind === 'governed-vocabulary' &&
+      provenance.planContentHash === run.planContentHash &&
+      provenance.reviewPending === run.report.review &&
+      provenance.safeApplied ===
+        (run.report.apply?.applied ?? run.report.rewritten) &&
+      sourceHashes(completionReport).has(provenance.sourceHashAfter) &&
+      sourceHashes(report).has(provenance.sourceHashBefore) &&
+      provenance.transitionId === transitionId);
+  return (
+    hash(JSON.stringify(canonicalizeJsonValue(run.plan.plan))) ===
+      run.planContentHash &&
+    sourceHashes(report).has(run.lockHashAtRun) &&
+    sourceHashes(completionReport).has(run.completionReportHash) &&
+    provenanceValid
+  );
+};
+
+export interface GovernedVocabularyHistoryIndex {
+  readonly byTransitionId: ReadonlyMap<
+    string,
+    GovernedVocabularyHistoryEvidence
+  >;
+  readonly issues: readonly GovernedVocabularyHistoryIssue[];
+}
+
+const normalizePath = (value: string): string => value.replaceAll('\\', '/');
+
+type HistoryFileResult =
+  | {
+      readonly kind: 'evidence';
+      readonly value: GovernedVocabularyHistoryEvidence;
+    }
+  | { readonly kind: 'ignore' }
+  | { readonly kind: 'issue'; readonly value: GovernedVocabularyHistoryIssue };
+
+const historyIssue = (
+  path: string,
+  message: string,
+  transitionId?: string
+): HistoryFileResult => ({
+  kind: 'issue',
+  value: {
+    message,
+    path,
+    ...(transitionId === undefined ? {} : { transitionId }),
+  },
+});
+
+const governedTransitionForRun = (run: z.infer<typeof historyRunSchema>) => {
+  const { plan } = run.plan;
+  if (plan.kind !== 'vocabulary') {
+    return;
+  }
+  const transitionIds = [
+    plan.id,
+    run.provenance?.transitionId,
+    run.plan.transitionId,
+  ];
+  for (const transitionId of transitionIds) {
+    if (transitionId === undefined) {
+      continue;
+    }
+    const transition = getGovernedVocabularyTransition(transitionId);
+    if (transition !== undefined) {
+      return transition;
+    }
+  }
+  return listGovernedVocabularyTransitions().find(
+    (transition) =>
+      transition.from === plan.from &&
+      (transition.target.kind === 'single'
+        ? transition.target.to === plan.to
+        : transition.target.options.some((option) => option.to === plan.to))
+  );
+};
+
+const loadHistoryFile = (rootDir: string, name: string): HistoryFileResult => {
+  const absolutePath = join(rootDir, '.trails', 'regrade', 'history', name);
+  const observedPath = normalizePath(relative(rootDir, absolutePath));
+  let json: unknown;
+  try {
+    json = JSON.parse(readFileSync(absolutePath, 'utf8'));
+  } catch {
+    return historyIssue(
+      observedPath,
+      'Committed Regrade history is not valid JSON.'
+    );
+  }
+  const parsed = historyArtifactSchema.safeParse(json);
+  if (!parsed.success) {
+    return historyIssue(
+      observedPath,
+      'Committed Regrade history has an invalid evidence shape.'
+    );
+  }
+  if (normalizePath(parsed.data.path) !== observedPath) {
+    return historyIssue(
+      observedPath,
+      'Committed Regrade history path does not match its observed file.'
+    );
+  }
+
+  const latestRun = parsed.data.runs.at(-1);
+  const transition =
+    latestRun === undefined ? undefined : governedTransitionForRun(latestRun);
+  if (transition === undefined) {
+    return { kind: 'ignore' };
+  }
+  const allRunsMatchTransition = parsed.data.runs.every((run) => {
+    const runPlan = run.plan.plan;
+    if (
+      runPlan.kind !== 'vocabulary' ||
+      governedTransitionForRun(run)?.id !== transition.id ||
+      runPlan.from !== transition.from
+    ) {
+      return false;
+    }
+    return transition.target.kind === 'single'
+      ? transition.target.to === runPlan.to
+      : transition.target.options.some((option) => option.to === runPlan.to);
+  });
+  if (!allRunsMatchTransition) {
+    return historyIssue(
+      observedPath,
+      'Committed Regrade history does not match its governed registry transition.',
+      transition.id
+    );
+  }
+  const governedRuns = parsed.data.runs.map((run) =>
+    governedHistoryRunSchema.safeParse(run)
+  );
+  const rawRuns = (
+    json as {
+      readonly runs: readonly RawGovernedHistoryRun[];
+    }
+  ).runs;
+  if (
+    transition.provenance.mode === 'regrade-history' &&
+    (governedRuns.some((run) => !run.success) ||
+      governedRuns.some(
+        (run, index) =>
+          run.success &&
+          !validatesDeterministicEvidence(
+            run.data,
+            rawRuns[index],
+            transition.id
+          )
+      ))
+  ) {
+    return historyIssue(
+      observedPath,
+      'Committed Regrade history has invalid deterministic run evidence.',
+      transition.id
+    );
+  }
+  if (
+    parsed.data.runs.some(
+      (run) =>
+        run.provenance !== undefined &&
+        run.provenance.transitionId !== transition.id
+    )
+  ) {
+    return historyIssue(
+      observedPath,
+      'Committed Regrade history provenance names a different governed transition.',
+      transition.id
+    );
+  }
+  if (
+    transition.provenance.mode === 'regrade-history' &&
+    parsed.data.runs.some((run) => run.provenance === undefined)
+  ) {
+    return historyIssue(
+      observedPath,
+      'Committed Regrade history lacks required governed provenance.',
+      transition.id
+    );
+  }
+  const provenance = parsed.data.runs.at(-1)?.provenance;
+  return {
+    kind: 'evidence',
+    value: {
+      id: parsed.data.id,
+      path: parsed.data.path,
+      ...(provenance === undefined ? {} : { provenance }),
+      runCount: parsed.data.runs.length,
+      transitionId: transition.id,
+    },
+  };
+};
+
+export const loadGovernedVocabularyHistory = (
+  rootDir: string
+): GovernedVocabularyHistoryIndex => {
+  const directory = join(rootDir, '.trails', 'regrade', 'history');
+  if (!existsSync(directory)) {
+    return { byTransitionId: new Map(), issues: [] };
+  }
+
+  const byTransitionId = new Map<string, GovernedVocabularyHistoryEvidence>();
+  const issues: GovernedVocabularyHistoryIssue[] = [];
+  const files = readdirSync(directory)
+    .filter((name) => name.endsWith('.json'))
+    .toSorted();
+
+  for (const name of files) {
+    const result = loadHistoryFile(rootDir, name);
+    if (result.kind === 'ignore') {
+      continue;
+    }
+    if (result.kind === 'issue') {
+      issues.push(result.value);
+      continue;
+    }
+    if (byTransitionId.has(result.value.transitionId)) {
+      issues.push({
+        message:
+          'Multiple committed Regrade histories claim the same governed transition.',
+        path: result.value.path,
+        transitionId: result.value.transitionId,
+      });
+      continue;
+    }
+    byTransitionId.set(result.value.transitionId, result.value);
+  }
+
+  return { byTransitionId, issues };
+};

--- a/packages/warden/src/rules/governed-symbol-residue.ts
+++ b/packages/warden/src/rules/governed-symbol-residue.ts
@@ -12,7 +12,13 @@ import type {
   GovernedVocabularySymbolRename,
   GovernedVocabularyTransition,
 } from './retired-vocabulary.js';
-import type { WardenDiagnostic, WardenFix, WardenRule } from './types.js';
+import type {
+  GovernedVocabularyHistoryEvidence,
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+  WardenFix,
+} from './types.js';
 
 const RULE_NAME = 'governed-symbol-residue';
 
@@ -37,11 +43,15 @@ const isAllowedSourcePath = (filePath: string): boolean =>
   );
 
 interface ActiveSymbolRename {
+  readonly history?: GovernedVocabularyHistoryEvidence;
   readonly rename: GovernedVocabularySymbolRename;
   readonly targetSegments: readonly string[];
+  readonly transition: GovernedVocabularyTransition;
 }
 
-const activeSymbolRenames = (): readonly ActiveSymbolRename[] =>
+const activeSymbolRenames = (
+  context?: ProjectContext
+): readonly ActiveSymbolRename[] =>
   listGovernedVocabularyTransitions()
     .filter(
       (transition) =>
@@ -52,9 +62,14 @@ const activeSymbolRenames = (): readonly ActiveSymbolRename[] =>
       const targetSegments = [
         ...new Set(transition.symbolRenames.map((rename) => rename.to)),
       ];
+      const history = context?.governedVocabularyHistoryByTransitionId?.get(
+        transition.id
+      );
       return transition.symbolRenames.map((rename) => ({
+        ...(history === undefined ? {} : { history }),
         rename,
         targetSegments,
+        transition,
       }));
     });
 
@@ -353,12 +368,28 @@ const safeFixFor = (match: SymbolRenameMatch): WardenFix | undefined => {
   };
 };
 
+const diagnosticMessageFor = (
+  match: SymbolRenameMatch,
+  transition?: GovernedVocabularyTransition,
+  history?: GovernedVocabularyHistoryEvidence
+): string => {
+  if (history !== undefined) {
+    return `Retired governed symbol '${match.from}' was reintroduced after governed transition '${history.transitionId}' in '${history.path}' (${history.id}); migrate to '${match.to}'.`;
+  }
+  if (transition?.provenance.mode === 'regrade-history') {
+    return `Retired governed symbol '${match.from}' belongs to governed transition '${transition.id}', but no committed Regrade history proves the migration ran.`;
+  }
+  return `Retired governed symbol '${match.from}' should migrate to '${match.to}'.`;
+};
+
 const diagnosticFor = (
   sourceCode: string,
   filePath: string,
   node: AstNode,
   match: SymbolRenameMatch,
-  reviewReason: string | null
+  reviewReason: string | null,
+  transition?: GovernedVocabularyTransition,
+  history?: GovernedVocabularyHistoryEvidence
 ): WardenDiagnostic => {
   const fix =
     reviewReason === null
@@ -368,71 +399,133 @@ const diagnosticFor = (
     filePath,
     ...(fix === undefined ? {} : { fix }),
     line: offsetToLine(sourceCode, node.start),
-    message: `Retired governed symbol '${match.from}' should migrate to '${match.to}'.`,
+    message: diagnosticMessageFor(match, transition, history),
     rule: RULE_NAME,
     severity: 'error',
   };
 };
 
-export const governedSymbolResidue: WardenRule = {
-  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
-    if (isAllowedSourcePath(filePath)) {
-      return [];
+const provenanceDiagnostics = (
+  context: ProjectContext
+): readonly WardenDiagnostic[] => {
+  const historyIssues = context.governedVocabularyHistoryIssues ?? [];
+  const invalidTransitionIds = new Set(
+    historyIssues.flatMap((issue) =>
+      issue.transitionId === undefined ? [] : [issue.transitionId]
+    )
+  );
+  const issues = historyIssues.map((issue) => ({
+    filePath: issue.path,
+    line: 1,
+    message: issue.message,
+    rule: RULE_NAME,
+    severity: 'error' as const,
+  }));
+  const missing = listGovernedVocabularyTransitions()
+    .filter(
+      (transition) =>
+        context.governedVocabularyHistoryRequired === true &&
+        transition.status === 'complete' &&
+        transition.provenance.mode === 'regrade-history' &&
+        !invalidTransitionIds.has(transition.id) &&
+        !context.governedVocabularyHistoryByTransitionId?.has(transition.id)
+    )
+    .map((transition) => ({
+      filePath: '<governed-vocabulary-history>',
+      line: 1,
+      message: `Governed transition '${transition.id}' is complete but has no valid committed Regrade history provenance. Run Regrade as the primary migration path before manual review or cleanup.`,
+      rule: RULE_NAME,
+      severity: 'error' as const,
+    }));
+  return [...issues, ...missing];
+};
+
+const checkSource = (
+  sourceCode: string,
+  filePath: string,
+  projectContext?: ProjectContext
+): readonly WardenDiagnostic[] => {
+  if (isAllowedSourcePath(filePath)) {
+    return [];
+  }
+
+  const renames = activeSymbolRenames(projectContext);
+  if (renames.length === 0) {
+    return [];
+  }
+
+  const parsed = parseWithDiagnostics(filePath, sourceCode);
+  if (!parsed.ast || parsed.diagnostics.length > 0) {
+    return [];
+  }
+
+  const shorthandIdentifiers = new Set<string>();
+  walkWithScopeContext(parsed.ast, (node, astContext) => {
+    if (!isShorthandPropertyKeyVisit(node, astContext)) {
+      return;
+    }
+    const name = identifierName(node);
+    if (name !== null) {
+      shorthandIdentifiers.add(name);
+    }
+  });
+
+  const diagnostics: WardenDiagnostic[] = [];
+  walkWithScopeContext(parsed.ast, (node, astContext) => {
+    if (isDuplicateShorthandValueVisit(node, astContext)) {
+      return;
     }
 
-    const renames = activeSymbolRenames();
-    if (renames.length === 0) {
-      return [];
+    const activeMatch = renames
+      .map(({ history, rename, targetSegments, transition }) => ({
+        history,
+        match: resolveSymbolRenameMatch(node, sourceCode, rename),
+        targetSegments,
+        transition,
+      }))
+      .find((candidate) => candidate.match !== null);
+    if (activeMatch === undefined || activeMatch.match === null) {
+      return;
     }
+    const { history, match, targetSegments, transition } = activeMatch;
 
-    const parsed = parseWithDiagnostics(filePath, sourceCode);
-    if (!parsed.ast || parsed.diagnostics.length > 0) {
-      return [];
-    }
-
-    const shorthandIdentifiers = new Set<string>();
-    walkWithScopeContext(parsed.ast, (node, context) => {
-      if (!isShorthandPropertyKeyVisit(node, context)) {
-        return;
-      }
-      const name = identifierName(node);
-      if (name !== null) {
-        shorthandIdentifiers.add(name);
-      }
-    });
-
-    const diagnostics: WardenDiagnostic[] = [];
-    walkWithScopeContext(parsed.ast, (node, context) => {
-      if (isDuplicateShorthandValueVisit(node, context)) {
-        return;
-      }
-
-      const activeMatch = renames
-        .map(({ rename, targetSegments }) => ({
-          match: resolveSymbolRenameMatch(node, sourceCode, rename),
-          targetSegments,
-        }))
-        .find((candidate) => candidate.match !== null);
-      if (activeMatch === undefined || activeMatch.match === null) {
-        return;
-      }
-      const { match, targetSegments } = activeMatch;
-
-      diagnostics.push(
-        diagnosticFor(
-          sourceCode,
-          filePath,
-          node,
+    diagnostics.push(
+      diagnosticFor(
+        sourceCode,
+        filePath,
+        node,
+        match,
+        reviewReasonFor(
+          astContext,
           match,
-          reviewReasonFor(context, match, shorthandIdentifiers, targetSegments)
-        )
-      );
-    });
+          shorthandIdentifiers,
+          targetSegments
+        ),
+        transition,
+        history
+      )
+    );
+  });
 
-    return diagnostics;
+  return diagnostics;
+};
+
+export const governedSymbolResidue: ProjectAwareWardenRule = {
+  check(sourceCode: string, filePath: string): readonly WardenDiagnostic[] {
+    return checkSource(sourceCode, filePath);
+  },
+  checkProject(context: ProjectContext): readonly WardenDiagnostic[] {
+    return provenanceDiagnostics(context);
+  },
+  checkWithContext(
+    sourceCode: string,
+    filePath: string,
+    context: ProjectContext
+  ): readonly WardenDiagnostic[] {
+    return checkSource(sourceCode, filePath, context);
   },
   description:
-    'Detect active governed vocabulary symbols that remain in source code.',
+    'Require committed Regrade provenance for governed transitions and detect retired symbols that remain or return.',
   name: RULE_NAME,
   severity: 'error',
 };

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -79,6 +79,8 @@ import { wardenRulesUseAst } from './warden-rules-use-ast.js';
 import { webhookRouteCollision } from './webhook-route-collision.js';
 
 export type {
+  GovernedVocabularyHistoryEvidence,
+  GovernedVocabularyHistoryIssue,
   WardenFix,
   WardenFixCapability,
   WardenFixClass,
@@ -107,7 +109,9 @@ export {
   getGovernedVocabularyTransition,
   governedVocabularyLiteralRenameSchema,
   governedVocabularyFileRenameSchema,
+  governedVocabularyHistoryProvenanceSchema,
   governedVocabularyPreserveRuleSchema,
+  governedVocabularyProvenancePolicySchema,
   governedVocabularyRegistrySchema,
   governedVocabularyScopeSchema,
   governedVocabularySymbolRenameSchema,
@@ -120,7 +124,9 @@ export {
 } from './retired-vocabulary.js';
 export type {
   GovernedVocabularyLiteralRename,
+  GovernedVocabularyHistoryProvenance,
   GovernedVocabularyPreserveRule,
+  GovernedVocabularyProvenancePolicy,
   GovernedVocabularyScope,
   GovernedVocabularySymbolRename,
   GovernedVocabularyTarget,

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -316,8 +316,23 @@ const builtinWardenRuleMetadataInput = {
   'governed-symbol-residue': {
     ...durableExternal,
     fix: { class: 'term-rewrite', safety: 'safe' },
+    guidance: {
+      docs: [
+        {
+          label: 'Vocabulary transition workflow',
+          path: 'docs/releases/v1-vocabulary-transition-workflow.md',
+        },
+      ],
+      steps: [
+        'Run the governed transition through Regrade so committed history proves the primary migration.',
+        'Use manual edits only for review or cleanup after Regrade exhausts the safe slice.',
+        'Keep the transition registry and committed history evidence aligned.',
+      ],
+      summary:
+        'Require committed Regrade evidence before completing a governed vocabulary migration.',
+    },
     invariant:
-      'Active governed vocabulary symbol renames do not leave retired identifiers in source.',
+      'Governed vocabulary transitions carry committed Regrade provenance and do not leave or reintroduce retired identifiers.',
     tier: 'source-static',
   },
   'implementation-returns-result': {

--- a/packages/warden/src/rules/retired-vocabulary.ts
+++ b/packages/warden/src/rules/retired-vocabulary.ts
@@ -81,6 +81,30 @@ export const governedVocabularyFileRenameSchema = z.object({
   to: z.string().min(1),
 });
 
+export const governedVocabularyProvenancePolicySchema = z.discriminatedUnion(
+  'mode',
+  [
+    z.object({ mode: z.literal('regrade-history') }),
+    z.object({
+      mode: z.literal('legacy'),
+      reason: z.string().min(1),
+    }),
+  ]
+);
+
+export const governedVocabularyHistoryProvenanceSchema = z
+  .object({
+    disposition: z.enum(['applied-clean', 'review-follow-up']),
+    kind: z.literal('governed-vocabulary'),
+    planContentHash: z.string().regex(/^[0-9a-f]{64}$/),
+    reviewPending: z.number().int().nonnegative(),
+    safeApplied: z.number().int().nonnegative(),
+    sourceHashAfter: z.string().regex(/^[0-9a-f]{64}$/),
+    sourceHashBefore: z.string().regex(/^[0-9a-f]{64}$/),
+    transitionId: z.string().min(1),
+  })
+  .strict();
+
 export const governedVocabularyTransitionSchema = z.object({
   codeIdentifiers: z.array(z.string().min(1)).default([]),
   docs: z.object({
@@ -95,6 +119,11 @@ export const governedVocabularyTransitionSchema = z.object({
   oldForms: z.array(z.string().min(1)).min(1),
   overrides: z.record(z.string().min(1), z.string().min(1)).default({}),
   preserve: z.array(governedVocabularyPreserveRuleSchema).default([]),
+  provenance: governedVocabularyProvenancePolicySchema.default({
+    mode: 'legacy',
+    reason:
+      'Transition completed before committed Regrade history provenance became enforceable.',
+  }),
   reviewForms: z.array(z.string().min(1)).default([]),
   safeRewriteForms: z.record(z.string().min(1), z.string().min(1)).default({}),
   scope: governedVocabularyScopeSchema.optional(),
@@ -130,6 +159,18 @@ export const governedVocabularyRegistrySchema = z
         });
       }
       seenFrom.add(transition.from);
+
+      if (
+        transition.status === 'planned' &&
+        transition.provenance.mode !== 'regrade-history'
+      ) {
+        ctx.addIssue({
+          code: 'custom',
+          message:
+            'Planned governed transitions must require committed Regrade history provenance.',
+          path: [index, 'provenance'],
+        });
+      }
     }
   });
 
@@ -150,6 +191,12 @@ export type GovernedVocabularyLiteralRename = z.output<
 >;
 export type GovernedVocabularyTransition = z.output<
   typeof governedVocabularyTransitionSchema
+>;
+export type GovernedVocabularyHistoryProvenance = z.output<
+  typeof governedVocabularyHistoryProvenanceSchema
+>;
+export type GovernedVocabularyProvenancePolicy = z.output<
+  typeof governedVocabularyProvenancePolicySchema
 >;
 export type GovernedVocabularyTransitionInput = z.input<
   typeof governedVocabularyTransitionSchema
@@ -762,6 +809,7 @@ export const governedVocabularyTransitions =
         'projected',
         'Projected',
       ],
+      provenance: { mode: 'regrade-history' },
       reviewForms: [
         'projection',
         'projections',
@@ -834,6 +882,11 @@ export const formatGovernedVocabularyTransitionGuide = (
         `- ${transition.id}: ${transition.from} -> ${target}`,
         `  - Status: ${transition.status}`,
         `  - Intent: ${transition.intent}`,
+        `  - Provenance: ${
+          transition.provenance.mode === 'regrade-history'
+            ? 'committed Regrade history required'
+            : `legacy (${transition.provenance.reason})`
+        }`,
         `  - Safe rewrites: ${Object.keys(transition.safeRewriteForms).length}`,
         `  - Review forms: ${transition.reviewForms.join(', ') || 'none'}`,
       ];

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -11,6 +11,7 @@ import type { TopoGraph } from '@ontrails/topography';
 import type { WardenDepth } from '../config.js';
 import type { WardenImportResolution } from '../resolve.js';
 import type { WardenPublicWorkspace } from '../workspaces.js';
+import type { GovernedVocabularyHistoryProvenance } from './retired-vocabulary.js';
 
 /**
  * Severity level for warden diagnostics.
@@ -304,6 +305,16 @@ export interface AuthoredMcpSurfaceBindingSet {
  * Options for compose-file rules that need knowledge of all trail IDs in a project.
  */
 export interface ProjectContext {
+  /** Whether this project owns the governed transition registry and must prove completed migrations. */
+  readonly governedVocabularyHistoryRequired?: boolean | undefined;
+  /** Validated committed Regrade history evidence keyed by governed transition. */
+  readonly governedVocabularyHistoryByTransitionId?:
+    | ReadonlyMap<string, GovernedVocabularyHistoryEvidence>
+    | undefined;
+  /** Invalid committed history artifacts observed while building context. */
+  readonly governedVocabularyHistoryIssues?:
+    | readonly GovernedVocabularyHistoryIssue[]
+    | undefined;
   /**
    * Per-app authored `mcp` surface bindings, resolved from the project's
    * topo targets (the serialized graph overlays when available, else the
@@ -368,10 +379,28 @@ export interface ProjectContext {
   readonly crudCoverageByEntity?: ReadonlyMap<string, ReadonlySet<string>>;
 }
 
+export interface GovernedVocabularyHistoryEvidence {
+  readonly id: string;
+  readonly path: string;
+  readonly provenance?: GovernedVocabularyHistoryProvenance;
+  readonly runCount: number;
+  readonly transitionId: string;
+}
+
+export interface GovernedVocabularyHistoryIssue {
+  readonly message: string;
+  readonly path: string;
+  readonly transitionId?: string;
+}
+
 /**
  * A project-aware rule that requires knowledge of all trail IDs.
  */
 export interface ProjectAwareWardenRule extends WardenRule {
+  /** Run project-wide validation once, independently of any source file. */
+  readonly checkProject?: (
+    context: ProjectContext
+  ) => readonly WardenDiagnostic[];
   /** Run the rule with project-level context */
   readonly checkWithContext: (
     sourceCode: string,

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -62,7 +62,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `draft-file-marking` (error, source/source-static, external): Draft-authored state is visibly marked in filenames.
 - `draft-visible-debt` (warn, source/source-static, external): Draft-authored IDs remain visible debt.
 - `fork-without-preserved-implementation` (error, source/source-static, external): Fork version entries preserve their historical implementation.
-- `governed-symbol-residue` (error, source/source-static, external): Active governed vocabulary symbol renames do not leave retired identifiers in source.
+- `governed-symbol-residue` (error, source/source-static, external): Governed vocabulary transitions carry committed Regrade provenance and do not leave or reintroduce retired identifiers. Guidance: Require committed Regrade evidence before completing a governed vocabulary migration.
 - `marker-schema-unsupported` (error, source/source-static, external): Versioned schemas stay inside the supported marker projection subset.
 - `pending-force` (warn, topo/topo-aware, external): Forced topo break audit events do not remain pending indefinitely.
 - `scheduled-destroy-intent` (warn, topo/topo-aware, external): Schedule-activated destroy trails make unattended destructive work visible for review.


### PR DESCRIPTION
## Context

[TRL-1116](https://linear.app/outfitter/issue/TRL-1116/harden-regrade-provenance-warden-enforcement-for-governed-transitions) makes governed vocabulary migrations prove they ran through Regrade instead of accepting equivalent hand edits.

## What changed

- adds typed required-versus-grandfathered provenance policy to the governed transition registry
- stamps deterministic provenance in apply/replay history and CLI/MCP results
- independently validates strict committed v2 history once per Warden project run
- distinguishes missing or invalid evidence from history-cited source residue
- updates generated Warden guidance and workflow docs
- adds a minor changeset for `@ontrails/regrade`, `@ontrails/trails`, and `@ontrails/warden`

## How to test

- `bun run check`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun apps/trails/bin/trails.ts warden --json`
- focused Regrade history, downstream report, Warden loader, rule, CLI, and MCP tests
- full pre-push test, typecheck, lint, format, governance, and dead-code suite

## Risks and rollout

- Only registry-governed transitions opt into required history; existing completed transitions are explicitly grandfathered.
- The planned projection derive/render transition opts in before its dogfood branch.
- This PR does not publish packages.
