### PR TITLE
fix(release): prune retired workspace changeset entries

### DIFF
--- a/.changeset/beta12-config-permits-crumbs.md
+++ b/.changeset/beta12-config-permits-crumbs.md
@@ -1,7 +1,6 @@
 ---
 "@ontrails/config": minor
 "@ontrails/permits": minor
-"@ontrails/tracing": minor
 "@ontrails/core": patch
 "@ontrails/cli": patch
 "@ontrails/testing": patch

--- a/.changeset/beta14-topo-store-stack.md
+++ b/.changeset/beta14-topo-store-stack.md
@@ -8,7 +8,6 @@
 '@ontrails/topography': minor
 '@ontrails/store': minor
 '@ontrails/testing': minor
-'@ontrails/tracing': minor
 '@ontrails/trails': minor
 '@ontrails/warden': minor
 ---

--- a/.changeset/boundary-tsdoc.md
+++ b/.changeset/boundary-tsdoc.md
@@ -1,7 +1,6 @@
 ---
 '@ontrails/commander': patch
 '@ontrails/hono': patch
-'@ontrails/observe': patch
 '@ontrails/vite': patch
 ---
 

--- a/.changeset/compose-cutover.md
+++ b/.changeset/compose-cutover.md
@@ -8,8 +8,6 @@
 '@ontrails/commander': patch
 '@ontrails/http': patch
 '@ontrails/mcp': patch
-'@ontrails/observe': patch
-'@ontrails/tracing': patch
 ---
 
 Rename first-class trail composition from the `cross` API family to the `compose` family across core contracts, testing helpers, topo projections, Warden rules, CLI scaffolds, and docs. `composes`, `ctx.compose`, `composeInput`, and `Compose*` type names are now the public authoring vocabulary; topo persistence migrates legacy composition rows and graph keys forward.

--- a/.changeset/compose-straggler-cleanup.md
+++ b/.changeset/compose-straggler-cleanup.md
@@ -1,7 +1,6 @@
 ---
 "@ontrails/core": patch
 "@ontrails/testing": patch
-"@ontrails/tracing": patch
 "@ontrails/warden": patch
 ---
 

--- a/.changeset/connector-guardrail-source-comments.md
+++ b/.changeset/connector-guardrail-source-comments.md
@@ -4,7 +4,6 @@
 "@ontrails/hono": patch
 "@ontrails/http": patch
 "@ontrails/mcp": patch
-"@ontrails/observe": patch
 ---
 
 Refresh source comments and test labels for retired connector terminology as adapter guardrails become strict.

--- a/.changeset/knip-dead-code.md
+++ b/.changeset/knip-dead-code.md
@@ -1,8 +1,6 @@
 ---
 "@ontrails/core": patch
-"@ontrails/observe": patch
 "@ontrails/store": patch
-"@ontrails/tracing": patch
 "@ontrails/trails": patch
 "@ontrails/warden": patch
 ---

--- a/.changeset/lexicon-rename-cleanup.md
+++ b/.changeset/lexicon-rename-cleanup.md
@@ -1,7 +1,6 @@
 ---
 '@ontrails/core': minor
 '@ontrails/cli': minor
-'@ontrails/tracing': minor
 '@ontrails/warden': minor
 ---
 

--- a/.changeset/logtape-observe-target.md
+++ b/.changeset/logtape-observe-target.md
@@ -1,5 +1,4 @@
 ---
-"@ontrails/observe": major
 ---
 
 Retarget the LogTape adapter to the `@ontrails/observe/logtape` subpath and use `createLogtapeSink` as the canonical factory name.

--- a/.changeset/observability-migration-docs.md
+++ b/.changeset/observability-migration-docs.md
@@ -1,6 +1,4 @@
 ---
-"@ontrails/observe": patch
-"@ontrails/tracing": patch
 ---
 
 Add migration guidance for the retired `@ontrails/logging` package and align observability README examples around `@ontrails/observe`, `@ontrails/tracing`, and `@ontrails/observe/logtape`.

