### PR TITLE
feat(source): expose parser-native comment spans

### DIFF
--- a/.changeset/source-parser-comment-spans.md
+++ b/.changeset/source-parser-comment-spans.md
@@ -1,0 +1,11 @@
+---
+'@ontrails/source': minor
+'@ontrails/warden': patch
+---
+
+Expose parser-native comment spans from `parseWithDiagnostics` so source-aware
+tooling can distinguish exact JavaScript and TypeScript comment trivia without
+reimplementing a lexer.
+
+Use the shared spans in Warden's public-example rule while keeping leading
+comment ownership fail-closed across JavaScript line terminators.

--- a/packages/source/README.md
+++ b/packages/source/README.md
@@ -9,7 +9,8 @@ Shared source-code machinery for Trails packages and repo tooling.
 `@ontrails/source` owns reusable source-code mechanics:
 
 - AST node guards and accessors for the OXC node shapes Trails tooling uses.
-- `parse` and `parseWithDiagnostics` wrappers over `oxc-parser`.
+- `parse` and `parseWithDiagnostics` wrappers over `oxc-parser`, including
+  parser-native comment spans for tools that must distinguish source trivia.
 - `walk`, parent-aware walking, and scope-aware walking over `oxc-walker`.
 - Source locations, source edits, literal extraction, and generic Trails syntax recognition.
 - Generic trail/entity discovery helpers such as `findTrailDefinitions`, `findImplementationBodies`, `findEntityDefinitions`, and `isImplementationCall`.
