### PR TITLE
fix(core): keep error rendering safe across surfaces

### DIFF
--- a/.changeset/trl-1246-safe-error-rendering.md
+++ b/.changeset/trl-1246-safe-error-rendering.md
@@ -1,0 +1,7 @@
+---
+'@ontrails/commander': patch
+'@ontrails/core': patch
+'@ontrails/library': patch
+---
+
+Keep public error projection shared and redacted while using transport-neutral CLI vocabulary and preserving safe topo diagnostics in structured output.

--- a/adapters/commander/src/__tests__/to-commander.test.ts
+++ b/adapters/commander/src/__tests__/to-commander.test.ts
@@ -2848,7 +2848,7 @@ describe('toCommander option wiring', () => {
         program.parseAsync(['node', 'test', 'fail'], { from: 'node' })
       ).rejects.toThrow('EXIT 8');
       expect(process.stderr.write).toHaveBeenCalledWith(
-        'Error: Internal server error\n'
+        'Error: Internal error\n'
       );
     });
   });
@@ -3101,6 +3101,80 @@ describe('toCommander option wiring', () => {
       expect(process.stderr.write).toHaveBeenCalledWith(
         '  - Resource "note-store" is not in the topo (notes.list)\n'
       );
+    });
+  });
+
+  test('error handling preserves redacted topo issues under --json', async () => {
+    await withMockedProcess(async () => {
+      const failTrail = trail('fail', {
+        implementation: () => Result.ok('ok'),
+        input: z.object({}),
+      });
+      const program = toCommander([
+        {
+          args: [],
+          execute: () => {
+            throw new ValidationError(
+              'Topo validation failed with 1 issue(s)',
+              {
+                context: {
+                  issues: [
+                    {
+                      message: 'Resource token=secret is not in the topo',
+                      rule: 'resource-exists',
+                      trailId: 'notes.add',
+                    },
+                  ],
+                },
+              }
+            );
+          },
+          flags: [
+            {
+              name: 'json',
+              required: false,
+              type: 'boolean' as const,
+              variadic: false,
+            },
+          ],
+          intent: 'read' as const,
+          path: ['fail'] as const,
+          trail: failTrail,
+        },
+      ]);
+
+      await expect(
+        program.parseAsync(['node', 'test', 'fail', '--json'], { from: 'node' })
+      ).rejects.toThrow('EXIT 1');
+      const output = String(
+        (process.stderr.write as ReturnType<typeof mock>).mock.calls[0]?.[0]
+      );
+      const envelope = JSON.parse(output) as {
+        context?: {
+          issues?: readonly {
+            message?: string;
+            rule?: string;
+            trailId?: string;
+          }[];
+        };
+        details?: readonly string[];
+        error?: { category?: string; message?: string };
+      };
+      expect(envelope.error).toEqual(
+        expect.objectContaining({
+          category: 'validation',
+          message: 'Topo validation failed with 1 issue(s)',
+        })
+      );
+      expect(envelope.context?.issues?.[0]).toMatchObject({
+        message: 'Resource [REDACTED] is not in the topo',
+        rule: 'resource-exists',
+        trailId: 'notes.add',
+      });
+      expect(envelope.details).toEqual([
+        '- Resource [REDACTED] is not in the topo (notes.add)',
+      ]);
+      expect(output).not.toContain('token=secret');
     });
   });
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -139,7 +139,7 @@ Dynamic classes:
 - `RetryExhaustedError` inherits category and surface codes from its wrapped `TrailsError`; retryable is always No.
 <!-- error-taxonomy:end -->
 
-Public surface renderings redact sensitive substrings before exposing a non-internal `TrailsError` message. Internal-category `TrailsError` instances and unknown native errors render with the generic message `Internal server error`; diagnostics and serialized payloads keep their useful structure while redacting messages, context, and stack strings.
+Public surfaces share one redacted rendering contract before applying surface codes. Sensitive substrings are removed from non-internal `TrailsError` messages. Internal-category `TrailsError` instances and unknown native errors remain opaque: HTTP, MCP, and library boundaries use `Internal server error`, while CLI uses the transport-neutral `Internal error`. Diagnostics and serialized payloads keep their useful structure while redacting messages, context, and stack strings.
 
 The developer returns `Result.err(new NotFoundError(...))`. The framework maps it to the right code on every surface.
 

