### PR TITLE
docs(adr): define governed Regrade lifecycle

### DIFF
--- a/docs/adr/0053-regrade-moves-governed-contract-change.md
+++ b/docs/adr/0053-regrade-moves-governed-contract-change.md
@@ -1,0 +1,238 @@
+---
+id: 53
+slug: regrade-moves-governed-contract-change
+title: Regrade Moves Governed Contract Change
+status: accepted
+created: 2026-07-15
+updated: 2026-07-15
+owners: ['[galligan](https://github.com/galligan)']
+depends_on: [0, 7, 23, 37]
+---
+
+# ADR-0053: Regrade Moves Governed Contract Change
+
+## Context
+
+Trails makes contract definition the source of truth. A trail ID, schema, intent, and error taxonomy fan out into surfaces, documentation, governance, and the resolved graph. The v1 vocabulary reset exposed the missing half of that model: changing an established contract can drift just as easily as defining one unless the change has its own authored intent and derived proof.
+
+A broad replacement script cannot tell which occurrence carries contract meaning. It sees the retired `project` verb and the ordinary `project` noun as the same token. It rewrites rendered outputs that should regenerate from their owner. It also has no durable answer for an ambiguous occurrence beyond changing it, skipping it, or leaving a comment for later.
+
+The first Regrade tracer proved that a plan, occurrence ledger, and report could preserve CLI and MCP behavior through a governed rename. The next three vocabulary families made the boundary sharper. They required AST-aware symbol work, public API review, protected historical evidence, file movement, reference closure, classification by lifecycle stage, and durable proof that a completed migration stayed complete.
+
+The question is not whether Trails needs a general codemod framework. It does not. The question is how Trails changes contract-bearing source without giving up the same alignment guarantees it provides when that source is first authored.
+
+## Decision
+
+**A governed contract change is a Regrade.** Regrade authors transient migration intent, applies the safe slice, routes uncertain occurrences to review, and commits immutable evidence of what was observed. It is Trails using Trails, not a new top-level framework primitive.
+
+### Regrade works because it knows Trails contracts
+
+An operation belongs in Regrade only when contract or graph knowledge makes it safer or smaller than a general source transform.
+
+The test:
+
+> Would this operation work just as well on code that has nothing to do with Trails?
+
+If yes, use a general tool such as an AST rewrite or search utility directly. If no—because the operation needs authored contract identity, topo facts, Warden diagnostics, surface derivation, or Trails lifecycle policy—it belongs in Regrade.
+
+This boundary means Regrade changes authored contracts and the source that establishes them. Derived facts and rendered outputs should regenerate from their owner. Rewriting a rendered output is a warning that Regrade has crossed the authored boundary, unless that artifact is intentionally committed because its diff is itself a governance surface.
+
+A name change can still pass the test. Renaming a trail ID is not only a text edit: the CLI command, MCP tool name, lock key, references, governance facts, and docs may derive from or teach the same authored identity. Regrade changes the owner, verifies the fan-out, and reviews occurrences where the relationship cannot be proved.
+
+### Ownership stays split by lifecycle
+
+No second database owns framework truth.
+
+| Owner | Responsibility |
+| --- | --- |
+| Trail contracts and the resolved graph | Current framework and application truth. |
+| Warden | Durable rules, reusable detection, severity, and structured fix metadata. |
+| Regrade plan | Authored, transient migration intent and reviewed scope. |
+| Regrade execution | Collection, check, preview, conservative apply, validation, and review routing. |
+| Regrade history | Immutable committed evidence for applied runs. |
+| Regrade report and audit | Derived views of observed occurrence state and current residue. |
+
+Warden governs what must remain true after a migration. Regrade moves the contract toward that truth. Regrade may consume Warden diagnostics selected by structured rule and fix fields, but it does not scrape diagnostic messages to decide what migration to run or whether an edit is safe. Message text may remain human-facing context; it is not the integration protocol.
+
+### The plan authors migration intent
+
+The plan is the one active, reviewable statement of a migration. Minimal `from` and `to` input may derive morphology, casing, namespace census, candidate file moves, live-topo preserves, and review proposals. Every derived field records provenance. Reviewers can then distinguish what a person chose from what the framework proposed.
+
+```json
+{
+  "kind": "regrade-plan",
+  "plan": {
+    "id": "v1-blaze-implementation",
+    "kind": "vocabulary",
+    "from": "blaze",
+    "to": "implementation",
+    "intent": "Move the authored trail behavior field for v1."
+  },
+  "provenance": {
+    "fields": {
+      "from": "authored",
+      "to": "authored",
+      "fileRenames": "derived",
+      "preserve": "derived"
+    }
+  }
+}
+```
+
+Authored overrides tighten or correct derivation. They do not create a second untracked migration path. If review changes the intended migration, update the active plan and rerun the lifecycle.
+
+### Scope has three tiers
+
+Every governed run separates collection policy from occurrence disposition:
+
+- **Hard excluded** paths are mechanical noise that is not scanned, such as
+  dependencies, build output, caches, and local scratch state.
+- **Policy-classified** paths are scanned and counted but protected from
+  default mutation. Changelogs, accepted ADR history, archived plans, and
+  changesets belong here when they preserve historical evidence.
+- **In-scope** paths are current source, tests, docs, examples, skills,
+  generated guidance, and release guidance. They are scanned normally.
+
+Collection uses the shared `PathScope` fields: `include`, `exclude`, and `extensions`. A plan adds `policyClassified` rules when protected evidence must remain visible and `teachingSurfaces` when current documentation coverage is part of completion. Current docs cannot disappear behind a broad exclusion to make the gate green.
+
+### Completion is occurrence-level and observed
+
+Regrade does not accept a declaration that a migration is done. It observes each occurrence and records one of four verdicts: applied, modified, deferred, or skipped. A separate disposition classifies why that verdict is correct. Preservation is a skipped verdict with an explicit preserve disposition and evidence, not a fifth verdict. The completion report derives its gate from those facts.
+
+This means:
+
+- a preserve in one path does not suppress the same form elsewhere;
+- an unknown form remains review inventory rather than becoming an inferred
+  replacement;
+- zero source matches is meaningful only when the expected scope and teaching
+  surfaces were actually scanned; and
+- Warden can use committed history to distinguish valid historical evidence,
+  a reintroduced retired form, and an unknown permutation.
+
+### Application is conservative and transactional
+
+`check` validates the active plan and its freshness. `preview` shows the run without writes. `apply --dry-run` exercises apply evaluation and preflight, then returns before the mutating branch. Real `apply` writes only the safe slice after preflight.
+
+Ambiguous or unsupported work stays in structured review inventory. It does not become a guessed edit. File moves are authored in the plan, applied before one derived reference-closure pass, and rolled back with earlier writes if a later mutation fails. Historical references remain counted without being silently rewritten.
+
+CLI and MCP render the same five lifecycle trails: plan, list, check, preview, and apply. Surface parity is part of the contract because an agent must see the same plan, gate, report, and history facts regardless of how it reaches the trail.
+
+### Applied plans become immutable history
+
+The lifecycle is:
+
+```text
+active plan -> check -> preview -> apply -> immutable committed history
+                                      |
+                                      +-> derived report and audit
+```
+
+Apply removes the active plan and appends a run to its consolidated history artifact. The run binds plan content, source state, completion evidence, and governed provenance with hashes. Warden validates governed histories through a dedicated loader instead of trusting provenance-shaped JSON.
+
+An adjustment is explicit. It copies a graduated transition back into an active plan without mutating prior runs. A later apply appends evidence to the same history spine. Immutable history is excluded from later source collection, preventing recursive evidence growth, while remaining available to Warden and audit through its owned reader.
+
+### Four vocabulary families establish the contract
+
+The v1 reset increased judgment density one family at a time.
+
+| Family | What the run proved | Failure that improved Regrade |
+| --- | --- | --- |
+| `facet` to `trailhead` | The tracer established registry-owned intent, plan/ledger/report flow, CLI/MCP parity, and a hard surface-visible cutover. | The first run exposed missing structured review and downstream-source seams instead of justifying a larger replacement script. |
+| `blaze` to `implementation` | A high-blast authored API field could move while English phrases, historical evidence, and public declarations stayed reviewed. Its consolidated history retains two runs. | Broad lexical matching could not decide that “blaze a trail” was ordinary prose; explicit preserves and AST/public-API review became required. |
+| `contour` to `entity` | A common domain noun could replace a framework declaration without treating every app-domain entity occurrence as migration work. Its history retains three runs. | Type names, fail-loud legacy guards, and historical ADR references needed distinct evidence instead of one family-wide skip. |
+| `projection`/`project` to `derive`/`render` | A classification family split contract-owned fact production from presentation, moved 16 files with reference closure, and preserved ordinary project nouns. The final consolidated run is green with zero open occurrences and the `docs/**` teaching gate satisfied. | A stale plan correctly stopped the first write; 21 residual reviews found a missed presentation verb; a 48 MB recursively scanned history forced history pruning and a dedicated provenance path. |
+
+The families differ deliberately. A single-target rename can derive more safe work. A common noun needs more preserves. A lifecycle split has no safe global replacement and therefore produces more review. Regrade is one contract across those cases because the plan, occurrence ledger, conservative apply, history, and report remain stable while the migration classes vary.
+
+### Durable governance outlives transient orchestration
+
+The active plan is temporary. The rules that reject retired API shapes, validate governed provenance, catch reintroduced forms, and watch unknown permutations remain after the plan graduates. This is the difference between a completed migration and a one-time cleanup: the old contract cannot silently return.
+
+## Consequences
+
+### Positive
+
+- Contract change follows the same one-write-many-reads model as contract
+  definition.
+- Reviewers can inspect authored intent, derived proposals, occurrence
+  outcomes, and immutable applied evidence separately.
+- Agents get the same migration lifecycle through CLI and MCP.
+- Historical evidence stays visible without being mistaken for current
+  residue.
+- Warden and Regrade keep distinct owners, preventing parallel governance and
+  migration databases.
+- Conservative application makes ambiguity explicit instead of hiding it
+  behind a successful command.
+
+### Tradeoffs
+
+- A governed migration requires plan review, scope classification, and
+  evidence maintenance beyond the source edit itself.
+- Conservative runs leave more work for human or agent review than a broad
+  replacement would.
+- Committed history can be large because it preserves occurrence-level proof.
+  Consolidation and history-pruning keep that cost bounded, but they do not
+  make the evidence free.
+- Regrade classes and Warden fix metadata carry compatibility obligations once
+  adopters depend on them.
+
+### Risks
+
+- **Generic-tool creep.** Regrade could become a bag of codemods. Mitigation:
+  apply the “works because of Trails” membership test during API and issue
+  review.
+- **Message-string coupling.** A consumer could infer migration semantics from
+  diagnostic prose. Mitigation: route on structured rule, class, safety, edit,
+  span, and provenance fields; treat prose only as explanation.
+- **False completion.** Broad exclusions or transition-wide preserves could
+  hide residue. Mitigation: occurrence-level dispositions, three-tier scope,
+  expected teaching surfaces, current-source audit, and Warden history checks.
+- **Evidence recursion.** History could scan itself and grow without bound.
+  Mitigation: source collection prunes immutable history; Warden and audit load
+  it through dedicated readers.
+
+## Non-goals
+
+- Building a general codemod framework for arbitrary repositories.
+- Settling speculative migration classes that the v1 runs did not prove.
+- Promising that every breaking change already has an adopter-ready Regrade.
+- Making every Warden finding automatically fixable.
+- Treating review-required occurrences as safe edits.
+- Rewriting historical ADRs, changelogs, release notes, or issue references to
+  erase the vocabulary that existed when they were written.
+
+## Non-decisions
+
+- The final public stability level of adopter-authored Regrade classes.
+- Which future contract changes require first-party migration classes.
+- Whether package-distributed migrations need an additional discovery or
+  compatibility protocol.
+- How long all occurrence detail remains in committed history after stable
+  release operations have their own retention evidence.
+- Any new vocabulary family after the v1 reset.
+
+## References
+
+- [ADR-0000: Core Premise](0000-core-premise.md) — defines authored,
+  derived, enforced, observed, and overridden information and the drift guard.
+- [ADR-0007: Governance as Trails](0007-governance-as-trails.md) — makes
+  Warden the trail-shaped owner of durable governance.
+- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md)
+  — establishes the vocabulary discipline applied by the v1 reset.
+- [ADR-0037: Owner-First Authority](0037-owner-first-authority.md) — keeps
+  migration facts with their natural owner and consumers on derived views.
+- [v1 Vocabulary Reset](../releases/v1-vocabulary-reset.md) — execution
+  order, family-specific evidence, compatibility posture, and cleanup record.
+- [v1 Vocabulary Transition Workflow](../releases/v1-vocabulary-transition-workflow.md)
+  — the supported plan/check/preview/apply workflow derived from dogfood.
+- [`blaze` to `implementation` history](../../.trails/regrade/history/blaze-to-implementation.json)
+  — two-run consolidated evidence for the authored behavior-field cutover.
+- [`contour` to `entity` history](../../.trails/regrade/history/contour-to-entity.json)
+  — three-run consolidated evidence for the domain-object vocabulary cutover.
+- [`projection` to `derive`/`render` history](../../.trails/regrade/history/v1-projection-derive-render.json)
+  — final governed provenance, scope, file moves, occurrence ledger, and
+  completion report for the classification family.
+- [#880](https://github.com/outfitter-dev/trails/pull/880) — merged tracer run
+  for `facet` to `trailhead`.
+- [TRL-829](https://linear.app/outfitter/issue/TRL-829/) — issue acceptance and
+  final evidence boundary for this decision.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,3 +59,4 @@ ADRs document the significant design decisions behind Trails — the choices tha
 | [0050](0050-surface-accommodations-preserve-trail-identity.md) | Surface Accommodations Preserve Trail Identity | Accepted |
 | [0051](0051-package-ownership-follows-natural-altitude.md) | Package Ownership Follows Natural Altitude | Accepted |
 | [0052](0052-overlays-one-extension-mechanism.md) | Overlays Are the Lock's One Extension Mechanism | Accepted |
+| [0053](0053-regrade-moves-governed-contract-change.md) | Regrade Moves Governed Contract Change | Accepted |

--- a/docs/adr/decision-map.json
+++ b/docs/adr/decision-map.json
@@ -135,6 +135,11 @@
           "fromPath": "docs/adr/0039-reactive-trail-activation.md"
         },
         {
+          "context": "- [ADR-0000: Core Premise](0000-core-premise.md) — defines authored,",
+          "from": "0053",
+          "fromPath": "docs/adr/0053-regrade-moves-governed-contract-change.md"
+        },
+        {
           "context": "- docs/adr/0000-core-premise.md",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-direct-invocation.md"
@@ -741,6 +746,11 @@
           "context": "- [ADR-0007: Governance as Trails](0007-governance-as-trails.md) - Warden",
           "from": "0038",
           "fromPath": "docs/adr/0038-typed-signal-emission.md"
+        },
+        {
+          "context": "- [ADR-0007: Governance as Trails](0007-governance-as-trails.md) — makes",
+          "from": "0053",
+          "fromPath": "docs/adr/0053-regrade-moves-governed-contract-change.md"
         },
         {
           "context": "Warden is the governance arm of Trails. It is where drift becomes visible before runtime, and [ADR-0007](../0007-governance-as-trails.md) made that governance trail-shaped instead of a parallel lint s",
@@ -1727,6 +1737,11 @@
           "fromPath": "docs/adr/0040-resource-scoped-store-signal-identity.md"
         },
         {
+          "context": "- [ADR-0023: Simplifying the Trails Lexicon](0023-simplifying-the-trails-lexicon.md)",
+          "from": "0053",
+          "fromPath": "docs/adr/0053-regrade-moves-governed-contract-change.md"
+        },
+        {
           "context": "- [ADR-0023: Simplifying the Trails Lexicon](../0023-simplifying-the-trails-lexicon.md) -- the lexicon renames; note that `resource` in this ADR refers to the distribution unit, distinct from `resourc",
           "from": "20260331",
           "fromPath": "docs/adr/drafts/20260331-pack-resources.md"
@@ -2362,6 +2377,11 @@
           "fromPath": "docs/adr/0047-stable-release-line-discipline.md"
         },
         {
+          "context": "- [ADR-0037: Owner-First Authority](0037-owner-first-authority.md) — keeps",
+          "from": "0053",
+          "fromPath": "docs/adr/0053-regrade-moves-governed-contract-change.md"
+        },
+        {
           "context": "- docs/adr/0037-owner-first-authority.md",
           "from": "20260503",
           "fromPath": "docs/adr/drafts/20260503-wayfinding.md"
@@ -2972,6 +2992,19 @@
       "superseded_by": null,
       "title": "Overlays Are the Lock's One Extension Mechanism",
       "updated": "2026-07-07"
+    },
+    {
+      "created": "2026-07-15",
+      "depends_on": ["0", "7", "23", "37"],
+      "inbound": [],
+      "number": "0053",
+      "owners": ["[galligan](https://github.com/galligan)"],
+      "path": "docs/adr/0053-regrade-moves-governed-contract-change.md",
+      "slug": "regrade-moves-governed-contract-change",
+      "status": "accepted",
+      "superseded_by": null,
+      "title": "Regrade Moves Governed Contract Change",
+      "updated": "2026-07-15"
     }
   ],
   "version": 1


