### PR TITLE
feat(warden): watch governed vocabulary permutations

### DIFF
--- a/.agents/skills/clark/references/warden-guide.md
+++ b/.agents/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 74
+- Rule count: 75
 
 ## Agent Instructions
 
@@ -63,6 +63,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `draft-visible-debt` (warn, source/source-static, external): Draft-authored IDs remain visible debt.
 - `fork-without-preserved-implementation` (error, source/source-static, external): Fork version entries preserve their historical implementation.
 - `governed-symbol-residue` (error, source/source-static, external): Governed vocabulary transitions carry committed Regrade provenance and do not leave or reintroduce retired identifiers. Guidance: Require committed Regrade evidence before completing a governed vocabulary migration.
+- `governed-vocabulary-permutation-watch` (warn, all/project-static, advisory): Committed Regrade history keeps unknown governed-stem permutations visible until they are classified. Guidance: Classify unknown governed-stem permutations recorded by committed Regrade history.
 - `marker-schema-unsupported` (error, source/source-static, external): Versioned schemas stay inside the supported marker projection subset.
 - `pending-force` (warn, topo/topo-aware, external): Forced topo break audit events do not remain pending indefinitely.
 - `scheduled-destroy-intent` (warn, topo/topo-aware, external): Schedule-activated destroy trails make unattended destructive work visible for review.

--- a/.changeset/calm-ridges-watch.md
+++ b/.changeset/calm-ridges-watch.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/warden': minor
+---
+
+Add an advisory project-static rule that reports unknown governed vocabulary permutations from the latest committed Regrade history until they are classified.

--- a/.claude/skills/clark/references/warden-guide.md
+++ b/.claude/skills/clark/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 74
+- Rule count: 75
 
 ## Agent Instructions
 
@@ -63,6 +63,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `draft-visible-debt` (warn, source/source-static, external): Draft-authored IDs remain visible debt.
 - `fork-without-preserved-implementation` (error, source/source-static, external): Fork version entries preserve their historical implementation.
 - `governed-symbol-residue` (error, source/source-static, external): Governed vocabulary transitions carry committed Regrade provenance and do not leave or reintroduce retired identifiers. Guidance: Require committed Regrade evidence before completing a governed vocabulary migration.
