### PR TITLE
feat(regrade): inventory classified source comments

### DIFF
--- a/.changeset/trl-1267-comment-review-inventory.md
+++ b/.changeset/trl-1267-comment-review-inventory.md
@@ -1,0 +1,7 @@
+---
+"@ontrails/regrade": minor
+"@ontrails/trails": minor
+---
+
+Inventory parser-native source comments and TSDoc as exact review-only entries
+for governed classified vocabulary transitions across CLI, MCP, and audit.

--- a/apps/trails/src/__tests__/mcp.test.ts
+++ b/apps/trails/src/__tests__/mcp.test.ts
@@ -466,6 +466,77 @@ describe('Trails MCP surface shaping', () => {
     }
   });
 
+  test('MCP inventories the same structured classified TSDoc review entry', async () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/project.ts',
+        [
+          '/**',
+          ' * Project an error through the shared public policy.',
+          ' */',
+          '// Use the project root consistently.',
+          'export const project = 1;',
+          '',
+        ].join('\n')
+      );
+      const tools = unwrapTools(trailsMcpApp, trailsMcpSurfaceOptions);
+      const planRegrade = requireTool(tools, 'trails_plan_regrade');
+      const previewRegrade = requireTool(tools, 'trails_preview_regrade');
+      const plan = await planRegrade.handler(
+        { from: 'projection', rootDir: dir, to: 'derive' },
+        {}
+      );
+      expect(plan.isError).toBeUndefined();
+
+      const preview = await previewRegrade.handler({ rootDir: dir }, {});
+      expect(preview.isError).toBeUndefined();
+      expect(preview.structuredContent).toMatchObject({
+        entries: [
+          {
+            outcome: 'needs-review',
+            path: 'src/project.ts',
+            reason: 'vocabulary-judgment-deferred',
+            reviewDetails: [
+              expect.objectContaining({
+                context: '* Project an error through the shared public policy.',
+                judgment: 'unresolved',
+                matchedForm: 'Project',
+                nodeKind: 'TSDocComment',
+                reason: 'source-comment-requires-review',
+                span: expect.objectContaining({ line: 2 }),
+              }),
+            ],
+          },
+        ],
+        run: {
+          ledger: {
+            occurrences: expect.arrayContaining([
+              expect.objectContaining({
+                form: 'Project',
+                path: 'src/project.ts',
+                sourceKind: 'tsdoc',
+                verdict: 'deferred',
+              }),
+              expect.objectContaining({
+                form: 'project',
+                path: 'src/project.ts',
+                sourceKind: 'source-comment',
+                verdict: 'skipped',
+              }),
+            ]),
+          },
+          report: {
+            gate: { remaining: 1, status: 'open' },
+          },
+        },
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('executes governed file moves through MCP plan, preview, and apply', async () => {
     const dir = makeTempDir();
     try {

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -25,6 +25,7 @@ import {
   projectExcludesForMarkdownAudit,
   projectIncludesForMarkdownAudit,
   projectPolicyClassifiedForMarkdownAudit,
+  sourceKindForRegradeAuditPath,
 } from '../regrade/audit.js';
 import { planRegradeTrail, regradeTrail } from '../trails/regrade.js';
 
@@ -2005,6 +2006,107 @@ describe('trails regrade', () => {
     }
   });
 
+  test('regrade audit reopens a classified transition for live TSDoc residue', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'apps/trails/src/__tests__/regrade.test.ts',
+        '// projection fixture evidence\n'
+      );
+      writeFile(
+        dir,
+        'docs/adr/0001-fixture.md',
+        'Historical projection evidence.\n'
+      );
+      const planned = runRawCli([
+        'regrade',
+        'plan',
+        'projection',
+        'derive',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+      expect(planned.exitCode).toBe(0);
+      const applied = runRawCli([
+        'regrade',
+        'apply',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+      expect(applied.exitCode).toBe(0);
+
+      writeFile(
+        dir,
+        'src/public.ts',
+        '/** Project an error through the shared public policy. */\nexport const value = 1;\n'
+      );
+      const audit = runRawCli([
+        'regrade',
+        'audit',
+        '--root-dir',
+        dir,
+        '--include-entries',
+        'all',
+        '--json',
+      ]);
+
+      expect(audit.stderr).toBe('');
+      expect(audit.exitCode).toBe(0);
+      const report = parseCliJson<{
+        readonly gate?: { readonly open?: number; readonly status?: string };
+        readonly transitions?: readonly {
+          readonly report?: {
+            readonly entries?: readonly {
+              readonly path?: string;
+              readonly reviewDetails?: readonly {
+                readonly matchedForm?: string;
+                readonly nodeKind?: string;
+              }[];
+            }[];
+          };
+        }[];
+      }>(audit);
+      expect(report).toMatchObject({
+        gate: { open: 1, status: 'open' },
+        transitions: [
+          {
+            report: {
+              entries: [
+                expect.objectContaining({
+                  path: 'src/public.ts',
+                  reviewDetails: [
+                    expect.objectContaining({
+                      matchedForm: 'Project',
+                      nodeKind: 'TSDocComment',
+                    }),
+                  ],
+                }),
+              ],
+            },
+          },
+        ],
+      });
+
+      const checked = runRawCli([
+        'regrade',
+        'audit',
+        '--fail-on-open',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+      expect(checked.exitCode).toBe(1);
+      expect(checked.stderr).toContain(
+        'Regrade audit found current-tree residue.'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
   test('regrade audit merges registry evidence into committed caller scope', () => {
     const latest = {
       from: 'projection',
@@ -2169,6 +2271,36 @@ describe('trails regrade', () => {
             reason: 'Markdown history evidence.',
           },
           {
+            disposition: 'explicit-preserve',
+            expectMatches: true,
+            paths: ['packages/example/src/index.ts'],
+            reason: 'Explicit source evidence.',
+          },
+          {
+            disposition: 'explicit-preserve',
+            expectMatches: true,
+            paths: ['package.json'],
+            reason: 'Package metadata evidence.',
+          },
+          {
+            disposition: 'explicit-preserve',
+            expectMatches: true,
+            paths: ['config/*.json'],
+            reason: 'Configuration evidence.',
+          },
+          {
+            disposition: 'explicit-preserve',
+            expectMatches: true,
+            paths: ['Dockerfile', '.env', 'src/**/Dockerfile'],
+            reason: 'Extensionless evidence.',
+          },
+          {
+            disposition: 'explicit-preserve',
+            expectMatches: true,
+            paths: ['????'],
+            reason: 'Fixed-width source filename evidence.',
+          },
+          {
             disposition: 'historical-by-policy',
             expectMatches: true,
             paths: ['.agents/goals/**'],
@@ -2179,11 +2311,55 @@ describe('trails regrade', () => {
       to: 'derive',
     };
     const projected = projectPolicyClassifiedForMarkdownAudit(plan);
+    const classifiedProjected = projectPolicyClassifiedForMarkdownAudit(
+      plan,
+      true
+    );
 
-    expect(projected?.[0]).not.toHaveProperty('expectMatches');
-    expect(projected?.[1]).toHaveProperty('expectMatches', true);
-    expect(projected?.[1]?.paths).toEqual(['docs/adr/0*.md']);
-    expect(projected).toHaveLength(2);
+    expect(
+      projected?.find((policy) =>
+        policy.paths.includes('packages/regrade/src/downstream/__tests__/**')
+      )
+    ).not.toHaveProperty('expectMatches');
+    expect(
+      projected?.find((policy) => policy.paths.includes('docs/adr/0*.md'))
+    ).toHaveProperty('expectMatches', true);
+    expect(projected).toHaveLength(7);
+    expect(
+      classifiedProjected?.find((policy) =>
+        policy.paths.includes('packages/regrade/src/downstream/__tests__/**')
+      )
+    ).toHaveProperty('expectMatches', true);
+    expect(
+      classifiedProjected?.find((policy) =>
+        policy.paths.includes('packages/example/src/index.ts')
+      )
+    ).toHaveProperty('expectMatches', true);
+    expect(
+      classifiedProjected?.find((policy) =>
+        policy.paths.includes('package.json')
+      )
+    ).not.toHaveProperty('expectMatches');
+    expect(
+      classifiedProjected?.find((policy) =>
+        policy.paths.includes('config/*.json')
+      )
+    ).not.toHaveProperty('expectMatches');
+    expect(
+      classifiedProjected?.find((policy) => policy.paths.includes('Dockerfile'))
+    ).not.toHaveProperty('expectMatches');
+    expect(
+      classifiedProjected?.find((policy) => policy.paths.includes('????'))
+    ).toHaveProperty('expectMatches', true);
+    expect(
+      sourceKindForRegradeAuditPath(
+        'packages/regrade/src/downstream/__tests__/fixture.test.ts',
+        classifiedProjected
+      )
+    ).toBe('all');
+    expect(
+      sourceKindForRegradeAuditPath('packages/other/src/index.ts', projected)
+    ).toBe('comments');
     expect(projectExcludesForMarkdownAudit(plan, projected)).toEqual([
       '.agents/goals/**',
     ]);
@@ -2930,6 +3106,137 @@ describe('trails regrade', () => {
       });
       expect(JSON.stringify(parseCliJson(planned))).not.toContain(
         '"safe-rewrite"'
+      );
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('CLI inventories classified TSDoc without rewriting ordinary project nouns', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/project.ts',
+        [
+          '/**',
+          ' * Project an error through the shared public policy.',
+          ' */',
+          '// Use the project root consistently.',
+          'export const project = 1;',
+          '',
+        ].join('\n')
+      );
+      const direct = runRawCli([
+        'regrade',
+        'projection',
+        'derive',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+      expect(direct.exitCode).toBe(0);
+      expect(
+        parseCliJson<{
+          readonly scan?: { readonly files?: { readonly scanned?: number } };
+          readonly scanned?: number;
+        }>(direct)
+      ).toMatchObject({
+        scan: { files: { scanned: 1 } },
+        scanned: 1,
+      });
+      const planned = runRawCli([
+        'regrade',
+        'plan',
+        'projection',
+        'derive',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+      expect(planned.exitCode).toBe(0);
+
+      const preview = runRawCli([
+        'regrade',
+        'preview',
+        '--root-dir',
+        dir,
+        '--json',
+      ]);
+      expect(preview.exitCode).toBe(0);
+      const report = parseCliJson<{
+        readonly entries?: readonly {
+          readonly path?: string;
+          readonly reviewDetails?: readonly {
+            readonly context?: string;
+            readonly judgment?: string;
+            readonly matchedForm?: string;
+            readonly nodeKind?: string;
+            readonly reason?: string;
+            readonly span?: { readonly line?: number };
+          }[];
+        }[];
+        readonly scan?: { readonly files?: { readonly scanned?: number } };
+        readonly scanned?: number;
+        readonly run?: {
+          readonly ledger?: {
+            readonly occurrences?: readonly {
+              readonly form?: string;
+              readonly path?: string;
+              readonly sourceKind?: string;
+              readonly verdict?: string;
+            }[];
+          };
+          readonly report?: {
+            readonly gate?: {
+              readonly remaining?: number;
+              readonly status?: string;
+            };
+          };
+        };
+      }>(preview);
+
+      expect(report.entries).toEqual([
+        expect.objectContaining({
+          path: 'src/project.ts',
+          reviewDetails: [
+            expect.objectContaining({
+              context: '* Project an error through the shared public policy.',
+              judgment: 'unresolved',
+              matchedForm: 'Project',
+              nodeKind: 'TSDocComment',
+              reason: 'source-comment-requires-review',
+              span: expect.objectContaining({ line: 2 }),
+            }),
+          ],
+        }),
+      ]);
+      expect(
+        report.run?.ledger?.occurrences?.filter(
+          (occurrence) => occurrence.path === 'src/project.ts'
+        )
+      ).toEqual([
+        expect.objectContaining({
+          form: 'Project',
+          path: 'src/project.ts',
+          sourceKind: 'tsdoc',
+          verdict: 'deferred',
+        }),
+        expect.objectContaining({
+          form: 'project',
+          path: 'src/project.ts',
+          sourceKind: 'source-comment',
+          verdict: 'skipped',
+        }),
+      ]);
+      expect(report.run?.report?.gate).toMatchObject({
+        remaining: 1,
+        status: 'open',
+      });
+      expect(report.scanned).toBe(2);
+      expect(report.scan?.files?.scanned).toBe(2);
+      expect(readFileSync(join(dir, 'src', 'project.ts'), 'utf8')).toContain(
+        'export const project = 1;'
       );
     } finally {
       rmSync(dir, { force: true, recursive: true });

--- a/apps/trails/src/regrade/audit.ts
+++ b/apps/trails/src/regrade/audit.ts
@@ -13,6 +13,7 @@ import {
   runVocabularyRegrade,
   vocabularyDispositionValues,
   vocabularyRegradePlanForInput,
+  vocabularyRegradeTransitionForInput,
 } from '@ontrails/regrade';
 import type { VocabularyRegradePlan } from '@ontrails/regrade';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
@@ -25,6 +26,17 @@ import {
   regradeHistoryPathForPlan,
 } from './history.js';
 import { rootRelativePath } from './plan-artifact.js';
+
+const sourceCommentExtensions = [
+  '.cjs',
+  '.cts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.mts',
+  '.ts',
+  '.tsx',
+] as const;
 
 export const regradeAuditInputSchema = z.object({
   failOnOpen: z
@@ -50,7 +62,7 @@ const regradeAuditTransitionSchema = z.object({
           z.enum(vocabularyDispositionValues),
           z.number().int().nonnegative()
         )
-        .describe('Current Markdown occurrence counts by classification'),
+        .describe('Current source occurrence counts by classification'),
       entries: regradeReportOutput.shape.entries
         .readonly()
         .describe('Actionable file-level residue details'),
@@ -58,12 +70,12 @@ const regradeAuditTransitionSchema = z.object({
         .number()
         .int()
         .nonnegative()
-        .describe('Total classified Markdown occurrences'),
+        .describe('Total classified current-source occurrences'),
       open: z
         .number()
         .int()
         .nonnegative()
-        .describe('Unresolved Markdown occurrences'),
+        .describe('Unresolved current-source occurrences'),
       scanned: z.number().int().nonnegative().describe('Files scanned'),
       status: z.enum(['green', 'open']).describe('Transition audit status'),
     })
@@ -293,10 +305,35 @@ type VocabularyPolicyClassified = NonNullable<
   NonNullable<VocabularyRegradePlan['scope']>['policyClassified']
 >;
 
+/**
+ * Select full evidence for classified paths and comments elsewhere.
+ *
+ * @internal
+ */
+export const sourceKindForRegradeAuditPath = (
+  path: string,
+  policyClassified: VocabularyPolicyClassified | undefined
+): 'all' | 'comments' => {
+  const isPolicyClassified = policyClassified?.some((policy) =>
+    matchesAnyPathGlob(path, policy.paths)
+  );
+  return sourceCommentExtensions.includes(
+    extname(path) as (typeof sourceCommentExtensions)[number]
+  ) && !isPolicyClassified
+    ? 'comments'
+    : 'all';
+};
+
 export const projectPolicyClassifiedForMarkdownAudit = (
-  plan: VocabularyRegradePlan
-): VocabularyPolicyClassified | undefined =>
-  plan.scope?.policyClassified
+  plan: VocabularyRegradePlan,
+  includeCodeComments = false
+): VocabularyPolicyClassified | undefined => {
+  const auditedExtensions = new Set<string>([
+    '.md',
+    '.mdx',
+    ...(includeCodeComments ? sourceCommentExtensions : []),
+  ]);
+  return plan.scope?.policyClassified
     ?.map((policy) => ({
       ...policy,
       paths: policy.paths.filter(
@@ -309,18 +346,40 @@ export const projectPolicyClassifiedForMarkdownAudit = (
     }))
     .filter((policy) => policy.paths.length > 0)
     .map((policy) => {
-      const hasExplicitMarkdownPath = policy.paths.some((path) => {
+      const hasAuditablePath = policy.paths.some((path) => {
         const extension = extname(path);
-        return extension === '.md' || extension === '.mdx';
+        if (auditedExtensions.has(extension)) {
+          return true;
+        }
+        const terminalPattern = basename(path);
+        const trailingWildcards = terminalPattern.match(/[*?]+$/)?.[0];
+        const canSelectAuditedExtension =
+          extension === '' &&
+          trailingWildcards !== undefined &&
+          [...auditedExtensions].some(
+            (auditedExtension) =>
+              trailingWildcards.includes('*') ||
+              (trailingWildcards.length >= auditedExtension.length &&
+                (terminalPattern.length > trailingWildcards.length ||
+                  trailingWildcards.length > auditedExtension.length))
+          );
+        return (
+          includeCodeComments &&
+          (canSelectAuditedExtension ||
+            [...auditedExtensions].some((auditedExtension) =>
+              matchesAnyPathGlob(auditedExtension, [extension])
+            ))
+        );
       });
-      if (policy.expectMatches !== true || hasExplicitMarkdownPath) {
+      if (policy.expectMatches !== true || hasAuditablePath) {
         return policy;
       }
-      // A Markdown-only audit cannot prove evidence for extensionless source
-      // globs. Markdown evidence requirements must name .md/.mdx explicitly.
+      // An extension-filtered audit cannot prove evidence for a path whose
+      // authored pattern does not identify one of the audited file families.
       const { expectMatches: _, ...markdownPolicy } = policy;
       return markdownPolicy;
     });
+};
 
 export const projectExcludesForMarkdownAudit = (
   plan: VocabularyRegradePlan,
@@ -354,8 +413,12 @@ const runRegradeAuditCandidate = async (
   input: RegradeAuditInput,
   rootDir: string
 ): Promise<TrailsResult<RegradeAuditOutput['transitions'][number], Error>> => {
+  const includeCodeComments =
+    vocabularyRegradeTransitionForInput(candidate.plan.from, candidate.plan.to)
+      ?.target.kind === 'classified';
   const policyClassified = projectPolicyClassifiedForMarkdownAudit(
-    candidate.plan
+    candidate.plan,
+    includeCodeComments
   );
   const exclude = projectExcludesForMarkdownAudit(
     candidate.plan,
@@ -369,7 +432,11 @@ const runRegradeAuditCandidate = async (
     ...candidate.plan,
     scope: {
       ...candidate.plan.scope,
-      extensions: ['.md', '.mdx'],
+      extensions: [
+        '.md',
+        '.mdx',
+        ...(includeCodeComments ? sourceCommentExtensions : []),
+      ],
       ...(exclude === undefined ? {} : { exclude }),
       ...(include === undefined ? {} : { include }),
       ...(policyClassified === undefined ? {} : { policyClassified }),
@@ -390,6 +457,12 @@ const runRegradeAuditCandidate = async (
       ? {}
       : { preserveInventory: preserveResult.value }),
     root: rootDir,
+    ...(includeCodeComments
+      ? {
+          sourceKindForPath: (path: string) =>
+            sourceKindForRegradeAuditPath(path, policyClassified),
+        }
+      : {}),
   });
   if (reportResult.isErr()) {
     return reportResult;

--- a/apps/trails/src/trails/regrade.ts
+++ b/apps/trails/src/trails/regrade.ts
@@ -881,6 +881,19 @@ const mergeTransitionRunReportWithSymbol = (
   };
 };
 
+const withScannedPaths = (
+  report: RegradeReport,
+  paths: readonly string[]
+): RegradeReport => {
+  Object.defineProperty(report, 'scannedPaths', {
+    configurable: false,
+    enumerable: false,
+    value: Object.freeze([...paths]),
+    writable: false,
+  });
+  return report;
+};
+
 const mergeRegradeReports = (
   vocabularyReport: RegradeReport,
   symbolReport: RegradeReport
@@ -914,7 +927,15 @@ const mergeRegradeReports = (
     symbolReport.skipsByReason
   );
   const apply = mergeApplySummary(vocabularyReport.apply, symbolReport.apply);
-  const scanned = vocabularyReport.scanned + symbolReport.scanned;
+  const scannedPaths = uniqueSorted([
+    ...(vocabularyReport.scannedPaths ?? []),
+    ...(symbolReport.scannedPaths ?? []),
+  ]);
+  const scanned =
+    vocabularyReport.scannedPaths === undefined ||
+    symbolReport.scannedPaths === undefined
+      ? vocabularyReport.scanned + symbolReport.scanned
+      : scannedPaths.length;
   const run =
     vocabularyReport.run === undefined
       ? undefined
@@ -926,36 +947,39 @@ const mergeRegradeReports = (
           ),
         };
 
-  return {
-    ...vocabularyReport,
-    ...(apply === undefined ? {} : { apply }),
-    entries,
-    matched,
-    review,
-    rewritten,
-    scan: {
-      byDirectory: mergedDirectoryBuckets(matchedPaths, occurrencePaths),
-      byExtension: mergedExtensionBuckets(matchedPaths, occurrencePaths),
-      files: {
-        matched: new Set(matchedPaths).size,
-        scanned,
-        skipped: Math.max(vocabularyReport.skipped, symbolReport.skipped),
+  return withScannedPaths(
+    {
+      ...vocabularyReport,
+      ...(apply === undefined ? {} : { apply }),
+      entries,
+      matched,
+      review,
+      rewritten,
+      scan: {
+        byDirectory: mergedDirectoryBuckets(matchedPaths, occurrencePaths),
+        byExtension: mergedExtensionBuckets(matchedPaths, occurrencePaths),
+        files: {
+          matched: new Set(matchedPaths).size,
+          scanned,
+          skipped: Math.max(vocabularyReport.skipped, symbolReport.skipped),
+        },
+        skippedByReason,
       },
-      skippedByReason,
+      ...(run === undefined ? {} : { run }),
+      scanned,
+      selectedClassIds: uniqueSorted([
+        ...vocabularyReport.selectedClassIds,
+        ...symbolReport.selectedClassIds,
+      ]),
+      skipped: Math.max(vocabularyReport.skipped, symbolReport.skipped),
+      skipsByReason: skippedByReason,
+      unknownClassIds: uniqueSorted([
+        ...vocabularyReport.unknownClassIds,
+        ...symbolReport.unknownClassIds,
+      ]),
     },
-    ...(run === undefined ? {} : { run }),
-    scanned,
-    selectedClassIds: uniqueSorted([
-      ...vocabularyReport.selectedClassIds,
-      ...symbolReport.selectedClassIds,
-    ]),
-    skipped: Math.max(vocabularyReport.skipped, symbolReport.skipped),
-    skipsByReason: skippedByReason,
-    unknownClassIds: uniqueSorted([
-      ...vocabularyReport.unknownClassIds,
-      ...symbolReport.unknownClassIds,
-    ]),
-  };
+    scannedPaths
+  );
 };
 
 const vocabularySymbolCollection = (
@@ -1052,40 +1076,61 @@ const withoutVocabularySourceFilterSkips = (
   if (report === null || rejected === 0) {
     return report;
   }
-  return {
-    ...report,
-    ...(report.apply === undefined
-      ? {}
-      : {
-          apply: {
-            ...report.apply,
-            skipped: Math.max(0, report.apply.skipped - rejected),
-          },
-        }),
-    entries: report.entries.filter(
-      (entry) => entry.reason !== 'not-selected-source'
-    ),
-    scan: {
-      ...report.scan,
-      files: {
-        ...report.scan.files,
-        skipped: Math.max(0, report.scan.files.skipped - rejected),
-      },
-      skippedByReason: withoutNotSelectedSourceCount(
-        report.scan.skippedByReason
+  return withScannedPaths(
+    {
+      ...report,
+      ...(report.apply === undefined
+        ? {}
+        : {
+            apply: {
+              ...report.apply,
+              skipped: Math.max(0, report.apply.skipped - rejected),
+            },
+          }),
+      entries: report.entries.filter(
+        (entry) => entry.reason !== 'not-selected-source'
       ),
+      scan: {
+        ...report.scan,
+        files: {
+          ...report.scan.files,
+          skipped: Math.max(0, report.scan.files.skipped - rejected),
+        },
+        skippedByReason: withoutNotSelectedSourceCount(
+          report.scan.skippedByReason
+        ),
+      },
+      skipped: Math.max(0, report.skipped - rejected),
+      skipsByReason: withoutNotSelectedSourceCount(report.skipsByReason),
     },
-    skipped: Math.max(0, report.skipped - rejected),
-    skipsByReason: withoutNotSelectedSourceCount(report.skipsByReason),
-  };
+    report.scannedPaths ?? []
+  );
 };
 
 const vocabularyEvidenceSource = (
   path: string,
-  scope: VocabularyRegradePlan['scope'] | undefined
+  scope: VocabularyRegradePlan['scope'] | undefined,
+  includeCodeComments = false
 ): boolean =>
   vocabularyProseExtensions.includes(extname(path)) ||
+  (includeCodeComments && symbolSourceExtensions.includes(extname(path))) ||
   symbolOccurrenceIsPolicyClassified(scope, path);
+
+const classifiedCommentInventoryApplies = (
+  plan: VocabularyRegradePlan
+): boolean =>
+  vocabularyRegradeTransitionForInput(plan.from, plan.to)?.target.kind ===
+  'classified';
+
+const vocabularyEvidenceSourceKind = (
+  path: string,
+  plan: VocabularyRegradePlan
+): 'all' | 'comments' =>
+  classifiedCommentInventoryApplies(plan) &&
+  symbolSourceExtensions.includes(extname(path)) &&
+  !symbolOccurrenceIsPolicyClassified(plan.scope, path)
+    ? 'comments'
+    : 'all';
 
 const vocabularyProseEngineApplies = (
   scope: VocabularyRegradePlan['scope'] | undefined
@@ -1322,18 +1367,21 @@ const reportWithVocabularyTransitionRun = (params: {
     report: transitionRunReportForRegradeReport(params.report),
   };
 
-  return {
-    ...params.report,
-    run: {
-      ...run,
-      plan: params.plan,
-      ...(preserveInventory === undefined ? {} : { preserveInventory }),
-      report:
-        params.report.run === undefined
-          ? transitionRunReportForRegradeReport(params.report)
-          : params.report.run.report,
+  return withScannedPaths(
+    {
+      ...params.report,
+      run: {
+        ...run,
+        plan: params.plan,
+        ...(preserveInventory === undefined ? {} : { preserveInventory }),
+        report:
+          params.report.run === undefined
+            ? transitionRunReportForRegradeReport(params.report)
+            : params.report.run.report,
+      },
     },
-  };
+    params.report.scannedPaths ?? []
+  );
 };
 
 const runGovernedSymbolRegrade = (params: {
@@ -2141,6 +2189,7 @@ const runResolvedVocabularyPlan = (params: {
     return fileRenamePreflight;
   }
   const evidencePlan = vocabularyEvidencePlan(params.plan);
+  const includeCodeComments = classifiedCommentInventoryApplies(params.plan);
   const runProse = (
     apply: boolean
   ): TrailsResult<RegradeReport | null, Error> =>
@@ -2155,7 +2204,13 @@ const runResolvedVocabularyPlan = (params: {
             : { preserveInventory: params.preserveInventory }),
           root: params.rootDir,
           sourceFilter: (path) =>
-            vocabularyEvidenceSource(path, evidencePlan.scope),
+            vocabularyEvidenceSource(
+              path,
+              evidencePlan.scope,
+              includeCodeComments
+            ),
+          sourceKindForPath: (path) =>
+            vocabularyEvidenceSourceKind(path, evidencePlan),
         });
   const runSymbols = (
     apply: boolean

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -580,6 +580,8 @@ For vocabulary work, `trails regrade plan <from> <to>` treats that pair as a see
 
 The Trails app history writer persists the canonical v3 receipt contract described above.
 
+For governed classified vocabulary transitions, parser-native source comments and TSDoc are exact review-only entries. Their structured details include source-line context, exact spans, and `SourceComment` or `TSDocComment` node kinds; they never authorize a rewrite and keep lifecycle and audit completion checks open until reviewed. Preserve rules can retain ordinary domain uses, and CLI, JSON, and MCP expose the same inventory.
+
 ## `@ontrails/config`
 
 ```typescript

--- a/docs/releases/v1-vocabulary-transition-workflow.md
+++ b/docs/releases/v1-vocabulary-transition-workflow.md
@@ -33,6 +33,8 @@ Use the family names for the current transition. The `from`/`to` pair is the pri
 
 For a governed classified transition, choose one ratified target as the plan seed. Regrade keys the active plan and history spine by the governed transition identity, defers every governed source form, and derives no safe rewrite. The selected target records planning intent; it does not claim that every occurrence shares that successor. Use the structured review inventory for contextual follow-up edits, rerun `plan --fresh` to capture the reviewed source state, then check and apply the clean evidence. Per-form overrides cannot express two meanings of the same source word and are not the graduation path for a classified transition.
 
+Classified scans also inventory governed forms in parser-native source comments and TSDoc. These entries carry exact spans, source-line context, and a `SourceComment` or `TSDocComment` node kind through CLI and MCP, remain review-only, and keep `regrade audit` open after graduation if live comment residue returns. Preserve ordinary domain uses explicitly; comment inventory never authorizes a mechanical rewrite.
+
 Record:
 
 - command;

--- a/packages/regrade/src/downstream/__tests__/report.test.ts
+++ b/packages/regrade/src/downstream/__tests__/report.test.ts
@@ -1305,6 +1305,11 @@ describe('runRegrade', () => {
         skipped: 1,
         unknown: 0,
       });
+      expect(report?.scannedPaths).toEqual([
+        'src/a.ts',
+        'src/b.ts',
+        'src/c.ts',
+      ]);
       expect(readFileSync(join(root, 'src', 'a.ts'), 'utf8')).toBe(
         'export const ping = 1;\n'
       );

--- a/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
+++ b/packages/regrade/src/downstream/__tests__/vocabulary.test.ts
@@ -599,6 +599,190 @@ describe('runVocabularyRegrade', () => {
     }
   });
 
+  test('surfaces classified TSDoc while preserving ordinary comment nouns', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/project.ts',
+        [
+          '/**',
+          ' * Project an error through the shared public policy.',
+          ' */',
+          '// Use the project root consistently.',
+          'export const project = 1;',
+          '',
+        ].join('\n')
+      );
+      const plan = vocabularyRegradePlanForInput('projection', 'derive');
+      if (plan === null) {
+        throw new Error('Expected classified projection plan.');
+      }
+
+      const report = runVocabularyRegrade({
+        plan: { ...plan, scope: { include: ['src/**'] } },
+        root: dir,
+        sourceKindForPath: () => 'comments',
+      });
+      expect(report.isOk()).toBe(true);
+      if (report.isErr()) {
+        throw report.error;
+      }
+
+      expect(report.value.run.ledger.occurrences).toEqual([
+        expect.objectContaining({
+          context: '* Project an error through the shared public policy.',
+          form: 'Project',
+          line: 2,
+          path: 'src/project.ts',
+          reason: 'source-comment-requires-review',
+          sourceKind: 'tsdoc',
+          verdict: 'deferred',
+        }),
+        expect.objectContaining({
+          context: '// Use the project root consistently.',
+          form: 'project',
+          line: 4,
+          path: 'src/project.ts',
+          sourceKind: 'source-comment',
+          verdict: 'skipped',
+        }),
+      ]);
+      expect(report.value.entries).toEqual([
+        expect.objectContaining({
+          outcome: 'needs-review',
+          path: 'src/project.ts',
+          reviewDetails: [
+            expect.objectContaining({
+              context: '* Project an error through the shared public policy.',
+              judgment: 'unresolved',
+              matchedForm: 'Project',
+              nodeKind: 'TSDocComment',
+              reason: 'source-comment-requires-review',
+              span: expect.objectContaining({ line: 2 }),
+            }),
+          ],
+        }),
+      ]);
+      expect(report.value.run.report.gate).toMatchObject({
+        remaining: 1,
+        status: 'open',
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('keeps classified comment inventory open when parsing fails', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(
+        dir,
+        'src/project.ts',
+        '/** Project an error through policy. */\nexport const = ;\n'
+      );
+      const plan = vocabularyRegradePlanForInput('projection', 'derive');
+      if (plan === null) {
+        throw new Error('Expected classified projection plan.');
+      }
+
+      const report = runVocabularyRegrade({
+        includeEntries: 'all',
+        plan: { ...plan, scope: { include: ['src/**'] } },
+        root: dir,
+        sourceKindForPath: () => 'comments',
+      });
+      expect(report.isOk()).toBe(true);
+      if (report.isErr()) {
+        throw report.error;
+      }
+
+      expect(report.value.entries).toContainEqual({
+        outcome: 'skip',
+        path: 'src/project.ts',
+        reason: 'source-comment-parse-diagnostics',
+      });
+      expect(report.value.run.report.gate).toMatchObject({
+        reasons: expect.arrayContaining(['source-comment-parse-diagnostics']),
+        status: 'open',
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('ignores unrelated source parse failures in comment-only scans', () => {
+    const dir = makeTempDir();
+    try {
+      writeFile(dir, 'src/broken.ts', 'export const = ;\n');
+      const plan = vocabularyRegradePlanForInput('projection', 'derive');
+      if (plan === null) {
+        throw new Error('Expected classified projection plan.');
+      }
+
+      const report = runVocabularyRegrade({
+        includeEntries: 'all',
+        plan: { ...plan, scope: { include: ['src/**'] } },
+        root: dir,
+        sourceKindForPath: () => 'comments',
+      });
+      expect(report.isOk()).toBe(true);
+      if (report.isErr()) {
+        throw report.error;
+      }
+
+      expect(report.value.entries).not.toContainEqual(
+        expect.objectContaining({
+          reason: 'source-comment-parse-diagnostics',
+        })
+      );
+      expect(report.value.run.report.gate).toMatchObject({
+        reasons: [],
+        status: 'green',
+      });
+    } finally {
+      rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test('reports exact comment context across JavaScript line terminators', () => {
+    const plan = vocabularyRegradePlanForInput('projection', 'derive');
+    if (plan === null) {
+      throw new Error('Expected classified projection plan.');
+    }
+
+    for (const separator of ['\r\n', '\r', '\u2028', '\u2029']) {
+      const dir = makeTempDir();
+      try {
+        writeFile(
+          dir,
+          'src/project.ts',
+          `export const before = 1;${separator}/** Project an error. */`
+        );
+        const report = runVocabularyRegrade({
+          plan: { ...plan, scope: { include: ['src/**'] } },
+          root: dir,
+          sourceKindForPath: () => 'comments',
+        });
+        expect(report.isOk()).toBe(true);
+        if (report.isErr()) {
+          throw report.error;
+        }
+
+        expect(report.value.run.ledger.occurrences).toContainEqual(
+          expect.objectContaining({
+            column: 5,
+            context: '/** Project an error. */',
+            form: 'Project',
+            line: 2,
+          })
+        );
+      } finally {
+        rmSync(dir, { force: true, recursive: true });
+      }
+    }
+  });
+
   test('does not turn review-only registry defaults into unsafe plans', () => {
     const transition = getGovernedVocabularyTransition('cross-compose');
     expect(transition).toBeDefined();

--- a/packages/regrade/src/downstream/export-restructure.ts
+++ b/packages/regrade/src/downstream/export-restructure.ts
@@ -1468,7 +1468,7 @@ const applyMcpTrailheadsClass = (
 };
 
 /**
- * Project call-site MCP trailhead maps into `surfaceOverlay({ mcp: { name:
+ * Convert call-site MCP trailhead maps into `surfaceOverlay({ mcp: { name:
  * [selectors] } })` group bindings. Because the map usually lives in a
  * different file than the app module, the default outcome is a classified
  * `needs-review` handoff naming the exact target shape; when the same file
@@ -1512,7 +1512,7 @@ export const exportRestructureClasses: readonly RegradeClass[] = Object.freeze([
 ]);
 
 /**
- * Project a Warden rule that advertises the `export-restructure` fix class
+ * Convert a Warden rule that advertises the `export-restructure` fix class
  * into its registered Regrade class. Warden owns detection and fix metadata;
  * Regrade owns the structural transform. Returns `null` for rules without an
  * `export-restructure` fix class or without a registered transform.

--- a/packages/regrade/src/downstream/report.ts
+++ b/packages/regrade/src/downstream/report.ts
@@ -174,6 +174,8 @@ export interface RegradeReviewDetail {
   readonly candidateReplacement?: string;
   /** Class that produced the review detail, injected by report building. */
   readonly classId?: string;
+  /** Exact source-line context containing the occurrence under review. */
+  readonly context?: string;
   /** Expected target shape when the class can describe one. */
   readonly expectedTarget?: string;
   /** Fixture or example reference that illustrates the expected migration. */
@@ -731,6 +733,12 @@ export interface RegradeReport {
   readonly unknownClassIds: readonly string[];
   /** Source files inspected. */
   readonly scanned: number;
+  /**
+   * Root-relative source paths used to deduplicate composed scans.
+   *
+   * @internal
+   */
+  readonly scannedPaths?: readonly string[];
   /** Files where a selected class produced a rewrite or review outcome. */
   readonly matched: number;
   /** Files with a rewrite outcome. */
@@ -774,6 +782,19 @@ export interface RegradeReport {
     readonly status: 'candidate' | 'applied' | 'checked';
   };
 }
+
+const withScannedPaths = (
+  report: RegradeReport,
+  paths: readonly string[]
+): RegradeReport => {
+  Object.defineProperty(report, 'scannedPaths', {
+    configurable: false,
+    enumerable: false,
+    value: Object.freeze([...paths]),
+    writable: false,
+  });
+  return report;
+};
 
 interface RegradeRewriteCandidate {
   readonly absolutePath: string;
@@ -1044,24 +1065,27 @@ const buildRegradeEvaluation = (params: {
   const skippedReasons = skipsByReason(allEntries);
 
   return {
-    report: {
-      entries,
-      matched: rewritten + review,
-      review,
-      rewritten,
-      root: params.root,
-      scan: buildRegradeScanSummary({
-        matchedPaths,
+    report: withScannedPaths(
+      {
+        entries,
+        matched: rewritten + review,
+        review,
+        rewritten,
+        root: params.root,
+        scan: buildRegradeScanSummary({
+          matchedPaths,
+          scanned: scannedEntries.length,
+          skipped,
+          skippedByReason: skippedReasons,
+        }),
         scanned: scannedEntries.length,
+        selectedClassIds: selected.map((cls) => cls.id),
         skipped,
-        skippedByReason: skippedReasons,
-      }),
-      scanned: scannedEntries.length,
-      selectedClassIds: selected.map((cls) => cls.id),
-      skipped,
-      skipsByReason: skippedReasons,
-      unknownClassIds,
-    },
+        skipsByReason: skippedReasons,
+        unknownClassIds,
+      },
+      scannedEntries.map((entry) => entry.path)
+    ),
     rewrites,
   };
 };
@@ -1131,10 +1155,16 @@ const applyRegradeEvaluation = (
 const withApplySummary = (
   report: RegradeReport,
   apply: RegradeApplySummary
-): RegradeReport => ({
-  ...report,
-  apply,
-});
+): RegradeReport => {
+  const appliedReport: RegradeReport = {
+    ...report,
+    apply,
+  };
+
+  return report.scannedPaths === undefined
+    ? appliedReport
+    : withScannedPaths(appliedReport, report.scannedPaths);
+};
 
 const canReadDownstreamRoot = (root: string): boolean => {
   try {
@@ -1392,6 +1422,10 @@ const regradeReportEntrySchema = z.object({
           .string()
           .optional()
           .describe('Class that produced the review detail'),
+        context: z
+          .string()
+          .optional()
+          .describe('Exact source-line context containing the occurrence'),
         expectedTarget: z
           .string()
           .optional()

--- a/packages/regrade/src/downstream/vocabulary.ts
+++ b/packages/regrade/src/downstream/vocabulary.ts
@@ -6,6 +6,8 @@ import {
   isPlainObject,
   matchesAnyPathGlob,
 } from '@ontrails/core';
+import { parseWithDiagnostics } from '@ontrails/source';
+import type { SourceComment } from '@ontrails/source';
 import { createHash } from 'node:crypto';
 import {
   dirname,
@@ -31,6 +33,8 @@ import type {
 import { buildRegradeScanSummary } from './scan-summary.js';
 
 export type VocabularyVerdict = 'applied' | 'deferred' | 'modified' | 'skipped';
+
+export type VocabularyOccurrenceSourceKind = 'source-comment' | 'tsdoc';
 
 export const vocabularyDispositionValues = [
   'code-context-out-of-engine',
@@ -170,6 +174,7 @@ export interface VocabularyOccurrence {
   readonly replacement?: string;
   readonly start: number;
   readonly scopeTier: VocabularyScopeTier;
+  readonly sourceKind?: VocabularyOccurrenceSourceKind;
   readonly verdict: VocabularyVerdict;
 }
 
@@ -252,6 +257,16 @@ interface SourceFile {
 interface SourceOccurrence extends VocabularyOccurrence {
   readonly absolutePath: string;
 }
+
+type VocabularySourceKind = 'all' | 'comments';
+
+const sourceCommentKind = (
+  file: SourceFile,
+  comment: SourceComment
+): VocabularyOccurrenceSourceKind =>
+  comment.type === 'Block' && file.source.startsWith('/**', comment.start)
+    ? 'tsdoc'
+    : 'source-comment';
 
 interface SourceOccurrenceDraft extends Omit<
   SourceOccurrence,
@@ -450,7 +465,16 @@ const lineColumnForOffset = (
   let line = 1;
   let column = 1;
   for (let index = 0; index < offset; index += 1) {
-    if (source.codePointAt(index) === 10) {
+    const codePoint = source.codePointAt(index);
+    if (
+      codePoint === 10 ||
+      codePoint === 13 ||
+      codePoint === 0x20_28 ||
+      codePoint === 0x20_29
+    ) {
+      if (codePoint === 13 && source.codePointAt(index + 1) === 10) {
+        index += 1;
+      }
       line += 1;
       column = 1;
     } else {
@@ -465,9 +489,32 @@ const contextDetailsForOffset = (
   start: number,
   end: number
 ): { readonly context: string; readonly contextColumn: number } => {
-  const lineStart = source.lastIndexOf('\n', start - 1) + 1;
-  const nextLine = source.indexOf('\n', end);
-  const lineEnd = nextLine === -1 ? source.length : nextLine;
+  let lineStart = start;
+  while (lineStart > 0) {
+    const codePoint = source.codePointAt(lineStart - 1);
+    if (
+      codePoint === 10 ||
+      codePoint === 13 ||
+      codePoint === 0x20_28 ||
+      codePoint === 0x20_29
+    ) {
+      break;
+    }
+    lineStart -= 1;
+  }
+  let lineEnd = end;
+  while (lineEnd < source.length) {
+    const codePoint = source.codePointAt(lineEnd);
+    if (
+      codePoint === 10 ||
+      codePoint === 13 ||
+      codePoint === 0x20_28 ||
+      codePoint === 0x20_29
+    ) {
+      break;
+    }
+    lineEnd += 1;
+  }
   const rawLine = source.slice(lineStart, lineEnd);
   const leadingTrimmed = rawLine.length - rawLine.trimStart().length;
   return {
@@ -734,6 +781,21 @@ const deferFormsForPlan = (plan: VocabularyRegradePlan): readonly string[] => {
     ...(plan.deferForms ?? []),
   ]);
 };
+
+const titleCaseVocabularyForm = (form: string): string => {
+  const first = form.at(0);
+  return first === undefined ? form : `${first.toUpperCase()}${form.slice(1)}`;
+};
+
+const commentReviewPlan = (
+  plan: VocabularyRegradePlan
+): VocabularyRegradePlan => ({
+  ...plan,
+  deferForms: uniqueSorted([
+    ...(plan.deferForms ?? []),
+    ...(plan.deferForms ?? []).map(titleCaseVocabularyForm),
+  ]),
+});
 
 /**
  * Synthesize the deterministic form proposal carried by a minimal plan seed.
@@ -1471,8 +1533,19 @@ const entryForOccurrences = (
       reviewDetails: occurrences
         .filter((occurrence) => occurrence.verdict === 'deferred')
         .map((occurrence) => ({
+          context: occurrence.context,
           expectedTarget:
             'Add an override or preserve rule to the regrade plan.',
+          judgment: 'unresolved' as const,
+          matchedForm: occurrence.form,
+          ...(occurrence.sourceKind === undefined
+            ? {}
+            : {
+                nodeKind:
+                  occurrence.sourceKind === 'tsdoc'
+                    ? 'TSDocComment'
+                    : 'SourceComment',
+              }),
           reason: occurrence.reason,
           span: {
             column: occurrence.column,
@@ -1528,6 +1601,9 @@ const buildVocabularyEvaluation = (params: {
   readonly preserveInventory?: readonly VocabularyPreserveInventoryEntry[];
   readonly root: string;
   readonly skipped: readonly SkippedSource[];
+  readonly sourceKindForPath?:
+    | ((path: string) => VocabularySourceKind)
+    | undefined;
 }): VocabularyEvaluation => {
   const effectivePlan = params.effectivePlan ?? params.plan;
   const targetForms = targetFormsForPlan(effectivePlan);
@@ -1537,21 +1613,59 @@ const buildVocabularyEvaluation = (params: {
   const scopeSkipped: SkippedSource[] = params.files
     .filter((file) => !includedByScope(file.path, effectivePlan.scope))
     .map((file) => ({ path: file.path, reason: 'excluded-by-regrade-scope' }));
+  const commentParseSkipped: SkippedSource[] = [];
   const occurrences = scopedFiles.flatMap((file) => {
+    const sourceKind = params.sourceKindForPath?.(file.path) ?? 'all';
+    const scanPlan =
+      sourceKind === 'comments'
+        ? commentReviewPlan(effectivePlan)
+        : effectivePlan;
     const deferredOccurrences = deferredOccurrencesForFile(
       file,
-      effectivePlan,
+      scanPlan,
       targetForms
     );
-    return [
-      ...occurrencesForFile(
-        file,
-        effectivePlan,
-        targetForms,
-        deferredOccurrences
-      ),
+    const fileOccurrences = [
+      ...occurrencesForFile(file, scanPlan, targetForms, deferredOccurrences),
       ...deferredOccurrences,
     ];
+    if (sourceKind === 'all') {
+      return fileOccurrences;
+    }
+    if (fileOccurrences.length === 0) {
+      return [];
+    }
+    const parsed = parseWithDiagnostics(file.path, file.source);
+    if (parsed.diagnostics.length > 0 || parsed.ast === null) {
+      commentParseSkipped.push({
+        path: file.path,
+        reason: 'source-comment-parse-diagnostics',
+      });
+      return [];
+    }
+    return fileOccurrences.flatMap((occurrence) => {
+      const comment = parsed.comments.find(
+        (candidate) =>
+          candidate.start <= occurrence.start && occurrence.end <= candidate.end
+      );
+      if (comment === undefined) {
+        return [];
+      }
+      const sourceKindForOccurrence = sourceCommentKind(file, comment);
+      if (occurrence.verdict === 'skipped') {
+        return [{ ...occurrence, sourceKind: sourceKindForOccurrence }];
+      }
+      const { replacement: _replacement, ...reviewOccurrence } = occurrence;
+      return [
+        {
+          ...reviewOccurrence,
+          disposition: 'in-family-unresolved' as const,
+          reason: 'source-comment-requires-review',
+          sourceKind: sourceKindForOccurrence,
+          verdict: 'deferred' as const,
+        },
+      ];
+    });
   });
   const occurrencesByPath = new Map<string, SourceOccurrence[]>();
   for (const occurrence of occurrences) {
@@ -1599,6 +1713,9 @@ const buildVocabularyEvaluation = (params: {
   if (deferredForms.length > 0) {
     gateReasons.push('deferred-forms-or-occurrences');
   }
+  if (commentParseSkipped.length > 0) {
+    gateReasons.push('source-comment-parse-diagnostics');
+  }
   const open = unresolvedOccurrences.length;
   const scopeEvidence = vocabularyScopeEvidence(effectivePlan, occurrences);
   gateReasons.push(...scopeEvidence.gateReasons);
@@ -1612,6 +1729,11 @@ const buildVocabularyEvaluation = (params: {
         reason: entry.reason,
       })),
       ...scopeSkipped.map((entry) => ({
+        outcome: 'skip' as const,
+        path: entry.path,
+        reason: entry.reason,
+      })),
+      ...commentParseSkipped.map((entry) => ({
         outcome: 'skip' as const,
         path: entry.path,
         reason: entry.reason,
@@ -1652,7 +1774,7 @@ const buildVocabularyEvaluation = (params: {
       },
     },
     scanned: scopedFiles.length,
-    skipped: [...params.skipped, ...scopeSkipped],
+    skipped: [...params.skipped, ...scopeSkipped, ...commentParseSkipped],
   };
 };
 
@@ -1670,13 +1792,30 @@ const skippedByReason = (
   );
 };
 
+const withScannedPaths = (
+  report: RegradeReport,
+  paths: readonly string[]
+): RegradeReport => {
+  Object.defineProperty(report, 'scannedPaths', {
+    configurable: false,
+    enumerable: false,
+    value: Object.freeze([...paths]),
+    writable: false,
+  });
+  return report;
+};
+
 const withApplySummary = (
   report: RegradeReport,
   apply: RegradeApplySummary
-): RegradeReport => ({
-  ...report,
-  apply,
-});
+): RegradeReport =>
+  withScannedPaths(
+    {
+      ...report,
+      apply,
+    },
+    report.scannedPaths ?? []
+  );
 
 const appliedVocabularyRunReport = (
   postApply: VocabularyRegradeRun,
@@ -1824,6 +1963,9 @@ const buildRunVocabularyEvaluation = (params: {
     | undefined;
   readonly root: string;
   readonly skipped: readonly SkippedSource[];
+  readonly sourceKindForPath?:
+    | ((path: string) => VocabularySourceKind)
+    | undefined;
 }): VocabularyEvaluation =>
   buildVocabularyEvaluation({
     apply: params.apply,
@@ -1835,6 +1977,7 @@ const buildRunVocabularyEvaluation = (params: {
       : { preserveInventory: params.preserveInventory }),
     root: params.root,
     skipped: params.skipped,
+    sourceKindForPath: params.sourceKindForPath,
   });
 
 const ignoredDirectoriesOpenedByPolicy = (
@@ -1900,6 +2043,7 @@ export const runVocabularyRegrade = (params: {
   readonly preserveInventory?: readonly VocabularyPreserveInventoryEntry[];
   readonly root: string;
   readonly sourceFilter?: (path: string) => boolean;
+  readonly sourceKindForPath?: (path: string) => VocabularySourceKind;
 }): Result<RegradeReport | null, InternalError | ValidationError> => {
   const planValidation = validateVocabularyPlan(params.plan);
   if (planValidation.isErr()) {
@@ -1951,6 +2095,7 @@ export const runVocabularyRegrade = (params: {
     preserveInventory: params.preserveInventory,
     root: params.root,
     skipped,
+    sourceKindForPath: params.sourceKindForPath,
   });
   let reportEvaluation = dryRunEffectiveEvaluation;
   let applySummary: RegradeApplySummary | undefined;
@@ -1976,6 +2121,7 @@ export const runVocabularyRegrade = (params: {
       preserveInventory: params.preserveInventory,
       root: params.root,
       skipped,
+      sourceKindForPath: params.sourceKindForPath,
     });
   }
 
@@ -1985,39 +2131,44 @@ export const runVocabularyRegrade = (params: {
     (entry) => entry.outcome === 'rewrite' || entry.outcome === 'needs-review'
   );
   const reportSkippedByReason = skippedByReason(reportEvaluation.skipped);
-  const report: RegradeReport = {
-    entries: entrySelection === 'all' ? reportEntries : actionableEntries,
-    matched: actionableEntries.length,
-    review: reportEntries.filter((entry) => entry.outcome === 'needs-review')
-      .length,
-    rewritten: reportEntries.filter((entry) => entry.outcome === 'rewrite')
-      .length,
-    root: collected.root,
-    run:
-      applySummary === undefined
-        ? reportEvaluation.run
-        : vocabularyRunWithAppliedOccurrences(
-            reportEvaluation.run,
-            dryRunEffectiveEvaluation.run,
-            applySummary
-          ),
-    scan: buildRegradeScanSummary({
-      matchedPaths: actionableEntries.map((entry) => entry.path),
-      occurrencePaths: reportEvaluation.occurrences.map(
-        (occurrence) => occurrence.path
-      ),
+  const report: RegradeReport = withScannedPaths(
+    {
+      entries: entrySelection === 'all' ? reportEntries : actionableEntries,
+      matched: actionableEntries.length,
+      review: reportEntries.filter((entry) => entry.outcome === 'needs-review')
+        .length,
+      rewritten: reportEntries.filter((entry) => entry.outcome === 'rewrite')
+        .length,
+      root: collected.root,
+      run:
+        applySummary === undefined
+          ? reportEvaluation.run
+          : vocabularyRunWithAppliedOccurrences(
+              reportEvaluation.run,
+              dryRunEffectiveEvaluation.run,
+              applySummary
+            ),
+      scan: buildRegradeScanSummary({
+        matchedPaths: actionableEntries.map((entry) => entry.path),
+        occurrencePaths: reportEvaluation.occurrences.map(
+          (occurrence) => occurrence.path
+        ),
+        scanned: reportEvaluation.scanned,
+        skipped: reportEvaluation.skipped.length,
+        skippedByReason: reportSkippedByReason,
+      }),
       scanned: reportEvaluation.scanned,
+      selectedClassIds: [
+        params.plan.id ?? `vocabulary:${params.plan.from}->${params.plan.to}`,
+      ],
       skipped: reportEvaluation.skipped.length,
-      skippedByReason: reportSkippedByReason,
-    }),
-    scanned: reportEvaluation.scanned,
-    selectedClassIds: [
-      params.plan.id ?? `vocabulary:${params.plan.from}->${params.plan.to}`,
-    ],
-    skipped: reportEvaluation.skipped.length,
-    skipsByReason: reportSkippedByReason,
-    unknownClassIds: [],
-  };
+      skipsByReason: reportSkippedByReason,
+      unknownClassIds: [],
+    },
+    files
+      .filter((file) => includedByScope(file.path, effectivePlan.scope))
+      .map((file) => file.path)
+  );
 
   return Result.ok(
     applySummary === undefined ? report : withApplySummary(report, applySummary)
@@ -2170,6 +2321,10 @@ export const vocabularyRegradeRunOutput = z.object({
             scopeTier: z
               .enum(['in-scope', 'policy-classified'])
               .describe('Three-tier scope classification for this occurrence'),
+            sourceKind: z
+              .enum(['source-comment', 'tsdoc'])
+              .optional()
+              .describe('Exact source-comment construct for comment inventory'),
             start: z.number().describe('Source start offset'),
             verdict: z
               .enum(['applied', 'deferred', 'modified', 'skipped'])

--- a/packages/regrade/src/index.ts
+++ b/packages/regrade/src/index.ts
@@ -75,6 +75,7 @@ export type {
   VocabularyFileRenameEvidence,
   VocabularyFormProposal,
   VocabularyOccurrence,
+  VocabularyOccurrenceSourceKind,
   VocabularyPreserveInventoryEntry,
   VocabularyPreserveRule,
   VocabularyRegradePlan,


### PR DESCRIPTION
## Context

[TRL-1267](https://linear.app/outfitter/issue/TRL-1267/) requires governed classified vocabulary scans to inventory live source comments and TSDoc honestly. Regrade previously scanned prose and governed symbols, but could report completion while classified vocabulary remained in code comments.

This PR is stacked on [#981](https://github.com/outfitter-dev/trails/pull/981), which exposes parser-native comment spans from `@ontrails/source` and updates Warden's narrow comment projection.

## What changed

- inventory parser-native source comments and TSDoc for governed classified transitions as exact review-only occurrences;
- carry source-line context, exact spans, matched forms, unresolved judgment, and `SourceComment`/`TSDocComment` node kinds through Regrade, CLI, and MCP schemas;
- preserve ordinary domain nouns and prevent comment inventory from producing rewrites;
- fail closed on parse diagnostics and keep `regrade audit` open when live classified comment residue returns;
- deduplicate physical scan counts when a code file participates in both comment and governed-symbol lanes without persisting the internal path inventory;
- document the workflow and add minor release intent for `@ontrails/regrade` and `@ontrails/trails`.

## Verification

- targeted local review: 5/5, zero P0-P3;
- standing local review: 5/5, zero P0-P3;
- `bun test packages/regrade`: 214/214, 949 expectations;
- `bun test apps/trails/src/__tests__/regrade.test.ts apps/trails/src/__tests__/mcp.test.ts`: 113/113, 943 expectations;
- full pre-push hook: 49/49 package test tasks, 719 Trails app tests, 30/30 typechecks, 31/31 lint tasks, AST-grep, format, release-pack coherence, and Knip passed;
- `bun run changeset:check` passed for Regrade, Source, Trails, and Warden;
- docs links, README snippets, and hardwrap checks passed;
- Warden pre-push: 0 errors; eight named pre-existing warnings remain.

## Risks and rollout

- Classified scans intentionally do more work by parsing code comments; TRL-1268 owns structured progress and deterministic lifecycle reuse above this branch.
- Parser diagnostics are conservative: unavailable comment facts keep completion open instead of being treated as clean.
- No ratified vocabulary semantics changed, no Warden rule was weakened, and receipts remain cache-independent.
