### PR TITLE
fix(regrade): reconcile accepted ADR receipt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
         # framework apps and examples/* stay covered from one source of truth.
         run: bun packages/warden/bin/warden.ts --ci
 
+      - name: Regrade audit
+        run: bun run regrade:audit
+
       - name: ADR check
         run: bun scripts/adr.ts check
 

--- a/.trails/regrade/history/v1-projection-derive-render.json
+++ b/.trails/regrade/history/v1-projection-derive-render.json
@@ -3719,6 +3719,1244 @@
       "runKind": "adjust",
       "timestamp": "2026-07-16T20:52:25.001Z",
       "transitionId": "f29fac3a4e47"
+    },
+    {
+      "classifiedState": {
+        "caseSensitive": true,
+        "forms": [
+          {
+            "disposition": "preserved",
+            "form": "20260608-release-provenance-as-lifecycle-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 5317,
+              "path": ".trails/regrade/v1-projection-derive-render.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "20260716regradereopenprojectionretro",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 469,
+              "path": ".agents/memory/decisions.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "ActivationSourceProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 20,
+              "path": ".changeset/topo-store-relocation.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "AstFieldProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 805,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "Default-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 160,
+              "path": ".agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-766-marker-diagnostics.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "DeriveTrailCliCommandProjectionOptions",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 806,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "ErrorClassSurfaceProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 807,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "ErrorDiagnosticsProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 808,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "HTTP_METHOD_PROJECTION_PATH",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 809,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "HttpInputProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 810,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "HttpLayerInputProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 811,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "LayerFieldProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 812,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "LayerFlagProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 813,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "LibraryInputProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 814,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "LibraryLayerFieldProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 815,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "LibraryLayerInputProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 816,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "LibraryProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 817,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "McpInputProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 818,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "McpLayerInputProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 819,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "NormalizedTopoProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 820,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "OutputSchemaProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 821,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "PROJECTION_BLOCKING_RULES",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 822,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "Project",
+            "reason": "Preserve project as an attributive noun before established repository and workspace concepts.",
+            "representative": {
+              "line": 1565,
+              "path": "packages/regrade/src/downstream/export-restructure.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "Projected",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 123,
+              "path": ".agents/memory/decisions.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "Projecting",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 34,
+              "path": ".trails/regrade/v1-projection-derive-render.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "Projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 72,
+              "path": ".agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-766-marker-diagnostics.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "ProjectionMap",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 823,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "Projects",
+            "reason": "Preserve exact projects domain literals, member accesses, route segments, and enum values.",
+            "representative": {
+              "line": 84,
+              "path": ".trails/regrade/v1-projection-derive-render.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "RenamedLayerFieldProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 826,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "ShippedSurfaceProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 827,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "SurfaceErrorProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 828,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "SurfaceProjectionSource",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 829,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "SurfaceTrailVersionProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 830,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "TopoGraphLibraryProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 831,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "TopoStoreSurfaceProjectionRecord",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 832,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "TopoSurfaceProjectionRow",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 833,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "TrailCliCommandProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 834,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "TrailCliProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 835,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "TrailCliProjectionInput",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 836,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "TrailErrorTaxonomyProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 837,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "activation-source-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 5325,
+              "path": ".trails/regrade/v1-projection-derive-render.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "buildOutputSchemaProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 838,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "buildProjectionDiagnostic",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 839,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "cliProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 840,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "cliProjectionSchema",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 841,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "collectLibraryProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 842,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "collectionExtensionProjectionForFileRenames",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 578,
+              "path": "packages/warden/src/__tests__/retired-vocabulary.test.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "deriveShippedSurfaceProjectionInventory",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 883,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "deriveTrailCliCommandProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 884,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "error-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 5329,
+              "path": ".trails/regrade/v1-projection-derive-render.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "errorSurfaceProjectionSchema",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 885,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "errorTaxonomyProjectionSchema",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 886,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "expectProjectionCounts",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 887,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "extensionProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 844,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "inputProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 888,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "isProjectionBlockingIssue",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 889,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "isTrailCliProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 890,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "keepProjectionBlockingIssues",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 891,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "layer-input-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 5321,
+              "path": ".trails/regrade/v1-projection-derive-render.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "layer-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 8,
+              "path": ".changeset/trl-474-layer-input-mcp-http.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "layerInputProjections",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 8,
+              "path": ".changeset/trl-474-layer-input-mcp-http.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "layerProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 892,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "library-layer-input-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 103,
+              "path": ".changeset/pre.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "library-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 5353,
+              "path": ".trails/regrade/v1-projection-derive-render.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "library-projection-coherence",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 5357,
+              "path": ".trails/regrade/v1-projection-derive-render.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "libraryProjectionCoherence",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 893,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "libraryProjectionCoherenceTrail",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 894,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "lockfile-as-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 255,
+              "path": "docs/adr/0018-signal-driven-governance.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "move-trails-repo-local-plugin-projections-onto-skillset",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 26,
+              "path": ".agents/plans/2026-08-06-skillset-migration/REFS.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "normalizeTopoProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 895,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "owner-projection-parity",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 5361,
+              "path": ".trails/regrade/v1-projection-derive-render.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "ownerProjectionParity",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 896,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "ownerProjectionParityTrail",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 897,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "policy-vs-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 180,
+              "path": "docs/adr/0037-owner-first-authority.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "project",
+            "reason": "Preserve exact project domain literals, example variables, route segments, and enum values.",
+            "representative": {
+              "line": 150,
+              "path": ".agents/memory/decisions.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "projected",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 5,
+              "path": ".agents/memory/decisions.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "projecting",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 34,
+              "path": ".agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-766-marker-diagnostics.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 5,
+              "path": ".agents/memory/decisions.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "projection-level",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 40,
+              "path": "docs/adr/0050-surface-accommodations-preserve-trail-identity.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "projection-travels-with-schema",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 7,
+              "path": ".agents/memory/decisions.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "projectionDb",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 898,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "projectionKeys",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 899,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "projectionSource",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 900,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "projectioned",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 56,
+              "path": ".trails/regrade/v1-projection-derive-render.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "projectioning",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 63,
+              "path": ".trails/regrade/v1-projection-derive-render.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "projections",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 41,
+              "path": ".agents/plans/2026-05-22-v1-release-readiness-closeout/reports/trl-766-marker-diagnostics.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "projects",
+            "reason": "Preserve projects as an ordinary plural repository or application noun selected by an established domain modifier.",
+            "representative": {
+              "line": 425,
+              "path": ".agents/memory/decisions.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "reconcile-the-projection-regrade-receipt-after-adr-0054-acceptance",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 189,
+              "path": ".agents/plans/2026-08-06-skillset-migration/RETRO.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "release-provenance-as-lifecycle-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 119,
+              "path": ".agents/memory/decisions.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "seedLegacyProjectionStore",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 901,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "simpleProjectionApp",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 902,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "surface-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 248,
+              "path": "docs/releases/beta15-to-beta19.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "surfaceProjectionBaseOutput",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 903,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "surfaceProjectionOutput",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 904,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "taxonomyProjection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 905,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "topoGraphLibraryProjectionSchema",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 906,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "trailCliProjectionFor",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 907,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "trl-1019-projection-derive-render",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 205,
+              "path": ".changeset/pre.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "trl-1019-projection-residue",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 206,
+              "path": ".changeset/pre.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "trl-1032-compile-error-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 216,
+              "path": ".changeset/pre.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "trl-473-layer-input-cli-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 335,
+              "path": ".changeset/pre.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "trl-958-cli-command-projection",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 406,
+              "path": ".changeset/pre.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "trl-980-library-projection-artifacts",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 413,
+              "path": ".changeset/pre.json"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "v1-projection-derive-render",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 86,
+              "path": ".agents/plans/2026-08-06-skillset-migration/RETRO.md"
+            }
+          },
+          {
+            "disposition": "preserved",
+            "form": "withProjectionDb",
+            "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger.",
+            "representative": {
+              "line": 908,
+              "path": "packages/warden/src/rules/retired-vocabulary.ts"
+            }
+          }
+        ],
+        "kind": "embedded",
+        "stateHash": "37e3ccf8b7319319e4579aceb9da9fb94b09ab3d80a6067e38c6d35e2fa06558"
+      },
+      "completion": {
+        "counts": {
+          "dispositions": {
+            "explicit-preserve": 671,
+            "historical-by-policy": 804
+          },
+          "matched": 1,
+          "preserved": 105,
+          "review": 0,
+          "rewritten": 1,
+          "skippedByReason": {
+            "ignored-directory": 6,
+            "ignored-glob": 1,
+            "immutable-regrade-history": 1,
+            "unsupported-extension": 933
+          },
+          "unknown": 0
+        },
+        "gate": {
+          "reasons": [],
+          "remaining": 0,
+          "status": "green"
+        },
+        "metrics": {
+          "filesChanged": 1,
+          "formsMapped": 0,
+          "occurrencesRewritten": 1
+        }
+      },
+      "evidence": {
+        "changedFiles": [
+          {
+            "afterBlobHash": "53212111596c98c6a11a59936f0aef9158b6793f",
+            "afterPath": "apps/trails/src/__tests__/regrade-history.test.ts",
+            "beforeBlobHash": "5d8d001f304536f409a7db1177ad71211a74ef54",
+            "beforePath": "apps/trails/src/__tests__/regrade-history.test.ts"
+          }
+        ],
+        "detailEvidenceHash": "8529a1ee3b9ac7db165974f92aaf1cb82392034ad1a8fe4e35e8313e1d5b9dcc",
+        "lockStateHash": "4512639c61f061f22dc3d949fe0d8d998fbeff7557d25240628bcd09faddac12",
+        "policyHash": "dbf2b0cdcda6a172ed62ff76f8823d3fa66d845c27add1448395ed5ed80d6c2a",
+        "sourceRevision": "d8a2e7a3e89ac06c1f594ef845ea18acaf58ea64",
+        "sourceStateHash": "d1b95af71bb5008ec5812e436e00e54ceb2d6c496bbf0d2043676e8493d4a114",
+        "toolVersion": "1.0.0-beta.47"
+      },
+      "intent": {
+        "kind": "embedded",
+        "plan": {
+          "caseSensitive": true,
+          "deferForms": [
+            "projection",
+            "projections",
+            "project",
+            "projects",
+            "Projects",
+            "projecting",
+            "Projecting",
+            "projected",
+            "Projected"
+          ],
+          "fileRenames": [
+            {
+              "from": "docs/adr/drafts/20260608-release-provenance-as-lifecycle-projection.md",
+              "to": "docs/adr/drafts/20260608-release-provenance-as-lifecycle-derivation.md"
+            },
+            {
+              "from": "packages/cli/src/__tests__/layer-input-projection.test.ts",
+              "to": "packages/cli/src/__tests__/layer-input-rendering.test.ts"
+            },
+            {
+              "from": "packages/core/src/__tests__/activation-source-projection.test.ts",
+              "to": "packages/core/src/__tests__/activation-source-derivation.test.ts"
+            },
+            {
+              "from": "packages/core/src/__tests__/error-projection.test.ts",
+              "to": "packages/core/src/__tests__/error-rendering.test.ts"
+            },
+            {
+              "from": "packages/core/src/activation-source-projection.ts",
+              "to": "packages/core/src/activation-source-derivation.ts"
+            },
+            {
+              "from": "packages/core/src/error-projection.ts",
+              "to": "packages/core/src/error-rendering.ts"
+            },
+            {
+              "from": "packages/core/src/layer-projection.ts",
+              "to": "packages/core/src/layer-field-rendering.ts"
+            },
+            {
+              "from": "packages/http/src/__tests__/layer-input-projection.test.ts",
+              "to": "packages/http/src/__tests__/layer-input-rendering.test.ts"
+            },
+            {
+              "from": "packages/mcp/src/__tests__/layer-input-projection.test.ts",
+              "to": "packages/mcp/src/__tests__/layer-input-rendering.test.ts"
+            },
+            {
+              "from": "packages/topography/src/library-projection.ts",
+              "to": "packages/topography/src/library-derivation.ts"
+            },
+            {
+              "from": "packages/warden/src/__tests__/library-projection-coherence.test.ts",
+              "to": "packages/warden/src/__tests__/library-render-coherence.test.ts"
+            },
+            {
+              "from": "packages/warden/src/__tests__/owner-projection-parity.test.ts",
+              "to": "packages/warden/src/__tests__/owner-render-parity.test.ts"
+            },
+            {
+              "from": "packages/warden/src/rules/library-projection-coherence.ts",
+              "to": "packages/warden/src/rules/library-render-coherence.ts"
+            },
+            {
+              "from": "packages/warden/src/rules/owner-projection-parity.ts",
+              "to": "packages/warden/src/rules/owner-render-parity.ts"
+            },
+            {
+              "from": "packages/warden/src/trails/library-projection-coherence.trail.ts",
+              "to": "packages/warden/src/trails/library-render-coherence.trail.ts"
+            },
+            {
+              "from": "packages/warden/src/trails/owner-projection-parity.trail.ts",
+              "to": "packages/warden/src/trails/owner-render-parity.trail.ts"
+            }
+          ],
+          "from": "projection",
+          "id": "v1-projection-derive-render",
+          "intent": "Split projection vocabulary into derive/render by lifecycle stage for v1.",
+          "kind": "vocabulary",
+          "preserve": [
+            {
+              "pattern": "\\b[Pp]roject(?:[-/:]|['’]s\\b)",
+              "reason": "Preserve compound project-domain nouns, permit scopes, paths, and possessives without suppressing the standalone retired verb."
+            },
+            {
+              "pattern": "\\b[Pp]roject\\s+(?:root|directory|files?|paths?|state|scripts?|guidance|structure|name|marker|context|conventions?|vocabulary|rules?|findings?|operations?|key|source|config|metadata|policy|package|scope|entities|resources|diagnostics|history|update|control|instructions?|overview|documentation|boundary|helpers?|shape|dependencies|dependency|detection|substrate|truth|work|writing|management|settings?|skills?|issue|ids?)\\b",
+              "reason": "Preserve project as an attributive noun before established repository and workspace concepts."
+            },
+            {
+              "pattern": "\\b(?:A|An|The|This|That|a|an|the|this|that|each|entire|every|existing|new|current|same|target|nested|downstream|Trails|Linear|Node|UX|logical|adopting|generated|scaffolded|source-shaped|first-party|temp)\\s+project\\b",
+              "reason": "Preserve project as an ordinary count noun selected by a determiner or domain adjective."
+            },
+            {
+              "pattern": "\\b(?:Trails|Matt[’']s|Vite|ADR|adopting|application|consumer|customer|developer|framework|package|software|source|workspace|generated|scaffolded|new|existing|source-shaped|first-party|downstream|most|large|all|many|multiple|other|our|several|their|these|those|your)\\s+projects\\b",
+              "reason": "Preserve projects as an ordinary plural repository or application noun selected by an established domain modifier."
+            },
+            {
+              "pattern": "\\b(?:across|among|between|for|from|in|inside|of|outside|under|within|with|without)\\s+(?:the\\s+)?projects\\b",
+              "reason": "Preserve projects as the object of a repository or application preposition."
+            },
+            {
+              "pattern": "(?:['\"`/.][Pp]rojects(?:['\"`/]|\\b)|\\b[Pp]rojects\\b\\s*(?:=|[):;,]))",
+              "reason": "Preserve exact projects domain literals, member accesses, route segments, and enum values."
+            },
+            {
+              "pattern": "\\b(?:in|for|within|across|under|outside|inside|from|of|with|without|per|before|after)\\s+(?:the\\s+)?project\\b",
+              "reason": "Preserve project as the object of a repository or workspace preposition."
+            },
+            {
+              "pattern": "(?:['\"`/]project(?:['\"`/]|\\b)|\\bproject\\b\\s*(?:=|[);,]))",
+              "reason": "Preserve exact project domain literals, example variables, route segments, and enum values."
+            },
+            {
+              "pattern": "(?:\\bmemory:\\s*project\\b|\\bproject\\b(?=\\s+(?:from|health-check|show)\\b))",
+              "reason": "Preserve project as an exact metadata value, import alias, or domain command segment."
+            },
+            {
+              "pattern": "(?:\\bA Node project\\b|\\ba non-trivial UX project\\b|\\bproject\\s+`warden\\.)",
+              "reason": "Preserve established multiword project nouns and project-scoped Warden configuration prose."
+            }
+          ],
+          "scope": {
+            "exclude": [
+              ".scratch/**",
+              "**/.scratch/**",
+              "**/.tmp-tests/**"
+            ],
+            "policyClassified": [
+              {
+                "disposition": "historical-by-policy",
+                "paths": [
+                  ".agents/goals/**",
+                  "**/.agents/goals/**",
+                  ".agents/memory/**",
+                  "**/.agents/memory/**",
+                  ".agents/notes/**",
+                  "**/.agents/notes/**",
+                  ".agents/plans/**",
+                  "**/.agents/plans/**",
+                  ".claude/agent-memory/**",
+                  "**/.claude/agent-memory/**",
+                  ".changeset/**",
+                  "**/.changeset/**",
+                  ".trails/regrade/*.json",
+                  "**/.trails/regrade/*.json",
+                  "**/CHANGELOG.md",
+                  "docs/adr/0*.md",
+                  "docs/adr/decision-map.json",
+                  "docs/migration/*-to-adapter.md",
+                  "docs/migration/*-to-compose.md",
+                  "docs/migration/trailhead-to-surface.md",
+                  "docs/releases/beta*.md",
+                  "docs/releases/v1-vocabulary-reset.md",
+                  "docs/releases/v1-vocabulary-transition-workflow.md",
+                  "packages/warden/src/__tests__/retired-vocabulary.test.ts",
+                  "packages/warden/src/rules/retired-vocabulary.ts"
+                ],
+                "reason": "Preserve authored migration plans and historical decision/release evidence while keeping occurrences visible to the run ledger."
+              },
+              {
+                "disposition": "explicit-preserve",
+                "expectMatches": true,
+                "paths": [
+                  "apps/trails/src/__tests__/mcp.test.ts",
+                  "apps/trails/src/__tests__/regrade.test.ts",
+                  "packages/regrade/src/downstream/__tests__/**/*.test.ts"
+                ],
+                "reason": "Preserve exact old/new vocabulary fixtures that prove CLI, MCP, registry, and rewrite behavior without treating them as current teaching or API residue."
+              },
+              {
+                "disposition": "historical-by-policy",
+                "expectMatches": true,
+                "paths": [
+                  "docs/adr/0*.md"
+                ],
+                "reason": "The Trails projection census records accepted ADR history that must remain visible during the v1 split."
+              }
+            ],
+            "teachingSurfaces": [
+              "docs/adr/drafts/20260331-direct-invocation.md",
+              "docs/adr/drafts/20260331-pack-resources.md",
+              "docs/adr/drafts/20260406-documentation-freshness.md",
+              "docs/adr/drafts/20260406-documentation-structure.md",
+              "docs/adr/drafts/20260524-scaffold-forward-compatibility.md",
+              "docs/adr/drafts/20260603-surface-trailheads-shape-dense-topos.md",
+              "docs/adr/drafts/20260608-release-provenance-as-lifecycle-derivation.md",
+              "docs/adr/drafts/20260612-library-surface-and-compiler.md",
+              "docs/adr/drafts/20260612-verdicts-run-on-stable-ground.md",
+              "docs/api-reference.md",
+              "docs/architecture.md",
+              "docs/contributing/codebase-navigation.md",
+              "docs/contributing/README.md",
+              "docs/contributing/warden-rules.md",
+              "docs/getting-started.md",
+              "docs/lexicon.md",
+              "docs/migration/topograph-artifact-family.md",
+              "docs/releases/plugin-release.md",
+              "docs/releases/release-rules-check.md",
+              "docs/releases/stable-cutover.md",
+              "docs/releases/surface-trailheads.md",
+              "docs/surfaces/mcp.md",
+              "docs/surfaces/surface-trailheads.md",
+              "docs/tenets.md",
+              "docs/topo-store.md",
+              "docs/warden.md",
+              "docs/why-trails.md"
+            ]
+          },
+          "to": "derive"
+        },
+        "planContentHash": "711fb0ffc295dc6f8b0cf9a62559ac8d25301954fbf511f33d867eeaa44fdfb1",
+        "provenance": {
+          "fields": {
+            "caseSensitive": "derived",
+            "deferForms": "derived",
+            "fileRenames": "derived",
+            "from": "authored",
+            "id": "derived",
+            "intent": "authored",
+            "kind": "derived",
+            "preserve": "derived",
+            "scope": "derived",
+            "to": "authored"
+          }
+        }
+      },
+      "project": {
+        "root": "."
+      },
+      "runId": "0a30c6fd98763639",
+      "runKind": "adjust",
+      "timestamp": "2026-08-10T21:57:52.649Z",
+      "transitionId": "f29fac3a4e47"
     }
   ],
   "schemaVersion": 3

--- a/apps/trails/src/__tests__/regrade-history.test.ts
+++ b/apps/trails/src/__tests__/regrade-history.test.ts
@@ -555,11 +555,11 @@ describe('appendRegradeHistoryRun', () => {
           'does not match its observed file'
         );
       }
-      const projected = readRegradeHistoryArtifact(historyPath);
-      if (projected.isErr()) {
-        throw projected.error;
+      const derived = readRegradeHistoryArtifact(historyPath);
+      if (derived.isErr()) {
+        throw derived.error;
       }
-      const verified = verifyRegradeHistoryRuns(projected.value);
+      const verified = verifyRegradeHistoryRuns(derived.value);
       if (verified.isErr()) {
         throw verified.error;
       }


### PR DESCRIPTION
## Context

[TRL-1277](https://linear.app/outfitter/issue/TRL-1277) closes the stale aggregate Regrade gate discovered while settling the agent-skill migration stack. The accepted ADR-0054 replaced a draft teaching surface, but the governed projection-to-derive receipt had not been reopened.

The receipt emitter repair and conversion-provenance regression were split into [#994](https://github.com/outfitter-dev/trails/pull/994) and landed first. Its squash commit, `d8a2e7a3e89ac06c1f594ef845ea18acaf58ea64`, is the durable pre-apply boundary required for the receipt evidence in this PR to survive squash merge.

## What changed

- regenerated the fourth adjustment run through the supported Regrade lifecycle: `adjust` → refreshed derived `plan` → `preview` → dry-run `apply` → real `apply`
- recorded the single safe governed rewrite in the existing test-local binding: `projected` → `derived`
- preserved the prior three receipt runs and top-level conversion provenance exactly
- added `bun run regrade:audit` to the hosted Governance job

## Durable receipt evidence

- `sourceRevision`: `d8a2e7a3e89ac06c1f594ef845ea18acaf58ea64`, the landed [#994](https://github.com/outfitter-dev/trails/pull/994) squash
- `beforeBlobHash`: `5d8d001f304536f409a7db1177ad71211a74ef54`, exactly the test file in that landed parent
- `afterBlobHash`: `53212111596c98c6a11a59936f0aef9158b6793f`, exactly the test file in this PR head
- all Git objects resolve; the source revision is an ancestor of this head
- prior three runs and top-level conversion are byte/JSON-equal to `main`
- fourth run: 1 safe rewrite, 0 review, 0 unknown; completion gate green

## Verification

- `bun test apps/trails/src/__tests__/regrade-history.test.ts` — 15 passed
- `bun run regrade:audit` — 9 transitions green, 0 open
- `bun run changeset:check`
- `bun run check`
- pre-push suite — green, including 747 Trails tests
- `git diff --check main...HEAD`
- Graphite submit dry run and exact-head submit

## Release intent

`release:none`: this child changes only the generated Regrade receipt, a Regrade-owned test-local identifier, and the hosted governance audit step. The publishable emitter repair and its patch changeset already landed in [#994](https://github.com/outfitter-dev/trails/pull/994); this PR changes no package content.

## Risk and review

The generated receipt diff is intentionally large because Regrade embeds the refreshed adjustment intent in the canonical fourth run. The PR remains draft until independent acceptance review, the original P2 discussion, and fresh exact-head hosted checks are all settled.