### PR TITLE
fix(release): distinguish generated release PRs

### DIFF
--- a/.changeset/release-policy-generated-pr-route.md
+++ b/.changeset/release-policy-generated-pr-route.md
@@ -1,0 +1,5 @@
+---
+"@ontrails/trails": patch
+---
+
+Keep ordinary source pull request labels out of generated release policy by requiring the canonical `changeset-release/main` head route during release PR discovery.

--- a/apps/trails/src/__tests__/release-policy.test.ts
+++ b/apps/trails/src/__tests__/release-policy.test.ts
@@ -7,6 +7,7 @@ import {
   labelsForReleasePullRequest,
   releaseIntentForVersionDelta,
   releasePolicyRequiresCiProof,
+  selectGeneratedReleasePullRequest,
   selectReleasePolicyCiProofTarget,
 } from '../release/policy.js';
 import type {
@@ -81,6 +82,42 @@ const releasePolicySuccessRun = (name: string): ReleasePolicyCheckRun => ({
   status: 'completed',
 });
 
+describe('selectGeneratedReleasePullRequest', () => {
+  const sourcePullRequest = {
+    base: { ref: 'main' },
+    head: { ref: 'docs/agents/process-capture' },
+    labels: [{ name: 'release:none' }],
+    number: 991,
+  };
+  const generatedReleasePullRequest = {
+    base: { ref: 'main' },
+    head: { ref: 'changeset-release/main' },
+    labels: [{ name: 'release:patch' }],
+    number: 995,
+  };
+
+  test('rejects ordinary source PRs from generated release discovery', () => {
+    expect(
+      selectGeneratedReleasePullRequest([sourcePullRequest])
+    ).toBeUndefined();
+  });
+
+  test('selects the generated release PR regardless of API order', () => {
+    expect(
+      selectGeneratedReleasePullRequest([
+        sourcePullRequest,
+        generatedReleasePullRequest,
+      ])
+    ).toBe(generatedReleasePullRequest);
+    expect(
+      selectGeneratedReleasePullRequest([
+        generatedReleasePullRequest,
+        sourcePullRequest,
+      ])
+    ).toBe(generatedReleasePullRequest);
+  });
+});
+
 describe('evaluateReleasePolicy', () => {
   test('allows publish:auto when generated release and stack evidence are complete', () => {
     const report = evaluateReleasePolicy(baseInput());
@@ -101,6 +138,31 @@ describe('evaluateReleasePolicy', () => {
     expect(report.diagnostics).toContain('CI proof has not been evaluated');
   });
 
+  test('keeps source PR release labels out of generated release intent', () => {
+    const report = evaluateReleasePolicy(
+      baseInput({
+        releasePullRequest: undefined,
+        sourcePullRequests: [
+          {
+            commitShas: ['abc123'],
+            hasChangeset: true,
+            labels: ['release:none', 'stack:boundary'],
+            number: 991,
+            title: 'docs: capture source process',
+          },
+        ],
+      })
+    );
+
+    expect(report.decision).toBe('manual');
+    expect(report.blockers).toEqual([]);
+    expect(report.shouldPublish).toBe(false);
+    expect(report.createGitHubRelease).toBe(false);
+    expect(report.reasons).toContain(
+      'No publish:* label is set; routing to manual approval'
+    );
+  });
+
   test('keeps manual publish paths independent from CI proof', () => {
     const report = evaluateReleasePolicy(
       baseInput({
@@ -113,6 +175,8 @@ describe('evaluateReleasePolicy', () => {
     );
 
     expect(report.decision).toBe('manual');
+    expect(report.shouldPublish).toBe(true);
+    expect(report.createGitHubRelease).toBe(true);
     expect(report.diagnostics).toEqual([]);
     expect(releasePolicyRequiresCiProof(baseInput())).toBe(true);
     expect(

--- a/apps/trails/src/release/policy.ts
+++ b/apps/trails/src/release/policy.ts
@@ -407,7 +407,8 @@ const makeReport = (
   }
 ): ReleasePolicyReport => {
   const canPublish =
-    options.decision === 'auto' || options.decision === 'manual';
+    input.releasePullRequest !== undefined &&
+    (options.decision === 'auto' || options.decision === 'manual');
   const packagesPublished = registryComplete(input.registryPackages);
   const reasons = [...options.reasons];
   if (canPublish) {
@@ -1125,6 +1126,20 @@ const managedGitHubLabels = [
   },
 ] as const;
 
+export const selectGeneratedReleasePullRequest = <
+  PullRequest extends {
+    readonly base: { readonly ref: string };
+    readonly head: { readonly ref: string };
+  },
+>(
+  pulls: readonly PullRequest[]
+): PullRequest | undefined =>
+  pulls.find(
+    (candidate) =>
+      candidate.base.ref === 'main' &&
+      candidate.head.ref === 'changeset-release/main'
+  );
+
 const readReleasePullRequest = async (
   repository: string,
   sha: string
@@ -1133,7 +1148,7 @@ const readReleasePullRequest = async (
     repository,
     `/commits/${sha}/pulls`
   );
-  const pull = pulls.find((candidate) => candidate.base.ref === 'main');
+  const pull = selectGeneratedReleasePullRequest(pulls);
   if (!pull) {
     return undefined;
   }
@@ -1161,9 +1176,7 @@ const readOpenReleasePullRequest = async (
     repository,
     '/pulls?state=open&base=main&per_page=100'
   );
-  const pull = pulls.find(
-    (candidate) => candidate.head.ref === 'changeset-release/main'
-  );
+  const pull = selectGeneratedReleasePullRequest(pulls);
   if (!pull) {
     return undefined;
   }


### PR DESCRIPTION
## Context

[TRL-1278](https://linear.app/outfitter/issue/TRL-1278) fixes a release-policy identity leak observed after [#991](https://github.com/outfitter-dev/trails/pull/991) and [#992](https://github.com/outfitter-dev/trails/pull/992) merged. GitHub commit-to-PR lookup returned those ordinary source PRs, and the generated-release reader accepted the first `main` PR. Their correct branch-local `release:none` label was then interpreted as an unknown generated `release:*` intent, blocking Publish Policy in runs `31348430271` and `31348483561`.

## What changed

- generated release PR discovery now requires both `base=main` and the canonical `head=changeset-release/main` route
- commit-to-PR policy lookup and open generated-release lookup share the same selector
- regression tests reject ordinary `main` source PRs, prove canonical selection regardless of API order, and keep source labels independent from generated release intent

## Why this boundary

`release:none` remains correct for ordinary source PRs. Generated release intent remains `publish:*`, `channel:*`, and generated `release:*`. Filtering discovery fixes the category error without loosening publish authorization, hiding source evidence, or teaching the generated evaluator to accept a source-only label.

## Verification

- `bun test apps/trails/src/__tests__/release-policy.test.ts` — 30 passed
- `bun run changeset:check`
- `bun run check`
- `bun run publish:check` — all package pack checks passed
- full pre-push suite — green
- `git diff --check`
- Graphite submit dry run

## Release intent

Patch changeset for `@ontrails/trails`: release policy no longer lets ordinary source PR labels occupy generated release intent.

## Distribution calls

- docs: not applicable; existing release rules already describe the source/generated separation
- workflow: not applicable; current publish decision/output gates remain correct
- Warden and Wayfinder: not applicable; no framework, topo, or governance surface changes
- migration: not applicable

## Risk

The change narrows only generated PR discovery. A missing generated PR continues to route to manual approval with no package publish or GitHub release authorization.