### PR TITLE
fix(release): use npm trusted publishing

### DIFF
--- a/.changeset/trl-1221-trusted-publishing.md
+++ b/.changeset/trl-1221-trusted-publishing.md
@@ -1,0 +1,29 @@
+---
+"@ontrails/adapter-kit": patch
+"@ontrails/cli": patch
+"@ontrails/cloudflare": patch
+"@ontrails/commander": patch
+"@ontrails/config": patch
+"@ontrails/core": patch
+"@ontrails/drizzle": patch
+"@ontrails/hono": patch
+"@ontrails/http": patch
+"@ontrails/library": patch
+"@ontrails/logtape": patch
+"@ontrails/mcp": patch
+"@ontrails/observability": patch
+"@ontrails/permits": patch
+"@ontrails/pino": patch
+"@ontrails/regrade": patch
+"@ontrails/source": patch
+"@ontrails/store": patch
+"@ontrails/testing": patch
+"@ontrails/topography": patch
+"@ontrails/trails": patch
+"@ontrails/vite": patch
+"@ontrails/warden": patch
+---
+
+Publish Bun-validated package tarballs through an npm trusted-publishing adapter
+binding, add exact repository metadata for each public workspace package, and
+correct the native Bun release descriptor to its pack-only runtime boundary.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,17 +5,17 @@ runs:
   using: composite
   steps:
     - name: Setup Node
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
       with:
         node-version: '22'
 
     - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       with:
         bun-version-file: .bun-version
 
     - name: Cache Bun dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: ~/.bun/install/cache
         key: bun-install-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.bun-version', 'bun.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
