### PR TITLE
chore(vocab): close v1 reset scaffolding

### DIFF
--- a/.agents/skills/regrade-loop/SKILL.md
+++ b/.agents/skills/regrade-loop/SKILL.md
@@ -87,7 +87,7 @@ Project defaults may narrow scope, but an explicit plan can override them.
 Run without `apply` first:
 
 ```bash
-trails regrade --root-dir . --from facet --to trailhead --json
+trails regrade --root-dir . --from '<from>' --to '<to>' --json
 trails regrade --root-dir . --class-ids term-rewrite:no-retired-cross-vocabulary --json
 ```
 
@@ -114,7 +114,7 @@ Never hide uncertainty by applying a broad replacement.
 Apply only after the dry-run report is understood:
 
 ```bash
-trails regrade --root-dir . --from facet --to trailhead --apply --json
+trails regrade --root-dir . --from '<from>' --to '<to>' --apply --json
 ```
 
 Safe apply may still leave the gate open when target text contains the source, when review inventory remains, or when new neighbor forms are discovered. That is expected. Continue the loop instead of calling the migration done.

--- a/.agents/skills/trails-writing-style/assets/SAMPLES.md
+++ b/.agents/skills/trails-writing-style/assets/SAMPLES.md
@@ -2,7 +2,8 @@
 
 Worked craft samples for Trails prose, adapted and expanded from the Outfitter styleguide samples. They cover both framework docs (ADRs, guides, reference, agent guidance, release notes) and trails.dev narrative and launch writing. Use them with `trails-writing-style` -- they illustrate the rules by example; they are not new rules.
 
-> Vocabulary note: examples here use only stable Trails terms on purpose. The framework's vocabulary is mid-cutover toward the v1 reset, so don't treat any single term as permanent -- when you write new samples, prefer terms that are settled.
+> Vocabulary note: examples here use the live v1 Trails terms. Use `derive`
+> for contract-owned facts and `render` for surface presentation.
 
 ## Opening moves
 

--- a/.changeset/trl-1020-vocabulary-cleanup.md
+++ b/.changeset/trl-1020-vocabulary-cleanup.md
@@ -1,0 +1,9 @@
+---
+'@ontrails/regrade': patch
+'@ontrails/trails': patch
+---
+
+Finish the v1 vocabulary reset cleanup by retaining the facet guard, adding a
+durable TopoGraph artifact-family guard, teaching the live lexicon directly in
+agent guidance, and replacing completed reset-family placeholders in public
+Regrade examples and CLI schema help.

--- a/.claude/skills/regrade-loop/SKILL.md
+++ b/.claude/skills/regrade-loop/SKILL.md
@@ -81,7 +81,7 @@ Project defaults may narrow scope, but an explicit plan can override them.
 Run without `apply` first:
 
 ```bash
-trails regrade --root-dir . --from facet --to trailhead --json
+trails regrade --root-dir . --from '<from>' --to '<to>' --json
 trails regrade --root-dir . --class-ids term-rewrite:no-retired-cross-vocabulary --json
 ```
 
@@ -108,7 +108,7 @@ Never hide uncertainty by applying a broad replacement.
 Apply only after the dry-run report is understood:
 
 ```bash
-trails regrade --root-dir . --from facet --to trailhead --apply --json
+trails regrade --root-dir . --from '<from>' --to '<to>' --apply --json
 ```
 
 Safe apply may still leave the gate open when target text contains the source, when review inventory remains, or when new neighbor forms are discovered. That is expected. Continue the loop instead of calling the migration done.

--- a/.claude/skills/trails-writing-style/assets/SAMPLES.md
+++ b/.claude/skills/trails-writing-style/assets/SAMPLES.md
@@ -2,7 +2,8 @@
 
 Worked craft samples for Trails prose, adapted and expanded from the Outfitter styleguide samples. They cover both framework docs (ADRs, guides, reference, agent guidance, release notes) and trails.dev narrative and launch writing. Use them with `trails-writing-style` -- they illustrate the rules by example; they are not new rules.
 
-> Vocabulary note: examples here use only stable Trails terms on purpose. The framework's vocabulary is mid-cutover toward the v1 reset, so don't treat any single term as permanent -- when you write new samples, prefer terms that are settled.
+> Vocabulary note: examples here use the live v1 Trails terms. Use `derive`
+> for contract-owned facts and `render` for surface presentation.
 
 ## Opening moves
 

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -341,7 +341,7 @@ const regradeAdjustInputSchema = z.object({
   transition: z
     .string()
     .min(1)
-    .describe('Graduated transition name, e.g. facet-to-trailhead'),
+    .describe('Graduated transition name, e.g. <transition-name>'),
 });
 
 type RegradePlanInput = z.output<typeof regradePlanInputSchema>;

--- a/docs/releases/v1-vocabulary-reset.md
+++ b/docs/releases/v1-vocabulary-reset.md
@@ -1,6 +1,6 @@
 # v1 Vocabulary Reset Transition Plan
 
-This is the executable plan for the v1 vocabulary reset. It coordinates the family order, safety policy, compatibility stance, and evidence required before any reset branch changes live code or public API names.
+This is the execution record for the v1 vocabulary reset. It preserves the family order, safety policy, compatibility stance, and evidence used to move live code and public API names. All four vocabulary families are now live; the cleanup branch closes their temporary scaffolding without weakening the durable regression boundary.
 
 The reset is not a broad text replacement. The typed transition facts live in `packages/warden/src/rules/retired-vocabulary.ts` and are consumed by Regrade. This document owns the narrative: order, boundaries, compatibility decisions, namespace census rules, and verification.
 
