### PR TITLE
fix(regrade): classify Warden AST regression fixtures

### DIFF
--- a/.changeset/classify-warden-ast-regression-fixtures.md
+++ b/.changeset/classify-warden-ast-regression-fixtures.md
@@ -1,0 +1,6 @@
+---
+"@ontrails/warden": patch
+---
+
+Classify adjacent package-route variants in the authored Warden AST regression
+fixtures as explicit preserves so the completed transition remains auditable.

--- a/apps/trails/src/__tests__/regrade.test.ts
+++ b/apps/trails/src/__tests__/regrade.test.ts
@@ -6344,6 +6344,41 @@ describe('trails regrade', () => {
     }
   });
 
+  test('v1 warden AST regression fixtures classify adjacent negative routes as preserved', () => {
+    const run = runRawCli([
+      'regrade',
+      '@ontrails/warden/ast',
+      '@ontrails/source',
+      '--root-dir',
+      repoRoot,
+      '--include-entries',
+      'all',
+      '--json',
+    ]);
+    expect(run.exitCode).toBe(0);
+    const parsed = parseCliJson<
+      {
+        readonly entries?: readonly { readonly outcome?: string }[];
+      } & Record<string, unknown>
+    >(run);
+    expect(parsed).toMatchObject({
+      review: 0,
+      rewritten: 0,
+      run: {
+        report: {
+          deferred: 0,
+          dispositions: { 'explicit-preserve': 6 },
+          gate: { remaining: 0, status: 'green' },
+          modified: 0,
+          open: 0,
+        },
+      },
+    });
+    expect(
+      parsed.entries?.filter((entry) => entry.outcome === 'needs-review')
+    ).toEqual([]);
+  });
+
   test('CLI regrade observes and applies governed package route source strings', () => {
     const dir = makeTempDir();
     const input = {

--- a/packages/warden/src/__tests__/retired-vocabulary.test.ts
+++ b/packages/warden/src/__tests__/retired-vocabulary.test.ts
@@ -512,6 +512,16 @@ describe('governed vocabulary registry', () => {
         pattern: '^@ontrails/warden/ast$',
       })
     );
+    expect(source?.preserve).toContainEqual(
+      expect.objectContaining({
+        paths: [
+          'apps/trails/src/__tests__/regrade.test.ts',
+          'packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts',
+          'packages/regrade/src/downstream/__tests__/vocabulary.test.ts',
+        ],
+        pattern: '^@ontrails/warden/ast(?:\\.js|\\.utils|/utils)$',
+      })
+    );
     expect(source?.preserve).not.toContainEqual(
       expect.objectContaining({
         paths: expect.arrayContaining([

--- a/packages/warden/src/rules/retired-vocabulary.ts
+++ b/packages/warden/src/rules/retired-vocabulary.ts
@@ -744,6 +744,16 @@ export const governedVocabularyTransitions =
           reason:
             'Preserve transition regression fixtures and the intentional negative resolver assertion after the public route is retired.',
         },
+        {
+          paths: [
+            'apps/trails/src/__tests__/regrade.test.ts',
+            'packages/regrade/src/downstream/__tests__/ast-rewrite.test.ts',
+            'packages/regrade/src/downstream/__tests__/vocabulary.test.ts',
+          ],
+          pattern: '^@ontrails/warden/ast(?:\\.js|\\.utils|/utils)$',
+          reason:
+            'Preserve the adjacent package-route variants used by the authored Warden AST transition regression fixtures.',
+        },
       ],
       reviewForms: [],
       safeRewriteForms: {


### PR DESCRIPTION
## Context

The first real `v1-warden-ast-source` proof run found adjacent package-route variants in the two authored Regrade regression fixtures. The transition preserved the exact retired route, but still left `.js`, `.utils`, and `/utils` negative cases open.

## What changed

- keep the existing exact-route preserve rule unchanged
- add a narrow preserve rule for the three proven adjacent forms on the two owning Regrade fixtures and the Trails proof test
- add a real-tree CLI regression that requires six explicit preserves, a green gate, zero open or modified items, and no review entries
- add Warden patch release intent

## Verification

- focused Trails CLI regression
- Warden governed-vocabulary suite
- `bun run regrade:audit`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:ast-grep`
- `bun run format:check`
- `bun run changeset:check`
- `git diff --check`
- full repository pre-push gate

## Risk / rollout

Low and policy-scoped. The rule names only the three established regression surfaces and the three observed adjacent forms; collection and completion semantics are unchanged.