@@ -85,7 +85,7 @@ jobs:
       tag: ${{ steps.policy.outputs.tag }}
       version: ${{ steps.policy.outputs.version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
@@ -107,14 +107,22 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
+      - name: Set up npm trusted publishing
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+      - name: Pin trusted publishing npm CLI
+        run: npm install --global npm@11.18.0
       - name: Validate package before publish
         run: bun run publish:check
       - name: Publish packages
-        run: bun run publish:packages
+        run: bun run publish:packages -- --trusted-publishing
       - name: Verify published packages
         run: bun run publish:registry-check:published --tag "${{ needs.publish-policy.outputs.tag }}"
 
@@ -128,14 +136,22 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
+      - name: Set up npm trusted publishing
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+      - name: Pin trusted publishing npm CLI
+        run: npm install --global npm@11.18.0
       - name: Validate package before publish
         run: bun run publish:check
       - name: Publish packages
-        run: bun run publish:packages
+        run: bun run publish:packages -- --trusted-publishing
       - name: Verify published packages
         run: bun run publish:registry-check:published --tag "${{ needs.publish-policy.outputs.tag }}"
 
@@ -147,7 +163,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -353,7 +353,7 @@ Use these constraints alongside the two principles:
 
 ## Releasing
 
-All `@ontrails/*` packages are versioned in lockstep using [Changesets](https://github.com/changesets/changesets) in pre-release (`beta`) mode. We use Changesets only for versioning and changelogs — **not** `changeset publish`. Publishing goes through `bun publish` via our script, which correctly resolves `workspace:^` to real versions (npm publish does not).
+All `@ontrails/*` packages are versioned in lockstep using [Changesets](https://github.com/changesets/changesets) in pre-release (`beta`) mode. We use Changesets only for versioning and changelogs, not `changeset publish`. The repo release flow packs and validates each package with Bun, then publishes that resolved tarball through npm. GitHub releases use npm trusted publishing; local credentialed publication remains the bootstrap and recovery path for first-time packages and dist-tag repairs. Do not invoke `npm publish` directly.
 
 ```bash
 # 1. Add a changeset (or create .changeset/<name>.md manually)
@@ -362,18 +362,18 @@ bunx changeset add
 # 2. Version
 bun run version:packages
 
-# 3. Commit, push, publish
-git add -A && git commit -m "chore: version packages to 1.0.0-beta.N"
-git push
+# 3. Validate the generated version branch before its Graphite PR
 bun run publish:check
-bun run publish:packages
+bun run publish:registry-check
 ```
+
+Stage only the generated version files, commit and submit the version branch through Graphite, and merge it after CI and review are clean. The GitHub release workflow publishes through npm trusted publishing after merge. Run `bun run publish:packages` locally only for first-time package bootstrap or explicit incident recovery.
 
 Every PR that changes publishable `@ontrails/*` package contents must satisfy branch-local release rules. The normal intent source is a `.changeset/*.md` entry for the affected package. The compatibility `release:none` label/flag is allowed only when the branch truly does not ship user-visible package content, and the PR, issue, or handoff explains why. The CI release check reads the GitHub PR file list, so stacked PRs are checked against their immediate PR diff rather than the whole local stack. Public trail additions/removals, visibility transitions, input schema changes, output schema changes, or surface exposure changes are release facts and need the same branch-local intent. Fix missing release intent on the owning Graphite branch; do not paper over lower-branch release gaps with a top-stack cleanup changeset.
 
 To exit pre-release mode for a stable release: `bunx changeset pre exit`, then version as usual. Stable 1.x release doctrine is captured in [ADR-0047](docs/adr/0047-stable-release-line-discipline.md), and the copy-pasteable beta-to-1.0 operator sequence lives in [Stable Cutover Runbook](docs/releases/stable-cutover.md).
 
-`bun run publish:check` auto-discovers every non-private workspace, topo-sorts by `workspace:` dep edges, runs `bun pm pack --dry-run` per package (required because `npm pack` does not resolve `catalog:`), and asserts the packed `package.json` contains no unresolved `workspace:` or `catalog:` ranges. It also verifies first-party `workspace:` ranges pack to the current lockstep package versions, so generated release PRs cannot merge with stale `bun.lock` workspace metadata. `bun run publish:registry-check` performs read-only registry/dist-tag probes before publication; missing packages are reported as first-time package candidates. After publishing, use `bun run publish:registry-check:published` to require every package and expected dist-tag to be present. `bun run publish:packages` uses the same discovery and applies the explicit dist-tag from `.changeset/pre.json` (falling back to `latest` outside prerelease mode). Packages intentionally ship source `.ts` files while their `exports` map points at `src`; test files, `dist`, `.turbo`, and `*.tsbuildinfo` should stay out of the published tarballs.
+`bun run publish:check` auto-discovers every non-private workspace, topo-sorts by `workspace:` dep edges, runs `bun pm pack --dry-run` per package (required because `npm pack` does not resolve `catalog:`), and asserts the packed `package.json` contains no unresolved `workspace:` or `catalog:` ranges. It also verifies first-party `workspace:` ranges pack to the current lockstep package versions, so generated release PRs cannot merge with stale `bun.lock` workspace metadata. `bun run publish:registry-check` performs read-only registry/dist-tag probes before publication; missing packages are reported as first-time package candidates. After publishing, use `bun run publish:registry-check:published` to require every package and expected dist-tag to be present. `bun run publish:packages` preflights the complete selected package set before mutation, packs each package with Bun, and publishes the resolved tarball through npm using the explicit dist-tag from `.changeset/pre.json` (falling back to `latest` outside prerelease mode). Packages intentionally ship source `.ts` files while their `exports` map points at `src`; test files, `dist`, `.turbo`, and `*.tsbuildinfo` should stay out of the published tarballs.
 
 ## Testing
 

--- a/adapters/cloudflare/package.json
+++ b/adapters/cloudflare/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/cloudflare",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "adapters/cloudflare"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/commander/package.json
+++ b/adapters/commander/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/commander",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "adapters/commander"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/drizzle/package.json
+++ b/adapters/drizzle/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/drizzle",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "adapters/drizzle"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/hono/package.json
+++ b/adapters/hono/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/hono",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "adapters/hono"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/logtape/package.json
+++ b/adapters/logtape/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/logtape",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "adapters/logtape"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/pino/package.json
+++ b/adapters/pino/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/pino",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "adapters/pino"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/adapters/vite/package.json
+++ b/adapters/vite/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/vite",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "adapters/vite"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/apps/trails/package.json
+++ b/apps/trails/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/trails",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "apps/trails"
+  },
   "bin": {
     "trails": "./bin/trails.ts"
   },

--- a/apps/trails/src/__tests__/release-bindings.test.ts
+++ b/apps/trails/src/__tests__/release-bindings.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, test } from 'bun:test';
 
 import {
+  nativeBunPackBinding,
   nativeBunReleaseBinding,
+  npmReleaseAdapterBinding,
   releaseBindingCapabilityValues,
   releaseBindingKindValues,
   releaseBindingPlacementValues,
 } from '../release/index.js';
 
 describe('release bindings', () => {
-  test('declares the native Bun release binding as the built-in default', () => {
+  test('declares the canonical Bun pack and npm publication bindings', () => {
     expect(releaseBindingKindValues).toEqual(['native', 'adapter']);
     expect(releaseBindingPlacementValues).toEqual([
       'same-package',
@@ -20,15 +22,30 @@ describe('release bindings', () => {
       'publish',
       'registry-preflight',
     ]);
-    expect(nativeBunReleaseBinding).toEqual({
+    expect(nativeBunPackBinding).toEqual({
       boundary: 'trails-owned',
-      capabilities: ['pack-check', 'publish', 'registry-preflight'],
+      capabilities: ['pack-check'],
       description:
-        'Built-in Bun release binding for Trails-owned package pack checks, npm registry preflight, and lockstep package publication.',
+        'Native Bun release binding for Trails-owned package packing and validation.',
       id: 'release.binding.native-bun',
       kind: 'native',
       placement: 'same-package',
       runtime: 'bun',
     });
+    expect(npmReleaseAdapterBinding).toEqual({
+      boundary: 'foreign',
+      capabilities: ['publish', 'registry-preflight'],
+      description:
+        'Same-package npm adapter binding for trusted publication, registry preflight, and lockstep recovery.',
+      id: 'release.binding.npm',
+      kind: 'adapter',
+      placement: 'same-package',
+      runtime: 'npm',
+    });
+  });
+
+  test('keeps the retired release binding name as a truthful pack alias', () => {
+    expect(nativeBunReleaseBinding).toEqual(nativeBunPackBinding);
+    expect(nativeBunReleaseBinding).not.toBe(nativeBunPackBinding);
   });
 });

--- a/apps/trails/src/__tests__/release-native-bun-publish.test.ts
+++ b/apps/trails/src/__tests__/release-native-bun-publish.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+
+import {
+  createNpmPublishCommand,
+  publicationActionForRegistryState,
+  trustedPublishingPreflightErrors,
+  unsupportedPublishLifecycleScripts,
+} from '../release/index.js';
+import type { NativeBunPublishWorkspace } from '../release/index.js';
+import { publishRepositoryMetadataErrors } from '../release/native-bun-publish.js';
+
+const coreWorkspace = (
+  overrides: Partial<NativeBunPublishWorkspace> = {}
+): NativeBunPublishWorkspace => ({
+  isPrivate: false,
+  name: '@ontrails/core',
+  path: join(process.cwd(), 'packages/core'),
+  repository: {
+    directory: 'packages/core',
+    type: 'git',
+    url: 'git+https://github.com/outfitter-dev/trails.git',
+  },
+  version: '1.0.0-beta.44',
+  workspaceDeps: [],
+  ...overrides,
+});
+
+describe('native Bun publish handoff', () => {
+  test('publishes the Bun-packed tarball through npm', () => {
+    expect(
+      createNpmPublishCommand({
+        otp: undefined,
+        tag: 'beta',
+        tarballPath: '/tmp/ontrails-core.tgz',
+      })
+    ).toEqual([
+      'npm',
+      'publish',
+      '/tmp/ontrails-core.tgz',
+      '--access',
+      'public',
+      '--tag',
+      'beta',
+    ]);
+    const otpCommand = createNpmPublishCommand({
+      otp: '123456',
+      tag: 'beta',
+      tarballPath: '/tmp/ontrails-core.tgz',
+    });
+    expect(otpCommand.slice(-2)).toEqual(['--otp', '123456']);
+  });
+
+  test('publishes missing targets, skips complete state, and blocks tag repair', () => {
+    expect(publicationActionForRegistryState({ kind: 'complete' })).toBe(
+      'skip'
+    );
+    expect(publicationActionForRegistryState({ kind: 'needs-publish' })).toBe(
+      'publish'
+    );
+    expect(
+      publicationActionForRegistryState({ kind: 'first-time-package' })
+    ).toBe('publish');
+    expect(
+      publicationActionForRegistryState({ kind: 'first-time-package' }, true)
+    ).toBe('block');
+    expect(
+      publicationActionForRegistryState({
+        currentTagVersion: '1.0.0-beta.42',
+        kind: 'needs-tag-repair',
+      })
+    ).toBe('block');
+  });
+
+  test('rejects publish-only lifecycle hooks that tarball publication skips', () => {
+    expect(
+      unsupportedPublishLifecycleScripts([
+        coreWorkspace({
+          publishLifecycleScripts: ['prepublishOnly', 'publish'],
+        }),
+      ])
+    ).toEqual([
+      '@ontrails/core defines unsupported prepublishOnly',
+      '@ontrails/core defines unsupported publish',
+    ]);
+  });
+
+  test('checks trusted-publishing repository metadata during ordinary validation', () => {
+    expect(publishRepositoryMetadataErrors([coreWorkspace()])).toEqual([]);
+    expect(
+      publishRepositoryMetadataErrors([
+        coreWorkspace({ repository: undefined }),
+        coreWorkspace({ isPrivate: true, repository: undefined }),
+      ])
+    ).toEqual([
+      '@ontrails/core must declare repository git+https://github.com/outfitter-dev/trails.git with directory packages/core',
+    ]);
+  });
+
+  test('accepts a complete trusted-publishing environment', () => {
+    expect(
+      trustedPublishingPreflightErrors({
+        env: {
+          ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'present',
+          ACTIONS_ID_TOKEN_REQUEST_URL: 'https://example.test/token',
+          GITHUB_ACTIONS: 'true',
+        },
+        nodeVersion: '24.6.0',
+        npmVersion: '11.18.0',
+        workspaces: [coreWorkspace()],
+      })
+    ).toEqual([]);
+  });
+
+  test('reports missing OIDC, runtime, and repository prerequisites together', () => {
+    expect(
+      trustedPublishingPreflightErrors({
+        env: {},
+        nodeVersion: '22.13.0',
+        npmVersion: '11.4.0',
+        workspaces: [coreWorkspace({ repository: undefined })],
+      })
+    ).toEqual([
+      'trusted publishing requires a GitHub Actions runner',
+      'GitHub OIDC request URL is unavailable (id-token: write)',
+      'GitHub OIDC request token is unavailable (id-token: write)',
+      'trusted publishing requires Node >= 22.14.0; found 22.13.0',
+      'trusted publishing requires npm >= 11.5.1; found 11.4.0',
+      '@ontrails/core must declare repository git+https://github.com/outfitter-dev/trails.git with directory packages/core',
+    ]);
+  });
+});

--- a/apps/trails/src/release/bindings.ts
+++ b/apps/trails/src/release/bindings.ts
@@ -27,13 +27,32 @@ export interface ReleaseBindingDescriptor {
   readonly runtime: string;
 }
 
-export const nativeBunReleaseBinding = {
+export const nativeBunPackBinding = {
   boundary: 'trails-owned',
-  capabilities: ['pack-check', 'publish', 'registry-preflight'],
+  capabilities: ['pack-check'],
   description:
-    'Built-in Bun release binding for Trails-owned package pack checks, npm registry preflight, and lockstep package publication.',
+    'Native Bun release binding for Trails-owned package packing and validation.',
   id: 'release.binding.native-bun',
   kind: 'native',
   placement: 'same-package',
   runtime: 'bun',
+} satisfies ReleaseBindingDescriptor;
+
+/**
+ * @deprecated Use `nativeBunPackBinding`. This alias preserves the exported
+ * name while correcting its descriptor to the Bun-owned pack boundary.
+ */
+export const nativeBunReleaseBinding = Object.freeze({
+  ...nativeBunPackBinding,
+});
+
+export const npmReleaseAdapterBinding = {
+  boundary: 'foreign',
+  capabilities: ['publish', 'registry-preflight'],
+  description:
+    'Same-package npm adapter binding for trusted publication, registry preflight, and lockstep recovery.',
+  id: 'release.binding.npm',
+  kind: 'adapter',
+  placement: 'same-package',
+  runtime: 'npm',
 } satisfies ReleaseBindingDescriptor;

--- a/apps/trails/src/release/index.ts
+++ b/apps/trails/src/release/index.ts
@@ -1,5 +1,7 @@
 export {
+  nativeBunPackBinding,
   nativeBunReleaseBinding,
+  npmReleaseAdapterBinding,
   releaseBindingCapabilityValues,
   releaseBindingKindValues,
   releaseBindingPlacementValues,
@@ -55,8 +57,12 @@ export {
   type ReleaseRuleInput,
 } from './config.js';
 export {
+  createNpmPublishCommand,
   findPackedFirstPartyDependencyMismatches,
+  publicationActionForRegistryState,
   runNativeBunPublishCli,
+  trustedPublishingPreflightErrors,
+  unsupportedPublishLifecycleScripts,
   type NativeBunPublishOptions,
   type NativeBunPublishPackageJson,
   type NativeBunPublishWorkspace,
@@ -79,6 +85,7 @@ export {
   checkRegistryPosture,
   classifyPackageRegistryState,
   discoverRegistryWorkspaces,
+  factsFromRegistryResult,
   formatDistTagSummary,
   npmRegistryVersionView,
   npmRegistryView,

--- a/apps/trails/src/release/native-bun-publish.ts
+++ b/apps/trails/src/release/native-bun-publish.ts
@@ -1,6 +1,6 @@
 /* oxlint-disable eslint-plugin-jest/require-hook, max-statements, func-style -- release script with module-level flow */
 /**
- * Native Bun release binding for public `@ontrails/*` workspace publication.
+ * Built-in release flow for public `@ontrails/*` workspace publication.
  *
  * Auto-discovers workspaces from the root `package.json` `workspaces` field,
  * topo-sorts them by `workspace:` dependency edges, enforces manifest-range
@@ -13,6 +13,15 @@
 import { mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, relative, resolve } from 'node:path';
+
+import {
+  checkRegistryPosture,
+  classifyPackageRegistryState,
+  factsFromRegistryResult,
+  npmRegistryVersionView,
+  npmRegistryView,
+} from './native-bun-registry.js';
+import type { PackageRegistryState } from './native-bun-registry.js';
 
 const REPO_ROOT = resolve(process.cwd());
 
@@ -34,6 +43,7 @@ export interface NativeBunPublishOptions {
   readonly tag: string | undefined;
   readonly otp: string | undefined;
   readonly only: readonly string[] | undefined;
+  readonly trustedPublishing?: boolean;
 }
 
 /** Minimal shape of a workspace `package.json` we care about. */
@@ -45,6 +55,14 @@ export interface NativeBunPublishPackageJson {
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  scripts?: Record<string, string>;
+  repository?:
+    | string
+    | {
+        directory?: string;
+        type?: string;
+        url?: string;
+      };
 }
 
 type DependencyField =
@@ -60,6 +78,8 @@ export interface NativeBunPublishWorkspace {
   readonly path: string;
   readonly isPrivate: boolean;
   readonly workspaceDeps: readonly string[];
+  readonly repository?: NativeBunPublishPackageJson['repository'];
+  readonly publishLifecycleScripts?: readonly string[];
 }
 
 const DEPENDENCY_FIELDS: readonly DependencyField[] = [
@@ -68,19 +88,32 @@ const DEPENDENCY_FIELDS: readonly DependencyField[] = [
   'peerDependencies',
   'optionalDependencies',
 ];
+const TRUSTED_REPOSITORY_URL =
+  'git+https://github.com/outfitter-dev/trails.git';
+const MINIMUM_TRUSTED_NODE = [22, 14, 0] as const;
+const MINIMUM_TRUSTED_NPM = [11, 5, 1] as const;
+const PUBLISH_ONLY_LIFECYCLE_SCRIPTS = [
+  'prepublishOnly',
+  'publish',
+  'postpublish',
+] as const;
 
 const USAGE = `Usage: bun scripts/publish.ts [options]
 
-Publish all public @ontrails/* workspaces in dep order using \`bun publish\`.
+Publish all public @ontrails/* workspaces in dependency order. Bun packs and
+validates each tarball; npm publishes the resolved tarball to the registry.
 
 Options:
   --check                Pre-publish verification only. Runs \`bun pm pack --dry-run\`
                          (required so \`catalog:\` resolves) and asserts the packed
-                         manifest has no \`workspace:\` or \`catalog:\` ranges. No publishing.
+                         manifest has no \`workspace:\` or \`catalog:\` ranges and
+                         validates trusted-publishing repository metadata. No publishing.
   --dry-run              Alias for --check.
   --tag <tag>            npm dist-tag. Defaults to .changeset/pre.json tag when in
                          prerelease mode, otherwise "latest".
   --otp <code>           Two-factor code. Also read from BUN_PUBLISH_OTP.
+  --trusted-publishing   Require GitHub Actions OIDC and npm trusted-publishing
+                         prerequisites before attempting the first package.
   --only <name[,name]>   Restrict to the named packages (repeatable). Useful for
                          partial reruns after a mid-matrix failure.
   -h, --help             Show this help and exit.
@@ -96,6 +129,7 @@ const parseArgs = (argv: readonly string[]): NativeBunPublishOptions => {
   let mode: NativeBunPublishOptions['mode'] = 'publish';
   let tag: string | undefined;
   let otp: string | undefined = process.env['BUN_PUBLISH_OTP'] || undefined;
+  let trustedPublishing = false;
   const only: string[] = [];
 
   const needsValue = (flag: string, value: string | undefined): string => {
@@ -118,6 +152,8 @@ const parseArgs = (argv: readonly string[]): NativeBunPublishOptions => {
     } else if (arg === '--otp') {
       i += 1;
       otp = needsValue('--otp', argv[i]);
+    } else if (arg === '--trusted-publishing') {
+      trustedPublishing = true;
     } else if (arg === '--only') {
       i += 1;
       const value = needsValue('--only', argv[i]);
@@ -143,6 +179,7 @@ const parseArgs = (argv: readonly string[]): NativeBunPublishOptions => {
     only: only.length > 0 ? only : undefined,
     otp,
     tag,
+    trustedPublishing,
   };
 };
 
@@ -334,6 +371,10 @@ const discoverWorkspaces = async (): Promise<NativeBunPublishWorkspace[]> => {
       isPrivate: pkg.private === true,
       name: pkg.name,
       path: dir,
+      publishLifecycleScripts: PUBLISH_ONLY_LIFECYCLE_SCRIPTS.filter(
+        (name) => pkg.scripts?.[name] !== undefined
+      ),
+      repository: pkg.repository,
       version: pkg.version ?? '0.0.0',
       workspaceDeps: collectWorkspaceDeps(pkg),
     });
@@ -433,23 +474,19 @@ const spawnCapture = async (
   return { exitCode, stdout };
 };
 
-/**
- * Pack a package to a temp dir and assert the resulting tarball's
- * `package/package.json` contains no `workspace:` or `catalog:` ranges.
- *
- * @throws When packing fails or forbidden ranges are found.
- */
-const assertManifestClean = async (
-  ws: NativeBunPublishWorkspace,
-  workspacesByName: ReadonlyMap<string, NativeBunPublishWorkspace>
-): Promise<void> => {
-  const tmp = await mkdtemp(join(tmpdir(), 'trails-publish-'));
+interface PackedWorkspaceTarball {
+  readonly directory: string;
+  readonly path: string;
+}
+
+/** Pack through Bun so workspace and catalog ranges resolve before npm sees the manifest. */
+const packWorkspaceTarball = async (
+  ws: NativeBunPublishWorkspace
+): Promise<PackedWorkspaceTarball> => {
+  const directory = await mkdtemp(join(tmpdir(), 'trails-publish-'));
   try {
-    // Use `bun pm pack` so the packed manifest reflects what `bun publish`
-    // will upload: workspace: and catalog: ranges are resolved the same way.
-    // npm pack does not resolve `catalog:` and would produce false positives.
     const pack = await spawnCapture(
-      ['bun', 'pm', 'pack', '--destination', tmp],
+      ['bun', 'pm', 'pack', '--destination', directory],
       ws.path
     );
     if (pack.exitCode !== 0) {
@@ -457,78 +494,133 @@ const assertManifestClean = async (
         `bun pm pack failed for ${ws.name} (exit ${pack.exitCode})`
       );
     }
-    const tarEntries = await readdir(tmp);
-    const tarName = tarEntries.find((n) =>
-      typeof n === 'string' ? n.endsWith('.tgz') : String(n).endsWith('.tgz')
+    const entries = await readdir(directory);
+    const tarName = entries.find((name) =>
+      typeof name === 'string'
+        ? name.endsWith('.tgz')
+        : String(name).endsWith('.tgz')
     );
     if (!tarName) {
       throw new Error(`bun pm pack produced no tarball for ${ws.name}`);
     }
-    const tarPath = join(tmp, String(tarName));
-
-    const extract = Bun.spawn(
-      ['tar', '-xOf', tarPath, 'package/package.json'],
-      { stderr: 'pipe', stdin: 'ignore', stdout: 'pipe' }
-    );
-    const [manifestText, tarStderr, extractExit] = await Promise.all([
-      new Response(extract.stdout).text(),
-      new Response(extract.stderr).text(),
-      extract.exited,
-    ]);
-    if (extractExit !== 0) {
-      const detail = tarStderr.trim() || '(no stderr output)';
-      throw new Error(
-        `tar extraction failed for ${ws.name} (exit ${extractExit}): ${detail}`
-      );
-    }
-
-    let packedPackage: NativeBunPublishPackageJson;
-    try {
-      packedPackage = JSON.parse(manifestText) as NativeBunPublishPackageJson;
-    } catch (error) {
-      throw new Error(
-        `Invalid packed package.json for ${ws.name}: ${(error as Error).message}`,
-        { cause: error }
-      );
-    }
-
-    const offenders: string[] = [];
-    for (const [lineNo, line] of manifestText.split('\n').entries()) {
-      if (line.includes('"workspace:') || line.includes('"catalog:')) {
-        offenders.push(`  line ${lineNo + 1}: ${line.trim()}`);
-      }
-    }
-    if (offenders.length > 0) {
-      const relPath = relative(REPO_ROOT, ws.path);
-      const hint =
-        '  Hint: `bun publish` rewrites these at pack time. Verify the package was packed via bun, not npm.';
-      throw new Error(
-        `Packed manifest for ${ws.name} (${relPath}) contains forbidden ranges:\n${offenders.join('\n')}\n${hint}`
-      );
-    }
-    const sourcePackage = await readJson<NativeBunPublishPackageJson>(
-      join(ws.path, 'package.json')
-    );
-    const mismatches = findPackedFirstPartyDependencyMismatches({
-      packageName: ws.name,
-      packagePath: ws.path,
-      packedPackage,
-      sourcePackage,
-      workspacesByName,
-    });
-    if (mismatches.length > 0) {
-      throw new Error(mismatches.join('\n'));
-    }
-  } finally {
-    await rm(tmp, { force: true, recursive: true });
+    return { directory, path: join(directory, String(tarName)) };
+  } catch (error) {
+    await rm(directory, { force: true, recursive: true });
+    throw error;
   }
 };
+
+/** Assert that a Bun-packed tarball contains publishable dependency ranges. */
+const assertPackedManifestClean = async (
+  ws: NativeBunPublishWorkspace,
+  workspacesByName: ReadonlyMap<string, NativeBunPublishWorkspace>,
+  tarPath: string
+): Promise<void> => {
+  const extract = Bun.spawn(['tar', '-xOf', tarPath, 'package/package.json'], {
+    stderr: 'pipe',
+    stdin: 'ignore',
+    stdout: 'pipe',
+  });
+  const [manifestText, tarStderr, extractExit] = await Promise.all([
+    new Response(extract.stdout).text(),
+    new Response(extract.stderr).text(),
+    extract.exited,
+  ]);
+  if (extractExit !== 0) {
+    const detail = tarStderr.trim() || '(no stderr output)';
+    throw new Error(
+      `tar extraction failed for ${ws.name} (exit ${extractExit}): ${detail}`
+    );
+  }
+
+  let packedPackage: NativeBunPublishPackageJson;
+  try {
+    packedPackage = JSON.parse(manifestText) as NativeBunPublishPackageJson;
+  } catch (error) {
+    throw new Error(
+      `Invalid packed package.json for ${ws.name}: ${(error as Error).message}`,
+      { cause: error }
+    );
+  }
+
+  const offenders: string[] = [];
+  for (const [lineNo, line] of manifestText.split('\n').entries()) {
+    if (line.includes('"workspace:') || line.includes('"catalog:')) {
+      offenders.push(`  line ${lineNo + 1}: ${line.trim()}`);
+    }
+  }
+  if (offenders.length > 0) {
+    const relPath = relative(REPO_ROOT, ws.path);
+    throw new Error(
+      `Packed manifest for ${ws.name} (${relPath}) contains forbidden ranges:\n${offenders.join('\n')}\n  Hint: publish the Bun-packed tarball instead of packing through npm.`
+    );
+  }
+  const sourcePackage = await readJson<NativeBunPublishPackageJson>(
+    join(ws.path, 'package.json')
+  );
+  const mismatches = findPackedFirstPartyDependencyMismatches({
+    packageName: ws.name,
+    packagePath: ws.path,
+    packedPackage,
+    sourcePackage,
+    workspacesByName,
+  });
+  if (mismatches.length > 0) {
+    throw new Error(mismatches.join('\n'));
+  }
+};
+
+export const unsupportedPublishLifecycleScripts = (
+  workspaces: readonly NativeBunPublishWorkspace[]
+): string[] =>
+  workspaces.flatMap((workspace) =>
+    workspace.isPrivate
+      ? []
+      : (workspace.publishLifecycleScripts ?? []).map(
+          (script) => `${workspace.name} defines unsupported ${script}`
+        )
+  );
+
+/** Validate repository metadata required by npm trusted publishing. */
+export const publishRepositoryMetadataErrors = (
+  workspaces: readonly NativeBunPublishWorkspace[]
+): string[] =>
+  workspaces.flatMap((workspace) => {
+    if (workspace.isPrivate) {
+      return [];
+    }
+    const { repository } = workspace;
+    const expectedDirectory = relative(REPO_ROOT, workspace.path);
+    if (
+      typeof repository !== 'string' &&
+      repository?.type === 'git' &&
+      repository.url === TRUSTED_REPOSITORY_URL &&
+      repository.directory === expectedDirectory
+    ) {
+      return [];
+    }
+    return [
+      `${workspace.name} must declare repository ${TRUSTED_REPOSITORY_URL} with directory ${expectedDirectory}`,
+    ];
+  });
 
 /** Run `--check` flow: pack dry-run plus manifest-range assertion per package. */
 const runCheck = async (
   workspaces: readonly NativeBunPublishWorkspace[],
   allWorkspaces: readonly NativeBunPublishWorkspace[]
 ): Promise<number> => {
+  const repositoryErrors = publishRepositoryMetadataErrors(workspaces);
+  if (repositoryErrors.length > 0) {
+    throw new Error(
+      `Package repository metadata check failed:\n${repositoryErrors.map((error) => `- ${error}`).join('\n')}`
+    );
+  }
+  const unsupportedLifecycle = unsupportedPublishLifecycleScripts(workspaces);
+  if (unsupportedLifecycle.length > 0) {
+    throw new Error(
+      `Tarball publication cannot honor publish-only lifecycle scripts:\n${unsupportedLifecycle.map((error) => `- ${error}`).join('\n')}`
+    );
+  }
   const workspacesByName = new Map(allWorkspaces.map((ws) => [ws.name, ws]));
   for (const ws of workspaces) {
     if (ws.isPrivate) {
@@ -545,7 +637,12 @@ const runCheck = async (
       return 1;
     }
     try {
-      await assertManifestClean(ws, workspacesByName);
+      const packed = await packWorkspaceTarball(ws);
+      try {
+        await assertPackedManifestClean(ws, workspacesByName, packed.path);
+      } finally {
+        await rm(packed.directory, { force: true, recursive: true });
+      }
     } catch (error) {
       fail((error as Error).message);
       return 1;
@@ -557,35 +654,245 @@ const runCheck = async (
   return 0;
 };
 
+const compareNumericVersion = (
+  version: string,
+  minimum: readonly [number, number, number]
+): number => {
+  const actual = version
+    .split('.')
+    .slice(0, 3)
+    .map((part) => Number.parseInt(part, 10));
+  if (actual.length !== 3 || actual.some((part) => Number.isNaN(part))) {
+    return -1;
+  }
+  for (let index = 0; index < minimum.length; index += 1) {
+    const delta = (actual[index] ?? 0) - (minimum[index] ?? 0);
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+  return 0;
+};
+
+export const trustedPublishingPreflightErrors = ({
+  env,
+  nodeVersion,
+  npmVersion,
+  workspaces,
+}: {
+  readonly env: Readonly<Record<string, string | undefined>>;
+  readonly nodeVersion: string;
+  readonly npmVersion: string;
+  readonly workspaces: readonly NativeBunPublishWorkspace[];
+}): string[] => {
+  const errors: string[] = [];
+  if (env['GITHUB_ACTIONS'] !== 'true') {
+    errors.push('trusted publishing requires a GitHub Actions runner');
+  }
+  if (!env['ACTIONS_ID_TOKEN_REQUEST_URL']) {
+    errors.push('GitHub OIDC request URL is unavailable (id-token: write)');
+  }
+  if (!env['ACTIONS_ID_TOKEN_REQUEST_TOKEN']) {
+    errors.push('GitHub OIDC request token is unavailable (id-token: write)');
+  }
+  if (compareNumericVersion(nodeVersion, MINIMUM_TRUSTED_NODE) < 0) {
+    errors.push(
+      `trusted publishing requires Node >= ${MINIMUM_TRUSTED_NODE.join('.')}; found ${nodeVersion}`
+    );
+  }
+  if (compareNumericVersion(npmVersion, MINIMUM_TRUSTED_NPM) < 0) {
+    errors.push(
+      `trusted publishing requires npm >= ${MINIMUM_TRUSTED_NPM.join('.')}; found ${npmVersion}`
+    );
+  }
+  errors.push(...publishRepositoryMetadataErrors(workspaces));
+  return errors;
+};
+
+export const createNpmPublishCommand = ({
+  otp,
+  tag,
+  tarballPath,
+}: {
+  readonly otp: string | undefined;
+  readonly tag: string;
+  readonly tarballPath: string;
+}): string[] => {
+  const command = [
+    'npm',
+    'publish',
+    tarballPath,
+    '--access',
+    'public',
+    '--tag',
+    tag,
+  ];
+  if (otp) {
+    command.push('--otp', otp);
+  }
+  return command;
+};
+
+export const publicationActionForRegistryState = (
+  state: PackageRegistryState,
+  trustedPublishing = false
+): 'block' | 'publish' | 'skip' => {
+  if (state.kind === 'complete') {
+    return 'skip';
+  }
+  if (state.kind === 'first-time-package') {
+    return trustedPublishing ? 'block' : 'publish';
+  }
+  if (state.kind === 'needs-publish') {
+    return 'publish';
+  }
+  return 'block';
+};
+
+const registryPublicationBlocker = (
+  workspace: NativeBunPublishWorkspace,
+  state: PackageRegistryState,
+  trustedPublishing: boolean
+): string => {
+  if (state.kind === 'first-time-package' && trustedPublishing) {
+    return `${workspace.name} is not published yet; bootstrap it with credentialed local tooling, configure its npm trusted publisher, then retry`;
+  }
+  if (state.kind === 'needs-tag-repair') {
+    return `${workspace.name}@${workspace.version} is published but the requested dist-tag points at ${state.currentTagVersion ?? '(missing)'}; repair it with credentialed npm tooling before retrying`;
+  }
+  if (state.kind === 'tag-points-ahead') {
+    return `${workspace.name} dist-tag points ahead at ${state.currentTagVersion}; refusing to publish ${workspace.version}`;
+  }
+  if (state.kind === 'registry-inaccessible') {
+    return `Could not inspect ${workspace.name}: ${state.error}`;
+  }
+  return `Could not determine whether ${workspace.name}@${workspace.version} is ready`;
+};
+
+const assertTrustedPublishingReady = async (
+  workspaces: readonly NativeBunPublishWorkspace[]
+): Promise<void> => {
+  const npmVersionResult = await spawnCapture(['npm', '--version'], REPO_ROOT);
+  if (npmVersionResult.exitCode !== 0) {
+    throw new Error('Could not read npm version for trusted publishing');
+  }
+  const nodeVersionResult = await spawnCapture(
+    ['node', '--version'],
+    REPO_ROOT
+  );
+  if (nodeVersionResult.exitCode !== 0) {
+    throw new Error('Could not read Node version for trusted publishing');
+  }
+  const errors = trustedPublishingPreflightErrors({
+    env: process.env,
+    nodeVersion: nodeVersionResult.stdout.trim().replace(/^v/, ''),
+    npmVersion: npmVersionResult.stdout.trim(),
+    workspaces,
+  });
+  if (errors.length > 0) {
+    throw new Error(
+      `Trusted publishing preflight failed:\n${errors.map((error) => `- ${error}`).join('\n')}`
+    );
+  }
+  success('Trusted publishing prerequisites are available');
+};
+
 /** Run the actual publish flow sequentially. Aborts on first failure. */
 const runPublish = async (
   workspaces: readonly NativeBunPublishWorkspace[],
+  allWorkspaces: readonly NativeBunPublishWorkspace[],
   tag: string,
-  otp: string | undefined
+  otp: string | undefined,
+  trustedPublishing: boolean
 ): Promise<number> => {
+  if (trustedPublishing) {
+    await assertTrustedPublishingReady(workspaces);
+  }
+  const unsupportedLifecycle = unsupportedPublishLifecycleScripts(workspaces);
+  if (unsupportedLifecycle.length > 0) {
+    throw new Error(
+      `Tarball publication cannot honor publish-only lifecycle scripts:\n${unsupportedLifecycle.map((error) => `- ${error}`).join('\n')}`
+    );
+  }
+  const publicWorkspaces = workspaces.filter(
+    (workspace) => !workspace.isPrivate
+  );
+  const registryResults = await checkRegistryPosture(
+    publicWorkspaces,
+    npmRegistryView,
+    npmRegistryVersionView,
+    tag
+  );
+  const registryStates = new Map<string, PackageRegistryState>();
+  const registryBlockers: string[] = [];
+  for (const workspace of publicWorkspaces) {
+    const registryResult = registryResults.find(
+      (result) => result.name === workspace.name
+    );
+    if (!registryResult) {
+      registryBlockers.push(
+        `Could not read registry posture for ${workspace.name}`
+      );
+      continue;
+    }
+    const state = classifyPackageRegistryState(
+      factsFromRegistryResult(registryResult)
+    );
+    registryStates.set(workspace.name, state);
+    if (
+      publicationActionForRegistryState(state, trustedPublishing) === 'block'
+    ) {
+      registryBlockers.push(
+        registryPublicationBlocker(workspace, state, trustedPublishing)
+      );
+    }
+  }
+  if (registryBlockers.length > 0) {
+    throw new Error(
+      `Registry preflight blocked publication before any package was published:\n${registryBlockers.map((error) => `- ${error}`).join('\n')}`
+    );
+  }
+  const workspacesByName = new Map(allWorkspaces.map((ws) => [ws.name, ws]));
   for (const ws of workspaces) {
     if (ws.isPrivate) {
       info(`Skipping ${ws.name} (private)`);
       continue;
     }
-    info(`Publishing ${ws.name}@${ws.version}... (tag=${tag})`);
-    const cmd: string[] = [
-      'bun',
-      'publish',
-      '--access',
-      'public',
-      '--tag',
-      tag,
-    ];
-    if (otp) {
-      cmd.push('--otp', otp);
-    }
-    const code = await spawnInherit(cmd, ws.path);
-    if (code !== 0) {
-      fail(
-        `Failed to publish ${ws.name} (exit ${code}); aborting remaining publishes`
-      );
+    const registryState = registryStates.get(ws.name);
+    if (!registryState) {
+      fail(`Registry preflight did not produce a state for ${ws.name}`);
       return 1;
+    }
+    const publicationAction = publicationActionForRegistryState(
+      registryState,
+      trustedPublishing
+    );
+    if (publicationAction === 'skip') {
+      success(
+        `${ws.name}@${ws.version} already published with ${tag} at target; continuing`
+      );
+      continue;
+    }
+    if (publicationAction === 'block') {
+      fail(registryPublicationBlocker(ws, registryState, trustedPublishing));
+      return 1;
+    }
+    info(`Publishing ${ws.name}@${ws.version}... (tag=${tag})`);
+    const packed = await packWorkspaceTarball(ws);
+    try {
+      await assertPackedManifestClean(ws, workspacesByName, packed.path);
+      const code = await spawnInherit(
+        createNpmPublishCommand({ otp, tag, tarballPath: packed.path }),
+        ws.path
+      );
+      if (code !== 0) {
+        fail(
+          `Failed to publish ${ws.name} (exit ${code}); aborting remaining publishes`
+        );
+        return 1;
+      }
+    } finally {
+      await rm(packed.directory, { force: true, recursive: true });
     }
     success(`${ws.name}@${ws.version} published`);
   }
@@ -635,7 +942,13 @@ export const runNativeBunPublishCli = async (
       fail('Could not resolve a dist-tag. Pass --tag <tag> explicitly.');
       return 1;
     }
-    return await runPublish(selected, tag, opts.otp);
+    return await runPublish(
+      selected,
+      all,
+      tag,
+      opts.otp,
+      opts.trustedPublishing ?? false
+    );
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     fail(msg);

--- a/apps/trails/src/release/native-bun-registry.ts
+++ b/apps/trails/src/release/native-bun-registry.ts
@@ -131,7 +131,9 @@ export const classifyPackageRegistryState = (
 };
 
 /** Map a registry probe result into the classifier's fact shape. */
-const factsFromResult = (result: RegistryResult): PackageRegistryFacts => {
+export const factsFromRegistryResult = (
+  result: RegistryResult
+): PackageRegistryFacts => {
   if (result.status === 'published') {
     return {
       expectedTagVersion: result.expectedTagVersion,
@@ -632,7 +634,7 @@ export const registryPostureErrors = (
   const phase = normalizeRegistryCheckPhase(phaseOrRequirePublished);
   const errors: string[] = [];
   for (const result of results) {
-    const state = classifyPackageRegistryState(factsFromResult(result));
+    const state = classifyPackageRegistryState(factsFromRegistryResult(result));
     if (state.kind === 'registry-inaccessible') {
       errors.push(`${result.name}: registry probe failed: ${state.error}`);
       continue;

--- a/docs/adr/0047-stable-release-line-discipline.md
+++ b/docs/adr/0047-stable-release-line-discipline.md
@@ -33,8 +33,8 @@ The repo already has a workable release mechanism:
 - `.changeset/config.json` fixes `@ontrails/*` packages together.
 - `bun run publish:check` packs public workspaces and rejects unresolved
   `workspace:` or `catalog:` ranges.
-- `bun run publish:packages` publishes through Bun and derives the dist-tag
-  from `.changeset/pre.json`.
+- `bun run publish:packages` packs and validates through Bun, publishes those
+  tarballs through npm, and derives the dist-tag from `.changeset/pre.json`.
 - `bun run publish:registry-check` and
   `bun run publish:registry-check:published` verify registry posture without
   mutating the registry. The first command is the pre-publish readiness check:
@@ -132,9 +132,9 @@ bun test
 
 The point is not just that the scaffold command runs. The generated `package.json`, selected lockfile versions, typecheck, and tests together prove that a new user can consume the published framework family.
 
-### Changesets computes; Bun publishes
+### Changesets computes; Bun packs; npm publishes
 
-Changesets owns version and changelog calculation. Bun owns publication.
+Changesets owns version and changelog calculation. Bun owns package discovery, packing, and validation. The npm CLI owns the authenticated registry mutation, including GitHub OIDC trusted publishing.
 
 The stable flow keeps these responsibilities separate:
 
@@ -145,7 +145,7 @@ The stable flow keeps these responsibilities separate:
 - use `bun run publish:check` to prove the package tarballs are clean;
 - use `bun run publish:packages` to publish.
 
-Do not use `changeset publish`, `npm publish`, or ad hoc package publication for the normal release path. If an emergency requires a different operation, that operation is an incident with written evidence, not a new default.
+Do not use `changeset publish`, a direct `npm publish`, or ad hoc package publication for the normal release path. If an emergency requires a different operation, that operation is an incident with written evidence, not a new default.
 
 ### Changelogs and release notes are part of the contract
 

--- a/docs/adr/drafts/20260608-release-provenance-as-lifecycle-derivation.md
+++ b/docs/adr/drafts/20260608-release-provenance-as-lifecycle-derivation.md
@@ -12,7 +12,7 @@ depends_on: [47, 48]
 
 ## Context
 
-Trails already treats package releases as part of the framework contract. ADR-0047 decides that public `@ontrails/*` packages stay lockstep for the 1.x line, Changesets computes version and changelog output, Bun publishes, and a release PR carries evidence. The repo also has a branch-local Changeset check: if a PR changes publishable package contents, the PR must include a matching changeset unless the branch explicitly explains why no user-visible package output exists.
+Trails already treats package releases as part of the framework contract. ADR-0047 decides that public `@ontrails/*` packages stay lockstep for the 1.x line, Changesets computes version and changelog output, Bun packs and validates, npm publishes the resulting tarballs, and a release PR carries evidence. The repo also has a branch-local Changeset check: if a PR changes publishable package contents, the PR must include a matching changeset unless the branch explicitly explains why no user-visible package output exists.
 
 That check is useful, but it still sees package files more readily than Trails contracts. A branch can change the public input or output schema of an exposed trail, or expose a trail on a new surface, while leaving the release story to reviewer memory. That fights the premise. The trail is the product, so public trail contract movement must be evaluated by release rules before a branch leaves draft.
 
@@ -120,7 +120,7 @@ Stacked branches make release provenance easy to smear. A top cleanup branch can
 ## References
 
 - [ADR-0047: Stable Release Line Discipline](../0047-stable-release-line-discipline.md)
-  - release line, Changesets, Bun publish, and stable preflight doctrine.
+  - release line, Changesets, Bun packing, npm publication, and stable preflight doctrine.
 - [ADR-0048: Trail Versioning v3](../0048-trail-versioning-v3.md) - trail contract versions are separate from package semver.
 - [Stable Cutover Runbook](../../releases/stable-cutover.md) - operator sequence for version PRs and publication.
 - [Beta Channel Policy](../../releases/beta-channel-policy.md) - branch-local changesets, `release:none`, and beta publication posture.

--- a/docs/contributing/script-graduation.md
+++ b/docs/contributing/script-graduation.md
@@ -54,7 +54,8 @@ Keep three axes distinct: native vs adapter is the *kind*; subpath/built-in vs e
 | release check (`release.check`) | durable | derives, serves users | public surface |
 | scaffold version pins (TRL-942) | durable | derives, serves users | public `create` surface |
 | public-API example coverage (TRL-943) | durable | derives, serves building Trails | repo-local Warden rule |
-| release publish via Bun (TRL-938) | durable | fills seam, ambient runtime | native Bun release binding |
+| release pack via Bun (TRL-938) | durable | fills seam, ambient runtime | native Bun release binding |
+| release registry preflight and publish via npm | durable | fills seam, foreign tool and registry | npm adapter binding |
 | packed artifact and Wayfinder dogfood (TRL-939) | durable | consumes, proves release confidence | public `release.smoke` surface |
 | changesets-CLI or foreign registry (TRL-938) | durable | fills seam, foreign boundary | adapter binding, extracted |
 | `.changeset/*.md` as release intent | durable | consumes authored input | neither — an intent source |
@@ -66,7 +67,7 @@ Keep three axes distinct: native vs adapter is the *kind*; subpath/built-in vs e
 
 `release.check` is the derives-and-graduates example: release rules are durable Trails-contract facts, so the script-era checker graduated into the `trails release check` surface, and package scripts became thin callers. A one-off vocab cleanup prototype is the derives-but-may-stay-tooling example: real derivation over a transient truth. A stable framework contract migration is different; it must become Warden/Regrade work so detection, repair facts, validation, and review routing stay inside Trails.
 
-The native Bun release binding is the fills-a-declared-seam example: `@ontrails/trails/release` owns the binding descriptor plus Bun pack, publish, and registry preflight implementation. Root `publish:*` scripts are compatibility wrappers around that binding. They remain useful named exits, but they do not own the release behavior.
+The built-in release flow is the fills-a-declared-seam example: `@ontrails/trails/release` owns a native Bun binding for packing and validation plus a same-package npm adapter binding for registry preflight and publication. Root `publish:*` scripts are compatibility wrappers around that flow. They remain useful named exits, but they do not own the release behavior.
 
 ## After graduation
 

--- a/docs/migration/connector-to-adapter.md
+++ b/docs/migration/connector-to-adapter.md
@@ -110,11 +110,11 @@ Do not run a broad automatic prose rewrite. Some sentences need `adapter`, some 
 
 ## Changesets And Publishing
 
-Changesets in this cutover are version and changelog metadata only. Package publication later uses the repo's Bun publish flow:
+Changesets in this cutover are version and changelog metadata only. The repo release flow packs and validates with Bun, then publishes the resolved tarball through npm:
 
 ```bash
 bun run publish:check
 bun run publish:packages
 ```
 
-Do not use `changeset publish` or `npm publish` for this migration.
+Do not invoke `changeset publish` or `npm publish` directly for this migration.

--- a/docs/releases/beta-channel-policy.md
+++ b/docs/releases/beta-channel-policy.md
@@ -44,7 +44,7 @@ For fully reproducible docs, replace `@beta` with the exact beta version named b
 
 `.changeset/pre.json` is the channel source while it has `mode: "pre"`. The current prerelease tag is `beta`.
 
-The native Bun release binding follows that source. The package scripts below are compatibility wrappers around the binding:
+The built-in release flow follows that source. The package scripts below are compatibility wrappers around its native Bun packing binding and npm registry adapter binding:
 
 - `bun run publish:check` is local and read-only.
 - `bun run publish:registry-check` defaults to `.changeset/pre.json`'s tag in
@@ -52,19 +52,21 @@ The native Bun release binding follows that source. The package scripts below ar
   readiness check: it proves the registry is reachable and the expected tag is
   not ahead of the repo target. It may pass while the tag still points at the
   previous published beta.
-- `bun run publish:packages` publishes with Bun and uses the same prerelease tag
-  by default.
+- `bun run publish:packages` packs and validates with Bun, publishes the packed
+  tarballs with npm, and uses the same prerelease tag by default. In GitHub
+  Actions, `--trusted-publishing` requires npm's OIDC credentials instead of a
+  long-lived registry token.
 - `bun run publish:registry-check:published` verifies the expected dist-tag
   after publication and requires every public package to exist at the repo
   target version.
 
 During the beta line, `latest` may intentionally lag behind `beta`. Operators should not advance `latest` after every beta publication. Move `latest` only when leaving prerelease mode for the stable 1.x line, or after a separate explicit release decision that says a beta should become the unqualified default.
 
-Do not use `npm publish`, `changeset publish`, or ad hoc dist-tag mutation for normal Trails package releases.
+Do not invoke `npm publish`, `changeset publish`, or ad hoc dist-tag mutation directly for normal Trails package releases. The repo publish command owns the npm invocation and its Bun-produced tarballs.
 
-## Native Bun Release Binding
+## Built-In Release Bindings
 
-`@ontrails/trails/release` declares the built-in native Bun release binding. It owns package discovery, workspace dependency ordering, `bun pm pack` verification, `bun publish` invocation, and read-only npm registry preflight. The binding is native because it is Trails-owned, same-package, and uses the ambient Bun runtime. Future integrations that cross into a foreign release tool or registry contract belong in adapter bindings instead.
+`@ontrails/trails/release` declares two bindings coordinated by the built-in release flow. The native Bun binding owns package discovery, workspace dependency ordering, packing, and tarball validation. The same-package npm adapter binding crosses the foreign npm tool and registry contract for read-only preflight and the controlled `npm publish <tarball>` handoff. Future integrations that cross into a different release tool or registry contract belong in their own adapter bindings.
 
 ## Read-Only Registry Checks
 
@@ -144,10 +146,28 @@ After substantial stacks merge to `main`:
    `publish:manual` uses the protected `npm` environment for incomplete or
    ambiguous low-risk proof. `publish:block` and unknown/conflicting managed
    labels stop the workflow.
-9. Use local publish commands only for diagnostics or explicit recovery:
+9. Use local publish commands only for diagnostics or explicit recovery.
+   Local recovery uses the operator's ambient npm authentication; it does not
+   create or repair a GitHub deployment record:
    `bun run publish:check`, `bun run publish:registry-check`,
    `bun run publish:packages`, then
    `bun run publish:registry-check:published`.
+
+### First-Time Package Bootstrap
+
+npm trusted publishing cannot create a package. When a release introduces a new public package, bootstrap only that package with authenticated local tooling, configure its trusted publisher, verify the record, then retry the GitHub release workflow:
+
+```bash
+bun run publish:packages -- --only @ontrails/<package> --tag beta
+npx npm@11.18.0 trust github @ontrails/<package> \
+  --file release.yml \
+  --repo outfitter-dev/trails \
+  --allow-publish \
+  --yes
+npx npm@11.18.0 trust list @ontrails/<package>
+```
+
+Do not set the trusted publisher's optional GitHub environment restriction. npm permits one trusted publisher per package, while Trails intentionally has two `main`-restricted GitHub environments: protected `npm` for manual approval and `npm-auto` for evidence-gated publication. The repository workflow and environment policies hold that distinction.
 
 Feature branches and release-readiness stacks may run read-only checks, but they must not publish.
 

--- a/docs/releases/beta15-to-beta19.md
+++ b/docs/releases/beta15-to-beta19.md
@@ -54,7 +54,7 @@ done
 
 The output makes `latest` lag visible alongside the current `beta` tag without touching the registry.
 
-Do not use `npm publish` or `changeset publish` for Trails packages. Trails uses Bun-based publish scripts because they correctly resolve `workspace:` and `catalog:` ranges.
+Do not invoke `npm publish` or `changeset publish` directly for Trails packages. The repo publish command uses Bun to resolve workspace ranges and validate the tarball before handing that tarball to npm for the registry mutation.
 
 ## Beta 18 to Beta 19
 
@@ -301,7 +301,7 @@ If `bun run validate` flags drift, regenerate locally with `bun run compile`, re
 ## References
 
 - [Beta 15](./beta15.md) — the prior beta line, including the surface API cutover, the lexicon cutover, and the retired `@ontrails/tracker` / `@ontrails/logging` package names.
-- [Beta Channel Policy](./beta-channel-policy.md) — install pins, `@beta` versus exact, `latest` lag, version-bump cadence, no `npm publish` / `changeset publish`.
+- [Beta Channel Policy](./beta-channel-policy.md) — install pins, `@beta` versus exact, `latest` lag, version-bump cadence, and no direct `npm publish` / `changeset publish`.
 - [Trailhead to Surface](../migration/trailhead-to-surface.md) — the surface-vocabulary cutover and trace/OTel/dev-store updates.
 - [Connector to Adapter](../migration/connector-to-adapter.md) — adapter package taxonomy and the `@ontrails/commander` cutover.
 - [Observability](#observability) — the historical beta.19 package graph, sink imports, and OTel export.

--- a/docs/releases/stable-cutover.md
+++ b/docs/releases/stable-cutover.md
@@ -2,7 +2,7 @@
 
 This runbook is the operator checklist for leaving the beta prerelease line and publishing the first stable 1.x Trails release.
 
-It is governed by [ADR-0047: Stable Release Line Discipline](../adr/0047-stable-release-line-discipline.md). The short version: public `@ontrails/*` packages stay lockstep for 1.x, Changesets computes versions and changelogs, Bun publishes packages, generated apps must install from the public registry, and partial publishes are handled as release incidents.
+It is governed by [ADR-0047: Stable Release Line Discipline](../adr/0047-stable-release-line-discipline.md). The short version: public `@ontrails/*` packages stay lockstep for 1.x, Changesets computes versions and changelogs, Bun packs and validates package tarballs, npm publishes them through the repo-owned flow, generated apps must install from the public registry, and partial publishes are handled as release incidents.
 
 Do not run this from an in-progress feature stack. The versioning PR and the publish step are separate operations.
 
@@ -15,7 +15,7 @@ There are two distinct phases:
 | Version PR | Exit prerelease mode, compute stable versions/changelogs, review the diff, and merge. | A normal Graphite branch and PR |
 | Publish | Publish already-merged package contents and verify registry/dist-tag state. | Clean `main` after the version PR merges |
 
-Never publish from an unmerged version PR. Never use `changeset publish`, `npm publish`, or ad hoc package publication for the normal stable cutover.
+Never publish from an unmerged version PR. Never use `changeset publish`, a direct `npm publish`, or ad hoc package publication for the normal stable cutover.
 
 Generated release PRs are policy-gated by labels. Source PRs that introduced consumed changesets should carry `stack:boundary` before the stable version PR is expected to reach `publish:auto`. Missing source evidence or missing `stack:boundary` routes publication to the protected manual environment; unknown/conflicting managed labels, registry contradictions, or `publish:block` stop the workflow. `publish:none` is only for generated release PRs and requires an audit reason in the release PR body or comments.
 
@@ -287,7 +287,9 @@ Keep the PR draft until CI is green and review is complete. The PR body should i
 
 Only publish after the version PR has merged.
 
-Start from clean, synced `main`:
+The normal publication path is the GitHub release workflow after the generated version PR merges. `publish:auto` uses the `npm-auto` environment when release evidence is complete. `publish:manual` pauses on the protected `npm` environment for approval. Both jobs publish through npm trusted publishing and produce the repository deployment record.
+
+Use clean, synced `main` for final read-only verification:
 
 ```bash
 gt sync
@@ -306,15 +308,25 @@ bun run publish:registry-check
 
 `publish:registry-check` is the readiness check before mutation. It should make registry drift visible, but it does not require the target version to be published yet. The strict equality check is the post-publish gate below.
 
-Publish with the repo script:
+The publish script discovers non-private workspaces, topo-sorts by workspace dependency edges, packs and validates each workspace with Bun, publishes the tarball with npm, and uses `latest` outside Changesets prerelease mode. GitHub Actions passes `--trusted-publishing`, which requires an OIDC-capable npm CLI and the package's configured trusted publisher.
+
+Use `bun run publish:packages` locally only for explicit bootstrap or incident recovery. Do not replace it with a direct `npm publish`. Do not run `changeset publish`.
+
+### First-Time Package Bootstrap
+
+npm requires the package to exist before its trusted publisher can be configured. Bootstrap only the new package with authenticated local tooling, then enroll and verify its trusted publisher before retrying the GitHub release:
 
 ```bash
-bun run publish:packages
+bun run publish:packages -- --only @ontrails/<package> --tag latest
+npx npm@11.18.0 trust github @ontrails/<package> \
+  --file release.yml \
+  --repo outfitter-dev/trails \
+  --allow-publish \
+  --yes
+npx npm@11.18.0 trust list @ontrails/<package>
 ```
 
-The publish script discovers non-private workspaces, topo-sorts by workspace dependency edges, runs `bun publish --access public --tag <tag>`, and uses `latest` outside Changesets prerelease mode.
-
-Do not replace this with `npm publish`. Do not run `changeset publish`.
+The trusted-publisher record deliberately omits a GitHub environment because npm permits only one trusted publisher per package while Trails supports both the protected `npm` job and the evidence-gated `npm-auto` job. Both GitHub environments are independently restricted to `main`.
 
 ## Post-Publish Verification
 
@@ -363,7 +375,7 @@ Record:
 
 ## Partial-Publish Recovery
 
-If `bun run publish:packages` fails after publishing one or more packages, stop immediately.
+If `bun run publish:packages` fails after publishing one or more packages, stop immediately. A retry is safe after investigating the failure: the command queries each exact package version and skips versions already present in npm.
 
 Create a release incident note with:
 
@@ -383,7 +395,7 @@ bun run publish:registry-check:published
 
 If that check fails because the release is incomplete, use targeted read-only registry probes for the packages already reported as published. Do not mutate dist-tags to hide an incomplete release.
 
-Resume only with an explicit package set after confirming which packages are already present:
+Resume with an explicit package set when narrowing the incident is useful:
 
 ```bash
 bun run publish:packages -- --only @ontrails/package-a,@ontrails/package-b

--- a/packages/adapter-kit/package.json
+++ b/packages/adapter-kit/package.json
@@ -2,6 +2,11 @@
   "name": "@ontrails/adapter-kit",
   "version": "1.0.0-beta.43",
   "description": "Internal adapter authoring kit for Trails metadata, scaffolding, and checks.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/adapter-kit"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/cli",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/cli"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/config",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/config"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/core",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/core"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/http",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/http"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/library/package.json
+++ b/packages/library/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/library",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/library"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/mcp",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/mcp"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/observability",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/observability"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/permits/package.json
+++ b/packages/permits/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/permits",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/permits"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/regrade/package.json
+++ b/packages/regrade/package.json
@@ -2,6 +2,11 @@
   "name": "@ontrails/regrade",
   "version": "1.0.0-beta.43",
   "description": "Downstream migration reporting and safe rewrite helpers for Trails.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/regrade"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -2,6 +2,11 @@
   "name": "@ontrails/source",
   "version": "1.0.0-beta.43",
   "description": "Shared source-code AST parsing, walking, location, edit, literal, and Trails syntax helpers.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/source"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/store",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/store"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/testing",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/testing"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/topography/package.json
+++ b/packages/topography/package.json
@@ -2,6 +2,11 @@
   "name": "@ontrails/topography",
   "version": "1.0.0-beta.43",
   "description": "Durable graph substrate for Trails: deterministic TopoGraphs, lockfile helpers, and semantic diffing.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/topography"
+  },
   "files": [
     "src/**/*.ts",
     "!src/**/__tests__/**",

--- a/packages/warden/package.json
+++ b/packages/warden/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@ontrails/warden",
   "version": "1.0.0-beta.43",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/outfitter-dev/trails.git",
+    "directory": "packages/warden"
+  },
   "bin": {
     "warden": "./bin/warden.ts"
   },


### PR DESCRIPTION
## Context

GitHub release jobs were publishing with local npm credentials while npm deployment records appeared failed and repository environments did not express the real approval boundary. This change moves normal package publication to npm trusted publishing with GitHub Actions OIDC, while preserving a narrow credentialed path for first-time package bootstrap and incident recovery.

Linear: [TRL-1221](https://linear.app/outfitter/issue/TRL-1221/)

## What changed

- Grant both release jobs `id-token: write`, pin `actions/setup-node` to an immutable v6 SHA, and use npm 11.18.0 for trusted publication.
- Keep Bun as the pack and validation owner, then publish the exact validated tarball through npm's OIDC-aware CLI.
- Add `--trusted-publishing` with runtime, repository, and OIDC preflight checks.
- Classify every selected package against exact registry and dist-tag state before any mutation.
- Skip packages already complete, fail closed on registry drift or inaccessible state, and retain `--only` for partial recovery.
- Reject package publish lifecycle hooks in check and publish modes so npm cannot run unreviewed package scripts during release.
- Add canonical Bun pack and npm publication binding descriptors, keeping the old Bun binding export as a deprecated truthful compatibility alias.
- Add exact repository metadata to all 23 public package manifests, validate it during ordinary `publish:check`, and include a branch-local lockstep changeset.
- Update beta, stable, ADR, migration, provenance, and agent documentation for the OIDC-first workflow and first-time-package bootstrap.

## External configuration completed

- Configured npm trusted publisher records for all 23 public `@ontrails/*` packages against `outfitter-dev/trails` and `.github/workflows/release.yml`.
- Verified every package with `npm trust list`.
- Configured GitHub environments so `npm` requires Matt's approval and `npm-auto` remains the trusted automatic lane; both are restricted to `main`.
- Deliberately omitted the GitHub environment from npm trust records because npm allows one trusted publisher per package while this repository has two environment-gated publication jobs.

## Verification

- `bun run check`
- `bun run build` (30/30)
- `bun run test` (49 Turbo tasks)
- `bun run typecheck` (30/30)
- `bun run publish:check` (all public packages packed successfully)
- `bun run changeset:check` (all 23 public packages covered)
- Focused release tests (63 pass, 0 fail)
- `bun run dead-code`
- `bun run format:check`
- `actionlint .github/workflows/release.yml`
- Docs link and wrap checks
- `git diff --check`
- Local review: three independent implementation, workflow-security, and operator-doc lanes; final result 5/5 with no P0-P3 findings.

Manual runtime proof:

- Credentialed `--only @ontrails/core --tag beta` skips cleanly because the exact version and tag already exist.
- Local `--trusted-publishing --only @ontrails/core --tag beta` fails closed before registry mutation because GitHub OIDC is unavailable outside Actions.

## Rollout and remaining proof

The next generated release after this PR merges is the final end-to-end proof. It must show GitHub obtaining an OIDC token, npm accepting trusted publication for every selected package, the strict post-publish registry check passing, and GitHub recording a successful npm deployment. Historical red deployment records cannot be rewritten and should remain historical evidence.
