### PR TITLE
fix(regrade): close projection vocabulary residue

### DIFF
--- a/.changeset/trl-1019-projection-residue.md
+++ b/.changeset/trl-1019-projection-residue.md
@@ -1,0 +1,11 @@
+---
+"@ontrails/core": patch
+"@ontrails/regrade": patch
+"@ontrails/trails": patch
+"@ontrails/warden": patch
+---
+
+Close missed projection vocabulary residue in Regrade internals and public
+error-rendering guidance, and keep lifecycle-ambiguous governed identifiers in
+the Warden review inventory instead of assigning them an unsafe automatic
+target.

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -1897,7 +1897,7 @@ const withFileRenameEvidence = (params: {
   ]);
   const filePolicyCount = params.run.policyOccurrencePaths.length;
   const fileInScopeCount = params.run.occurrencePaths.length - filePolicyCount;
-  const projectedFileInScopeCount =
+  const derivedFileInScopeCount =
     params.run.report.rewritten + params.run.report.review;
   return {
     ...params.report,
@@ -1914,7 +1914,7 @@ const withFileRenameEvidence = (params: {
         scopeTiers: {
           'in-scope':
             params.report.run.report.scopeTiers['in-scope'] -
-            projectedFileInScopeCount +
+            derivedFileInScopeCount +
             fileInScopeCount,
           'policy-classified':
             params.report.run.report.scopeTiers['policy-classified'] +

--- a/packages/core/src/error-rendering.ts
+++ b/packages/core/src/error-rendering.ts
@@ -58,7 +58,7 @@ export const renderErrorDiagnostics = (
 };
 
 /**
- * Project an error through the shared public redaction policy.
+ * Render an error through the shared public redaction policy.
  *
  * @example
  * ```ts

--- a/packages/regrade/src/downstream/file-renames.ts
+++ b/packages/regrade/src/downstream/file-renames.ts
@@ -232,16 +232,16 @@ const preserveVocabularyCase = (
     : replacement;
 };
 
-const projectVocabularyText = (
+const deriveVocabularyText = (
   source: string,
   plan: VocabularyRegradePlan
 ): string => {
-  let projected = source;
+  let derived = source;
   const safeForms = vocabularyRewriteFormsForPlan(plan).toSorted(
     ([left], [right]) => right.length - left.length
   );
   for (const [from, to] of safeForms) {
-    projected = projected.replaceAll(
+    derived = derived.replaceAll(
       new RegExp(
         `(?<![A-Za-z0-9_$-])${escapeRegExp(from)}(?![A-Za-z0-9_$-])`,
         plan.caseSensitive === true ? 'gu' : 'giu'
@@ -250,7 +250,7 @@ const projectVocabularyText = (
         plan.caseSensitive === true ? to : preserveVocabularyCase(matched, to)
     );
   }
-  return projected;
+  return derived;
 };
 
 const astReferenceMappings = (
@@ -372,7 +372,7 @@ const referenceMappingsForPath = (
       rename.from,
       ...(vocabularyPlan === undefined
         ? []
-        : [projectVocabularyText(rename.from, vocabularyPlan)]),
+        : [deriveVocabularyText(rename.from, vocabularyPlan)]),
     ].filter((value, index, values) => values.indexOf(value) === index);
     for (const sourcePath of sourcePaths) {
       mappings.push(
@@ -1121,7 +1121,7 @@ const isGeneratedRegradeArtifactPath = (path: string): boolean =>
 const filterOpenedPolicyDirectories = (
   collected: DownstreamSourceCollection,
   opened: readonly string[],
-  projectedTargetPaths: ReadonlySet<string>,
+  derivedTargetPaths: ReadonlySet<string>,
   scope: VocabularyRegradeScope | undefined,
   renames: readonly VocabularyFileRename[],
   apply: boolean
@@ -1137,7 +1137,7 @@ const filterOpenedPolicyDirectories = (
     );
     return (
       !insideOpenedDirectory ||
-      projectedTargetPaths.has(normalizeRenamePath(file.path)) ||
+      derivedTargetPaths.has(normalizeRenamePath(file.path)) ||
       policyForPath(scopePath, scope) !== undefined
     );
   });
@@ -1199,22 +1199,22 @@ const collectionExcludeForFileRenames = (params: {
 const normalizeExtension = (extension: string): string =>
   extension === '' || extension.startsWith('.') ? extension : `.${extension}`;
 
-const collectionExtensionProjectionForFileRenames = (params: {
+const deriveCollectionExtensionsForFileRenames = (params: {
   readonly apply: boolean;
   readonly extensions: readonly string[];
   readonly renames: readonly VocabularyFileRename[];
 }): {
   readonly extensions: readonly string[];
-  readonly projectedTargetPaths: ReadonlySet<string>;
+  readonly derivedTargetPaths: ReadonlySet<string>;
 } => {
   const sourceExtensions = new Set(params.extensions.map(normalizeExtension));
   if (!params.apply || sourceExtensions.size === 0) {
     return {
+      derivedTargetPaths: new Set(),
       extensions: params.extensions,
-      projectedTargetPaths: new Set(),
     };
   }
-  const projectedTargetPaths = new Set(
+  const derivedTargetPaths = new Set(
     params.renames
       .filter((rename) =>
         sourceExtensions.has(
@@ -1224,18 +1224,18 @@ const collectionExtensionProjectionForFileRenames = (params: {
       .map((rename) => normalizeRenamePath(rename.to))
   );
   return {
+    derivedTargetPaths,
     extensions: [
       ...sourceExtensions,
-      ...new Set([...projectedTargetPaths].map((path) => extname(path))),
+      ...new Set([...derivedTargetPaths].map((path) => extname(path))),
     ],
-    projectedTargetPaths,
   };
 };
 
-const filterProjectedTargetExtensions = (
+const filterDerivedTargetExtensions = (
   collected: DownstreamSourceCollection,
   sourceExtensions: readonly string[],
-  projectedTargetPaths: ReadonlySet<string>
+  derivedTargetPaths: ReadonlySet<string>
 ): DownstreamSourceCollection => {
   const normalizedSourceExtensions = new Set(
     sourceExtensions.map(normalizeExtension)
@@ -1246,7 +1246,7 @@ const filterProjectedTargetExtensions = (
   const files = collected.files.filter(
     (file) =>
       normalizedSourceExtensions.has(extname(file.path)) ||
-      projectedTargetPaths.has(normalizeRenamePath(file.path))
+      derivedTargetPaths.has(normalizeRenamePath(file.path))
   );
   const selected = new Set(files.map((file) => file.path));
   return {
@@ -1264,7 +1264,7 @@ const filterProjectedTargetExtensions = (
 const withExactMovedTargets = (params: {
   readonly apply: boolean;
   readonly collected: DownstreamSourceCollection;
-  readonly projectedTargetPaths: ReadonlySet<string>;
+  readonly derivedTargetPaths: ReadonlySet<string>;
   readonly renames: readonly VocabularyFileRename[];
   readonly resolved: readonly ResolvedFileRename[];
   readonly scope: VocabularyRegradeScope | undefined;
@@ -1279,7 +1279,7 @@ const withExactMovedTargets = (params: {
     const path = normalizeRenamePath(rename.to);
     const sourcePath = sourcePathForMovedTarget(path, params.renames);
     if (
-      !params.projectedTargetPaths.has(path) ||
+      !params.derivedTargetPaths.has(path) ||
       (params.scope?.include !== undefined &&
         !matchesAnyPathGlob(sourcePath, params.scope.include)) ||
       (params.scope?.exclude !== undefined &&
@@ -1430,13 +1430,13 @@ export const runFileRenameRegrade = (params: {
   });
   const sourceExtensions =
     params.scope?.extensions ?? fileRenameSourceExtensions;
-  const extensionProjection = collectionExtensionProjectionForFileRenames({
+  const derivedExtensions = deriveCollectionExtensionsForFileRenames({
     apply,
     extensions: sourceExtensions,
     renames: params.renames,
   });
   const rawCollection = collectDownstreamSources(params.root, {
-    extensions: extensionProjection.extensions,
+    extensions: derivedExtensions.extensions,
     ...(exclude === undefined ? {} : { exclude }),
     ...(include === undefined ? {} : { include }),
     ignoredDirectories: DEFAULT_IGNORED_DIRECTORIES.filter(
@@ -1452,20 +1452,20 @@ export const runFileRenameRegrade = (params: {
   const exactTargetCollection = withExactMovedTargets({
     apply,
     collected: rawCollection,
-    projectedTargetPaths: extensionProjection.projectedTargetPaths,
+    derivedTargetPaths: derivedExtensions.derivedTargetPaths,
     renames: params.renames,
     resolved: validated.value,
     scope: params.scope,
   });
-  const extensionScopedCollection = filterProjectedTargetExtensions(
+  const extensionScopedCollection = filterDerivedTargetExtensions(
     exactTargetCollection,
     sourceExtensions,
-    extensionProjection.projectedTargetPaths
+    derivedExtensions.derivedTargetPaths
   );
   const scopedCollection = filterOpenedPolicyDirectories(
     extensionScopedCollection,
     opened,
-    extensionProjection.projectedTargetPaths,
+    derivedExtensions.derivedTargetPaths,
     params.scope,
     params.renames,
     apply
@@ -1516,7 +1516,7 @@ export const runFileRenameRegrade = (params: {
     }
   }
 
-  const projectedEvidence = params.renames.map((rename, index) => ({
+  const derivedEvidence = params.renames.map((rename, index) => ({
     ...rename,
     ...(evidence[index] ?? emptyEvidence()),
   }));
@@ -1548,10 +1548,10 @@ export const runFileRenameRegrade = (params: {
             applied:
               validated.value.filter((rename) => !rename.alreadyApplied)
                 .length +
-              projectedEvidence.reduce((sum, item) => sum + item.rewritten, 0),
+              derivedEvidence.reduce((sum, item) => sum + item.rewritten, 0),
             filesChanged: changedFiles.size,
             review,
-            skipped: projectedEvidence.reduce(
+            skipped: derivedEvidence.reduce(
               (sum, item) => sum + item.skipped,
               0
             ),
@@ -1582,7 +1582,7 @@ export const runFileRenameRegrade = (params: {
 
   return Result.ok({
     changedPaths: [...changedFiles].toSorted(),
-    evidence: projectedEvidence,
+    evidence: derivedEvidence,
     occurrencePaths: referenceResult.value.occurrencePaths,
     policyOccurrencePaths: referenceResult.value.policyOccurrencePaths,
     report,

--- a/packages/warden/src/__tests__/governed-symbol-residue.test.ts
+++ b/packages/warden/src/__tests__/governed-symbol-residue.test.ts
@@ -362,6 +362,56 @@ describe('governed-symbol-residue', () => {
     ]);
   });
 
+  test('routes every lifecycle-ambiguous bare projection symbol to review', () => {
+    const diagnostics = check(
+      [
+        'export function projected() {',
+        '  return projected();',
+        '}',
+        'const value = projected;',
+        '',
+      ].join('\n')
+    );
+
+    expect(diagnostics).toHaveLength(3);
+    expect(diagnostics.map((diagnostic) => diagnostic.fix?.safety)).toEqual([
+      'review',
+      'review',
+      'review',
+    ]);
+    expect(diagnostics.map((diagnostic) => diagnostic.fix?.edits)).toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ]);
+    expect(
+      diagnostics.every((diagnostic) =>
+        diagnostic.fix?.reason.includes('requires semantic classification')
+      )
+    ).toBe(true);
+  });
+
+  test('routes lifecycle-ambiguous projection parameters to review', () => {
+    const diagnostics = check(
+      [
+        'function consume(projected: string) {',
+        '  return projected;',
+        '}',
+        '',
+      ].join('\n')
+    );
+
+    expect(diagnostics).toHaveLength(2);
+    expect(diagnostics.map((diagnostic) => diagnostic.fix?.safety)).toEqual([
+      'review',
+      'review',
+    ]);
+    expect(diagnostics.map((diagnostic) => diagnostic.fix?.edits)).toEqual([
+      undefined,
+      undefined,
+    ]);
+  });
+
   test('routes import and export boundary names to review', () => {
     for (const source of [
       "import { contourId } from 'external';\n",

--- a/packages/warden/src/__tests__/retired-vocabulary.test.ts
+++ b/packages/warden/src/__tests__/retired-vocabulary.test.ts
@@ -557,6 +557,38 @@ describe('governed vocabulary registry', () => {
     expect(wayfinder?.symbolRenames).toEqual([]);
   });
 
+  test('governs Regrade identifiers missed by the first projection census', () => {
+    const projection = getGovernedVocabularyTransition(
+      'v1-projection-derive-render'
+    );
+
+    expect(projection?.symbolRenames).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: 'collectionExtensionProjectionForFileRenames',
+          to: 'deriveCollectionExtensionsForFileRenames',
+        }),
+        expect.objectContaining({
+          from: 'projectVocabularyText',
+          to: 'deriveVocabularyText',
+        }),
+        expect.objectContaining({
+          from: 'projectedTargetPaths',
+          to: 'derivedTargetPaths',
+        }),
+        expect.objectContaining({
+          from: 'projected',
+          safety: 'review',
+          to: 'derived',
+        }),
+        expect.objectContaining({
+          from: 'projectedFileInScopeCount',
+          to: 'derivedFileInScopeCount',
+        }),
+      ])
+    );
+  });
+
   test('rejects duplicate ids and duplicate source terms', () => {
     const [transition] = governedVocabularyTransitions;
     if (transition === undefined) {

--- a/packages/warden/src/rules/governed-symbol-residue.ts
+++ b/packages/warden/src/rules/governed-symbol-residue.ts
@@ -286,6 +286,10 @@ const reviewReasonFor = (
     }
   }
 
+  if (match.rename.safety === 'review') {
+    return 'requires semantic classification';
+  }
+
   if (shorthandIdentifiers.has(match.from)) {
     return 'participates in an authored shorthand property';
   }

--- a/packages/warden/src/rules/retired-vocabulary.ts
+++ b/packages/warden/src/rules/retired-vocabulary.ts
@@ -62,6 +62,7 @@ export const governedVocabularySymbolRenameSchema = z.object({
   from: z.string().min(1),
   match: z.enum(governedVocabularySymbolRenameMatchModes).default('exact'),
   reviewDeclarationTypes: z.array(z.string().min(1)).default([]),
+  safety: z.enum(['safe', 'review']).optional(),
   to: z.string().min(1),
 });
 
@@ -829,6 +830,9 @@ export const governedVocabularyTransitions =
         'cliProjection',
         'cliProjectionSchema',
         'collectLibraryProjection',
+        'collectionExtensionProjectionForFileRenames',
+        'extensionProjection',
+        'filterProjectedTargetExtensions',
         'projectActivationEdge',
         'projectActivationSource',
         'projectActivationSourceDeclaration',
@@ -860,6 +864,11 @@ export const governedVocabularyTransitions =
         'projectTrailVersions',
         'projectVersionDetours',
         'projectVersionRuntimeRefs',
+        'projectVocabularyText',
+        'projected',
+        'projectedEvidence',
+        'projectedFileInScopeCount',
+        'projectedTargetPaths',
         'SchemaProjector',
         'deriveShippedSurfaceProjectionInventory',
         'deriveTrailCliCommandProjection',
@@ -1190,6 +1199,15 @@ export const governedVocabularyTransitions =
           from: 'collectLibraryProjection',
           to: 'deriveTopoGraphLibrary',
         },
+        {
+          from: 'collectionExtensionProjectionForFileRenames',
+          to: 'deriveCollectionExtensionsForFileRenames',
+        },
+        { from: 'extensionProjection', to: 'derivedExtensions' },
+        {
+          from: 'filterProjectedTargetExtensions',
+          to: 'filterDerivedTargetExtensions',
+        },
         { from: 'projectActivationEdge', to: 'deriveActivationEdge' },
         { from: 'projectActivationSource', to: 'deriveActivationSource' },
         {
@@ -1233,6 +1251,18 @@ export const governedVocabularyTransitions =
           from: 'projectVersionRuntimeRefs',
           to: 'deriveVersionRuntimeRefs',
         },
+        { from: 'projectVocabularyText', to: 'deriveVocabularyText' },
+        {
+          from: 'projected',
+          safety: 'review',
+          to: 'derived',
+        },
+        { from: 'projectedEvidence', to: 'derivedEvidence' },
+        {
+          from: 'projectedFileInScopeCount',
+          to: 'derivedFileInScopeCount',
+        },
+        { from: 'projectedTargetPaths', to: 'derivedTargetPaths' },
         { from: 'SchemaProjector', to: 'SchemaDeriver' },
         {
           from: 'deriveShippedSurfaceProjectionInventory',


### PR DESCRIPTION
## Context

The applied `projection -> derive/render` transition missed current Regrade implementation identifiers in two source files. This branch reopens the graduated transition through `regrade adjust`, adds the missing governed mappings, reapplies them on the original transition spine, and closes the remaining reviewed TSDoc residue.

Closes [TRL-1019](https://linear.app/outfitter/issue/TRL-1019/). Supports the final cleanup gate in [TRL-1020](https://linear.app/outfitter/issue/TRL-1020/).

## What changed

- Added the missed Regrade identifiers to the governed projection transition.
- Used `adjust -> plan -> check -> preview -> apply` to rename the two affected source files.
- Preserved the original transition id `f29fac3a4e47`; history now carries the original run, the two-file corrective run, and a final zero-actionable proof run.
- Routed bare `projected` variables to review because their correct target can be `derive` or `render`; compound lifecycle-specific identifiers remain exact mappings.
- Corrected one live TSDoc sentence from `Project an error` to `Render an error` after the classified scan exposed that source comments are outside its current review inventory.
- Left no active Regrade plan behind.

## Regrade evidence

- Corrective apply: 2 matched, 2 rewritten, 2 files changed, 0 review, 0 unknown.
- Final check/apply: 0 actionable, 0 open, completion gate green.
- Full `regrade:audit`: all governed transitions green.
- Current history: 3 runs on one stable transition id.

The dogfood pass also produced two follow-ups:

- [TRL-1267](https://linear.app/outfitter/issue/TRL-1267/) for TSDoc/source-comment review visibility.
- [TRL-1268](https://linear.app/outfitter/issue/TRL-1268/) for multi-minute silent lifecycle runs and large repeated history evidence.

## Verification

- `bun test packages/regrade/src/downstream/__tests__/file-renames.test.ts packages/regrade/src/downstream/__tests__/vocabulary.test.ts packages/warden/src/__tests__/retired-vocabulary.test.ts packages/warden/src/__tests__/governed-symbol-residue.test.ts apps/trails/src/__tests__/regrade-plan-derivation.test.ts apps/trails/src/__tests__/regrade.test.ts` - 218 pass, 0 fail
- `bun run check` - pass
- `bun run test` - 49 tasks pass; `@ontrails/trails` 724 pass, 0 fail
- `bun run build` - pass
- `bun run publish:check` - pass
- `bun run changeset:check -- --changed-files <pr-files> --base-ref main` - pass; patch intent covers `@ontrails/core`, `@ontrails/regrade`, `@ontrails/trails`, and `@ontrails/warden`
- `git diff --check` - pass
- Pre-push suite - pass

## Review

Local full-stack review: 5/5, clean, no open P0-P2 findings. The large history append is generated migration evidence, not hand-authored source churn.

## Risk

The main review surface is the generated history size. The code changes are internal identifier corrections plus governance/tests; there is no public package release intent.
