### PR TITLE
fix(regrade): preserve governed receipt provenance

### DIFF
--- a/.changeset/regrade-conversion-provenance.md
+++ b/.changeset/regrade-conversion-provenance.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Preserve governed conversion provenance when Regrade appends a run to an existing v3 receipt.

--- a/apps/trails/src/__tests__/regrade-history.test.ts
+++ b/apps/trails/src/__tests__/regrade-history.test.ts
@@ -412,6 +412,53 @@ describe('appendRegradeHistoryRun', () => {
     });
   });
 
+  test('preserves governed conversion provenance when appending runs', () => {
+    withFixtureDir((dir) => {
+      const artifact = makePlanArtifact(makePlanBody());
+      const report = makeReport([]);
+      const first = appendRegradeHistoryRun({ artifact, report, rootDir: dir });
+      if (first.isErr()) {
+        throw first.error;
+      }
+
+      const historyPath = regradeHistoryPathForPlan(dir, artifact.plan);
+      const prior = readRegradeReceipt(historyPath);
+      if (prior.isErr()) {
+        throw prior.error;
+      }
+      const conversion = {
+        convertedAt: '2026-07-16T23:02:23.000Z',
+        fromSchemaVersion: 2 as const,
+        sourceContentHash:
+          '6a56009d0621a4ef5ad5b6c1618cfade9fe459b0e2c166b930d8d8f9dbb2a649',
+        toolVersion: '1.0.0-beta.45',
+      };
+      const converted = serializeRegradeHistoryReceipt({
+        ...prior.value.artifact,
+        conversion,
+      });
+      if (converted.isErr()) {
+        throw converted.error;
+      }
+      writeFileSync(historyPath, converted.value);
+
+      const appended = appendRegradeHistoryRun({
+        artifact,
+        report,
+        rootDir: dir,
+      });
+      if (appended.isErr()) {
+        throw appended.error;
+      }
+      const persisted = JSON.parse(readFileSync(historyPath, 'utf8')) as {
+        conversion?: typeof conversion;
+        runs: unknown[];
+      };
+      expect(persisted.conversion).toEqual(conversion);
+      expect(persisted.runs).toHaveLength(2);
+    });
+  });
+
   test('persists canonical v3 receipts with exact Git blob evidence and hash references', () => {
     withFixtureDir((dir) => {
       const artifact = makePlanArtifact(makePlanBody());

--- a/apps/trails/src/regrade/receipt-history.ts
+++ b/apps/trails/src/regrade/receipt-history.ts
@@ -405,6 +405,7 @@ export const buildRegradeHistoryReceipt = (params: {
     transitionId: params.transitionId,
   };
   const receipt = {
+    conversion: params.prior?.artifact.conversion,
     id: params.transitionId,
     kind: 'regrade-history',
     path: params.historyPath,


### PR DESCRIPTION
This is the durable baseline required before #993 can record a squash-stable Regrade adjustment.

It carries the pre-existing conversion provenance forward whenever Regrade appends to a v3 history receipt, and adds a regression that reconstructs a converted receipt before appending a second run. The governed projected identifier and generated receipt intentionally remain out of this PR; Regrade will own that rewrite in #993 after this parent lands.

## Verification

- bun test apps/trails/src/__tests__/regrade-history.test.ts — 15 pass
- bun run changeset:check
- full pre-push gate — Warden, ADR, all 49 test tasks, typecheck, lint, AST lint, format, release-pack, and dead-code passed
- git diff --check

## Release and rollout

- Patch changeset for @ontrails/trails
- No migration, documentation, Warden rule, Wayfinder, lockfile, workflow, or deployment changes
- Risk is limited to retaining already-validated optional conversion metadata while appending a receipt run