--- a/.changeset/observability-v1-boundary.md
+++ b/.changeset/observability-v1-boundary.md
@@ -1,6 +1,4 @@
 ---
-"@ontrails/observe": patch
-"@ontrails/tracing": patch
 ---
 
 Document the v1 observability package boundary: `@ontrails/observe` is the production sink contract package, while `@ontrails/tracing` remains the compatibility and developer-state package with the supported `@ontrails/tracing/otel` adapter subpath.

--- a/.changeset/observe-log-forwarding-subpaths.md
+++ b/.changeset/observe-log-forwarding-subpaths.md
@@ -1,5 +1,4 @@
 ---
-"@ontrails/observe": major
 ---
 
 Fold LogTape and Pino log forwarding into `@ontrails/observe/logtape` and `@ontrails/observe/pino`, and remove the standalone `@ontrails/logtape` and `@ontrails/pino` workspaces.

--- a/.changeset/remove-legacy-logging-package.md
+++ b/.changeset/remove-legacy-logging-package.md
@@ -1,8 +1,6 @@
 ---
-"@ontrails/observe": minor
 "@ontrails/trails": patch
 "@ontrails/testing": patch
-"@ontrails/tracing": patch
 "@ontrails/warden": patch
 ---
 

--- a/.changeset/retired-package-row-cleanup.md
+++ b/.changeset/retired-package-row-cleanup.md
@@ -1,0 +1,7 @@
+---
+'@ontrails/trails': patch
+---
+
+Allow release checks to recognize changeset edits that only remove release rows
+for packages absent from the live workspace while rejecting any additional
+changes hidden beside that cleanup.

--- a/.changeset/taxonomy-docs-pass.md
+++ b/.changeset/taxonomy-docs-pass.md
@@ -5,7 +5,6 @@
 "@ontrails/hono": patch
 "@ontrails/http": patch
 "@ontrails/mcp": patch
-"@ontrails/observe": patch
 "@ontrails/store": patch
 ---
 

--- a/.changeset/tracing-compat-boundary.md
+++ b/.changeset/tracing-compat-boundary.md
@@ -1,5 +1,4 @@
 ---
-'@ontrails/tracing': patch
 ---
 
 Document the completed tracing compatibility boundary and add tests proving core tracing primitive re-exports and the observe-owned memory sink compatibility wrapper.

--- a/.changeset/tracing-otel-connector-to-adapter.md
+++ b/.changeset/tracing-otel-connector-to-adapter.md
@@ -1,5 +1,4 @@
 ---
-"@ontrails/tracing": major
 ---
 
 BREAKING: rename the OpenTelemetry tracing connector API to adapter vocabulary.

--- a/.changeset/tracing-ownership-foundations.md
+++ b/.changeset/tracing-ownership-foundations.md
@@ -1,7 +1,5 @@
 ---
 '@ontrails/core': patch
-'@ontrails/observe': patch
-'@ontrails/tracing': patch
 ---
 
 Promote signal trace helpers from tracing compatibility code to core exports, and make tracing's memory sink wrapper use the observe-owned implementation.

--- a/.changeset/trailhead-surface-tracing.md
+++ b/.changeset/trailhead-surface-tracing.md
@@ -1,5 +1,4 @@
 ---
-"@ontrails/tracing": minor
 ---
 
 **BREAKING:** Complete the tracing wire-format cutover from `trailhead` to `surface`.

--- a/.changeset/trl-1018-implementation-cutover.md
+++ b/.changeset/trl-1018-implementation-cutover.md
@@ -11,7 +11,6 @@
 '@ontrails/regrade': minor
 '@ontrails/store': minor
 '@ontrails/testing': minor
-'@ontrails/tracing': minor
 '@ontrails/trails': minor
 '@ontrails/warden': minor
 ---

--- a/.changeset/trl-1057-xdg-state-store.md
+++ b/.changeset/trl-1057-xdg-state-store.md
@@ -1,7 +1,6 @@
 ---
 "@ontrails/core": patch
 "@ontrails/trails": patch
-"@ontrails/tracing": patch
 "@ontrails/topography": patch
 ---
 

