### PR TITLE
fix(release): require consumer publication proof

### DIFF
--- a/.changeset/trl-1260-consumer-publication-proof.md
+++ b/.changeset/trl-1260-consumer-publication-proof.md
@@ -1,0 +1,5 @@
+---
+'@ontrails/trails': patch
+---
+
+Require strict registry checks to prove exact-version consumer availability instead of trusting package access or dist-tags alone.

--- a/apps/trails/src/__tests__/release-policy.test.ts
+++ b/apps/trails/src/__tests__/release-policy.test.ts
@@ -227,6 +227,7 @@ describe('evaluateReleasePolicy', () => {
             name: '@ontrails/core',
             status: 'published',
             version: '1.0.0-beta.19',
+            versionPublished: true,
           },
         ],
       })
@@ -238,6 +239,24 @@ describe('evaluateReleasePolicy', () => {
     expect(report.reasons).toContain(
       'Registry package state already matches this release; npm publish will be skipped'
     );
+  });
+
+  test('does not skip publish when the tag matches without consumer proof', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        registryPackages: [
+          {
+            expectedTagVersion: '1.0.0-beta.19',
+            name: '@ontrails/core',
+            status: 'published',
+            version: '1.0.0-beta.19',
+          },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe('auto');
+    expect(report.shouldPublish).toBe(true);
   });
 
   test('blocks registry drift before publication routing', () => {

--- a/apps/trails/src/__tests__/release-registry-classifier.test.ts
+++ b/apps/trails/src/__tests__/release-registry-classifier.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, test } from 'bun:test';
 import {
   checkRegistryPosture,
   classifyPackageRegistryState,
+  createNpmRegistryVersionProofView,
   createNpmRegistryVersionView,
   createNpmRegistryView,
+  factsFromRegistryResult,
   parseNpmDistTagListOutput,
   parseNpmPackDryRunPublishedVersion,
   registryPostureErrors,
@@ -47,13 +49,12 @@ describe('classifyPackageRegistryState', () => {
     );
   });
 
-  test('complete when publish state is unknown but the tag is at target', () => {
-    // Preserves the policy `versionPublished ?? true` default.
+  test('needs-publish when consumer proof is unknown but the tag is at target', () => {
     expect(
       classifyPackageRegistryState(
         publishedFacts({ versionPublished: undefined })
       ).kind
-    ).toBe('complete');
+    ).toBe('needs-publish');
   });
 
   test('first-time-package when the package is missing entirely', () => {
@@ -168,6 +169,11 @@ const unauthorizedNpmRunner: NpmCommandRunner = async () => ({
   stderr: 'npm error code E401\nnpm error 401 Unauthorized',
   stdout: '',
 });
+const exactMetadataRunner: NpmCommandRunner = async () => ({
+  exitCode: 0,
+  stderr: '',
+  stdout: JSON.stringify('1.0.0-beta.39'),
+});
 
 describe('registryPostureErrors — live beta.28 incident', () => {
   test('ready phase passes (publish pending); published phase fails', async () => {
@@ -259,6 +265,93 @@ describe('registryPostureErrors — phase behavior', () => {
     );
 
     expect(registryPostureErrors(results, 'beta', 'published')).toEqual([]);
+  });
+
+  test('beta.39 split-brain fails until consumer metadata or pack proof is available', async () => {
+    const commands: string[][] = [];
+    const runNpm: NpmCommandRunner = async (args) => {
+      commands.push([...args]);
+      if (args[0] === 'view' && args[1] === '@ontrails/cloudflare') {
+        return {
+          exitCode: 0,
+          stderr: '',
+          stdout: JSON.stringify({
+            'dist-tags': { beta: '1.0.0-beta.39' },
+            name: '@ontrails/cloudflare',
+            version: '1.0.0-beta.39',
+          }),
+        };
+      }
+      if (args[0] === 'view') {
+        return {
+          exitCode: 1,
+          stderr:
+            'npm error code ETARGET\nnpm error notarget No matching version found for @ontrails/cloudflare@1.0.0-beta.39.',
+          stdout: '',
+        };
+      }
+      if (args[0] === 'pack') {
+        return {
+          exitCode: 1,
+          stderr:
+            'npm ERR! 404 Not Found - GET https://registry.npmjs.org/@ontrails%2fcloudflare - Not found',
+          stdout: '',
+        };
+      }
+      throw new Error(`unexpected npm command: ${args.join(' ')}`);
+    };
+    const results = await checkRegistryPosture(
+      [
+        {
+          name: '@ontrails/cloudflare',
+          path: 'adapters/cloudflare',
+          version: '1.0.0-beta.39',
+        },
+      ],
+      createNpmRegistryView(runNpm),
+      createNpmRegistryVersionProofView(runNpm),
+      'beta'
+    );
+
+    expect(registryPostureErrors(results, 'beta', 'ready')).toEqual([]);
+    expect(registryPostureErrors(results, 'beta', 'published')).toEqual([
+      '@ontrails/cloudflare: target version 1.0.0-beta.39 lacks exact-version metadata and consumer pack proof',
+    ]);
+    expect(results[0]).toMatchObject({
+      versionProof: { kind: 'unavailable', published: false },
+    });
+    expect(commands).toEqual([
+      [
+        'view',
+        '@ontrails/cloudflare',
+        'name',
+        'version',
+        'dist-tags',
+        '--json',
+      ],
+      ['view', '@ontrails/cloudflare@1.0.0-beta.39', 'version', '--json'],
+      ['pack', '@ontrails/cloudflare@1.0.0-beta.39', '--dry-run', '--json'],
+    ]);
+  });
+
+  test('consumer proof overrides contradictory legacy publication state', () => {
+    const result: RegistryResult = {
+      distTags: { beta: '1.0.0-beta.39' },
+      expectedTagVersion: '1.0.0-beta.39',
+      name: '@ontrails/cloudflare',
+      status: 'published',
+      version: '1.0.0-beta.39',
+      versionProof: { kind: 'unavailable', published: false },
+      versionPublished: true,
+      workspaceVersion: '1.0.0-beta.39',
+    };
+
+    expect(
+      classifyPackageRegistryState(factsFromRegistryResult(result))
+    ).toEqual({ kind: 'needs-publish' });
+    expect(registryPostureErrors([result], 'beta', 'published')).toEqual([
+      '@ontrails/cloudflare: target version 1.0.0-beta.39 lacks exact-version metadata and consumer pack proof',
+    ]);
   });
 });
 
@@ -415,6 +508,35 @@ describe('npm registry fallback wiring', () => {
       ['view', '@ontrails/regrade@1.0.0-beta.29', 'version', '--json'],
       ['pack', '@ontrails/regrade@1.0.0-beta.29', '--dry-run', '--json'],
     ]);
+
+    commands.length = 0;
+    await expect(
+      createNpmRegistryVersionProofView(runNpm)(
+        '@ontrails/regrade',
+        '1.0.0-beta.29'
+      )
+    ).resolves.toEqual({ kind: 'consumer-pack', published: true });
+    expect(commands).toEqual([
+      ['view', '@ontrails/regrade@1.0.0-beta.29', 'version', '--json'],
+      ['pack', '@ontrails/regrade@1.0.0-beta.29', '--dry-run', '--json'],
+    ]);
+  });
+
+  test('reports whether exact metadata or consumer pack proved the target', async () => {
+    const splitBrainRunner: NpmCommandRunner = async () => notFoundResult;
+
+    await expect(
+      createNpmRegistryVersionProofView(exactMetadataRunner)(
+        '@ontrails/cloudflare',
+        '1.0.0-beta.39'
+      )
+    ).resolves.toEqual({ kind: 'exact-metadata', published: true });
+    await expect(
+      createNpmRegistryVersionProofView(splitBrainRunner)(
+        '@ontrails/cloudflare',
+        '1.0.0-beta.39'
+      )
+    ).resolves.toEqual({ kind: 'unavailable', published: false });
   });
 
   test('treats npm exact-version ETARGET as an unpublished target', async () => {
@@ -422,6 +544,9 @@ describe('npm registry fallback wiring', () => {
     const runNpm: NpmCommandRunner = async (args) => {
       commands.push([...args]);
       if (args[0] === 'view') {
+        return noMatchingVersionResult;
+      }
+      if (args[0] === 'pack') {
         return noMatchingVersionResult;
       }
       throw new Error(`unexpected npm command: ${args.join(' ')}`);
@@ -432,6 +557,7 @@ describe('npm registry fallback wiring', () => {
     ).resolves.toBe(false);
     expect(commands).toEqual([
       ['view', '@ontrails/core@1.0.0-beta.30', 'version', '--json'],
+      ['pack', '@ontrails/core@1.0.0-beta.30', '--dry-run', '--json'],
     ]);
   });
 });

--- a/apps/trails/src/release/native-bun-publish.ts
+++ b/apps/trails/src/release/native-bun-publish.ts
@@ -18,7 +18,7 @@ import {
   checkRegistryPosture,
   classifyPackageRegistryState,
   factsFromRegistryResult,
-  npmRegistryVersionView,
+  npmRegistryVersionProofView,
   npmRegistryView,
 } from './native-bun-registry.js';
 import type { PackageRegistryState } from './native-bun-registry.js';
@@ -820,7 +820,7 @@ const runPublish = async (
   const registryResults = await checkRegistryPosture(
     publicWorkspaces,
     npmRegistryView,
-    npmRegistryVersionView,
+    npmRegistryVersionProofView,
     tag
   );
   const registryStates = new Map<string, PackageRegistryState>();

--- a/apps/trails/src/release/native-bun-registry.ts
+++ b/apps/trails/src/release/native-bun-registry.ts
@@ -43,6 +43,7 @@ export type RegistryResult =
       readonly status: 'published';
       readonly version: string;
       readonly versionPublished: boolean | undefined;
+      readonly versionProof?: RegistryVersionProof | undefined;
       readonly workspaceVersion: string;
     }
   | {
@@ -82,18 +83,20 @@ export interface PackageRegistryFacts {
   readonly error?: string | undefined;
 }
 
+/** Consumer-facing evidence for an exact package version. */
+export type RegistryVersionProof =
+  | { readonly kind: 'consumer-pack'; readonly published: true }
+  | { readonly kind: 'exact-metadata'; readonly published: true }
+  | { readonly kind: 'unavailable'; readonly published: false };
+
 /**
  * Classify a package's registry state from two orthogonal facts — whether the
  * target version is published, and where the dist-tag points relative to it —
  * plus reachability. Members are mutually exclusive by construction.
  *
- * `versionPublished` is read strictly only in the behind-tag case: a behind tag
- * becomes a `needs-tag-repair` only when the target is known published (`true`);
- * `undefined` or `false` route to `needs-publish`, preserving the conservative
- * release-policy behavior. When the tag already points at the target, an
- * unprobed (`undefined`) state counts as published and yields `complete`, which
- * matches the policy `versionPublished ?? true` default. `undefined` means the
- * exact-version probe was not run, including policy inputs and compatibility
+ * `complete` requires affirmative consumer proof. A matching dist-tag cannot
+ * substitute for exact-version metadata or an equivalent package fetch.
+ * `undefined` means the consumer probe was not run, including compatibility
  * callers that supply an injected registry view without a version probe.
  */
 export const classifyPackageRegistryState = (
@@ -120,9 +123,9 @@ export const classifyPackageRegistryState = (
     return { currentTagVersion: expectedTagVersion, kind: 'tag-points-ahead' };
   }
   if (tagAtTarget) {
-    return versionPublished === false
-      ? { kind: 'needs-publish' }
-      : { kind: 'complete' };
+    return versionPublished === true
+      ? { kind: 'complete' }
+      : { kind: 'needs-publish' };
   }
   if (versionPublished === true) {
     return { currentTagVersion: expectedTagVersion, kind: 'needs-tag-repair' };
@@ -139,7 +142,8 @@ export const factsFromRegistryResult = (
       expectedTagVersion: result.expectedTagVersion,
       status: 'published',
       targetVersion: result.workspaceVersion,
-      versionPublished: result.versionPublished,
+      versionPublished:
+        result.versionProof?.published ?? result.versionPublished,
     };
   }
   if (result.status === 'inaccessible') {
@@ -167,7 +171,8 @@ Options:
   --tag <tag>            Expected npm dist-tag. Defaults to .changeset/pre.json
                          tag while in prerelease mode, otherwise "latest".
   --require-published    Fail when any workspace package is missing from npm.
-                         Use after publication to verify every package exists.
+                         Use after publication to require exact metadata or
+                         equivalent consumer package-fetch proof.
   -h, --help             Show this help and exit.
 
 Exit codes: 0 success, 1 registry posture failure, 2 arg-parse error.`;
@@ -461,12 +466,23 @@ export type RegistryVersionView = (
   version: string
 ) => Promise<boolean | undefined>;
 
+/** Probe with evidence that distinguishes metadata from package fetch proof. */
+export type RegistryVersionProofView = (
+  name: string,
+  version: string
+) => Promise<RegistryVersionProof>;
+
+export type RegistryVersionProbeView = (
+  name: string,
+  version: string
+) => Promise<boolean | RegistryVersionProof | undefined>;
+
 const UNKNOWN_REGISTRY_VERSION_STATE: { readonly published?: boolean } = {};
 const unknownRegistryVersionView: RegistryVersionView = async () =>
   UNKNOWN_REGISTRY_VERSION_STATE.published;
 
-export const createNpmRegistryVersionView =
-  (runNpm: NpmCommandRunner = runNpmCommand): RegistryVersionView =>
+export const createNpmRegistryVersionProofView =
+  (runNpm: NpmCommandRunner = runNpmCommand): RegistryVersionProofView =>
   async (name, version) => {
     const { exitCode, stderr, stdout } = await runNpm([
       'view',
@@ -476,12 +492,14 @@ export const createNpmRegistryVersionView =
     ]);
 
     if (exitCode === 0) {
-      return JSON.parse(stdout.trim()) === version;
+      return JSON.parse(stdout.trim()) === version
+        ? { kind: 'exact-metadata', published: true }
+        : { kind: 'unavailable', published: false };
     }
-    if (isNpmExactVersionMissingOutput(stdout, stderr)) {
-      return false;
-    }
-    if (!isNpmNotFoundOutput(stdout, stderr)) {
+    if (
+      !isNpmExactVersionMissingOutput(stdout, stderr) &&
+      !isNpmNotFoundOutput(stdout, stderr)
+    ) {
       throw new Error(
         stderr.trim() || `npm view failed for ${name}@${version}`
       );
@@ -498,21 +516,35 @@ export const createNpmRegistryVersionView =
         packResult.stdout,
         name,
         version
-      );
+      )
+        ? { kind: 'consumer-pack', published: true }
+        : { kind: 'unavailable', published: false };
     }
     if (isNpmExactVersionMissingOutput(packResult.stdout, packResult.stderr)) {
-      return false;
+      return { kind: 'unavailable', published: false };
     }
     if (isNpmNotFoundOutput(packResult.stdout, packResult.stderr)) {
-      return false;
+      return { kind: 'unavailable', published: false };
     }
     throw new Error(
       packResult.stderr.trim() || `npm pack failed for ${name}@${version}`
     );
   };
 
+export const createNpmRegistryVersionView = (
+  runNpm: NpmCommandRunner = runNpmCommand
+): RegistryVersionView => {
+  const proofView = createNpmRegistryVersionProofView(runNpm);
+  return async (name, version) => {
+    const proof = await proofView(name, version);
+    return proof.published;
+  };
+};
+
 export const npmRegistryVersionView: RegistryVersionView =
   createNpmRegistryVersionView();
+export const npmRegistryVersionProofView: RegistryVersionProofView =
+  createNpmRegistryVersionProofView();
 
 /** Run async tasks with a bounded number in flight, preserving input order. */
 const mapBounded = async <T, R>(
@@ -538,7 +570,7 @@ const mapBounded = async <T, R>(
 const checkWorkspaceRegistryPosture = async (
   workspace: RegistryWorkspace,
   view: RegistryView,
-  versionView: RegistryVersionView,
+  versionView: RegistryVersionProbeView,
   expectedTag: string
 ): Promise<RegistryResult> => {
   try {
@@ -551,13 +583,19 @@ const checkWorkspaceRegistryPosture = async (
       };
     }
     const distTags = registry['dist-tags'] ?? {};
+    const versionProbe = await versionView(workspace.name, workspace.version);
+    const versionProof =
+      typeof versionProbe === 'object' ? versionProbe : undefined;
+    const versionPublished =
+      typeof versionProbe === 'object' ? versionProbe.published : versionProbe;
     return {
       distTags,
       expectedTagVersion: distTags[expectedTag],
       name: workspace.name,
       status: 'published',
       version: registry.version ?? '(unknown)',
-      versionPublished: await versionView(workspace.name, workspace.version),
+      ...(versionProof === undefined ? {} : { versionProof }),
+      versionPublished,
       workspaceVersion: workspace.version,
     };
   } catch (error) {
@@ -571,14 +609,14 @@ const checkWorkspaceRegistryPosture = async (
 };
 
 type CheckRegistryPostureArgs =
-  | readonly [versionView: RegistryVersionView, expectedTag: string]
+  | readonly [versionView: RegistryVersionProbeView, expectedTag: string]
   | readonly [expectedTag: string];
 
 const normalizeCheckRegistryPostureArgs = (
   args: CheckRegistryPostureArgs
 ): {
   readonly expectedTag: string;
-  readonly versionView: RegistryVersionView;
+  readonly versionView: RegistryVersionProbeView;
 } => {
   if (args.length === 1) {
     return { expectedTag: args[0], versionView: unknownRegistryVersionView };
@@ -594,7 +632,7 @@ export function checkRegistryPosture(
 export function checkRegistryPosture(
   workspaces: readonly RegistryWorkspace[],
   view: RegistryView,
-  versionView: RegistryVersionView,
+  versionView: RegistryVersionProbeView,
   expectedTag: string
 ): Promise<RegistryResult[]>;
 export async function checkRegistryPosture(
@@ -626,6 +664,19 @@ const normalizeRegistryCheckPhase = (
   return phaseOrRequirePublished ? 'published' : 'ready';
 };
 
+const targetVersionFailure = (result: RegistryResult): string => {
+  if (result.status !== 'published') {
+    return 'is not published';
+  }
+  if (result.versionProof?.kind === 'unavailable') {
+    return 'lacks exact-version metadata and consumer pack proof';
+  }
+  if (result.versionPublished === undefined) {
+    return 'publish state was not probed';
+  }
+  return 'is not published';
+};
+
 export const registryPostureErrors = (
   results: readonly RegistryResult[],
   expectedTag: string,
@@ -651,12 +702,8 @@ export const registryPostureErrors = (
     if (state.kind === 'first-time-package') {
       errors.push(`${result.name}: package is missing from the registry`);
     } else if (state.kind === 'needs-publish') {
-      const targetState =
-        result.status === 'published' && result.versionPublished === undefined
-          ? 'publish state was not probed'
-          : 'is not published';
       errors.push(
-        `${result.name}: target version ${result.workspaceVersion} ${targetState}`
+        `${result.name}: target version ${result.workspaceVersion} ${targetVersionFailure(result)}`
       );
     } else if (state.kind === 'needs-tag-repair') {
       errors.push(
@@ -675,8 +722,18 @@ export const formatDistTagSummary = (
   );
 
 const formatTargetVersionStatus = (
+  proof: RegistryVersionProof | undefined,
   versionPublished: boolean | undefined
 ): string => {
+  if (proof?.kind === 'exact-metadata') {
+    return 'exact-version metadata available';
+  }
+  if (proof?.kind === 'consumer-pack') {
+    return 'exact-version metadata unavailable, consumer pack available';
+  }
+  if (proof?.kind === 'unavailable') {
+    return 'exact-version metadata and consumer pack unavailable';
+  }
   if (versionPublished === true) {
     return 'target version published';
   }
@@ -693,7 +750,10 @@ const printResults = (
   console.log(`Registry preflight for dist-tag "${expectedTag}"`);
   for (const result of results) {
     if (result.status === 'published') {
-      const targetStatus = formatTargetVersionStatus(result.versionPublished);
+      const targetStatus = formatTargetVersionStatus(
+        result.versionProof,
+        result.versionPublished
+      );
       console.log(
         `✓ ${result.name}@${result.workspaceVersion}: package exists, ${targetStatus} (registry version ${result.version}, expected ${expectedTag}=${result.expectedTagVersion ?? 'missing'}, tags ${formatDistTagSummary(result.distTags)})`
       );
@@ -711,11 +771,14 @@ const normalizeRegistryPreflightViews = (
   view: RegistryView | undefined,
   versionView: RegistryVersionView | undefined
 ): {
-  readonly versionView: RegistryVersionView;
+  readonly versionView: RegistryVersionProbeView;
   readonly view: RegistryView;
 } => {
   if (view === undefined) {
-    return { versionView: npmRegistryVersionView, view: npmRegistryView };
+    return {
+      versionView: npmRegistryVersionProofView,
+      view: npmRegistryView,
+    };
   }
   return { versionView: versionView ?? unknownRegistryVersionView, view };
 };

--- a/apps/trails/src/release/policy.ts
+++ b/apps/trails/src/release/policy.ts
@@ -999,13 +999,13 @@ const registryPackagesFromResults = (
 const readRegistryPackages = async (
   distTag: string
 ): Promise<readonly ReleasePolicyRegistryPackage[]> => {
-  const { checkRegistryPosture, npmRegistryView, npmRegistryVersionView } =
+  const { checkRegistryPosture, npmRegistryView, npmRegistryVersionProofView } =
     await import('./native-bun-registry.js');
   const workspaces = await discoverRegistryWorkspaces(repoRoot);
   const results = await checkRegistryPosture(
     workspaces,
     npmRegistryView,
-    npmRegistryVersionView,
+    npmRegistryVersionProofView,
     distTag
   );
   return registryPackagesFromResults(results);

--- a/docs/adr/0047-stable-release-line-discipline.md
+++ b/docs/adr/0047-stable-release-line-discipline.md
@@ -40,7 +40,9 @@ The repo already has a workable release mechanism:
   mutating the registry. The first command is the pre-publish readiness check:
   it proves the registry is reachable and the expected tag is not ahead of the
   repo target, but it may pass while the target version is still unpublished.
-  The `:published` variant is the post-publish equality gate.
+  The `:published` variant is the post-publish equality gate: it requires
+  exact-version metadata or equivalent consumer package-fetch proof in addition
+  to the expected dist-tag.
 
 What was missing was the stable-line decision those tools enforce. Without an ADR, release docs can drift back toward operator memory: "run the right thing, publish the right packages, recover carefully." Stable needs that memory turned into a contract.
 

--- a/docs/releases/beta-channel-policy.md
+++ b/docs/releases/beta-channel-policy.md
@@ -57,8 +57,9 @@ The built-in release flow follows that source. The package scripts below are com
   Actions, `--trusted-publishing` requires npm's OIDC credentials instead of a
   long-lived registry token.
 - `bun run publish:registry-check:published` verifies the expected dist-tag
-  after publication and requires every public package to exist at the repo
-  target version.
+  after publication and requires every public package to expose the repo target
+  through exact-version metadata or an equivalent consumer package fetch. A
+  visible access record or dist-tag alone is not publication proof.
 
 During the beta line, `latest` may intentionally lag behind `beta`. Operators should not advance `latest` after every beta publication. Move `latest` only when leaving prerelease mode for the stable 1.x line, or after a separate explicit release decision that says a beta should become the unqualified default.
 
@@ -84,7 +85,7 @@ After publishing, use the strict equality gate:
 bun run publish:registry-check:published
 ```
 
-That check requires every public workspace package to exist at the repo target version and the expected dist-tag to point at that version.
+That check requires every public workspace package to resolve at the repo target version through exact-version metadata or an equivalent consumer package fetch, and the expected dist-tag to point at that version. Its diagnostics distinguish a visible package and tag from pending consumer proof.
 
 For a small representative spot check:
 

--- a/docs/releases/stable-cutover.md
+++ b/docs/releases/stable-cutover.md
@@ -83,8 +83,9 @@ Before creating the version PR:
    and the expected dist-tag is not ahead of the repo target. It can pass while
    the tag still points at the previous published version, and first-time public
    packages can be reported as first-time package candidates. After publishing,
-   use `bun run publish:registry-check:published` to require every package and
-   dist-tag to match the repo target.
+   use `bun run publish:registry-check:published` to require every package to
+   expose exact-version metadata or equivalent consumer package-fetch proof and
+   every dist-tag to match the repo target.
 
 7. The local package tarballs are clean:
 
@@ -330,11 +331,13 @@ The trusted-publisher record deliberately omits a GitHub environment because npm
 
 ## Post-Publish Verification
 
-After publish, require every public package and expected dist-tag to be visible:
+After publish, require every public package to have consumer-facing proof and every expected dist-tag to match:
 
 ```bash
 bun run publish:registry-check:published
 ```
+
+Package access and dist-tag visibility are not sufficient. The strict check requires exact-version metadata or an equivalent consumer package fetch before it reports a package complete.
 
 Spot-check representative packages directly when debugging:
 


### PR DESCRIPTION
## Context

TRL-1260 closes the remaining strict post-publication split-brain gap: npm access and dist-tags can be visible while an exact package version is still unavailable to consumers.

## Behavior

- Require exact-version metadata or equivalent consumer pack proof before the published phase reports complete.
- Continue from ETARGET to the consumer-pack fallback.
- Keep structured proof authoritative while preserving legacy injected/offline helper behavior without hidden npm probes.
- Distinguish exact metadata, consumer pack, and unavailable proof in diagnostics and release guidance.

## Verification

- Focused registry classifier/policy/publish tests: 60 passed.
- Full test, typecheck, lint, AST lint, build, aggregate check, docs, Wayfinder dogfood, and lock round-trip passed.
- `bun run publish:check` passed for every public package.
- Live beta.43: 23/23 exact metadata resolutions and 23/23 cold exact installs.
- Current unpublished beta.44: strict published check fails all 23 packages with the expected consumer-proof diagnostic; no publication attempted.
- Standing and targeted local reviews: 5/5 clean, zero open findings.

## Release intent

Patch changeset for `@ontrails/trails`: `.changeset/trl-1260-consumer-publication-proof.md`.

## Risks / rollout

Registry error classification remains conservative. Pre-publish readiness still allows absent targets. The stricter behavior applies only when publication proof is required. No package publication, tag mutation, or environment approval is part of this PR.

[TRL-1260](https://linear.app/outfitter/issue/TRL-1260/require-strict-post-publish-installability-proof-for-first-time)