### PR DESCRIPTION
## Context

TRL-829 closes the Regrade doctrine from the four shipped v1 vocabulary dogfood families. The decision needed to match the live library, CLI, MCP, Warden, plan/history lifecycle, and scope behavior rather than earlier exploratory notes.

## What changed

- adds accepted ADR-0053, `Regrade Moves Governed Contract Change`
- defines the contract-aware membership test: Regrade belongs where Trails contract or graph knowledge changes the operation
- records the Warden/Regrade ownership boundary and active plan to immutable history lifecycle
- defines four occurrence verdicts with separate dispositions, three-tier scope, field provenance, conservative file/reference application, and CLI/MCP parity
- compares `facet` to `trailhead`, `blaze` to `implementation`, `contour` to `entity`, and `projection`/`project` to `derive`/`render`, including failures that improved the engine
- regenerates the ADR index and decision map

## Verification

- `bun scripts/adr.ts check`
- `bun run docs:links`
- `bun run docs:snippets`
- `bun run docs:wrap-check`
- `bun run format:check`
- `bun run changeset:check`
- `bun run check`
- `bun run test`
- `bun run build`
- `bun run publish:check`
- pre-push stable checks
- fresh local review: 5/5, zero P0-P3 after two precision fixes

## Risks and rollout

Documentation-only. No publishable package content changed, so no changeset or migration step is required. The main risk is doctrine drifting from shipped behavior; the ADR cites committed histories and current owner code, and ADR/link/Regrade audit checks are green.