@@ -12,8 +12,7 @@ Use these artifacts together:
 
 | Artifact | Role |
 | --- | --- |
-| `docs/lexicon.md` | Current live vocabulary until the cutover lands. |
-| `docs/lexicon.md` | Canonical live vocabulary after each completed family lands. |
+| `docs/lexicon.md` | Canonical live vocabulary for the completed reset. |
 | `packages/warden/src/rules/retired-vocabulary.ts` | Typed governed vocabulary registry: family ids, forms, symbol renames, review forms, and target shape. |
 | `packages/regrade/src/downstream/vocabulary-registry.ts` | Registry-to-Regrade bridge for single-target vocabulary plans. |
 | Regrade run output | Observed ledger and report for an execution attempt. |
@@ -192,6 +191,8 @@ Cleanup must:
 - regenerate Warden guide output and agent guidance;
 - confirm docs, skills, plugin guidance, release notes, and changesets match the final vocabulary.
 
+The cleanup branch retained the facet transition's repo-local Warden guard, added a durable TopoGraph artifact-family guard, confirmed there are no active Regrade plans, and retained the governed transition registry plus legacy-input rejection paths as durable regression checks. Repo-local Claude, Codex, and Clark guidance now teaches the live lexicon directly, matching the distributed plugin skills. Generic Regrade examples no longer use a completed reset family as their default placeholder.
+
 ## Execution Gate
 
 A family branch cannot leave draft until it records:
@@ -223,7 +224,7 @@ Run narrower checks first while iterating. The full gate is required before read
 
 ## What This Does Not Decide
 
-This plan does not start the actual reset.
+This record does not authorize another vocabulary reset.
 
 It also does not decide:
 

--- a/packages/regrade/src/downstream/file-renames.ts
+++ b/packages/regrade/src/downstream/file-renames.ts
@@ -46,9 +46,9 @@ import type {
  * @example
  * ```ts
  * const candidate: FileRenameCandidate = {
- *   evidence: ['docs/surface-facets.md'],
- *   from: 'docs/surface-facets.md',
- *   to: 'docs/surface-trailheads.md',
+ *   evidence: ['docs/legacy-guide.md'],
+ *   from: 'docs/legacy-guide.md',
+ *   to: 'docs/current-guide.md',
  * };
  * ```
  */
@@ -1311,7 +1311,7 @@ const withExactMovedTargets = (params: {
  * @example
  * ```ts
  * const candidates = deriveFileRenameCandidates({
- *   plan: { from: 'facet', kind: 'vocabulary', to: 'trailhead' },
+ *   plan: { from: 'legacy', kind: 'vocabulary', to: 'current' },
  *   root: process.cwd(),
  * });
  * ```

--- a/packages/regrade/src/downstream/vocabulary.ts
+++ b/packages/regrade/src/downstream/vocabulary.ts
@@ -124,11 +124,11 @@ export interface VocabularyFileRenameEvidence extends VocabularyFileRename {
  * @example
  * ```ts
  * const proposal: VocabularyFormProposal = {
- *   from: 'facets',
+ *   from: 'legacies',
  *   kind: 'safe-rewrite',
  *   reason: 'default-morphology',
  *   source: 'default-morphology',
- *   to: 'trailheads',
+ *   to: 'currents',
  * };
  * ```
  */
@@ -741,9 +741,9 @@ const deferFormsForPlan = (plan: VocabularyRegradePlan): readonly string[] => {
  * @example
  * ```ts
  * const forms = deriveVocabularyFormProposals({
- *   from: 'facet',
+ *   from: 'legacy',
  *   kind: 'vocabulary',
- *   to: 'trailhead',
+ *   to: 'current',
  * });
  * ```
  */


### PR DESCRIPTION
## Context

TRL-1020 closes temporary scaffolding left after the v1 vocabulary families landed. Durable governed-transition history and legacy-input rejection remain in place. The facet Markdown guard stays temporarily because facet predates immutable Regrade history and does not yet have equivalent history-backed audit coverage.

## What changed

- retain the project-local facet-to-trailhead Warden rules until equivalent committed history/audit coverage exists
- teach the live v1 lexicon directly across Claude, Codex, and Clark guidance
- replace reset-family command examples with quoted `'<from>'` and `'<to>'` placeholders
- remove other completed reset-family placeholders and stale teaching surfaces
- record the reset as completed and add patch release intent for `@ontrails/regrade` and `@ontrails/trails`

## Verification

- `bun run check`
- `bun run test` (49 tasks; Trails app 697 pass)
- `bun run build`
- `bun run wayfinder:dogfood` (69 trails)
- `bun run changeset:check`
- `bun run publish:check`
- `bun run skillset:check`
- full repository Warden run with both repo-local vocabulary guards
- Graphite pre-push suite

## Risk / rollout

Low. The cleanup keeps the remaining facet guard explicit rather than claiming history-backed coverage that does not exist. The package-owned governed vocabulary registry, committed Regrade history, legacy artifact rejection, and current-facing documentation guard remain intact. No active Regrade plans or lock changes remain.