--- a/.changeset/trl-1236-observability-package-rename.md
+++ b/.changeset/trl-1236-observability-package-rename.md
@@ -1,7 +1,6 @@
 ---
 '@ontrails/core': patch
 '@ontrails/observability': major
-'@ontrails/tracing': patch
 '@ontrails/testing': patch
 '@ontrails/trails': patch
 '@ontrails/warden': patch

--- a/.changeset/trl-411-trace-tree-renderer.md
+++ b/.changeset/trl-411-trace-tree-renderer.md
@@ -1,5 +1,4 @@
 ---
-'@ontrails/observe': minor
 ---
 
 Add `renderTraceTree(records: readonly TraceRecord[]): string` — a pure post-execution renderer that builds a readable execution tree from `TraceRecord` entries. Renders root spans with `●`, children with `├──`/`└──`, status glyphs (`✓`/`✗`/`⊘`), durations, and parallel-branch detection (overlapping siblings render as a bracketed group with wall-vs-total summary). Tolerates forward-compatible record shapes (signal/activation kinds, `attrs.layer` from upcoming layer composition) without crashing — unknown kinds fall through to a generic span renderer. No live streaming; the tree is drawn once after the trail completes.

--- a/.changeset/trl-700-trails-workspace-layout.md
+++ b/.changeset/trl-700-trails-workspace-layout.md
@@ -1,7 +1,6 @@
 ---
 '@ontrails/core': major
 '@ontrails/config': major
-'@ontrails/tracing': major
 '@ontrails/trails': major
 ---
 

--- a/.changeset/trl-720-pino-package.md
+++ b/.changeset/trl-720-pino-package.md
@@ -1,5 +1,4 @@
 ---
-'@ontrails/observe': minor
 ---
 
 Add the supported `@ontrails/observe/pino` forwarding subpath.

--- a/.changeset/trl-721-pino-sink.md
+++ b/.changeset/trl-721-pino-sink.md
@@ -1,5 +1,4 @@
 ---
-'@ontrails/observe': minor
 ---
 
 Implement the structural Pino log sink under `@ontrails/observe/pino`.

--- a/.changeset/trl-722-pino-docs.md
+++ b/.changeset/trl-722-pino-docs.md
@@ -1,5 +1,4 @@
 ---
-'@ontrails/observe': patch
 ---
 
 Document Pino sink usage and publish-readiness checks.

--- a/.changeset/trl-723-otel-attribute-mapping.md
+++ b/.changeset/trl-723-otel-attribute-mapping.md
@@ -1,5 +1,4 @@
 ---
-"@ontrails/tracing": minor
 ---
 
 Complete the stable `trails.*` OpenTelemetry attribute mapping for trace identity, lineage, status, timing, signal lifecycle, and activation boundary records while filtering raw payload and unredacted error-message custom attributes.

--- a/.changeset/trl-725-otel-buffering.md
+++ b/.changeset/trl-725-otel-buffering.md
@@ -1,5 +1,4 @@
 ---
-"@ontrails/tracing": patch
 ---
 
 Harden the OTel adapter flush lifecycle by validating batch sizes, sharing concurrent flush drains, and preserving failed batches for retry without silent record loss.

--- a/.changeset/trl-726-tracing-otel-docs.md
+++ b/.changeset/trl-726-tracing-otel-docs.md
@@ -1,6 +1,4 @@
 ---
-"@ontrails/observe": patch
-"@ontrails/tracing": patch
 ---
 
 Document the v1 `@ontrails/tracing/otel` OpenTelemetry adapter boundary, including callback export, stable `trails.*` attributes, flush behavior, and the absence of a standalone `@ontrails/otel` package.

--- a/.changeset/unified-observability-adr.md
+++ b/.changeset/unified-observability-adr.md
@@ -1,8 +1,6 @@
 ---
 "@ontrails/core": minor
 "@ontrails/http": minor
-"@ontrails/observe": minor
-"@ontrails/tracing": minor
 "@ontrails/warden": minor
 ---
 