--- a/packages/core/src/__tests__/error-rendering.test.ts
+++ b/packages/core/src/__tests__/error-rendering.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test';
 import { InternalError, PermissionError } from '../errors.js';
 import {
   INTERNAL_ERROR_PUBLIC_MESSAGE,
+  renderPublicError,
   renderErrorDiagnostics,
   redactErrorString,
 } from '../error-rendering.js';
@@ -43,6 +44,36 @@ describe('error rendering redaction', () => {
       retryable: false,
       surface: 'mcp',
     });
+  });
+
+  test('projects one redacted public contract before surface mapping', () => {
+    const error = new PermissionError('Denied token=secret');
+
+    expect(renderPublicError(error)).toEqual({
+      category: 'permission',
+      message: 'Denied [REDACTED]',
+      name: 'PermissionError',
+      retryable: false,
+    });
+    expect(renderPublicError(new Error('token=secret'))).toEqual({
+      category: 'internal',
+      message: INTERNAL_ERROR_PUBLIC_MESSAGE,
+      name: 'InternalError',
+      retryable: false,
+    });
+  });
+
+  test('keeps public projection parity while using CLI vocabulary', () => {
+    const error = new Error('token=secret');
+
+    expect(renderPublicSurfaceError('cli', error).message).toBe(
+      'Internal error'
+    );
+    for (const surface of ['http', 'jsonRpc', 'mcp'] as const) {
+      expect(renderPublicSurfaceError(surface, error).message).toBe(
+        INTERNAL_ERROR_PUBLIC_MESSAGE
+      );
+    }
   });
 
   test('uses a generic public message for internal TrailsError instances', () => {

--- a/packages/core/src/error-rendering.ts
+++ b/packages/core/src/error-rendering.ts
@@ -15,6 +15,13 @@ export interface ErrorDiagnosticsRendering {
   readonly stack?: string | undefined;
 }
 
+export interface PublicErrorRendering {
+  readonly category: ErrorCategory;
+  readonly message: string;
+  readonly name: string;
+  readonly retryable: boolean;
+}
+
 export const redactErrorString = (value: string): string =>
   errorRedactor.redact(value);
 
@@ -47,5 +54,34 @@ export const renderErrorDiagnostics = (
     message: redactErrorString(error.message),
     name: error.name || error.constructor.name || 'Error',
     ...(stack === undefined ? {} : { stack }),
+  };
+};
+
+/**
+ * Project an error through the shared public redaction policy.
+ *
+ * @example
+ * ```ts
+ * const rendering = renderPublicError(new NotFoundError('missing'));
+ * ```
+ */
+export const renderPublicError = (error: Error): PublicErrorRendering => {
+  if (isTrailsError(error)) {
+    return {
+      category: error.category,
+      message:
+        error.category === 'internal'
+          ? INTERNAL_ERROR_PUBLIC_MESSAGE
+          : redactErrorString(error.message),
+      name: error.name,
+      retryable: error.retryable,
+    };
+  }
+
+  return {
+    category: 'internal',
+    message: INTERNAL_ERROR_PUBLIC_MESSAGE,
+    name: 'InternalError',
+    retryable: false,
   };
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,11 +63,15 @@ export type {
 export {
   INTERNAL_ERROR_PUBLIC_MESSAGE,
   renderErrorDiagnostics,
+  renderPublicError,
   redactErrorContext,
   redactErrorStack,
   redactErrorString,
 } from './error-rendering.js';
-export type { ErrorDiagnosticsRendering } from './error-rendering.js';
+export type {
+  ErrorDiagnosticsRendering,
+  PublicErrorRendering,
+} from './error-rendering.js';
 export type {
   DiagnosticBase,
   DiagnosticSeverity,

--- a/packages/core/src/transport-error-map.ts
+++ b/packages/core/src/transport-error-map.ts
@@ -9,14 +9,12 @@ import {
   codesByCategory,
   errorClasses,
   exitCodeMap,
-  isTrailsError,
   jsonRpcCodeMap,
   statusCodeMap,
 } from './errors.js';
-import {
-  INTERNAL_ERROR_PUBLIC_MESSAGE,
-  redactErrorString,
-} from './error-rendering.js';
+import { renderPublicError } from './error-rendering.js';
+
+const CLI_INTERNAL_ERROR_PUBLIC_MESSAGE = 'Internal error';
 
 export const surfaceNames = ['cli', 'http', 'jsonRpc', 'mcp'] as const;
 
@@ -118,23 +116,14 @@ export const renderPublicSurfaceError = (
   surface: SurfaceName,
   error: Error
 ): SurfaceErrorRendering => {
-  if (isTrailsError(error)) {
-    const rendering = renderSurfaceError(surface, error);
-    return {
-      ...rendering,
-      message:
-        rendering.category === 'internal'
-          ? INTERNAL_ERROR_PUBLIC_MESSAGE
-          : redactErrorString(rendering.message),
-    };
-  }
-
+  const rendering = renderPublicError(error);
   return {
-    category: 'internal',
-    code: codesByCategory.internal[surfaceCodeKeys[surface]],
-    message: INTERNAL_ERROR_PUBLIC_MESSAGE,
-    name: 'InternalError',
-    retryable: false,
+    ...rendering,
+    code: codesByCategory[rendering.category][surfaceCodeKeys[surface]],
+    message:
+      surface === 'cli' && rendering.category === 'internal'
+        ? CLI_INTERNAL_ERROR_PUBLIC_MESSAGE
+        : rendering.message,
     surface,
   };
 };

--- a/packages/library/src/errors.ts
+++ b/packages/library/src/errors.ts
@@ -1,11 +1,10 @@
 /* oxlint-disable max-classes-per-file -- package-facing error taxonomy stays co-located */
 import {
-  INTERNAL_ERROR_PUBLIC_MESSAGE,
   createSurfaceErrorMapper,
   isTrailsError,
-  redactErrorString,
+  renderPublicError,
 } from '@ontrails/core';
-import type { ErrorCategory, TrailsError } from '@ontrails/core';
+import type { ErrorCategory } from '@ontrails/core';
 
 export interface LibraryErrorOptions {
   readonly cause?: Error | undefined;
@@ -171,25 +170,21 @@ const libraryErrorClasses = {
 
 const mapLibraryErrorClass = createSurfaceErrorMapper(libraryErrorClasses);
 
-const publicMessage = (error: TrailsError): string =>
-  error.category === 'internal'
-    ? INTERNAL_ERROR_PUBLIC_MESSAGE
-    : redactErrorString(error.message);
-
 export const toLibraryError = (error: Error): LibraryError => {
   if (error instanceof LibraryError) {
     return error;
   }
 
+  const rendering = renderPublicError(error);
   if (!isTrailsError(error)) {
-    return new LibraryInternalError(INTERNAL_ERROR_PUBLIC_MESSAGE, {
+    return new LibraryInternalError(rendering.message, {
       cause: error,
       originalName: error.name || 'Error',
     });
   }
 
   const ErrorClass = mapLibraryErrorClass(error);
-  return new ErrorClass(publicMessage(error), {
+  return new ErrorClass(rendering.message, {
     cause: error,
     originalName: error.name,
   });


### PR DESCRIPTION
## Context

[TRL-1246](https://linear.app/outfitter/issue/TRL-1246) closes the remaining error-rendering honesty gaps without weakening public redaction. The topo-validation context path was already implemented; this branch adds the missing structured/redaction proof and fixes HTTP-specific wording on CLI.

## Behavior

- centralizes the redacted public category/message/name/retryable contract in `@ontrails/core`
- keeps internal and unknown failures opaque by construction
- uses transport-neutral `Internal error` for CLI while preserving `Internal server error` for HTTP, MCP, and library compatibility
- routes library errors through the shared public renderer instead of duplicating policy
- proves structured topo issues retain redacted context independently of display details

## Checks

- focused core/Commander/library: 110 tests / 364 expectations
- peer HTTP/MCP/Trails app: 123 tests / 493 expectations
- full typecheck, test, lint, AST lint, build, aggregate check, changeset, publish, Wayfinder dogfood, lock round-trip, docs, taxonomy, and diff checks
- manual synthetic-canary topo JSON and internal CLI text proofs
- standing and targeted local-review round 2: 5/5, zero findings

## Release intent

Patch changeset for `@ontrails/commander`, `@ontrails/core`, and `@ontrails/library`.

## Risks

The only compatibility change is the authorized CLI phrase. Public internal/unknown details remain opaque; HTTP, MCP, and library wording is unchanged. No Warden taxonomy or broad AST work is included.