+- `governed-vocabulary-permutation-watch` (warn, all/project-static, advisory): Committed Regrade history keeps unknown governed-stem permutations visible until they are classified. Guidance: Classify unknown governed-stem permutations recorded by committed Regrade history.
 - `marker-schema-unsupported` (error, source/source-static, external): Versioned schemas stay inside the supported marker projection subset.
 - `pending-force` (warn, topo/topo-aware, external): Forced topo break audit events do not remain pending indefinitely.
 - `scheduled-destroy-intent` (warn, topo/topo-aware, external): Schedule-activated destroy trails make unattended destructive work visible for review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@ See [ADR-0050](docs/adr/0050-surface-accommodations-preserve-trail-identity.md) 
 This section is generated from the live `@ontrails/warden` rule manifest. Keep the human-authored guidance above as orientation; use this block as the enforceable-rule index.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --manifest`
-- Rule count: 74
+- Rule count: 75
 
 ### Rule Index
 
@@ -159,6 +159,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `draft-visible-debt` (warn, source/source-static, external): Draft-authored IDs remain visible debt.
 - `fork-without-preserved-implementation` (error, source/source-static, external): Fork version entries preserve their historical implementation.
 - `governed-symbol-residue` (error, source/source-static, external): Governed vocabulary transitions carry committed Regrade provenance and do not leave or reintroduce retired identifiers.
+- `governed-vocabulary-permutation-watch` (warn, all/project-static, advisory): Committed Regrade history keeps unknown governed-stem permutations visible until they are classified.
 - `marker-schema-unsupported` (error, source/source-static, external): Versioned schemas stay inside the supported marker projection subset.
 - `pending-force` (warn, topo/topo-aware, external): Forced topo break audit events do not remain pending indefinitely.
 - `scheduled-destroy-intent` (warn, topo/topo-aware, external): Schedule-activated destroy trails make unattended destructive work visible for review.
@@ -220,6 +221,7 @@ This section is generated from the live `@ontrails/warden` rule manifest. Keep t
 - `duplicate-public-contract`: Keep duplicate public contract facts from drifting into separate capabilities.
 - `example-valid`: Keep trail examples synchronized with their authored schemas.
 - `governed-symbol-residue`: Require committed Regrade evidence before completing a governed vocabulary migration.
+- `governed-vocabulary-permutation-watch`: Classify unknown governed-stem permutations recorded by committed Regrade history.
 - `library-projection-coherence`: Keep resolved library projection exports collision-free and attached to one trail contract.
 - `no-throw-in-implementation`: Convert thrown failures in implementations into explicit Result.err() outcomes.
 - `no-top-level-surface`: Keep topo entry modules side-effect-free for survey, guide, compile, and lock generation.

--- a/docs/releases/v1-vocabulary-transition-workflow.md
+++ b/docs/releases/v1-vocabulary-transition-workflow.md
@@ -99,6 +99,8 @@ Regrade is the primary migration engine. Apply consumes an active plan artifact 
 
 For a registry-governed transition, apply also stamps the history run and the CLI/MCP result with governed provenance: transition identity, plan and source hashes, safely applied count, and remaining review count. Warden loads that committed evidence once per project run. A completed transition that requires Regrade provenance cannot be satisfied by an equivalent hand migration with no history entry.
 
+Warden also keeps the latest committed run's unknown stem permutations visible as advisory findings. Each transition/form pair appears once. Add the form to an incremental plan and rerun Regrade, or classify it as out-of-family or preserved; that persisted classification suppresses the advisory on later runs. Earlier history runs remain evidence, but they do not resurrect forms that the latest run has classified or cleared.
+
 Use `trails regrade check --root-dir . --plan "$PLAN_PATH"` when a family should prove the saved plan gate without writing. The check succeeds only when the plan is fresh and its completion gate is green. Use `trails regrade plans --root-dir .` when more than one active plan may exist, because commands without `--plan <path-or-name>` intentionally fail on ambiguity.
 
 Safe follow-up edits usually include:

--- a/packages/warden/src/__tests__/governed-symbol-residue.test.ts
+++ b/packages/warden/src/__tests__/governed-symbol-residue.test.ts
@@ -23,7 +23,9 @@ describe('governed-symbol-residue', () => {
           [
             'v1-contour-entity',
             {
+              caseSensitive: true,
               id: 'history-id',
+              latestFormObservations: [],
               path: '.trails/regrade/history/contour-to-entity.json',
               runCount: 2,
               transitionId: 'v1-contour-entity',

--- a/packages/warden/src/__tests__/governed-vocabulary-permutation-watch.test.ts
+++ b/packages/warden/src/__tests__/governed-vocabulary-permutation-watch.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createTrailContext } from '@ontrails/core';
+
+import { governedVocabularyPermutationWatch } from '../rules/governed-vocabulary-permutation-watch.js';
+import { governedVocabularyPermutationWatchTrail } from '../trails/governed-vocabulary-permutation-watch.trail.js';
+import { runProjectWardenRules, runWardenTrails } from '../trails/run.js';
+import type {
+  GovernedVocabularyHistoryEvidence,
+  GovernedVocabularyHistoryFormObservation,
+  ProjectContext,
+} from '../rules/types.js';
+
+const observation = (
+  form: string,
+  overrides: Partial<GovernedVocabularyHistoryFormObservation> = {}
+): GovernedVocabularyHistoryFormObservation => ({
+  disposition: 'in-family-unresolved',
+  form,
+  line: 4,
+  path: 'src/example.ts',
+  reason: 'unclassified-neighbor',
+  scopeTier: 'in-scope',
+  verdict: 'deferred',
+  ...overrides,
+});
+
+const evidence = (
+  latestFormObservations: readonly GovernedVocabularyHistoryFormObservation[],
+  overrides: Partial<GovernedVocabularyHistoryEvidence> = {}
+): GovernedVocabularyHistoryEvidence => ({
+  caseSensitive: false,
+  id: 'history-id',
+  latestFormObservations,
+  path: '.trails/regrade/history/contour-to-entity.json',
+  runCount: 2,
+  transitionId: 'v1-contour-entity',
+  ...overrides,
+});
+
+const context = (
+  histories: readonly GovernedVocabularyHistoryEvidence[] = []
+): ProjectContext => ({
+  governedVocabularyHistoryByTransitionId: new Map(
+    histories.map((history) => [history.transitionId, history])
+  ),
+  knownTrailIds: new Set(),
+});
+
+describe('governed-vocabulary-permutation-watch', () => {
+  test('advises once per governed transition and normalized form', () => {
+    const diagnostics = governedVocabularyPermutationWatch.checkProject?.(
+      context([
+        evidence([
+          observation('Discontour', { path: 'src/z.ts' }),
+          observation('discontour', { line: 2, path: 'src/a.ts' }),
+        ]),
+      ])
+    );
+
+    expect(diagnostics).toEqual([
+      {
+        filePath: 'src/a.ts',
+        line: 2,
+        message:
+          "Governed transition 'v1-contour-entity' recorded unknown vocabulary form 'discontour' in committed Regrade history '.trails/regrade/history/contour-to-entity.json' (history-id). Add the form and run an incremental plan, or classify it as out-of-family or preserved.",
+        rule: 'governed-vocabulary-permutation-watch',
+        severity: 'warn',
+      },
+    ]);
+  });
+
+  test('keeps case-sensitive forms distinct and orders output', () => {
+    const diagnostics = governedVocabularyPermutationWatch.checkProject?.(
+      context([
+        evidence([observation('Zcontour'), observation('acontour')], {
+          caseSensitive: true,
+        }),
+      ])
+    );
+
+    expect(diagnostics?.map((diagnostic) => diagnostic.message)).toEqual([
+      expect.stringContaining("'acontour'"),
+      expect.stringContaining("'Zcontour'"),
+    ]);
+  });
+
+  test('persisted preserve and policy classifications suppress repeats', () => {
+    const diagnostics = governedVocabularyPermutationWatch.checkProject?.(
+      context([
+        evidence([
+          observation('DISCONTOUR', {
+            disposition: 'out-of-family',
+            reason: 'explicit preserve',
+            verdict: 'skipped',
+          }),
+          observation('PRECONTOUR', {
+            disposition: 'historical-by-policy',
+            reason: 'protected history',
+            scopeTier: 'policy-classified',
+            verdict: 'skipped',
+          }),
+        ]),
+      ])
+    );
+
+    expect(diagnostics).toEqual([]);
+  });
+
+  test('a path-scoped classification does not hide an unresolved occurrence', () => {
+    const diagnostics = governedVocabularyPermutationWatch.checkProject?.(
+      context([
+        evidence([
+          observation('discontour', {
+            line: 8,
+            path: 'src/live.ts',
+          }),
+          observation('DISCONTOUR', {
+            disposition: 'explicit-preserve',
+            line: 2,
+            path: 'docs/history.md',
+            reason: 'historical evidence',
+            verdict: 'skipped',
+          }),
+        ]),
+      ])
+    );
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        filePath: 'src/live.ts',
+        line: 8,
+        message: expect.stringContaining("'discontour'"),
+      }),
+    ]);
+  });
+
+  test('ignores missing history and file-scoped entrypoints', () => {
+    expect(
+      governedVocabularyPermutationWatch.checkProject?.(context())
+    ).toEqual([]);
+    expect(
+      governedVocabularyPermutationWatch.check(
+        'const discontour = true;',
+        'x.ts'
+      )
+    ).toEqual([]);
+    expect(
+      governedVocabularyPermutationWatch.checkWithContext(
+        'const discontour = true;',
+        'x.ts',
+        context()
+      )
+    ).toEqual([]);
+  });
+
+  test('keeps the exported rule trail file-scoped', async () => {
+    const result = await governedVocabularyPermutationWatchTrail.implementation(
+      {
+        filePath: 'project.ts',
+        governedVocabularyHistories: [evidence([observation('discontour')])],
+        sourceCode: '',
+      },
+      createTrailContext()
+    );
+
+    expect(result.unwrap().diagnostics).toEqual([]);
+  });
+
+  test('runs committed-history diagnostics once through the project runner', () => {
+    const diagnostics = runProjectWardenRules({
+      governedVocabularyHistories: [evidence([observation('discontour')])],
+    });
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          filePath: 'src/example.ts',
+          message: expect.stringContaining(
+            "unknown vocabulary form 'discontour'"
+          ),
+        }),
+      ])
+    );
+  });
+
+  test('forwards invalid governed history context through the project runner', () => {
+    const diagnostics = runProjectWardenRules({
+      governedVocabularyHistoryIssues: [
+        {
+          message: 'Committed history evidence is invalid.',
+          path: '.trails/regrade/history/invalid.json',
+          transitionId: 'v1-projection-derive-render',
+        },
+      ],
+      governedVocabularyHistoryRequired: true,
+    });
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        {
+          filePath: '.trails/regrade/history/invalid.json',
+          line: 1,
+          message: 'Committed history evidence is invalid.',
+          rule: 'governed-symbol-residue',
+          severity: 'error',
+        },
+      ])
+    );
+  });
+
+  test('does not duplicate project diagnostics through file-scoped runs', async () => {
+    const options = {
+      governedVocabularyHistories: [evidence([observation('discontour')])],
+    };
+
+    const first = await runWardenTrails('src/a.ts', '', options);
+    const second = await runWardenTrails('src/b.ts', '', options);
+
+    expect(first).toEqual([]);
+    expect(second).toEqual([]);
+  });
+
+  test('handles representative history volume in one bounded project pass', () => {
+    const observations = Array.from({ length: 10_000 }, (_, index) =>
+      observation(`neighborContour${index % 100}`, {
+        line: index + 1,
+        path: `src/fixture-${index % 250}.ts`,
+      })
+    );
+    const startedAt = performance.now();
+
+    const diagnostics = governedVocabularyPermutationWatch.checkProject?.(
+      context([evidence(observations)])
+    );
+
+    expect(diagnostics).toHaveLength(100);
+    expect(performance.now() - startedAt).toBeLessThan(1000);
+  });
+});

--- a/packages/warden/src/__tests__/regrade-history.test.ts
+++ b/packages/warden/src/__tests__/regrade-history.test.ts
@@ -76,9 +76,18 @@ const completionReport = {
   unknownClassIds: [],
 };
 
-const withNumericFileRenameEvidence = (
-  value: typeof report | typeof completionReport
-) => ({
+type TestReport = (typeof report | typeof completionReport) & {
+  readonly run?: {
+    readonly ledger: {
+      readonly cycle: number;
+      readonly forms: Readonly<Record<string, string>>;
+      readonly occurrences: readonly Record<string, unknown>[];
+    };
+    readonly report: Record<string, unknown>;
+  };
+};
+
+const withNumericFileRenameEvidence = (value: TestReport): TestReport => ({
   ...value,
   run: {
     ledger: { cycle: 1, forms: {}, occurrences: [] },
@@ -98,13 +107,11 @@ const withNumericFileRenameEvidence = (
   },
 });
 
-const numericEvidenceSourceHash = (
-  value: ReturnType<typeof withNumericFileRenameEvidence>
-): string =>
+const sourceHash = (value: TestReport): string =>
   hash({
     entries: value.entries,
-    fileRenames: value.run.report.fileRenames,
-    ledger: value.run.ledger,
+    fileRenames: value.run?.report.fileRenames,
+    ledger: value.run?.ledger,
     selectedClassIds: value.selectedClassIds,
   });
 
@@ -206,15 +213,6 @@ const legacyPolicyEvidenceSourceHash = (
     },
     selectedClassIds: value.selectedClassIds,
   });
-
-const sourceHash = (value: typeof report | typeof completionReport): string =>
-  hash({
-    entries: value.entries,
-    fileRenames: undefined,
-    ledger: undefined,
-    selectedClassIds: value.selectedClassIds,
-  });
-
 const withHistory = (
   run: Record<string, unknown> | readonly Record<string, unknown>[],
   exercise: (rootDir: string) => void,
@@ -245,17 +243,21 @@ const withHistory = (
   }
 };
 
-const run = (provenance = true): Record<string, unknown> => ({
-  completionReport,
-  completionReportHash: sourceHash(completionReport),
-  lockHashAtRun: sourceHash(report),
+const run = (
+  provenance = true,
+  reportValue: TestReport = report,
+  completionValue: TestReport = completionReport
+): Record<string, unknown> => ({
+  completionReport: completionValue,
+  completionReportHash: sourceHash(completionValue),
+  lockHashAtRun: sourceHash(reportValue),
   plan: {
     kind: 'regrade-plan',
     path: '.trails/regrade/projection-to-derive.json',
     plan,
     provenance: { fields: {} },
     schemaVersion: 1,
-    sourceHash: sourceHash(report),
+    sourceHash: sourceHash(reportValue),
     transitionId: 'v1-projection-derive-render',
   },
   planContentHash: hash(plan),
@@ -266,14 +268,14 @@ const run = (provenance = true): Record<string, unknown> => ({
           kind: 'governed-vocabulary',
           planContentHash: hash(plan),
           reviewPending: 0,
-          safeApplied: 3,
-          sourceHashAfter: sourceHash(completionReport),
-          sourceHashBefore: sourceHash(report),
+          safeApplied: reportValue.rewritten,
+          sourceHashAfter: sourceHash(completionValue),
+          sourceHashBefore: sourceHash(reportValue),
           transitionId: 'v1-projection-derive-render',
         },
       }
     : {}),
-  report,
+  report: reportValue,
 });
 
 const runWithNumericFileRenameEvidence = (
@@ -299,7 +301,6 @@ const runWithNumericFileRenameEvidence = (
     report: before,
   };
 };
-
 const runWithPolicyEvidence = (
   sourceHashFor = policyEvidenceSourceHash
 ): Record<string, unknown> => {
@@ -323,7 +324,6 @@ const runWithPolicyEvidence = (
     report: before,
   };
 };
-
 describe('loadGovernedVocabularyHistory', () => {
   test('indexes validated committed provenance once per transition', () => {
     withHistory(run(), (rootDir) => {
@@ -333,7 +333,9 @@ describe('loadGovernedVocabularyHistory', () => {
       expect(
         index.byTransitionId.get('v1-projection-derive-render')
       ).toMatchObject({
+        caseSensitive: false,
         id: 'history-id',
+        latestFormObservations: [],
         path: '.trails/regrade/history/projection-to-derive.json',
         runCount: 1,
         transitionId: 'v1-projection-derive-render',
@@ -394,13 +396,114 @@ describe('loadGovernedVocabularyHistory', () => {
   });
 
   test('accepts authoritative numeric file-rename evidence', () => {
-    withHistory(runWithNumericFileRenameEvidence(), (rootDir) => {
+    withHistory(
+      run(
+        true,
+        withNumericFileRenameEvidence(report),
+        withNumericFileRenameEvidence(completionReport)
+      ),
+      (rootDir) => {
+        const index = loadGovernedVocabularyHistory(rootDir);
+
+        expect(index.issues).toEqual([]);
+        expect(
+          index.byTransitionId.get('v1-projection-derive-render')
+        ).toBeDefined();
+      }
+    );
+  });
+
+  test('indexes latest-run vocabulary form observations', () => {
+    const preApplyObservation = {
+      column: 7,
+      context: 'const projectionist = true;',
+      disposition: 'in-family-unresolved',
+      end: 20,
+      form: 'projectionist',
+      line: 3,
+      path: 'src/example.ts',
+      reason: 'unclassified-neighbor',
+      scopeTier: 'in-scope',
+      start: 6,
+      verdict: 'deferred',
+    };
+    const completionObservation = {
+      ...preApplyObservation,
+      form: 'derivationist',
+      line: 5,
+    };
+    const reportWithObservation: TestReport = {
+      ...report,
+      run: {
+        ledger: {
+          cycle: 1,
+          forms: { projectionist: 'deferred' },
+          occurrences: [preApplyObservation],
+        },
+        report: {},
+      },
+    };
+    const completionWithObservation: TestReport = {
+      ...completionReport,
+      run: {
+        ledger: {
+          cycle: 2,
+          forms: { derivationist: 'deferred' },
+          occurrences: [completionObservation],
+        },
+        report: {},
+      },
+    };
+
+    withHistory(
+      run(true, reportWithObservation, completionWithObservation),
+      (rootDir) => {
+        const history = loadGovernedVocabularyHistory(
+          rootDir
+        ).byTransitionId.get('v1-projection-derive-render');
+
+        expect(history?.latestFormObservations).toEqual([
+          {
+            disposition: 'in-family-unresolved',
+            form: 'derivationist',
+            line: 5,
+            path: 'src/example.ts',
+            reason: 'unclassified-neighbor',
+            scopeTier: 'in-scope',
+            verdict: 'deferred',
+          },
+        ]);
+      }
+    );
+  });
+
+  test('accepts legacy minimal occurrences without projecting observations', () => {
+    const legacyCompletionReport: TestReport = {
+      ...completionReport,
+      run: {
+        ledger: {
+          cycle: 1,
+          forms: { projectionist: 'skipped' },
+          occurrences: [
+            {
+              form: 'projectionist',
+              path: 'docs/history.md',
+              scopeTier: 'legacy-policy',
+            },
+          ],
+        },
+        report: {},
+      },
+    };
+
+    withHistory(run(true, report, legacyCompletionReport), (rootDir) => {
       const index = loadGovernedVocabularyHistory(rootDir);
 
       expect(index.issues).toEqual([]);
       expect(
         index.byTransitionId.get('v1-projection-derive-render')
-      ).toBeDefined();
+          ?.latestFormObservations
+      ).toEqual([]);
     });
   });
 
@@ -490,6 +593,80 @@ describe('loadGovernedVocabularyHistory', () => {
     provenance.safeApplied = 99;
 
     withHistory(tampered, (rootDir) => {
+      const index = loadGovernedVocabularyHistory(rootDir);
+
+      expect(index.byTransitionId.size).toBe(0);
+      expect(index.issues[0]?.message).toBe(
+        'Committed Regrade history has invalid deterministic run evidence.'
+      );
+    });
+  });
+
+  test('rejects required history with an invented occurrence classification', () => {
+    const reportWithInvalidClassification = {
+      ...report,
+      run: {
+        ledger: {
+          cycle: 1,
+          forms: { projectionist: 'deferred' },
+          occurrences: [
+            {
+              column: 7,
+              context: 'const projectionist = true;',
+              disposition: 'invented-classification',
+              end: 20,
+              form: 'projectionist',
+              line: 3,
+              path: 'src/example.ts',
+              reason: 'unclassified-neighbor',
+              scopeTier: 'in-scope',
+              start: 6,
+              verdict: 'deferred',
+            },
+          ],
+        },
+        report: {},
+      },
+    } as TestReport;
+
+    withHistory(run(true, reportWithInvalidClassification), (rootDir) => {
+      const index = loadGovernedVocabularyHistory(rootDir);
+
+      expect(index.byTransitionId.size).toBe(0);
+      expect(index.issues[0]?.message).toBe(
+        'Committed Regrade history has invalid deterministic run evidence.'
+      );
+    });
+  });
+
+  test('rejects modern occurrences with an invented scope tier', () => {
+    const reportWithInvalidScopeTier = {
+      ...report,
+      run: {
+        ledger: {
+          cycle: 1,
+          forms: { projectionist: 'deferred' },
+          occurrences: [
+            {
+              column: 7,
+              context: 'const projectionist = true;',
+              disposition: 'in-family-unresolved',
+              end: 20,
+              form: 'projectionist',
+              line: 3,
+              path: 'src/example.ts',
+              reason: 'unclassified-neighbor',
+              scopeTier: 'legacy-policy',
+              start: 6,
+              verdict: 'deferred',
+            },
+          ],
+        },
+        report: {},
+      },
+    } as TestReport;
+
+    withHistory(run(true, reportWithInvalidScopeTier), (rootDir) => {
       const index = loadGovernedVocabularyHistory(rootDir);
 
       expect(index.byTransitionId.size).toBe(0);

--- a/packages/warden/src/__tests__/trails.test.ts
+++ b/packages/warden/src/__tests__/trails.test.ts
@@ -9,8 +9,8 @@ import { wardenTopo } from '../trails/topo.js';
 testAll(wardenTopo);
 
 describe('wardenTopo', () => {
-  test('contains all 74 rule trails', () => {
-    expect(wardenTopo.count).toBe(74);
+  test('contains all 75 rule trails', () => {
+    expect(wardenTopo.count).toBe(75);
   });
 
   test('all trail IDs follow warden.rule.* naming', () => {

--- a/packages/warden/src/__tests__/wrap-rule.test.ts
+++ b/packages/warden/src/__tests__/wrap-rule.test.ts
@@ -50,4 +50,53 @@ describe('wrapRule', () => {
     });
     expect(capturedContext?.knownResourceIds).toBeUndefined();
   });
+
+  test('keeps wrapped rule trails file-scoped', async () => {
+    const rule: ProjectAwareWardenRule = {
+      check: () => [],
+      checkProject: (context) => [
+        {
+          filePath: 'project.ts',
+          line: context.governedVocabularyHistoryByTransitionId?.size ?? 0,
+          message: 'project hook',
+          rule: 'combined-rule',
+          severity: 'warn',
+        },
+      ],
+      checkWithContext: () => [
+        {
+          filePath: 'file.ts',
+          line: 2,
+          message: 'file hook',
+          rule: 'combined-rule',
+          severity: 'warn',
+        },
+      ],
+      description: 'combined rule',
+      name: 'combined-rule',
+      severity: 'warn',
+    };
+    const wrapped = wrapRule({ examples: [], rule });
+    const result = await wrapped.implementation(
+      {
+        filePath: 'entity.ts',
+        governedVocabularyHistories: [
+          {
+            caseSensitive: false,
+            id: 'history-id',
+            latestFormObservations: [],
+            path: '.trails/regrade/history/contour-to-entity.json',
+            runCount: 1,
+            transitionId: 'v1-contour-entity',
+          },
+        ],
+        sourceCode: '',
+      },
+      createTrailContext()
+    );
+
+    expect(result.unwrap()).toEqual({
+      diagnostics: [expect.objectContaining({ line: 2, message: 'file hook' })],
+    });
+  });
 });

--- a/packages/warden/src/index.ts
+++ b/packages/warden/src/index.ts
@@ -11,6 +11,7 @@
 export type {
   BuiltinWardenRuleName,
   GovernedVocabularyHistoryEvidence,
+  GovernedVocabularyHistoryFormObservation,
   GovernedVocabularyHistoryIssue,
   ProjectAwareWardenRule,
   ProjectContext,
@@ -194,7 +195,11 @@ export {
 
 // Trail layer
 export { wardenTopo } from './trails/topo.js';
-export { runTopoAwareWardenTrails, runWardenTrails } from './trails/run.js';
+export {
+  runProjectWardenRules,
+  runTopoAwareWardenTrails,
+  runWardenTrails,
+} from './trails/run.js';
 export {
   activationOrphanTrail,
   capturedKernelTrail,
@@ -216,6 +221,7 @@ export {
   firesDeclarationsTrail,
   forkWithoutPreservedImplementationTrail,
   governedSymbolResidueTrail,
+  governedVocabularyPermutationWatchTrail,
   implementationReturnsResultTrail,
   incompleteAccessorForStandardOpTrail,
   incompleteCrudTrail,

--- a/packages/warden/src/regrade-history.ts
+++ b/packages/warden/src/regrade-history.ts
@@ -16,6 +16,7 @@ import type {
 const planBodySchema = z.discriminatedUnion('kind', [
   z
     .object({
+      caseSensitive: z.boolean().optional(),
       from: z.string().min(1),
       id: z.string().optional(),
       kind: z.literal('vocabulary'),
@@ -80,6 +81,59 @@ const reportEntrySchema = z
   })
   .passthrough();
 
+const vocabularyDispositionSchema = z.enum([
+  'code-context-out-of-engine',
+  'docs-only',
+  'explicit-preserve',
+  'forward-pointer',
+  'historical-by-policy',
+  'ignored-by-scope',
+  'in-family-modified',
+  'in-family-unresolved',
+  'out-of-family',
+  'preserve-current-live-api',
+]);
+
+const historyOccurrenceSchema = z
+  .object({
+    disposition: vocabularyDispositionSchema.optional(),
+    form: z.string(),
+    line: z.number().int().positive().optional(),
+    path: z.string(),
+    reason: z.string().optional(),
+    scopeTier: z.string().nullish(),
+    verdict: z.enum(['applied', 'deferred', 'modified', 'skipped']).optional(),
+  })
+  .passthrough()
+  .superRefine((occurrence, ctx) => {
+    const modernOccurrence =
+      occurrence.disposition !== undefined &&
+      occurrence.line !== undefined &&
+      occurrence.reason !== undefined &&
+      occurrence.verdict !== undefined;
+    if (
+      modernOccurrence &&
+      occurrence.scopeTier !== undefined &&
+      occurrence.scopeTier !== null &&
+      occurrence.scopeTier !== 'in-scope' &&
+      occurrence.scopeTier !== 'policy-classified'
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Modern Regrade occurrences use a recognized scope tier.',
+        path: ['scopeTier'],
+      });
+    }
+  });
+
+const governedObservationSchema = historyOccurrenceSchema.safeExtend({
+  disposition: vocabularyDispositionSchema,
+  line: z.number().int().positive(),
+  reason: z.string(),
+  scopeTier: z.enum(['in-scope', 'policy-classified']).nullish(),
+  verdict: z.enum(['applied', 'deferred', 'modified', 'skipped']),
+});
+
 const reportSchema = z
   .object({
     apply: z.object({ applied: z.number() }).passthrough().optional(),
@@ -94,15 +148,7 @@ const reportSchema = z
           .object({
             cycle: z.unknown(),
             forms: z.record(z.string(), z.unknown()),
-            occurrences: z.array(
-              z
-                .object({
-                  form: z.string(),
-                  path: z.string(),
-                  scopeTier: z.string().optional(),
-                })
-                .passthrough()
-            ),
+            occurrences: z.array(historyOccurrenceSchema),
           })
           .passthrough(),
         report: z
@@ -154,6 +200,7 @@ const governedHistoryRunSchema = historyRunSchema.extend({
 });
 
 type GovernedHistoryRun = z.infer<typeof governedHistoryRunSchema>;
+type HistoryRun = z.infer<typeof historyRunSchema>;
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -302,6 +349,50 @@ export interface GovernedVocabularyHistoryIndex {
 }
 
 const normalizePath = (value: string): string => value.replaceAll('\\', '/');
+
+const latestRunFacts = (
+  run: HistoryRun | undefined
+): Pick<
+  GovernedVocabularyHistoryEvidence,
+  'caseSensitive' | 'latestFormObservations'
+> => {
+  if (run === undefined || run.plan.plan.kind !== 'vocabulary') {
+    return { caseSensitive: false, latestFormObservations: [] };
+  }
+  const report = reportSchema.safeParse(run.completionReport ?? run.report);
+  if (!report.success) {
+    return {
+      caseSensitive: run.plan.plan.caseSensitive === true,
+      latestFormObservations: [],
+    };
+  }
+  return {
+    caseSensitive: run.plan.plan.caseSensitive === true,
+    latestFormObservations: (report.data.run?.ledger.occurrences ?? []).flatMap(
+      (occurrence) => {
+        const observation = governedObservationSchema.safeParse(occurrence);
+        if (!observation.success) {
+          return [];
+        }
+        const { disposition, form, line, path, reason, scopeTier, verdict } =
+          observation.data;
+        return [
+          {
+            disposition,
+            form,
+            line,
+            path,
+            reason,
+            ...(scopeTier === undefined || scopeTier === null
+              ? {}
+              : { scopeTier }),
+            verdict,
+          },
+        ];
+      }
+    ),
+  };
+};
 
 type HistoryFileResult =
   | {
@@ -455,9 +546,11 @@ const loadHistoryFile = (rootDir: string, name: string): HistoryFileResult => {
     );
   }
   const provenance = parsed.data.runs.at(-1)?.provenance;
+  const facts = latestRunFacts(parsed.data.runs.at(-1));
   return {
     kind: 'evidence',
     value: {
+      ...facts,
       id: parsed.data.id,
       path: parsed.data.path,
       ...(provenance === undefined ? {} : { provenance }),

--- a/packages/warden/src/rules/governed-vocabulary-permutation-watch.ts
+++ b/packages/warden/src/rules/governed-vocabulary-permutation-watch.ts
@@ -1,0 +1,76 @@
+import type {
+  GovernedVocabularyHistoryEvidence,
+  GovernedVocabularyHistoryFormObservation,
+  ProjectAwareWardenRule,
+  ProjectContext,
+  WardenDiagnostic,
+} from './types.js';
+
+const RULE_NAME = 'governed-vocabulary-permutation-watch';
+
+const formIdentity = (
+  form: string,
+  evidence: GovernedVocabularyHistoryEvidence
+): string => (evidence.caseSensitive ? form : form.toLowerCase());
+
+const isUnknownPermutation = (
+  observation: GovernedVocabularyHistoryFormObservation
+): boolean =>
+  observation.reason === 'unclassified-neighbor' &&
+  observation.verdict === 'deferred' &&
+  (observation.scopeTier === undefined || observation.scopeTier === 'in-scope');
+
+const compareObservation = (
+  left: GovernedVocabularyHistoryFormObservation,
+  right: GovernedVocabularyHistoryFormObservation
+): number =>
+  left.path.localeCompare(right.path) ||
+  left.line - right.line ||
+  left.form.localeCompare(right.form);
+
+const diagnosticsForHistory = (
+  evidence: GovernedVocabularyHistoryEvidence
+): readonly WardenDiagnostic[] => {
+  const unknownByIdentity = new Map<
+    string,
+    GovernedVocabularyHistoryFormObservation
+  >();
+
+  for (const observation of evidence.latestFormObservations) {
+    if (!isUnknownPermutation(observation)) {
+      continue;
+    }
+    const identity = formIdentity(observation.form, evidence);
+    const current = unknownByIdentity.get(identity);
+    if (current === undefined || compareObservation(observation, current) < 0) {
+      unknownByIdentity.set(identity, observation);
+    }
+  }
+
+  return [...unknownByIdentity.entries()]
+    .toSorted(([left], [right]) => left.localeCompare(right))
+    .map(([, observation]) => ({
+      filePath: observation.path,
+      line: observation.line,
+      message: `Governed transition '${evidence.transitionId}' recorded unknown vocabulary form '${observation.form}' in committed Regrade history '${evidence.path}' (${evidence.id}). Add the form and run an incremental plan, or classify it as out-of-family or preserved.`,
+      rule: RULE_NAME,
+      severity: 'warn' as const,
+    }));
+};
+
+const checkProject = (context: ProjectContext): readonly WardenDiagnostic[] =>
+  [...(context.governedVocabularyHistoryByTransitionId?.values() ?? [])]
+    .toSorted((left, right) =>
+      left.transitionId.localeCompare(right.transitionId)
+    )
+    .flatMap(diagnosticsForHistory);
+
+export const governedVocabularyPermutationWatch: ProjectAwareWardenRule = {
+  check: () => [],
+  checkProject,
+  checkWithContext: () => [],
+  description:
+    'Advise when committed Regrade history records unclassified permutations of governed vocabulary.',
+  name: RULE_NAME,
+  severity: 'warn',
+};

--- a/packages/warden/src/rules/index.ts
+++ b/packages/warden/src/rules/index.ts
@@ -15,6 +15,7 @@ import { errorMappingCompleteness } from './error-mapping-completeness.js';
 import { exampleValid } from './example-valid.js';
 import { firesDeclarations } from './fires-declarations.js';
 import { governedSymbolResidue } from './governed-symbol-residue.js';
+import { governedVocabularyPermutationWatch } from './governed-vocabulary-permutation-watch.js';
 import { implementationReturnsResult } from './implementation-returns-result.js';
 import { incompleteAccessorForStandardOp } from './incomplete-accessor-for-standard-op.js';
 import { incompleteCrud } from './incomplete-crud.js';
@@ -80,6 +81,7 @@ import { webhookRouteCollision } from './webhook-route-collision.js';
 
 export type {
   GovernedVocabularyHistoryEvidence,
+  GovernedVocabularyHistoryFormObservation,
   GovernedVocabularyHistoryIssue,
   WardenFix,
   WardenFixCapability,
@@ -164,6 +166,7 @@ export { errorMappingCompleteness } from './error-mapping-completeness.js';
 export { exampleValid } from './example-valid.js';
 export { firesDeclarations } from './fires-declarations.js';
 export { governedSymbolResidue } from './governed-symbol-residue.js';
+export { governedVocabularyPermutationWatch } from './governed-vocabulary-permutation-watch.js';
 export { incompleteAccessorForStandardOp } from './incomplete-accessor-for-standard-op.js';
 export { incompleteCrud } from './incomplete-crud.js';
 export { intentPropagation } from './intent-propagation.js';
@@ -242,6 +245,7 @@ export const wardenRules: ReadonlyMap<string, WardenRule> = new Map<
   [exampleValid.name, exampleValid],
   [firesDeclarations.name, firesDeclarations],
   [governedSymbolResidue.name, governedSymbolResidue],
+  [governedVocabularyPermutationWatch.name, governedVocabularyPermutationWatch],
   [incompleteCrud.name, incompleteCrud],
   [intentPropagation.name, intentPropagation],
   [layerFieldNameDrift.name, layerFieldNameDrift],

--- a/packages/warden/src/rules/metadata.ts
+++ b/packages/warden/src/rules/metadata.ts
@@ -84,6 +84,7 @@ const concernByRuleName: Partial<Record<string, WardenRuleConcern>> = {
   'fires-declarations': 'signals',
   'fork-without-preserved-implementation': 'lifecycle',
   'governed-symbol-residue': 'lifecycle',
+  'governed-vocabulary-permutation-watch': 'lifecycle',
   'implementation-returns-result': 'results',
   'intent-propagation': 'composition',
   'library-projection-coherence': 'meta',
@@ -334,6 +335,27 @@ const builtinWardenRuleMetadataInput = {
     invariant:
       'Governed vocabulary transitions carry committed Regrade provenance and do not leave or reintroduce retired identifiers.',
     tier: 'source-static',
+  },
+  'governed-vocabulary-permutation-watch': {
+    guidance: {
+      docs: [
+        {
+          label: 'Vocabulary transition workflow',
+          path: 'docs/releases/v1-vocabulary-transition-workflow.md',
+        },
+      ],
+      steps: [
+        'Add the unknown form to the governed vocabulary plan and run an incremental Regrade plan.',
+        'If the form is intentionally unrelated or preserved, classify it so later history suppresses the advisory.',
+      ],
+      summary:
+        'Classify unknown governed-stem permutations recorded by committed Regrade history.',
+    },
+    invariant:
+      'Committed Regrade history keeps unknown governed-stem permutations visible until they are classified.',
+    lifecycle: { state: 'durable' },
+    scope: 'advisory',
+    tier: 'project-static',
   },
   'implementation-returns-result': {
     ...durableExternal,

--- a/packages/warden/src/rules/registry-names.ts
+++ b/packages/warden/src/rules/registry-names.ts
@@ -23,6 +23,7 @@ import { errorMappingCompleteness } from './error-mapping-completeness.js';
 import { exampleValid } from './example-valid.js';
 import { firesDeclarations } from './fires-declarations.js';
 import { governedSymbolResidue } from './governed-symbol-residue.js';
+import { governedVocabularyPermutationWatch } from './governed-vocabulary-permutation-watch.js';
 import { implementationReturnsResult } from './implementation-returns-result.js';
 import { incompleteAccessorForStandardOp } from './incomplete-accessor-for-standard-op.js';
 import { incompleteCrud } from './incomplete-crud.js';
@@ -109,6 +110,7 @@ export const registeredRuleNames: readonly string[] = [
   exampleValid.name,
   firesDeclarations.name,
   governedSymbolResidue.name,
+  governedVocabularyPermutationWatch.name,
   forkWithoutPreservedImplementation.name,
   implementationReturnsResult.name,
   incompleteAccessorForStandardOp.name,

--- a/packages/warden/src/rules/types.ts
+++ b/packages/warden/src/rules/types.ts
@@ -380,11 +380,24 @@ export interface ProjectContext {
 }
 
 export interface GovernedVocabularyHistoryEvidence {
+  readonly caseSensitive: boolean;
   readonly id: string;
+  readonly latestFormObservations: readonly GovernedVocabularyHistoryFormObservation[];
   readonly path: string;
   readonly provenance?: GovernedVocabularyHistoryProvenance;
   readonly runCount: number;
   readonly transitionId: string;
+}
+
+/** One vocabulary-form observation preserved in committed Regrade history. */
+export interface GovernedVocabularyHistoryFormObservation {
+  readonly disposition: string;
+  readonly form: string;
+  readonly line: number;
+  readonly path: string;
+  readonly reason: string;
+  readonly scopeTier?: 'in-scope' | 'policy-classified' | undefined;
+  readonly verdict: 'applied' | 'deferred' | 'modified' | 'skipped';
 }
 
 export interface GovernedVocabularyHistoryIssue {

--- a/packages/warden/src/trails/governed-vocabulary-permutation-watch.trail.ts
+++ b/packages/warden/src/trails/governed-vocabulary-permutation-watch.trail.ts
@@ -1,0 +1,16 @@
+import { governedVocabularyPermutationWatch } from '../rules/governed-vocabulary-permutation-watch.js';
+import { wrapRule } from './wrap-rule.js';
+
+export const governedVocabularyPermutationWatchTrail = wrapRule({
+  examples: [
+    {
+      expected: { diagnostics: [] },
+      input: {
+        filePath: 'packages/example/src/trails/play.ts',
+        sourceCode: 'const entityId = "track";\n',
+      },
+      name: 'Project history watch runs at the project boundary',
+    },
+  ],
+  rule: governedVocabularyPermutationWatch,
+});

--- a/packages/warden/src/trails/index.ts
+++ b/packages/warden/src/trails/index.ts
@@ -17,6 +17,7 @@ export { exampleValidTrail } from './example-valid.trail.js';
 export { firesDeclarationsTrail } from './fires-declarations.trail.js';
 export { forkWithoutPreservedImplementationTrail } from './fork-without-preserved-implementation.trail.js';
 export { governedSymbolResidueTrail } from './governed-symbol-residue.trail.js';
+export { governedVocabularyPermutationWatchTrail } from './governed-vocabulary-permutation-watch.trail.js';
 export { implementationReturnsResultTrail } from './implementation-returns-result.trail.js';
 export { incompleteAccessorForStandardOpTrail } from './incomplete-accessor-for-standard-op.trail.js';
 export { incompleteCrudTrail } from './incomplete-crud.trail.js';

--- a/packages/warden/src/trails/run.ts
+++ b/packages/warden/src/trails/run.ts
@@ -9,12 +9,20 @@
 import type { Intent, Topo } from '@ontrails/core';
 import { run } from '@ontrails/core';
 
-import { wardenTopoRules } from '../rules/index.js';
-import type { WardenDiagnostic } from '../rules/types.js';
+import { wardenRules, wardenTopoRules } from '../rules/index.js';
+import type {
+  GovernedVocabularyHistoryEvidence,
+  GovernedVocabularyHistoryIssue,
+  ProjectAwareWardenRule,
+  WardenDiagnostic,
+  WardenRule,
+} from '../rules/types.js';
 import type { WardenImportResolution } from '../resolve.js';
 import type { WardenPublicWorkspace } from '../workspaces.js';
+import { projectAwareRuleInput } from './schema.js';
 import type { RuleOutput } from './schema.js';
 import { wardenTopo } from './topo.js';
+import { buildProjectContext } from './wrap-rule.js';
 
 /**
  * Run all file-scoped warden rule trails for a given file and collect diagnostics.
@@ -34,6 +42,9 @@ const appendDiagnostics = (
 type TrailIntentMap = Readonly<Record<string, Intent>>;
 
 interface ProjectRuleOptions {
+  readonly governedVocabularyHistories?: readonly GovernedVocabularyHistoryEvidence[];
+  readonly governedVocabularyHistoryIssues?: readonly GovernedVocabularyHistoryIssue[];
+  readonly governedVocabularyHistoryRequired?: boolean;
   readonly entityReferencesByName?: Readonly<Record<string, readonly string[]>>;
   readonly composeTargetTrailIds?: readonly string[];
   readonly crudTableIds?: readonly string[];
@@ -55,6 +66,9 @@ interface ProjectRuleOptions {
 }
 
 const PROJECT_OPTION_KEYS = [
+  'governedVocabularyHistories',
+  'governedVocabularyHistoryIssues',
+  'governedVocabularyHistoryRequired',
   'entityReferencesByName',
   'composeTargetTrailIds',
   'crudTableIds',
@@ -133,6 +147,34 @@ export const runWardenTrails = async (
   }
 
   return allDiagnostics;
+};
+
+const isProjectAwareRule = (rule: WardenRule): rule is ProjectAwareWardenRule =>
+  'checkWithContext' in rule;
+
+/**
+ * Run project-wide built-in Warden diagnostics once for one project context.
+ *
+ * @example
+ * ```ts
+ * const diagnostics = runProjectWardenRules({
+ *   governedVocabularyHistories: histories,
+ * });
+ * ```
+ */
+export const runProjectWardenRules = (
+  options?: ProjectRuleOptions
+): readonly WardenDiagnostic[] => {
+  const context = buildProjectContext(
+    projectAwareRuleInput.parse(buildRuleInput('<project>', '', options))
+  );
+  const diagnostics: WardenDiagnostic[] = [];
+  for (const rule of wardenRules.values()) {
+    if (isProjectAwareRule(rule) && rule.checkProject !== undefined) {
+      appendDiagnostics(diagnostics, rule.checkProject(context));
+    }
+  }
+  return diagnostics;
 };
 
 /**

--- a/packages/warden/src/trails/schema.ts
+++ b/packages/warden/src/trails/schema.ts
@@ -119,6 +119,27 @@ export const authoredMcpSurfaceBindingSetSchema = z.object({
     .describe('Trail ids registered in the owning app topo'),
 });
 
+const governedVocabularyHistoryObservationSchema = z.object({
+  disposition: z.string(),
+  form: z.string(),
+  line: z.number().int().positive(),
+  path: z.string(),
+  reason: z.string(),
+  scopeTier: z.enum(['in-scope', 'policy-classified']).optional(),
+  verdict: z.enum(['applied', 'deferred', 'modified', 'skipped']),
+});
+
+const governedVocabularyHistoryEvidenceSchema = z.object({
+  caseSensitive: z.boolean(),
+  id: z.string(),
+  latestFormObservations: z
+    .array(governedVocabularyHistoryObservationSchema)
+    .readonly(),
+  path: z.string(),
+  runCount: z.number().int().nonnegative(),
+  transitionId: z.string(),
+});
+
 export const projectAwareRuleInput = ruleInput.extend({
   authoredMcpSurfaceBindingSets: z
     .array(authoredMcpSurfaceBindingSetSchema)
@@ -153,6 +174,26 @@ export const projectAwareRuleInput = ruleInput.extend({
     .record(z.string(), z.array(exportedSymbolDefinitionSchema))
     .optional()
     .describe('Public exported symbol definitions grouped by exported name'),
+  governedVocabularyHistories: z
+    .array(governedVocabularyHistoryEvidenceSchema)
+    .readonly()
+    .optional()
+    .describe('Validated committed Regrade histories by governed transition'),
+  governedVocabularyHistoryIssues: z
+    .array(
+      z.object({
+        message: z.string(),
+        path: z.string(),
+        transitionId: z.string().optional(),
+      })
+    )
+    .readonly()
+    .optional()
+    .describe('Invalid committed Regrade history artifacts'),
+  governedVocabularyHistoryRequired: z
+    .boolean()
+    .optional()
+    .describe('Whether the project must prove completed governed migrations'),
   importResolutionsByFile: z
     .record(z.string(), z.array(importResolutionSchema))
     .optional()

--- a/packages/warden/src/trails/wrap-rule.ts
+++ b/packages/warden/src/trails/wrap-rule.ts
@@ -50,7 +50,47 @@ const buildRuleMeta = (rule: WardenRule | TopoAwareWardenRule) => {
   };
 };
 
-const buildProjectContext = (input: ProjectAwareRuleInput): ProjectContext => ({
+const buildGovernedHistoryContext = (
+  input: ProjectAwareRuleInput
+): Pick<
+  ProjectContext,
+  | 'governedVocabularyHistoryByTransitionId'
+  | 'governedVocabularyHistoryIssues'
+  | 'governedVocabularyHistoryRequired'
+> => ({
+  ...(input.governedVocabularyHistories
+    ? {
+        governedVocabularyHistoryByTransitionId: new Map(
+          input.governedVocabularyHistories.map((history) => [
+            history.transitionId,
+            history,
+          ])
+        ),
+      }
+    : {}),
+  ...(input.governedVocabularyHistoryIssues
+    ? {
+        governedVocabularyHistoryIssues:
+          input.governedVocabularyHistoryIssues.map((issue) => ({
+            message: issue.message,
+            path: issue.path,
+            ...(issue.transitionId === undefined
+              ? {}
+              : { transitionId: issue.transitionId }),
+          })),
+      }
+    : {}),
+  ...(input.governedVocabularyHistoryRequired === undefined
+    ? {}
+    : {
+        governedVocabularyHistoryRequired:
+          input.governedVocabularyHistoryRequired,
+      }),
+});
+
+export const buildProjectContext = (
+  input: ProjectAwareRuleInput
+): ProjectContext => ({
   ...(input.authoredMcpSurfaceBindingSets
     ? { authoredMcpSurfaceBindingSets: input.authoredMcpSurfaceBindingSets }
     : {}),
@@ -98,6 +138,7 @@ const buildProjectContext = (input: ProjectAwareRuleInput): ProjectContext => ({
         ),
       }
     : {}),
+  ...buildGovernedHistoryContext(input),
   ...(input.publicWorkspaces
     ? { publicWorkspaces: new Map(Object.entries(input.publicWorkspaces)) }
     : {}),
@@ -151,10 +192,11 @@ export function wrapRule(
         RuleOutput
       >['examples'],
       implementation: (input: ProjectAwareRuleInput) => {
+        const context = buildProjectContext(input);
         const diagnostics = projectAwareRule.checkWithContext(
           input.sourceCode,
           input.filePath,
-          buildProjectContext(input)
+          context
         );
         return Result.ok({ diagnostics: [...diagnostics] });
       },

--- a/plugin/skills/trails/references/warden-guide.md
+++ b/plugin/skills/trails/references/warden-guide.md
@@ -5,7 +5,7 @@
 This file is generated from the live `@ontrails/warden` rule manifest. Repo-tracked skills, agents, and plugin prompts should reference this file instead of copying rule prose by hand.
 
 - Guide input command: `bun apps/trails/bin/trails.ts warden guide --agent-json`
-- Rule count: 74
+- Rule count: 75
 
 ## Agent Instructions
 
@@ -63,6 +63,7 @@ This file is generated from the live `@ontrails/warden` rule manifest. Repo-trac
 - `draft-visible-debt` (warn, source/source-static, external): Draft-authored IDs remain visible debt.
 - `fork-without-preserved-implementation` (error, source/source-static, external): Fork version entries preserve their historical implementation.
 - `governed-symbol-residue` (error, source/source-static, external): Governed vocabulary transitions carry committed Regrade provenance and do not leave or reintroduce retired identifiers. Guidance: Require committed Regrade evidence before completing a governed vocabulary migration.
+- `governed-vocabulary-permutation-watch` (warn, all/project-static, advisory): Committed Regrade history keeps unknown governed-stem permutations visible until they are classified. Guidance: Classify unknown governed-stem permutations recorded by committed Regrade history.
 - `marker-schema-unsupported` (error, source/source-static, external): Versioned schemas stay inside the supported marker projection subset.
 - `pending-force` (warn, topo/topo-aware, external): Forced topo break audit events do not remain pending indefinitely.
 - `scheduled-destroy-intent` (warn, topo/topo-aware, external): Schedule-activated destroy trails make unattended destructive work visible for review.


### PR DESCRIPTION
## Context

[TRL-1135](https://linear.app/outfitter/issue/TRL-1135/warden-history-powered-residue-and-unknown-permutation-watch) turns committed Regrade history into durable post-migration coaching without keeping migration-time enforcement alive.

## What changed

- keeps live retired-symbol reintroductions on the existing error rule, citing transition and immutable history identity
- adds a separate warn/advisory project-static rule for deferred `unclassified-neighbor` forms in the latest committed run
- deduplicates by transition and normalized form while preserving unresolved occurrences across path-scoped classifications
- strictly projects typed latest-run observation facts through the shared Warden history index
- adds the wrapped public rule trail, metadata/registry wiring, workflow docs, and regenerated agent/skill guidance
- adds a minor `@ontrails/warden` changeset

## How to test

- `bun test packages/warden/src` (1,323 tests)
- `bun run check`
- `bun run publish:check`
- `bun run wayfinder:dogfood`
- `bun apps/trails/bin/trails.ts warden --json`
- full pre-push test, typecheck, lint, format, governance, and dead-code suite

## Risks and rollout

- The advisory consumes only the latest immutable history run; earlier unresolved observations do not resurrect after a later clean or classified run.
- A classification in one protected path does not hide a deferred occurrence of the same form elsewhere.
- Current repository history is clean, so the new rule adds no warnings to the existing Warden baseline.
- This PR does not publish packages.
