### PR TITLE
fix(warden): preserve Result provenance through expressions

### DIFF
--- a/.changeset/trl-1245-result-provenance.md
+++ b/.changeset/trl-1245-result-provenance.md
@@ -1,0 +1,6 @@
+---
+'@ontrails/trails': patch
+'@ontrails/warden': patch
+---
+
+Recognize conditional, aliased, and parenthesized Result provenance while invalidating provenance after reassignment across the implementation-return and redundant-error-wrap rules.

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -3520,7 +3520,7 @@ export const regradeTrail = trail('regrade', {
         )
       : await runClassModeRegrade(input, rootDirResult.value, configScope);
     if (reportResult.isErr()) {
-      return Result.err(reportResult.error);
+      return reportResult;
     }
     const outputResult = validateOutput(
       regradeReportOutput,

--- a/packages/warden/src/__tests__/implementation-returns-result.test.ts
+++ b/packages/warden/src/__tests__/implementation-returns-result.test.ts
@@ -112,6 +112,136 @@ trail("entity.pick", {
     expect(diagnostics.length).toBe(0);
   });
 
+  test('allows conditional Result expressions assigned before return', () => {
+    const code = `
+trail("entity.pick", {
+  implementation: async (input, ctx) => {
+    const result = input.id === undefined
+      ? await ctx.compose("entity.default", {})
+      : Result.ok({ id: input.id });
+    return result;
+  }
+})`;
+
+    expect(implementationReturnsResult.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('allows conditional Result helper calls assigned before return', () => {
+    const code = `
+const loadDefault = (): Result<object, Error> => Result.ok({ id: "default" });
+const loadInput = (): Result<object, Error> => Result.ok({ id: "input" });
+
+trail("entity.pick", {
+  implementation: (input, ctx) => {
+    const result = input.id === undefined ? loadDefault() : loadInput();
+    return result;
+  }
+})`;
+
+    expect(implementationReturnsResult.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('allows aliases and parenthesized compose results', () => {
+    const code = `
+trail("entity.pick", {
+  implementation: async (input, ctx) => {
+    const composed = (await ctx.compose("entity.default", {}));
+    const result = composed;
+    return result;
+  }
+})`;
+
+    expect(implementationReturnsResult.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('clears Result provenance after raw reassignment', () => {
+    const code = `
+trail("entity.pick", {
+  implementation: async (input, ctx) => {
+    let result = Result.ok({ id: input.id });
+    result = { id: input.id };
+    return result;
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('entity.pick');
+  });
+
+  test('preserves proven Result provenance across Result reassignments', () => {
+    const code = `
+trail("entity.pick", {
+  implementation: async (input, ctx) => {
+    let result = Result.ok({ id: input.id });
+    if (input.useDefault) {
+      result = await ctx.compose("entity.default", {});
+    }
+    return result;
+  }
+})`;
+
+    expect(implementationReturnsResult.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('tracks Result provenance from straight-line assignments', () => {
+    const code = `
+trail("entity.pick", {
+  implementation: async (input, ctx) => {
+    let result;
+    result = await ctx.compose("entity.default", {});
+    return result;
+  }
+})`;
+
+    expect(implementationReturnsResult.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('clears Result provenance after compound assignments', () => {
+    const code = `
+trail("entity.pick", {
+  implementation: async (input, ctx) => {
+    let result = Result.ok({ id: input.id });
+    result += Result.ok({ id: "other" });
+    return result;
+  }
+})`;
+
+    expect(implementationReturnsResult.check(code, TEST_FILE)).toHaveLength(1);
+  });
+
+  test('does not promote branch-local assignments to unconditional Result provenance', () => {
+    const code = `
+trail("entity.pick", {
+  implementation: async (input, ctx) => {
+    let result = { id: input.id };
+    if (input.valid) {
+      result = Result.ok({ id: input.id });
+    }
+    return result;
+  }
+})`;
+
+    const diagnostics = implementationReturnsResult.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('entity.pick');
+  });
+
+  test('does not promote unbraced branch assignments', () => {
+    const code = `
+trail("entity.pick", {
+  implementation: async (input, ctx) => {
+    let result = { id: input.id };
+    if (input.valid) result = Result.ok({ id: input.id });
+    return result;
+  }
+})`;
+
+    expect(implementationReturnsResult.check(code, TEST_FILE)).toHaveLength(1);
+  });
+
   test('allows awaited conditional returns whose branches produce Results', () => {
     const code = `
 trail("entity.pick", {

--- a/packages/warden/src/__tests__/no-redundant-result-error-wrap.test.ts
+++ b/packages/warden/src/__tests__/no-redundant-result-error-wrap.test.ts
@@ -63,6 +63,56 @@ trail('entity.load', {
     expect(diagnostics[0]?.message).toContain('Return parsed directly');
   });
 
+  test('flags re-wrapping conditional Result helper provenance', () => {
+    const code = `
+import {
+  Result,
+  trail
+} from '@ontrails/core';
+import type {
+  Result as ResultType
+} from '@ontrails/core';
+
+const parseLeft = (): ResultType<object, Error> => Result.err(new Error('left'));
+const parseRight = (): ResultType<object, Error> => Result.err(new Error('right'));
+
+trail('entity.load', {
+  implementation: async (input, ctx) => {
+    const parsed = input.left ? parseLeft() : parseRight();
+    return Result.err(parsed.error);
+  },
+});
+`;
+
+    const diagnostics = noRedundantResultErrorWrap.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('Return parsed directly');
+  });
+
+  test('flags re-wrapping aliased parenthesized compose provenance', () => {
+    const code = `
+import {
+  Result,
+  trail
+} from '@ontrails/core';
+
+trail('entity.load', {
+  composes: ['entity.fetch'],
+  implementation: async (input, ctx) => {
+    const composed = (await ctx.compose('entity.fetch', input));
+    const fetched = composed;
+    return Result.err(fetched.error);
+  },
+});
+`;
+
+    const diagnostics = noRedundantResultErrorWrap.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('Return fetched directly');
+  });
+
   test('allows returning the Result directly', () => {
     const code = `
 import {
@@ -142,6 +192,110 @@ trail('entity.load', {
     let fetched = await ctx.compose('entity.fetch', input);
     fetched = { error: new Error('different') };
     return Result.err(fetched.error);
+  },
+});
+`;
+
+    expect(noRedundantResultErrorWrap.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('preserves proven provenance across Result reassignments', () => {
+    const code = `
+import {
+  Result,
+  trail
+} from '@ontrails/core';
+
+trail('entity.load', {
+  composes: ['entity.fetch'],
+  implementation: async (input, ctx) => {
+    let fetched = Result.err(new Error('initial'));
+    if (input.refresh) {
+      fetched = await ctx.compose('entity.fetch', input);
+    }
+    return Result.err(fetched.error);
+  },
+});
+`;
+
+    const diagnostics = noRedundantResultErrorWrap.check(code, TEST_FILE);
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.message).toContain('Return fetched directly');
+  });
+
+  test('tracks provenance from straight-line Result assignments', () => {
+    const code = `
+import {
+  Result,
+  trail
+} from '@ontrails/core';
+
+trail('entity.load', {
+  composes: ['entity.fetch'],
+  implementation: async (input, ctx) => {
+    let fetched;
+    fetched = await ctx.compose('entity.fetch', input);
+    return Result.err(fetched.error);
+  },
+});
+`;
+
+    expect(noRedundantResultErrorWrap.check(code, TEST_FILE)).toHaveLength(1);
+  });
+
+  test('clears proven provenance after compound assignments', () => {
+    const code = `
+import {
+  Result,
+  trail
+} from '@ontrails/core';
+
+trail('entity.load', {
+  implementation: async (input, ctx) => {
+    let fetched = Result.err(new Error('initial'));
+    fetched += Result.err(new Error('other'));
+    return Result.err(fetched.error);
+  },
+});
+`;
+
+    expect(noRedundantResultErrorWrap.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('does not promote branch-local assignments to unconditional Result provenance', () => {
+    const code = `
+import {
+  Result,
+  trail
+} from '@ontrails/core';
+
+trail('entity.load', {
+  implementation: async (input, ctx) => {
+    let result = { error: new Error('plain') };
+    if (input.valid) {
+      result = Result.err(new Error('result'));
+    }
+    return Result.err(result.error);
+  },
+});
+`;
+
+    expect(noRedundantResultErrorWrap.check(code, TEST_FILE)).toEqual([]);
+  });
+
+  test('does not promote unbraced branch assignments', () => {
+    const code = `
+import {
+  Result,
+  trail
+} from '@ontrails/core';
+
+trail('entity.load', {
+  implementation: async (input, ctx) => {
+    let result = { error: new Error('plain') };
+    if (input.valid) result = Result.err(new Error('result'));
+    return Result.err(result.error);
   },
 });
 `;

--- a/packages/warden/src/rules/implementation-returns-result.ts
+++ b/packages/warden/src/rules/implementation-returns-result.ts
@@ -25,8 +25,11 @@ import {
   getNodeImported,
   getNodeInit,
   getNodeLocal,
+  getNodeLeft,
   getNodeName,
+  getNodeOperator,
   getNodeReturnType,
+  getNodeRight,
   getNodeSource,
   getNodeTypeAnnotation,
   getNodeValue,
@@ -97,12 +100,15 @@ export type ScopedHelperMap = ReadonlyMap<
 
 export type MutableScopedHelperMap = Map<ReadonlySet<string>, Set<string>>;
 
-type ScopedResultVariableMap = ReadonlyMap<
+export type ScopedResultVariableMap = ReadonlyMap<
   ReadonlySet<string>,
   ReadonlySet<string>
 >;
 
-type MutableScopedResultVariableMap = Map<ReadonlySet<string>, Set<string>>;
+export type MutableScopedResultVariableMap = Map<
+  ReadonlySet<string>,
+  Set<string>
+>;
 
 export const findNearestBindingScope = (
   name: string,
@@ -224,8 +230,8 @@ const unwrapReturnExpression = (node: AstNode): AstNode => {
   return current;
 };
 
-/** Check if a return argument is an allowed Result value. */
-const isAllowedReturnArgument = (
+/** Check whether an expression has visible Result-producing provenance. */
+export const isResultProducingExpression = (
   argument: AstNode,
   helperNames: ReadonlySet<string>,
   resultVars: ScopedResultVariableMap,
@@ -240,7 +246,7 @@ const isAllowedReturnArgument = (
     return (
       consequent !== undefined &&
       alternate !== undefined &&
-      isAllowedReturnArgument(
+      isResultProducingExpression(
         consequent,
         helperNames,
         resultVars,
@@ -248,7 +254,7 @@ const isAllowedReturnArgument = (
         scopes,
         scopedHelpers
       ) &&
-      isAllowedReturnArgument(
+      isResultProducingExpression(
         alternate,
         helperNames,
         resultVars,
@@ -369,6 +375,14 @@ const addScopedResultVariable = (
   resultVars.set(scope, new Set([name]));
 };
 
+const clearScopedResultVariable = (
+  resultVars: MutableScopedResultVariableMap,
+  scope: ReadonlySet<string>,
+  name: string
+): void => {
+  resultVars.get(scope)?.delete(name);
+};
+
 /** Record `const helper = (): Result<...> => ...` declarations for the current lexical scope. */
 export const trackScopedResultHelperDeclaration = (
   node: AstNode,
@@ -440,8 +454,14 @@ const trackResultVariable = (
     }
     if (
       hasResultVariableAnnotation(id, sourceCode, resultTypeNames) ||
-      isResultExpression(init) ||
-      isHelperCall(init, helperNames, namespaceHelpers, scopes, scopedHelpers)
+      isResultProducingExpression(
+        init,
+        helperNames,
+        resultVars,
+        namespaceHelpers,
+        scopes,
+        scopedHelpers
+      )
     ) {
       const bindingScope = findNearestBindingScope(name, scopes);
       if (bindingScope) {
@@ -449,6 +469,63 @@ const trackResultVariable = (
       }
     }
   }
+};
+
+export const collectDirectResultAssignments = (
+  body: AstNode
+): ReadonlySet<AstNode> => {
+  const assignments = new Set<AstNode>();
+  for (const statement of getNodeBodyStatements(body)) {
+    if (statement.type !== 'ExpressionStatement') {
+      continue;
+    }
+    const expression = getNodeExpression(statement);
+    if (expression?.type === 'AssignmentExpression') {
+      assignments.add(expression);
+    }
+  }
+  return assignments;
+};
+
+const trackResultAssignment = (
+  node: AstNode,
+  resultVars: MutableScopedResultVariableMap,
+  helperNames: ReadonlySet<string>,
+  namespaceHelpers: NamespaceHelperMap,
+  directAssignments: ReadonlySet<AstNode>,
+  scopes: readonly ReadonlySet<string>[],
+  scopedHelpers: ScopedHelperMap
+): void => {
+  const left = getNodeLeft(node);
+  const name = identifierName(left);
+  if (!name) {
+    return;
+  }
+  const bindingScope = findNearestBindingScope(name, scopes);
+  if (!bindingScope) {
+    return;
+  }
+  const right = getNodeRight(node);
+  const resultRhs =
+    getNodeOperator(node) === '=' &&
+    right &&
+    isResultProducingExpression(
+      right,
+      helperNames,
+      resultVars,
+      namespaceHelpers,
+      scopes,
+      scopedHelpers
+    );
+  if (
+    resultRhs &&
+    (isScopedResultVariableBinding(name, scopes, resultVars) ||
+      directAssignments.has(node))
+  ) {
+    addScopedResultVariable(resultVars, bindingScope, name);
+    return;
+  }
+  clearScopedResultVariable(resultVars, bindingScope, name);
 };
 
 // ---------------------------------------------------------------------------
@@ -470,6 +547,7 @@ const checkReturnStatements = (
   const resultVars: MutableScopedResultVariableMap = new Map();
   const scopedHelpers: MutableScopedHelperMap = new Map();
   const initialScopes = implScope.size > 0 ? [implScope] : [];
+  const directAssignments = collectDirectResultAssignments(blockBody);
 
   walkWithScopes(
     blockBody,
@@ -494,6 +572,18 @@ const checkReturnStatements = (
         );
       }
 
+      if (node.type === 'AssignmentExpression') {
+        trackResultAssignment(
+          node,
+          resultVars,
+          helperNames,
+          namespaceHelpers,
+          directAssignments,
+          currentScopes,
+          scopedHelpers
+        );
+      }
+
       if (node.type !== 'ReturnStatement') {
         return;
       }
@@ -505,7 +595,7 @@ const checkReturnStatements = (
       }
 
       if (
-        isAllowedReturnArgument(
+        isResultProducingExpression(
           argument,
           helperNames,
           resultVars,

--- a/packages/warden/src/rules/no-redundant-result-error-wrap.ts
+++ b/packages/warden/src/rules/no-redundant-result-error-wrap.ts
@@ -23,11 +23,11 @@ import {
 import type { AstNode, AstParentContext } from '@ontrails/source';
 import {
   collectAllResultHelperNames,
+  collectDirectResultAssignments,
   collectNamespaceHelperImports,
   collectResultTypeNames,
   findNearestBindingScope,
-  isHelperCall,
-  isResultExpression,
+  isResultProducingExpression,
   trackScopedResultHelperDeclaration,
 } from './implementation-returns-result.js';
 import { isTestFile } from './scan.js';
@@ -81,16 +81,6 @@ const getErrorSourceVariable = (node: AstNode | null): string | null => {
   const member = getMemberExpression(node);
   return identifierName(member?.object);
 };
-
-const isResultProducingExpression = (
-  node: AstNode,
-  helperNames: ReadonlySet<string>,
-  namespaceHelpers: NamespaceHelperMap,
-  scopes: readonly ReadonlySet<string>[],
-  scopedHelpers: ScopedHelperMap
-): boolean =>
-  isResultExpression(node) ||
-  isHelperCall(node, helperNames, namespaceHelpers, scopes, scopedHelpers);
 
 type ResultProvenance = Map<ReadonlySet<string>, Set<string>>;
 
@@ -158,6 +148,7 @@ const trackVariableDeclarator = (
     isResultProducingExpression(
       init,
       helperNames,
+      provenance,
       namespaceHelpers,
       scopes,
       scopedHelpers
@@ -175,11 +166,10 @@ const trackAssignmentExpression = (
   helperNames: ReadonlySet<string>,
   namespaceHelpers: NamespaceHelperMap,
   scopedHelpers: ScopedHelperMap,
+  directAssignments: ReadonlySet<AstNode>,
   scopes: readonly ReadonlySet<string>[]
 ): void => {
   const left = getNodeLeft(node);
-  const operator = getNodeOperator(node);
-  const right = getNodeRight(node);
   const name = identifierName(left);
   if (!name) {
     return;
@@ -188,16 +178,22 @@ const trackAssignmentExpression = (
   if (!scope) {
     return;
   }
-  if (
-    operator === '=' &&
+  const right = getNodeRight(node);
+  const resultRhs =
+    getNodeOperator(node) === '=' &&
     right &&
     isResultProducingExpression(
       right,
       helperNames,
+      provenance,
       namespaceHelpers,
       scopes,
       scopedHelpers
-    )
+    );
+  if (
+    resultRhs &&
+    (hasResultProvenance(provenance, scope, name) ||
+      directAssignments.has(node))
   ) {
     markResultVariable(provenance, scope, name);
     return;
@@ -258,6 +254,7 @@ const checkFunctionBody = (
   const scopedHelpers: MutableScopedHelperMap = new Map();
   const implScope = collectScopeFrameBindings(owner);
   const initialScopes = implScope.size > 0 ? [implScope] : [];
+  const directAssignments = collectDirectResultAssignments(body);
 
   walkWithScopes(
     body,
@@ -287,6 +284,7 @@ const checkFunctionBody = (
           helperNames,
           namespaceHelpers,
           scopedHelpers,
+          directAssignments,
           scopes
         );
         return;


### PR DESCRIPTION
## Context

[TRL-1245](https://linear.app/outfitter/issue/TRL-1245) closes the remaining Result-provenance gaps that made idiomatic conditional/helper/alias expressions fail Warden and encouraged type-erasing workarounds.

## Behavior

- shares one Result-producing expression classifier across `implementation-returns-result` and `no-redundant-result-error-wrap`
- recognizes conditional branches, helper calls, parenthesized expressions, awaited aliases, and compose Results
- preserves provenance when an already-proven binding receives another Result through simple `=`
- lets a direct function-body `=` assignment with a statically Result-producing RHS establish provenance
- keeps raw assignments, compound assignments, and assignments nested under conditional/control-flow structures conservative
- returns the existing Regrade Result directly instead of redundantly wrapping its error

## Checks

- focused Warden rules: 80 tests / 107 expectations
- full Warden package: 1,358 tests / 3,673 expectations
- temp-app and repo source-depth Warden JSON: zero diagnostics
- full typecheck, test, lint, AST lint, build, check, changeset, publish, Wayfinder dogfood, lock round-trip, docs, and diff checks
- standing and targeted straight-line correction reviews: 5/5, zero findings
- latest corrected stack pre-push: 165.30 seconds, green

## Release intent

Patch changeset for `@ontrails/warden` and `@ontrails/trails`.

## Risks

The analysis remains deliberately lexical and path-insensitive. New provenance is established only for direct function-body assignment statements; nested branch, loop, switch, try, callback, sequence, raw, and compound forms stay conservative.