@@ -43,6 +44,21 @@ const ast = parse(
 
 const trailIds = ast ? findTrailDefinitions(ast).map((trail) => trail.id) : [];
 ```
+
+Inspect exact comment spans without rebuilding a JavaScript or TypeScript lexer:
+
+```ts
+import { parseWithDiagnostics } from '@ontrails/source';
+
+const sourceCode = '/** Describe a trail. */\nexport const show = 1;\n';
+const parsed = parseWithDiagnostics('example.ts', sourceCode);
+const comments = parsed.comments.map((comment) => ({
+  ...comment,
+  source: sourceCode.slice(comment.start, comment.end),
+}));
+```
+
+Comment spans are returned only when the parser reports no diagnostics. Tools must treat an empty comment inventory on a recovered parse as unknown rather than as proof that the source contains no comments.
 
 Walk source with parent context:
 

--- a/packages/source/src/__tests__/public-api.test.ts
+++ b/packages/source/src/__tests__/public-api.test.ts
@@ -35,6 +35,7 @@ import type {
   RestElementNode,
   ReturnStatementNode,
   SourceEdit,
+  SourceComment,
   SourceLocation,
   StringLiteralMatch,
   StringLiteralNode,
@@ -192,6 +193,7 @@ interface SourceTypeExportContract {
   readonly RestElementNode: RestElementNode;
   readonly ReturnStatementNode: ReturnStatementNode;
   readonly SourceEdit: SourceEdit;
+  readonly SourceComment: SourceComment;
   readonly SourceLocation: SourceLocation;
   readonly StringLiteralMatch: StringLiteralMatch;
   readonly StringLiteralNode: StringLiteralNode;
@@ -244,5 +246,48 @@ describe('@ontrails/source public API', () => {
       sawImplementationCall ||= source.isImplementationCall(node);
     });
     expect(sawImplementationCall).toBe(true);
+  });
+
+  test('returns exact parser-native comment spans with parse diagnostics', () => {
+    const sourceCode = [
+      '/** Project an error. */',
+      'export const project = 1; // ordinary project noun',
+      '',
+    ].join('\n');
+    const result = source.parseWithDiagnostics('example.ts', sourceCode);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(
+      result.comments.map((comment) => ({
+        ...comment,
+        source: sourceCode.slice(comment.start, comment.end),
+      }))
+    ).toEqual([
+      {
+        end: 24,
+        source: '/** Project an error. */',
+        start: 0,
+        type: 'Block',
+        value: '* Project an error. ',
+      },
+      {
+        end: 75,
+        source: '// ordinary project noun',
+        start: 51,
+        type: 'Line',
+        value: ' ordinary project noun',
+      },
+    ]);
+  });
+
+  test('fails comment recovery closed when the parser reports diagnostics', () => {
+    const result = source.parseWithDiagnostics(
+      'broken.ts',
+      '/** Project an error. */\nexport const = ;\n'
+    );
+
+    expect(result.ast).not.toBeNull();
+    expect(result.comments).toEqual([]);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 });

--- a/packages/source/src/nodes.ts
+++ b/packages/source/src/nodes.ts
@@ -245,8 +245,19 @@ export interface AstParseDiagnostic {
   readonly severity: string;
 }
 
+/** Parser-native source comment span. Offsets include the comment delimiters. */
+export interface SourceComment {
+  readonly end: number;
+  readonly start: number;
+  readonly type: 'Block' | 'Line';
+  /** Comment text without the line or block delimiters. */
+  readonly value: string;
+}
+
 export interface AstParseResult {
   readonly ast: AstNode | null;
+  /** Exact parser-native comments for a diagnostic-free parse; empty on errors. */
+  readonly comments: readonly SourceComment[];
   readonly diagnostics: readonly AstParseDiagnostic[];
 }
 

--- a/packages/source/src/parse.ts
+++ b/packages/source/src/parse.ts
@@ -25,22 +25,25 @@ export const parseWithDiagnostics = (
 ): AstParseResult => {
   try {
     const result = parseSync(filePath, sourceCode, { sourceType: 'module' });
+    const diagnostics = result.errors.map((error) => ({
+      helpMessage: error.helpMessage,
+      labels: error.labels.map((label) => ({
+        end: label.end,
+        message: label.message,
+        start: label.start,
+      })),
+      message: error.message,
+      severity: error.severity,
+    }));
     return {
       ast: result.program as unknown as AstNode,
-      diagnostics: result.errors.map((error) => ({
-        helpMessage: error.helpMessage,
-        labels: error.labels.map((label) => ({
-          end: label.end,
-          message: label.message,
-          start: label.start,
-        })),
-        message: error.message,
-        severity: error.severity,
-      })),
+      comments: diagnostics.length === 0 ? result.comments : [],
+      diagnostics,
     };
   } catch (error) {
     return {
       ast: null,
+      comments: [],
       diagnostics: [
         {
           helpMessage: null,

--- a/packages/warden/src/__tests__/public-export-example-coverage.test.ts
+++ b/packages/warden/src/__tests__/public-export-example-coverage.test.ts
@@ -135,6 +135,37 @@ describe('public-export-example-coverage', () => {
       expect(diagnostics).toEqual([]);
     });
 
+    test('a comment trailing the previous statement does not cover the export', () => {
+      const barrel = `export { alpha } from './alpha.js';\n`;
+      const fixture = buildFixture(barrel, {
+        'alpha.ts':
+          'const prior = 1; /** @example belongs to prior */\nexport const alpha = (): number => 1;\n',
+      });
+      const diagnostics = checkPublicExportExampleCoverage(
+        barrel,
+        fixture.barrelPath,
+        fixture.targets
+      );
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.message).toContain('missing a leading @example');
+    });
+
+    test('a leading comment after a carriage return covers the export', () => {
+      const barrel = `export { alpha } from './alpha.js';\n`;
+      const fixture = buildFixture(barrel, {
+        'alpha.ts':
+          'const prior = 1;\r/** @example alpha() */\rexport const alpha = (): number => 1;\r',
+      });
+      const diagnostics = checkPublicExportExampleCoverage(
+        barrel,
+        fixture.barrelPath,
+        fixture.targets
+      );
+
+      expect(diagnostics).toEqual([]);
+    });
+
     test('missing @example on a minimum export is an error', () => {
       const barrel = `export { alpha } from './alpha.js';\n`;
       const fixture = buildFixture(barrel, { 'alpha.ts': UNCOVERED_ALPHA });
@@ -306,6 +337,22 @@ export const alphaImpl = (): number => 1;
       expect(diagnostics[0]?.severity).toBe('error');
       expect(diagnostics[0]?.message).toContain('unreadable source');
       expect(diagnostics[0]?.message).toContain('ghost.ts');
+    });
+
+    test('recovered source parses fail closed instead of claiming coverage', () => {
+      const barrel = `export { alpha } from './alpha.js';\n`;
+      const fixture = buildFixture(barrel, {
+        'alpha.ts': '/** @example alpha() */\nexport const alpha = ;\n',
+      });
+      const diagnostics = checkPublicExportExampleCoverage(
+        barrel,
+        fixture.barrelPath,
+        fixture.targets
+      );
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.severity).toBe('error');
+      expect(diagnostics[0]?.message).toContain('unparseable source');
     });
   });
 });

--- a/packages/warden/src/rules/public-export-example-coverage.ts
+++ b/packages/warden/src/rules/public-export-example-coverage.ts
@@ -44,8 +44,9 @@ import {
   getNodeValue,
   offsetToLine,
   parse,
+  parseWithDiagnostics,
 } from '@ontrails/source';
-import type { AstNode } from '@ontrails/source';
+import type { AstNode, SourceComment } from '@ontrails/source';
 import type { WardenDiagnostic, WardenRule } from './types.js';
 
 const RULE_NAME = 'public-export-example-coverage';
@@ -379,44 +380,19 @@ const declarationNameMatches = (
   return false;
 };
 
-/**
- * Comment texts found in an inter-statement trivia gap. The gap between two
- * top-level statements contains only whitespace and comments, so a small
- * line/block comment scan recovers the same comment set TypeScript's
- * `getLeadingCommentRanges` returns for the statement's full start.
- */
-const collectCommentTexts = (gapText: string): readonly string[] => {
-  const comments: string[] = [];
-  let index = 0;
-  while (index < gapText.length - 1) {
-    if (gapText[index] === '/' && gapText[index + 1] === '/') {
-      const lineEnd = gapText.indexOf('\n', index);
-      const stop = lineEnd === -1 ? gapText.length : lineEnd;
-      comments.push(gapText.slice(index, stop));
-      index = stop + 1;
-    } else if (gapText[index] === '/' && gapText[index + 1] === '*') {
-      const blockEnd = gapText.indexOf('*/', index + 2);
-      const stop = blockEnd === -1 ? gapText.length : blockEnd + 2;
-      comments.push(gapText.slice(index, stop));
-      index = stop;
-    } else {
-      index += 1;
-    }
-  }
-  return comments;
-};
-
 const EXAMPLE_TAG_PATTERN = /@example\b/;
+const LINE_TERMINATOR_PATTERN = /[\n\r\u2028\u2029]/u;
 
 /**
  * True when the exported declaration named `importedName` in `sourceText`
- * carries a leading comment containing `@example`. Leading comments are
- * recovered from the trivia gap between the preceding top-level statement's
- * end (or file start) and the matching export statement's start.
+ * carries a leading comment containing `@example`. Parser-native comments in
+ * the trivia gap between the preceding top-level statement's end (or file
+ * start) and the matching export statement are considered leading.
  */
 const hasLeadingExampleForExport = (
   sourceText: string,
   ast: AstNode,
+  comments: readonly SourceComment[],
   importedName: string
 ): boolean => {
   const body = programBody(ast);
@@ -429,9 +405,16 @@ const hasLeadingExampleForExport = (
       continue;
     }
     const previous = body[statementIndex - 1];
-    const gapText = sourceText.slice(previous?.end ?? 0, statement.start);
-    return collectCommentTexts(gapText).some((comment) =>
-      EXAMPLE_TAG_PATTERN.test(comment)
+    const gapStart = previous?.end ?? 0;
+    return comments.some(
+      (comment) =>
+        gapStart <= comment.start &&
+        comment.end <= statement.start &&
+        (previous === undefined ||
+          LINE_TERMINATOR_PATTERN.test(
+            sourceText.slice(gapStart, comment.start)
+          )) &&
+        EXAMPLE_TAG_PATTERN.test(comment.value)
     );
   }
   return false;
@@ -468,8 +451,8 @@ const coverageDiagnosticsForSpecifier = (
       ),
     ];
   }
-  const sourceAst = parse(sourcePath, sourceText);
-  if (!sourceAst) {
+  const parsedSource = parseWithDiagnostics(sourcePath, sourceText);
+  if (!parsedSource.ast || parsedSource.diagnostics.length > 0) {
     return [
       diagnostic(
         sourceCode,
@@ -481,7 +464,12 @@ const coverageDiagnosticsForSpecifier = (
     ];
   }
   if (
-    hasLeadingExampleForExport(sourceText, sourceAst, specifier.importedName)
+    hasLeadingExampleForExport(
+      sourceText,
+      parsedSource.ast,
+      parsedSource.comments,
+      specifier.importedName
+    )
   ) {
     return [];
   }

--- a/scripts/check-readme-snippets.ts
+++ b/scripts/check-readme-snippets.ts
@@ -202,6 +202,7 @@ export const NotFoundError: any;
 export const output: any;
 export const outputModePreset: any;
 export const parse: any;
+export const parseWithDiagnostics: any;
 export const passthroughResolver: any;
 export const permitPreset: any;
 export const pruneUnpinnedSnapshots: any;


### PR DESCRIPTION
## Context

[TRL-1267](https://linear.app/outfitter/issue/TRL-1267/) requires Regrade to inventory exact JavaScript and TypeScript comment/TSDoc occurrences without guessing from raw source text. OXC already derives exact comment spans, but the shared `@ontrails/source` facade discarded them. This focused lower branch exposes that reusable fact before the Regrade behavior branch consumes it.

## What changed

- Expose diagnostic-free parser-native line/block comment spans from `parseWithDiagnostics`.
- Fail comment inventory closed when OXC reports recovery diagnostics.
- Replace Warden's local public-`@example` trivia scanner with the shared parser result.
- Keep leading-comment ownership strict across LF, CR, U+2028, and U+2029; a same-line trailing comment cannot cover the following export.
- Document the source API and add release intent for `@ontrails/source` and `@ontrails/warden`.

## Verification

- Source/Warden focused comment tests: 23/23.
- Complete Source/Warden package suites: 1,355/1,355 tests, 3,670 expectations.
- Source and Warden typecheck/lint: pass.
- Format and diff checks: pass; only the five pre-existing TRL-575 advisories remain.
- Live Warden: 0 errors, 24 existing warnings.
- Targeted local review: 5/5, zero P0-P3.
- Standing local review: 5/5, zero P0-P3.
- Graphite pre-push aggregate gate: pass.

## Risks and rollout

The API is additive. Consumers must treat an empty comment list on a recovered parse as unknown, not as proof of no comments. Warden becomes stricter for a previously misattributed same-line trailing `@example`; the patch changeset records that diagnostic correction. Regrade policy and automatic rewriting remain out of this branch and land in the dependent [TRL-1267](https://linear.app/outfitter/issue/TRL-1267/) branch.