--- a/.changeset/vocabulary-cutover.md
+++ b/.changeset/vocabulary-cutover.md
@@ -7,7 +7,6 @@
 "@ontrails/permits": minor
 "@ontrails/topography": minor
 "@ontrails/testing": minor
-"@ontrails/tracing": minor
 "@ontrails/warden": minor
 ---
 

--- a/.changeset/wayfinder-shell.md
+++ b/.changeset/wayfinder-shell.md
@@ -1,5 +1,4 @@
 ---
-'@ontrails/observe': patch
 '@ontrails/topography': patch
 ---
 

--- a/apps/trails/src/__tests__/release-check.test.ts
+++ b/apps/trails/src/__tests__/release-check.test.ts
@@ -450,6 +450,87 @@ describe('checkReleaseRules', () => {
     }
   });
 
+  test('allows pruning release rows for packages absent from the live workspace', () => {
+    const { repoRoot, value: baseRef } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'retired-package.md'),
+        "---\n'@ontrails/core': patch\n'@ontrails/retired': patch\n---\n\nHistorical release note.\n"
+      );
+      execSync('git init', { cwd: root, stdio: 'ignore' });
+      execSync('git add .', { cwd: root, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m base',
+        { cwd: root, stdio: 'ignore' }
+      );
+      const committedRef = execSync('git rev-parse HEAD', {
+        cwd: root,
+        encoding: 'utf8',
+      }).trim();
+      writeFileSync(
+        join(root, '.changeset', 'retired-package.md'),
+        "---\n'@ontrails/core': patch\n---\n\nHistorical release note.\n"
+      );
+      return committedRef;
+    });
+
+    try {
+      const result = checkReleaseRules({
+        baseRef,
+        baseWorkspaces: workspaces,
+        changedFiles: ['.changeset/retired-package.md'],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(true);
+      expect(result.activePackageChangesetsWithoutReleaseFacts).toEqual([]);
+      expect(result.coveredPackages).toEqual(['@ontrails/core']);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
+  test('rejects other changes hidden beside a retired package row removal', () => {
+    const { repoRoot, value: baseRef } = withTempRepo((root) => {
+      writeFileSync(
+        join(root, '.changeset', 'retired-package.md'),
+        "---\n'@ontrails/core': patch\n'@ontrails/retired': patch\n---\n\nHistorical release note.\n"
+      );
+      execSync('git init', { cwd: root, stdio: 'ignore' });
+      execSync('git add .', { cwd: root, stdio: 'ignore' });
+      execSync(
+        'git -c user.email=test@example.com -c user.name=Test commit -m base',
+        { cwd: root, stdio: 'ignore' }
+      );
+      const committedRef = execSync('git rev-parse HEAD', {
+        cwd: root,
+        encoding: 'utf8',
+      }).trim();
+      writeFileSync(
+        join(root, '.changeset', 'retired-package.md'),
+        "---\n'@ontrails/core': minor\n---\n\nHistorical release note.\n"
+      );
+      return committedRef;
+    });
+
+    try {
+      const result = checkReleaseRules({
+        baseRef,
+        baseWorkspaces: workspaces,
+        changedFiles: ['.changeset/retired-package.md'],
+        repoRoot,
+        workspaces,
+      });
+
+      expect(result.passed).toBe(false);
+      expect(result.activePackageChangesetsWithoutReleaseFacts).toEqual([
+        '.changeset/retired-package.md',
+      ]);
+    } finally {
+      rmSync(repoRoot, { force: true, recursive: true });
+    }
+  });
+
   test('rejects active package changesets without a matching release fact', () => {
     const { repoRoot } = withTempRepo((root) => {
       writeFileSync(

--- a/apps/trails/src/release/check.ts
+++ b/apps/trails/src/release/check.ts
@@ -436,6 +436,84 @@ const parseChangesetPackages = (content: string): readonly string[] => {
   });
 };
 
+const readBaseChangeset = (
+  repoRoot: string,
+  baseRef: string | undefined,
+  path: string
+): string | null => {
+  if (baseRef === undefined) {
+    return null;
+  }
+
+  const result = Bun.spawnSync({
+    cmd: ['git', 'show', `${baseRef}:${path}`],
+    cwd: repoRoot,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+
+  return result.exitCode === 0 ? result.stdout.toString() : null;
+};
+
+const removeChangesetPackageRows = (
+  content: string,
+  packages: ReadonlySet<string>
+): string => {
+  let insideFrontmatter = false;
+
+  return content
+    .split('\n')
+    .filter((line, index) => {
+      const normalizedLine = line.replace(/\r$/u, '');
+
+      if (normalizedLine === '---') {
+        insideFrontmatter = index === 0;
+        return true;
+      }
+
+      if (!insideFrontmatter) {
+        return true;
+      }
+
+      const packageName = normalizedLine.match(CHANGESET_PACKAGE_PATTERN)?.[1];
+      return packageName === undefined || !packages.has(packageName);
+    })
+    .join('\n');
+};
+
+const findRetiredPackageChangesetCleanups = (
+  changedChangesetPaths: readonly string[],
+  input: ReleaseCheckInput
+): readonly string[] => {
+  const workspaceNames = new Set(
+    input.workspaces.map((workspace) => workspace.name)
+  );
+
+  return changedChangesetPaths.filter((path) => {
+    const absolutePath = join(input.repoRoot, path);
+    if (!existsSync(absolutePath)) {
+      return false;
+    }
+
+    const baseContent = readBaseChangeset(input.repoRoot, input.baseRef, path);
+    if (baseContent === null) {
+      return false;
+    }
+
+    const retiredPackages = new Set(
+      parseChangesetPackages(baseContent).filter(
+        (packageName) => !workspaceNames.has(packageName)
+      )
+    );
+
+    return (
+      retiredPackages.size > 0 &&
+      removeChangesetPackageRows(baseContent, retiredPackages) ===
+        readFileSync(absolutePath, 'utf8')
+    );
+  });
+};
+
 const findChangedChangesetPaths = (
   changedFiles: readonly string[]
 ): readonly string[] =>
@@ -563,6 +641,9 @@ export const checkReleaseRules = (
     input.changedFiles,
     input.repoRoot
   );
+  const retiredPackageChangesetCleanups = new Set(
+    findRetiredPackageChangesetCleanups(changedChangesets, input)
+  );
   const changesets = findChangedChangesets(changedChangesets, input.repoRoot);
   const coveredPackages = [
     ...new Set(changesets.flatMap((changeset) => changeset.packages)),
@@ -590,7 +671,9 @@ export const checkReleaseRules = (
     versionRelease;
   const activePackageChangesetsWithoutReleaseFacts =
     activeChangedChangesets.length > 0 && !hasReleaseFacts
-      ? activeChangedChangesets
+      ? activeChangedChangesets.filter(
+          (path) => !retiredPackageChangesetCleanups.has(path)
+        )
       : [];
   const matchedRuleIds = findMatchedRuleIds(input);
   const requiresPackageIntent = ruleMatchesFactType(input, 'package-content');


### PR DESCRIPTION
## Context

The main Release workflow failed after #967 because Changesets still referenced the retired @ontrails/observe and @ontrails/tracing workspaces. This closes the release-metadata gap left by TRL-1236 and TRL-1237.

## What changed

- removed 22 @ontrails/tracing release rows and 18 @ontrails/observe release rows from existing prerelease changesets
- preserved every historical changeset file and description
- taught the release checker to accept only a byte-exact cleanup that removes rows for packages absent from the live workspace
- added regression coverage that accepts a pure retired-row cleanup and rejects any surviving package bump change hidden beside it
- added a patch changeset for @ontrails/trails

## Verification

- bun run check
- bun run publish:check
- bunx changeset status
- isolated bun run version:packages through release-pack lockfile coherence
- full pre-push gate: 49 test tasks, 713 Trails app tests, typecheck, lint, format, AST-grep, and Knip

## Risk

The exception is deliberately narrow: current content must equal the base changeset byte-for-byte after removing only release rows whose package names are absent from the live workspace. Any description edit, surviving bump edit, or other change remains blocked.